### PR TITLE
feat: allow export and import custom translate prompts

### DIFF
--- a/.changeset/eight-buses-brake.md
+++ b/.changeset/eight-buses-brake.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat: allow export and import custom translate prompts

--- a/apps/extension/src/entrypoints/options/main.tsx
+++ b/apps/extension/src/entrypoints/options/main.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 
 import ReactDOM from 'react-dom/client'
 import { HashRouter } from 'react-router'
+import { Toaster } from 'sonner'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { configAtom } from '@/utils/atoms/config'
 import { globalConfig, loadGlobalConfig } from '@/utils/config/config'
@@ -47,6 +48,7 @@ async function initApp() {
             <SidebarProvider>
               <AppSidebar />
               <App />
+              <Toaster />
             </SidebarProvider>
           </HashRouter>
         </HydrateAtoms>

--- a/apps/extension/src/entrypoints/options/pages/translation/personalized-prompt.tsx
+++ b/apps/extension/src/entrypoints/options/pages/translation/personalized-prompt.tsx
@@ -75,7 +75,7 @@ function PromptList() {
                     isDefaultPrompt(pattern.id)
                       ? i18n.t('options.translation.personalizedPrompt.default')
                       : (
-                          <>
+                          <div>
                             <Checkbox
                               id={`translate-prompt-${pattern.id}`}
                               checked={selectedPrompts.includes(pattern.id)}
@@ -89,7 +89,7 @@ function PromptList() {
                             >
                             </Checkbox>
                             {pattern.name}
-                          </>
+                          </div>
                         )
                   }
                 </CardTitle>
@@ -213,7 +213,7 @@ function ConfigurePrompt({ originPrompt }: { originPrompt?: TranslatePrompt }) {
               )
             : (
                 <Button>
-                  <Plus className="size-4"></Plus>
+                  <Plus className="size-4" />
                   {i18n.t('options.translation.personalizedPrompt.addPrompt')}
                 </Button>
               )
@@ -283,39 +283,41 @@ function ImportPrompts() {
     })
   }
 
+  const importPrompts = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    try {
+      const files = e.target.files
+      if (!files || !files[0])
+        return
+      const config = await analysisJSONFile(files[0])
+      injectPrompts(config)
+      toast.success(`${i18n.t('options.translation.personalizedPrompt.importSuccess')} !`)
+    }
+    catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message)
+      }
+      else {
+        toast.error('Something went error when importing')
+      }
+    }
+    finally {
+      e.target.value = ''
+      e.target.files = null
+    }
+  }
+
   return (
     <Button variant="outline" className="p-0">
       <Label htmlFor="import-file" className="w-full px-3">
         <FileDown className="size-4" />
-        导入
+        {i18n.t('options.translation.personalizedPrompt.export')}
       </Label>
       <Input
         type="file"
         id="import-file"
         className="hidden"
         accept=".json"
-        onChange={async (e) => {
-          try {
-            const files = e.target.files
-            if (!files || !files[0])
-              return
-            const config = await analysisJSONFile(files[0])
-            injectPrompts(config)
-            toast.success(`${i18n.t('options.translation.personalizedPrompt.importSuccess')} !`)
-          }
-          catch (error) {
-            if (error instanceof Error) {
-              toast.error(error.message)
-            }
-            else {
-              toast.error('Something went error when importing')
-            }
-          }
-          finally {
-            e.target.value = ''
-            e.target.files = null
-          }
-        }}
+        onChange={importPrompts}
       >
       </Input>
     </Button>
@@ -343,7 +345,7 @@ function ExportPrompts({ selectedPrompts }: { selectedPrompts: string[] }) {
       disabled={!selectedPrompts.length}
     >
       <FileUp className="size-4" />
-      导出
+      {i18n.t('options.translation.personalizedPrompt.export')}
     </Button>
   )
 }

--- a/apps/extension/src/entrypoints/options/pages/translation/personalized-prompt.tsx
+++ b/apps/extension/src/entrypoints/options/pages/translation/personalized-prompt.tsx
@@ -70,12 +70,12 @@ function PromptList() {
           patterns.map(pattern => (
             <Card className="h-fit gap-4" key={pattern.id}>
               <CardHeader className="grid-rows-1">
-                <CardTitle className="truncate leading-relaxed gap-3 flex items-center">
+                <CardTitle className="leading-relaxed">
                   {
                     isDefaultPrompt(pattern.id)
                       ? i18n.t('options.translation.personalizedPrompt.default')
                       : (
-                          <div>
+                          <div className="truncate leading-relaxed gap-3 flex items-center">
                             <Checkbox
                               id={`translate-prompt-${pattern.id}`}
                               checked={selectedPrompts.includes(pattern.id)}
@@ -310,7 +310,7 @@ function ImportPrompts() {
     <Button variant="outline" className="p-0">
       <Label htmlFor="import-file" className="w-full px-3">
         <FileDown className="size-4" />
-        {i18n.t('options.translation.personalizedPrompt.export')}
+        {i18n.t('options.translation.personalizedPrompt.import')}
       </Label>
       <Input
         type="file"

--- a/apps/extension/src/entrypoints/options/pages/translation/personalized-prompt.tsx
+++ b/apps/extension/src/entrypoints/options/pages/translation/personalized-prompt.tsx
@@ -1,7 +1,9 @@
+import type { PromptConfigList } from '../../utils/prompt-file'
 import type { TranslatePrompt } from '@/types/config/provider'
 import { useAtom, useAtomValue } from 'jotai'
-import { Pencil, Trash2 } from 'lucide-react'
+import { FileDown, FileUp, Pencil, Plus, Trash2 } from 'lucide-react'
 import { useState } from 'react'
+import { toast } from 'sonner'
 import {
   AlertDialog,
   AlertDialogAction,
@@ -22,6 +24,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import {
@@ -37,6 +40,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { configFields } from '@/utils/atoms/config'
 import { DEFAULT_TRANSLATE_PROMPT_ID } from '@/utils/constants/prompt'
 import { ConfigCard } from '../../components/config-card'
+import { analysisJSONFile, downloadJSONFile } from '../../utils/prompt-file'
 
 const isDefaultPrompt = (id: string) => id === DEFAULT_TRANSLATE_PROMPT_ID
 
@@ -52,10 +56,13 @@ function PromptList() {
   const translateConfig = useAtomValue(configFields.translate)
   const promptsConfig = translateConfig.promptsConfig
   const patterns = promptsConfig.patterns
+  const [selectedPrompts, setSelectedPrompts] = useState<string[]>([])
 
   return (
     <section className="w-full">
-      <header className="w-full text-end mb-4">
+      <header className="w-full text-end mb-4 gap-3 flex justify-end">
+        <ImportPrompts />
+        <ExportPrompts selectedPrompts={selectedPrompts} />
         <ConfigurePrompt />
       </header>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 max-h-96 overflow-auto p-2">
@@ -63,9 +70,27 @@ function PromptList() {
           patterns.map(pattern => (
             <Card className="h-fit gap-4" key={pattern.id}>
               <CardHeader className="grid-rows-1">
-                <CardTitle className="truncate leading-relaxed">
+                <CardTitle className="truncate leading-relaxed gap-3 flex items-center">
                   {
-                    isDefaultPrompt(pattern.id) ? i18n.t('options.translation.personalizedPrompt.default') : pattern.name
+                    isDefaultPrompt(pattern.id)
+                      ? i18n.t('options.translation.personalizedPrompt.default')
+                      : (
+                          <>
+                            <Checkbox
+                              id={`translate-prompt-${pattern.id}`}
+                              checked={selectedPrompts.includes(pattern.id)}
+                              onCheckedChange={(checked) => {
+                                setSelectedPrompts((prev) => {
+                                  return checked
+                                    ? [...prev, pattern.id]
+                                    : prev.filter(id => id !== pattern.id)
+                                })
+                              }}
+                            >
+                            </Checkbox>
+                            {pattern.name}
+                          </>
+                        )
                   }
                 </CardTitle>
                 <CardAction className="leading-relaxed">
@@ -186,7 +211,12 @@ function ConfigurePrompt({ originPrompt }: { originPrompt?: TranslatePrompt }) {
                   <Pencil className="size-4" />
                 </Button>
               )
-            : <Button>{i18n.t('options.translation.personalizedPrompt.addPrompt')}</Button>
+            : (
+                <Button>
+                  <Plus className="size-4"></Plus>
+                  {i18n.t('options.translation.personalizedPrompt.addPrompt')}
+                </Button>
+              )
         }
       </SheetTrigger>
       <SheetContent className="w-[500px] sm:w-[640px]">
@@ -232,5 +262,88 @@ function ConfigurePrompt({ originPrompt }: { originPrompt?: TranslatePrompt }) {
         </SheetFooter>
       </SheetContent>
     </Sheet>
+  )
+}
+
+function ImportPrompts() {
+  const [translateConfig, setTranslateConfig] = useAtom(configFields.translate)
+
+  const injectPrompts = (list: PromptConfigList) => {
+    const originPatterns = translateConfig.promptsConfig.patterns
+    const patterns = list.map(item => ({
+      ...item,
+      id: crypto.randomUUID(),
+    }))
+
+    setTranslateConfig({
+      promptsConfig: {
+        ...translateConfig.promptsConfig,
+        patterns: [...originPatterns, ...patterns],
+      },
+    })
+  }
+
+  return (
+    <Button variant="outline" className="p-0">
+      <Label htmlFor="import-file" className="w-full px-3">
+        <FileDown className="size-4" />
+        导入
+      </Label>
+      <Input
+        type="file"
+        id="import-file"
+        className="hidden"
+        accept=".json"
+        onChange={async (e) => {
+          try {
+            const files = e.target.files
+            if (!files || !files[0])
+              return
+            const config = await analysisJSONFile(files[0])
+            injectPrompts(config)
+            toast.success(`${i18n.t('options.translation.personalizedPrompt.importSuccess')} !`)
+          }
+          catch (error) {
+            if (error instanceof Error) {
+              toast.error(error.message)
+            }
+            else {
+              toast.error('Something went error when importing')
+            }
+          }
+          finally {
+            e.target.value = ''
+            e.target.files = null
+          }
+        }}
+      >
+      </Input>
+    </Button>
+  )
+}
+
+function ExportPrompts({ selectedPrompts }: { selectedPrompts: string[] }) {
+  const translateConfig = useAtomValue(configFields.translate)
+  const promptsConfig = translateConfig.promptsConfig
+  const patterns = promptsConfig.patterns
+
+  const sortOutDownloadPrompts = patterns
+    .filter(pattern => selectedPrompts.includes(pattern.id))
+    .map(pattern => ({
+      name: pattern.name,
+      prompt: pattern.prompt,
+    }))
+
+  return (
+    <Button
+      variant="outline"
+      onClick={() => {
+        downloadJSONFile(sortOutDownloadPrompts)
+      }}
+      disabled={!selectedPrompts.length}
+    >
+      <FileUp className="size-4" />
+      导出
+    </Button>
   )
 }

--- a/apps/extension/src/entrypoints/options/utils/prompt-file.ts
+++ b/apps/extension/src/entrypoints/options/utils/prompt-file.ts
@@ -1,0 +1,50 @@
+import type { TranslatePrompt } from '@/types/config/provider'
+import { saveAs } from 'file-saver'
+import { APP_NAME } from '@/utils/constants/app'
+
+export type PromptConfig = Omit<TranslatePrompt, 'id'>
+export type PromptConfigList = PromptConfig[]
+
+const TRANSLATE_PROMPTS_FILE = `${APP_NAME}: translate_prompts`
+
+const reader = new FileReader()
+
+export function checkPromptConfig(list: PromptConfig[]) {
+  if (!Array.isArray(list)) {
+    return false
+  }
+  list.forEach((item) => {
+    if (!item.name || !item.prompt) {
+      return false
+    }
+  })
+
+  return true
+}
+
+export function downloadJSONFile(data: object) {
+  const json = JSON.stringify(data, null, 2)
+  const blob = new Blob([json], { type: 'text/json' })
+  saveAs(blob, `${TRANSLATE_PROMPTS_FILE}.json`)
+}
+
+export function analysisJSONFile(file: File): Promise<PromptConfigList> {
+  return new Promise((resolve, reject) => {
+    reader.readAsText(file)
+    reader.onload = (e) => {
+      try {
+        const fileResult = e.target?.result ?? '[]'
+        if (typeof fileResult === 'string') {
+          const list = JSON.parse(fileResult)
+          const checked = checkPromptConfig(list)
+          checked ? resolve(list) : reject(new Error('Prompt config is invalid'))
+        }
+        reject(new Error('Prompt config is invalid'))
+      }
+      catch (e) {
+        reject(e)
+      }
+    }
+    reader.onerror = error => reject(error)
+  })
+}

--- a/apps/extension/src/entrypoints/options/utils/prompt-file.ts
+++ b/apps/extension/src/entrypoints/options/utils/prompt-file.ts
@@ -7,19 +7,12 @@ export type PromptConfigList = PromptConfig[]
 
 const TRANSLATE_PROMPTS_FILE = `${APP_NAME}: translate_prompts`
 
-const reader = new FileReader()
-
 export function checkPromptConfig(list: PromptConfig[]) {
   if (!Array.isArray(list)) {
     return false
   }
-  list.forEach((item) => {
-    if (!item.name || !item.prompt) {
-      return false
-    }
-  })
 
-  return true
+  return list.every(item => item.name && item.prompt)
 }
 
 export function downloadJSONFile(data: object) {
@@ -30,6 +23,7 @@ export function downloadJSONFile(data: object) {
 
 export function analysisJSONFile(file: File): Promise<PromptConfigList> {
   return new Promise((resolve, reject) => {
+    const reader = new FileReader()
     reader.readAsText(file)
     reader.onload = (e) => {
       try {
@@ -39,7 +33,9 @@ export function analysisJSONFile(file: File): Promise<PromptConfigList> {
           const checked = checkPromptConfig(list)
           checked ? resolve(list) : reject(new Error('Prompt config is invalid'))
         }
-        reject(new Error('Prompt config is invalid'))
+        else {
+          reject(new Error('Prompt config is invalid'))
+        }
       }
       catch (e) {
         reject(e)

--- a/apps/extension/src/locales/en.yml
+++ b/apps/extension/src/locales/en.yml
@@ -78,6 +78,7 @@ options:
       description: Customizing different types of Prompts allows you to adjust the Prompt type yourself during translation. A Prompt represents the text that the user sends to the LLM, where {{input}} denotes the text content of the paragraph and {{targetLang}} denotes the target language.
       addPrompt: Add Prompt
       default: Default
+      importSuccess: Import Success
       editPrompt:
         title: Edit Prompt
         name: Name

--- a/apps/extension/src/locales/en.yml
+++ b/apps/extension/src/locales/en.yml
@@ -79,6 +79,8 @@ options:
       addPrompt: Add Prompt
       default: Default
       importSuccess: Import Success
+      import: Import
+      export: Export
       editPrompt:
         title: Edit Prompt
         name: Name

--- a/apps/extension/src/locales/ja.yml
+++ b/apps/extension/src/locales/ja.yml
@@ -76,6 +76,7 @@ options:
       description: 異なるタイプのプロンプトをカスタマイズすることで、翻訳時にプロンプトタイプを自ら調整できます。プロンプトとは、ユーザーがLLMに送信するテキストを指し、その中で {{input}} は段落のテキスト内容を、{{targetLang}} はターゲット言語を表します。
       addPrompt: プロンプトを追加
       default: デフォルト
+      importSuccess: インポート成功
       editPrompt:
         title: プロンプトを編集
         name: 名前

--- a/apps/extension/src/locales/ja.yml
+++ b/apps/extension/src/locales/ja.yml
@@ -77,6 +77,8 @@ options:
       addPrompt: プロンプトを追加
       default: デフォルト
       importSuccess: インポート成功
+      import: インポート
+      export: エクスポート
       editPrompt:
         title: プロンプトを編集
         name: 名前

--- a/apps/extension/src/locales/ko.yml
+++ b/apps/extension/src/locales/ko.yml
@@ -78,6 +78,7 @@ options:
       description: 다양한 유형의 프롬프트를 사용자 정의하여, 번역 시 프롬프트 유형을 직접 조정할 수 있습니다. 프롬프트는 사용자가 LLM에게 보내는 텍스트를 나타내며, 여기서 {{input}}은 문단의 텍스트 내용을, {{targetLang}}은 목표 언어를 나타냅니다.
       addPrompt: 프롬프트 추가
       default: 기본
+      importSuccess: 가져오기 성공
       editPrompt:
         title: 프롬프트 편집
         name: 이름

--- a/apps/extension/src/locales/ko.yml
+++ b/apps/extension/src/locales/ko.yml
@@ -79,6 +79,8 @@ options:
       addPrompt: 프롬프트 추가
       default: 기본
       importSuccess: 가져오기 성공
+      import: 가져오기
+      export: 내보내기
       editPrompt:
         title: 프롬프트 편집
         name: 이름

--- a/apps/extension/src/locales/zh-CN.yml
+++ b/apps/extension/src/locales/zh-CN.yml
@@ -79,6 +79,7 @@ options:
       description: 自定义不同类型的 Prompt，可以在翻译时自行调整 Prompt 类型。Prompt 表示以用户身份发送给 llm 的文本，其中 {{input}} 表示段落的文本内容，{{targetLang}} 表示目标语言。
       addPrompt: 添加 Prompt
       default: 通用
+      importSuccess: 导入成功
       editPrompt:
         title: 编辑 Prompt
         name: 标题

--- a/apps/extension/src/locales/zh-CN.yml
+++ b/apps/extension/src/locales/zh-CN.yml
@@ -80,6 +80,8 @@ options:
       addPrompt: 添加 Prompt
       default: 通用
       importSuccess: 导入成功
+      import: 导入
+      export: 导出
       editPrompt:
         title: 编辑 Prompt
         name: 标题

--- a/apps/extension/src/locales/zh-TW.yml
+++ b/apps/extension/src/locales/zh-TW.yml
@@ -79,6 +79,8 @@ options:
       addPrompt: 添加 Prompt
       default: 通用
       importSuccess: 導入成功
+      import: 導入
+      export: 導出
       editPrompt:
         title: 編輯 Prompt
         name: 標題

--- a/apps/extension/src/locales/zh-TW.yml
+++ b/apps/extension/src/locales/zh-TW.yml
@@ -78,6 +78,7 @@ options:
       description: 自訂不同類型的 Prompt，可以在翻譯時自行調整 Prompt 類型。Prompt 表示以用戶身份發送給 LLM 的文字，其中 {{input}} 表示段落的文字內容，{{targetLang}} 表示目標語言。
       addPrompt: 添加 Prompt
       default: 通用
+      importSuccess: 導入成功
       editPrompt:
         title: 編輯 Prompt
         name: 標題


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [x] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in this PR and the problem it solves -->
allow export and import custom translate prompts

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #160 

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->
