### PR TITLE
fix(api-config-warning): fixed the display anomaly in dark mode

### DIFF
--- a/src/components/api-config-warning.tsx
+++ b/src/components/api-config-warning.tsx
@@ -2,7 +2,7 @@ export function APIConfigWarning({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        'rounded-md border border-amber-500 bg-amber-100 px-2 py-1.5 text-center text-sm font-medium',
+        'rounded-md border border-amber-500 bg-amber-100 px-2 py-1.5 text-center text-sm font-medium dark:bg-amber-900',
         className,
       )}
     >


### PR DESCRIPTION

## Type of Changes
- [x] 💄 UI/style change (style)

## Description
Fixed the abnormal background display of the `api-config-warning` component in the plugin when the browser is in dark mode.

## Related Issue
no