### PR TITLE
feat: added hot key for toggling translation

### DIFF
--- a/.changeset/tasty-moose-agree.md
+++ b/.changeset/tasty-moose-agree.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat: added hot key for toggling translation

--- a/apps/extension/src/entrypoints/host.content/index.tsx
+++ b/apps/extension/src/entrypoints/host.content/index.tsx
@@ -42,6 +42,18 @@ export default defineContentScript({
       handleUrlChange(from, to)
     })
 
+    window.addEventListener('keydown', (e: KeyboardEvent) => {
+      // Listen for Alt + Q for translation
+      if (e.altKey && e.key === 'q') {
+        if (manager.isActive) {
+          manager.stop()
+        }
+        else {
+          manager.start()
+        }
+      }
+    })
+
     port.onMessage.addListener((msg) => {
       logger.info('onMessage', msg)
       if (msg.type !== 'STATUS_PUSH' || msg.enabled === manager.isActive)

--- a/apps/extension/src/entrypoints/host.content/index.tsx
+++ b/apps/extension/src/entrypoints/host.content/index.tsx
@@ -43,8 +43,8 @@ export default defineContentScript({
     })
 
     window.addEventListener('keydown', (e: KeyboardEvent) => {
-      // Listen for Alt + Q for translation
-      if (e.altKey && e.key === 'q') {
+      // Listen for Alt + Q for translation toggle
+      if (e.altKey && e.key === 'q' && !e.ctrlKey && !e.shiftKey && !e.metaKey) {
         if (manager.isActive) {
           manager.stop()
         }

--- a/apps/extension/src/entrypoints/popup/components/translate-button.tsx
+++ b/apps/extension/src/entrypoints/popup/components/translate-button.tsx
@@ -7,6 +7,7 @@ import { pureTranslateProvider } from '@/types/config/provider'
 import { configFields } from '@/utils/atoms/config'
 import { hasSetAPIKey } from '@/utils/config/config'
 import { sendMessage } from '@/utils/message'
+import { formatHotkey } from '@/utils/os.ts'
 import { cn } from '@/utils/tailwind'
 import { isPageTranslatedAtom } from '../atoms/auto-translate'
 import { isIgnoreTabAtom } from '../atoms/ignore'
@@ -54,7 +55,7 @@ export default function TranslateButton({ className }: { className?: string }) {
     >
       {isPageTranslated
         ? i18n.t('popup.showOriginal')
-        : i18n.t('popup.translate')}
+        : `${i18n.t('popup.translate')} (${formatHotkey(['alt', 'q'])})`}
     </Button>
   )
 }

--- a/apps/extension/src/utils/os.ts
+++ b/apps/extension/src/utils/os.ts
@@ -7,7 +7,7 @@ function detectOS(): OS {
     return 'Unknown'
 
   // Modern browsers expose navigator.userAgentData.platform
-  const platform = (navigator as any).userAgentData?.platform || ''
+  const platform = (navigator as any).userAgentData?.platform || navigator.platform || navigator.userAgent || ''
 
   if (/Win/i.test(platform))
     return 'Windows'
@@ -15,7 +15,7 @@ function detectOS(): OS {
     return 'MacOS'
   if (/Linux/i.test(platform))
     return 'Linux'
-  if (/iPhone|iPad|iPod/i.test(platform))
+  if (/iPhone|iPad|iPod|iOS/i.test(platform))
     return 'iOS'
   if (/Android/i.test(platform))
     return 'Android'

--- a/apps/extension/src/utils/os.ts
+++ b/apps/extension/src/utils/os.ts
@@ -1,0 +1,54 @@
+type OS = 'Windows' | 'MacOS' | 'Linux' | 'iOS' | 'Android' | 'Unknown'
+type Key = 'alt' | 'ctrl' | 'shift' | 'enter' | 'backspace' | 'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j'
+  | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z'
+
+function detectOS(): OS {
+  if (typeof navigator === 'undefined')
+    return 'Unknown'
+
+  // Modern browsers expose navigator.userAgentData.platform
+  const platform = (navigator as any).userAgentData?.platform || ''
+
+  if (/Win/i.test(platform))
+    return 'Windows'
+  if (/Mac/i.test(platform))
+    return 'MacOS'
+  if (/Linux/i.test(platform))
+    return 'Linux'
+  if (/iPhone|iPad|iPod/i.test(platform))
+    return 'iOS'
+  if (/Android/i.test(platform))
+    return 'Android'
+  return 'Unknown'
+}
+
+export function formatHotkey(keys: Key[]): string {
+  const os = detectOS()
+
+  // Define your mappings per platform
+  const keyMap: Record<string, string>
+    = os === 'MacOS'
+      ? {
+          // Option is the Mac equivalent of Alt
+          alt: 'Option',
+          ctrl: '⌘',
+          shift: '⇧',
+          enter: '↩︎',
+          backspace: '⌫',
+        }
+      : {
+          alt: 'Alt',
+          ctrl: 'Ctrl',
+          shift: 'Shift',
+          enter: 'Enter',
+          backspace: 'Backspace',
+        }
+
+  // Map each key, fall back to uppercase raw if unknown
+  const parts = keys.map((k) => {
+    const key = k.toLowerCase()
+    return keyMap[key] ?? k.toUpperCase()
+  })
+
+  return parts.join(' + ')
+}


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [x] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in this PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #196 

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

## Summary by Sourcery

Add a global Alt+Q hotkey to start and stop the translation manager in the content script, update the popup UI to show the shortcut, and include a new utility for formatting hotkeys based on the user’s operating system

New Features:
- Add Alt+Q keyboard shortcut to toggle translation on/off
- Display the translation toggle hotkey in the popup button label

Enhancements:
- Introduce OS detection and key formatting utility for cross-platform hotkey display

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **New Features**
  * Added a global keyboard shortcut (Alt + Q) to enable or disable the translation manager directly from any page.
  * Displayed a hotkey hint (Alt + Q) on the translate button to inform users of the new shortcut.
  * Introduced platform-aware formatting for keyboard shortcuts, ensuring hotkey hints match the user's operating system conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->