### PR TITLE
fix: underline anchor elements and update style

### DIFF
--- a/.changeset/shy-socks-share.md
+++ b/.changeset/shy-socks-share.md
@@ -1,0 +1,5 @@
+---
+"read-frog": patch
+---
+
+underline anchor elements in translated content

--- a/src/entrypoints/host.content/style.css
+++ b/src/entrypoints/host.content/style.css
@@ -45,7 +45,8 @@
 }
 
 .read-frog-translated-inline-content {
-  display: inline-block;
-  color: inherit; /* 保持文本颜色与周围文本一致 */
+  display: inline;
+  color: inherit;
   font-family: inherit;
+  text-decoration: inherit;
 }


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

This PR updates the rendering of translated `<a>` elements, which helps clearly indicate clickable links after translation.

## Related Issue

https://github.com/mengxi-ream/read-frog/issues/68

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

## Screenshots

<img width="764" alt="c31a24dd499cae4e4230b6693bf1960" src="https://github.com/user-attachments/assets/de282a83-f1b3-4bd4-b0fd-ab72ec29b58e" />

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.
