### PR TITLE
fix: resolve issue #68

### DIFF
--- a/src/utils/host/translate.ts
+++ b/src/utils/host/translate.ts
@@ -173,6 +173,9 @@ function insertTranslatedNodeIntoWrapper(
     // not inline or block, maybe notranslate
     return
   }
+  if (isHTMLElement(targetNode) && targetNode.tagName === 'A') {
+    translatedNode.style.textDecoration = 'underline'
+  }
 
   translatedNode.textContent = translatedText
   translatedWrapperNode.appendChild(translatedNode)


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

This PR enhances the translated text display behavior by adding an underline to anchor (`<a>`) tags when rendered, which helps clearly indicate clickable links after translation.

## Related Issue

https://github.com/mengxi-ream/read-frog/issues/68

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.