### PR TITLE
fix: disable the translate switch for ignore tabs

### DIFF
--- a/.changeset/wild-birds-notice.md
+++ b/.changeset/wild-birds-notice.md
@@ -1,0 +1,5 @@
+---
+"read-frog": patch
+---
+
+fix: disable the translate switch for ignore tabs

--- a/src/entrypoints/popup/atom.ts
+++ b/src/entrypoints/popup/atom.ts
@@ -10,6 +10,7 @@ const EMPTY_TAB_URLS = [
 ]
 
 const EXTENSION_URLS = [
+  'chrome://extensions/',
   'chrome-extension://',
   'edge-extension://',
   'chrome://newtab/',

--- a/src/entrypoints/popup/components/always-translate.tsx
+++ b/src/entrypoints/popup/components/always-translate.tsx
@@ -1,13 +1,13 @@
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { useEffect } from 'react'
 import { Switch } from '@/components/ui/switch'
-import { initIsCurrentSiteInPatternsAtom, isCurrentSiteInPatternsAtom, toggleCurrentSiteAtom } from '../atom'
+import { initIsCurrentSiteInPatternsAtom, isCurrentSiteInPatternsAtom, isIgnoreTabAtom, toggleCurrentSiteAtom } from '../atom'
 
 export function AlwaysTranslate() {
   const isCurrentSiteInPatterns = useAtomValue(isCurrentSiteInPatternsAtom)
   const initIsCurrentSiteInPatterns = useSetAtom(initIsCurrentSiteInPatternsAtom)
   const [, toggleCurrentSite] = useAtom(toggleCurrentSiteAtom)
-
+  const [isIgnoreTab] = useAtom(isIgnoreTabAtom)
   // Initialize the state when component mounts
   useEffect(() => {
     initIsCurrentSiteInPatterns()
@@ -21,6 +21,7 @@ export function AlwaysTranslate() {
       <Switch
         checked={isCurrentSiteInPatterns}
         onCheckedChange={toggleCurrentSite}
+        disabled={isIgnoreTab}
       />
     </div>
   )


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [√] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

fix: disable the translate switch for ignore tabs

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->
https://github.com/mengxi-ream/read-frog/issues/123

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [√] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ √] I have tested these changes locally
- [√] I have updated the documentation accordingly if necessary
- [√] My code follows the code style of this project
- [√] My changes do not break existing functionality
- [√] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->
