### PR TITLE
fix(toast): extend error message display duration

### DIFF
--- a/src/entrypoints/popup/app.tsx
+++ b/src/entrypoints/popup/app.tsx
@@ -60,7 +60,7 @@ function App() {
           <span className="text-[13px] font-medium">Github</span>
         </button>
       </div>
-      <Toaster richColors position="bottom-center" className="-translate-y-8" />
+      <Toaster richColors position="bottom-center" className="-translate-y-8" duration={10000} />
     </>
   )
 }

--- a/src/entrypoints/side.content/components/floating-button/index.tsx
+++ b/src/entrypoints/side.content/components/floating-button/index.tsx
@@ -142,7 +142,7 @@ export default function FloatingButton() {
             sendMessage('openOptionsPage', undefined)
           }}
         />
-        <Toaster richColors className="z-[2147483647]" />
+        <Toaster richColors className="z-[2147483647]" duration={10000} />
       </div>
     )
   )

--- a/src/entrypoints/side.content/components/side-content/index.tsx
+++ b/src/entrypoints/side.content/components/side-content/index.tsx
@@ -116,7 +116,7 @@ export default function SideContent() {
           <Metadata className="mx-3" />
           <Content />
         </div>
-        <Toaster richColors className="z-[2147483647]" />
+        <Toaster richColors className="z-[2147483647]" duration={10000} />
       </div>
 
       {/* Transparent overlay to prevent other events during resizing */}


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in this PR and the problem it solves -->

This PR increased error message show-up duration. From default 4 seconds to 10 seconds.
This improves user experience by giving users more time to read error message.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes [#93](https://github.com/mengxi-ream/read-frog/issues/93)

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [x] Verified through manual testing
- [ ] Added unit tests

**Test steps:**

1. If the api key is empty, click read article. The error message will show up for 10 seconds now.
2.If the open api account is no balance, click read article. Message will show up for 10 seconds now.

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

_No UI screenshots included as the change is minor and self-explanatory._

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.



