### PR TITLE
feat: add translation style: `weakened`

### DIFF
--- a/.changeset/chubby-meals-carry.md
+++ b/.changeset/chubby-meals-carry.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+feat: added new translation style `weakened`

--- a/apps/extension/src/assets/tailwind/custom-translation-node.css
+++ b/apps/extension/src/assets/tailwind/custom-translation-node.css
@@ -15,3 +15,8 @@
   border-left: 4px solid var(--read-frog-primary);
   padding: 4px 0 4px 12px;
 }
+
+[data-read-frog-custom-translation-style='weakened'] {
+  opacity: 1;
+  color: var(--muted-foreground);
+}

--- a/apps/extension/src/locales/en.yml
+++ b/apps/extension/src/locales/en.yml
@@ -109,6 +109,7 @@ options:
         default: None
         blur: Blur Effect
         blockquote: Blockquote Style
+        weakened: Weakened
 side:
   sourceLang: Source Language
   targetLang: Target Language

--- a/apps/extension/src/locales/ja.yml
+++ b/apps/extension/src/locales/ja.yml
@@ -107,6 +107,7 @@ options:
         default: なし
         blur: ぼかし効果
         blockquote: 引用スタイル
+        weakened: 弱化
 side:
   sourceLang: ソース言語
   targetLang: 翻訳言語

--- a/apps/extension/src/locales/ko.yml
+++ b/apps/extension/src/locales/ko.yml
@@ -109,6 +109,7 @@ options:
         default: 없음
         blur: 흐림 효과
         blockquote: 인용 스타일
+        weakened: 약화
 side:
   sourceLang: 원본 언어
   targetLang: 대상 언어

--- a/apps/extension/src/locales/zh-CN.yml
+++ b/apps/extension/src/locales/zh-CN.yml
@@ -110,6 +110,7 @@ options:
         default: 无
         blur: 模糊效果
         blockquote: 引用样式
+        weakened: 弱化
 side:
   sourceLang: 来源语言
   targetLang: 目标语言

--- a/apps/extension/src/locales/zh-TW.yml
+++ b/apps/extension/src/locales/zh-TW.yml
@@ -109,6 +109,7 @@ options:
         default: 無
         blur: 模糊效果
         blockquote: 引用樣式
+        weakened: 弱化
 side:
   sourceLang: 來源語言
   targetLang: 目標語言

--- a/apps/extension/src/utils/constants/translation-node-style.ts
+++ b/apps/extension/src/utils/constants/translation-node-style.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_TRANSLATION_NODE_STYLE = 'default'
 
-export const TRANSLATION_NODE_STYLE = [DEFAULT_TRANSLATION_NODE_STYLE, 'blur', 'blockquote'] as const
+export const TRANSLATION_NODE_STYLE = [DEFAULT_TRANSLATION_NODE_STYLE, 'blur', 'blockquote', 'weakened'] as const
 
 export const CUSTOM_TRANSLATION_NODE_ATTRIBUTE = 'read-frog-custom-translation-style'


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->
参考沉浸式翻译，增添了一种翻译样式“弱化”。

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

浅色模式：
<img width="598" height="157" alt="image" src="https://github.com/user-attachments/assets/aba7d27e-50e0-4f7c-a2c1-0c983236cbfa" />
深色模式：
<img width="624" height="162" alt="image" src="https://github.com/user-attachments/assets/ba68ed2a-db51-4987-bbef-83b33cf24b09" />


## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

## Summary by Sourcery

Add a new 'weakened' translation style with muted text appearance and update constants and localization entries accordingly

New Features:
- Add 'weakened' option to translation style constants and UI
- Define CSS rules for the 'weakened' translation style to render muted text

Enhancements:
- Add localization entries for 'weakened' style in English, Japanese, Korean, Simplified Chinese, and Traditional Chinese

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Translation Display Style: "Weakened". Select it in settings to display translations with a softer, de-emphasized look using a muted color while remaining fully legible.

* **Localization**
  * Added labels for the Weakened style across languages: English (Weakened), Japanese (弱化), Korean (약화), Simplified Chinese (弱化), Traditional Chinese (弱化).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->