### PR TITLE
fix: translate to zh-TW when user select cmn-Hant

### DIFF
--- a/.changeset/little-flies-refuse.md
+++ b/.changeset/little-flies-refuse.md
@@ -1,0 +1,5 @@
+---
+"read-frog": patch
+---
+
+fix: translate to zh-TW when user select cmn-Hant

--- a/src/types/config/languages.ts
+++ b/src/types/config/languages.ts
@@ -83,7 +83,8 @@ export const langCodeISO6393Schema = z.enum([
 
 export const langCodeISO6391Schema = z.enum([
   'en', // English
-  'zh', // Chinese（包含简/繁/粤等；只是在 BCP-47 里再加 -Hans / -Hant / -yue）
+  'zh', // Chinese（包含简/粤等；只是在 BCP-47 里再加 -Hans / -Hant / -yue）
+  'zh-TW', // Traditional Chinese
   'es',
   'ru',
   'ar',
@@ -314,7 +315,7 @@ export const LANG_CODE_TO_LOCALE_NAME: Record<LangCodeISO6393, string> = {
 export const ISO6393_TO_6391: Record<LangCodeISO6393, LangCodeISO6391 | undefined> = {
   'eng': 'en',
   'cmn': 'zh',
-  'cmn-Hant': 'zh',
+  'cmn-Hant': 'zh-TW',
   'yue': 'zh',
   'spa': 'es',
   'rus': 'ru',

--- a/src/utils/host/__test__/free-api.test.ts
+++ b/src/utils/host/__test__/free-api.test.ts
@@ -2,14 +2,28 @@ import { googleTranslate, microsoftTranslate } from '../translate/api'
 
 describe('googleTranslate', () => {
   it('should translate text', async () => {
-    const result = await googleTranslate('Hello', 'en', 'zh')
-    expect(result).toBe('你好')
+    const result = await googleTranslate('Library', 'en', 'zh')
+    expect(result).toBe('图书馆')
   })
 })
 
 describe('microsoftTranslate', () => {
   it('should translate text', async () => {
-    const result = await microsoftTranslate('Hello', 'en', 'zh')
-    expect(result).toBe('你好')
+    const result = await microsoftTranslate('Library', 'en', 'zh')
+    expect(result).toBe('图书馆')
+  })
+})
+
+describe('googleTranslateZhTW', () => {
+  it('should translate text to traditional chinese', async () => {
+    const result = await googleTranslate('Library', 'en', 'zh-TW')
+    expect(result).toBe('圖書館')
+  })
+})
+
+describe('microsoftTranslateZhTW', () => {
+  it('should translate text to traditional chinese', async () => {
+    const result = await microsoftTranslate('Library', 'en', 'zh-TW')
+    expect(result).toBe('圖書館')
   })
 })


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] 🐛 Bug fix (fix)


## Description

<!--- Please describe the changes in this PR and the problem it solves -->

When user select zh-TW to translate, it will still translate the text to simplified mandarin Chinese. fix this bug

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #114 

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [x] Added unit tests
- [x] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->
