### PR TITLE
fix: can't translate on Notion

### DIFF
--- a/.changeset/cold-plants-shop.md
+++ b/.changeset/cold-plants-shop.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: support notion

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,3 +130,16 @@ Follow conventional commits format: `type(scope): description`, keep the commit 
 - `docs: update contribution guide`
 - `i18n(extension): add Japanese translations`
 - `ai(extension): integrate new DeepSeek model`
+
+## Logging in the extension
+
+If you want to log something in the extension, you can use the `logger` object.
+
+```ts
+import { logger } from '@/utils/logger'
+
+logger.info('Hello, world!')
+logger.warn('This is a warning!')
+```
+
+The `logger` object is a wrapper around the `console` object. It only logs when you are in development mode.

--- a/apps/extension/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/apps/extension/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -3,6 +3,7 @@ import { deepQueryTopLevelSelector } from '@/utils/host/dom/find'
 import { translateWalkedElement, walkAndLabelElement } from '@/utils/host/dom/traversal'
 import { removeAllTranslatedWrapperNodes } from '@/utils/host/translate/node-manipulation'
 import { sendMessage } from '@/utils/message'
+import { safeGetAttribute, safeHasAttribute } from '@/utils/notion-bypass'
 
 type SimpleIntersectionOptions = Omit<IntersectionObserverInit, 'threshold'> & {
   threshold?: number
@@ -184,7 +185,7 @@ export class PageTranslationManager implements IPageTranslationManager {
 
     walkAndLabelElement(container, this.walkId)
     // if container itself has paragraph and the id
-    if (container.hasAttribute('data-read-frog-paragraph') && container.getAttribute('data-read-frog-walked') === this.walkId) {
+    if (safeHasAttribute(container, 'data-read-frog-paragraph') && safeGetAttribute(container, 'data-read-frog-walked') === this.walkId) {
       observer.observe(container)
       return
     }

--- a/apps/extension/src/entrypoints/notion-bypass.content/index.ts
+++ b/apps/extension/src/entrypoints/notion-bypass.content/index.ts
@@ -1,0 +1,245 @@
+import { defineContentScript } from '#imports'
+import { logger } from '@/utils/logger'
+
+export default defineContentScript({
+  matches: [
+    '*://*.notion.so/*',
+    '*://*.notion.site/*',
+    '*://*.notion.com/*',
+  ],
+  runAt: 'document_start',
+  world: 'MAIN',
+  allFrames: true,
+  main() {
+    // 超早期脚本注入 - 在 Notion 初始化前拦截 MutationObserver
+    (function () {
+      'use strict'
+
+      logger.info('[Read Frog] Notion bypass script loaded at document_start')
+
+      // 保存原始的 MutationObserver
+      const OriginalMutationObserver = window.MutationObserver
+
+      // 创建被过滤的 MutationObserver 构造函数
+      function FilteredMutationObserver(callback: MutationCallback) {
+        // 创建一个包装后的回调函数
+        const wrappedCallback: MutationCallback = function (this: MutationObserver, mutations: MutationRecord[], observer: MutationObserver) {
+          // 过滤掉与 read-frog 相关的变化
+          const filteredMutations = mutations.filter((mutation) => {
+            // 过滤属性变化
+            if (mutation.type === 'attributes') {
+              const attributeName = mutation.attributeName
+              if (attributeName && attributeName.includes('read-frog')) {
+                logger.info('[Read Frog] Blocked attribute mutation:', attributeName)
+                return false
+              }
+            }
+
+            // 过滤子节点变化（如果添加的节点包含 read-frog 类或属性）
+            if (mutation.type === 'childList') {
+              // 检查删除的节点中是否有翻译节点
+              const removedReadFrogNodes = Array.from(mutation.removedNodes).some((node) => {
+                if (node.nodeType === Node.ELEMENT_NODE) {
+                  const element = node as Element
+                  if (element.className && element.className.includes('read-frog')) {
+                    logger.warn('[Read Frog] Translation node was removed by Notion:', element.className)
+                    return true
+                  }
+                }
+                return false
+              })
+
+              const hasReadFrogNodes = Array.from(mutation.addedNodes).some((node) => {
+                if (node.nodeType === Node.ELEMENT_NODE) {
+                  const element = node as Element
+                  // 检查是否有 read-frog 相关的类名或属性
+                  if (element.className && element.className.includes('read-frog')) {
+                    logger.info('[Read Frog] Blocked childList mutation with read-frog class')
+                    return true
+                  }
+                  // 检查属性
+                  if (element.hasAttributes()) {
+                    for (const attr of element.attributes) {
+                      if (attr.name.includes('read-frog')) {
+                        logger.info('[Read Frog] Blocked childList mutation with read-frog attribute:', attr.name)
+                        return true
+                      }
+                    }
+                  }
+                }
+                return false
+              })
+
+              if (hasReadFrogNodes || removedReadFrogNodes) {
+                return false
+              }
+            }
+
+            return true
+          })
+
+          // 只有当有非 read-frog 相关的变化时才调用原始回调
+          if (filteredMutations.length > 0) {
+            callback.call(this, filteredMutations, observer)
+          }
+        }
+
+        // 使用包装后的回调创建原始 MutationObserver
+        return new OriginalMutationObserver(wrappedCallback)
+      }
+
+      // 复制原始构造函数的属性和方法
+      FilteredMutationObserver.prototype = OriginalMutationObserver.prototype
+      Object.setPrototypeOf(FilteredMutationObserver, OriginalMutationObserver)
+
+      // 替换全局的 MutationObserver
+      ;(window as any).MutationObserver = FilteredMutationObserver
+
+      // 同时替换可能的其他引用
+      if (typeof globalThis !== 'undefined') {
+        ;(globalThis as any).MutationObserver = FilteredMutationObserver
+      }
+
+      logger.info('[Read Frog] MutationObserver monkey patch applied successfully')
+
+      // 额外的 DOM API 保护
+      const originalSetAttribute = Element.prototype.setAttribute
+      const originalRemoveAttribute = Element.prototype.removeAttribute
+
+      Element.prototype.setAttribute = function (this: Element, name: string, value: string) {
+        // 对于 read-frog 属性，使用更隐蔽的方式设置
+        if (name.includes('read-frog')) {
+          logger.info('[Read Frog] Silent setAttribute:', name, value)
+          // 使用 Object.defineProperty 直接在元素上定义属性，绕过 setAttribute
+          Object.defineProperty(this, `__read_frog_${name.replace('data-read-frog-', '')}`, {
+            value,
+            configurable: true,
+            enumerable: false,
+            writable: true,
+          })
+          return
+        }
+        return originalSetAttribute.call(this, name, value)
+      }
+
+      Element.prototype.removeAttribute = function (this: Element, name: string) {
+        if (name.includes('read-frog')) {
+          logger.info('[Read Frog] Silent removeAttribute:', name)
+          delete (this as any)[`__read_frog_${name.replace('data-read-frog-', '')}`]
+          return
+        }
+        return originalRemoveAttribute.call(this, name)
+      }
+
+      // 保护翻译节点不被删除
+      const originalRemove = Element.prototype.remove
+      const originalRemoveChild = Node.prototype.removeChild
+      const originalReplaceChild = Node.prototype.replaceChild
+      const originalInnerHTML = Object.getOwnPropertyDescriptor(Element.prototype, 'innerHTML')!
+      const originalTextContent = Object.getOwnPropertyDescriptor(Node.prototype, 'textContent')!
+
+      // 检查元素或其后代是否包含翻译节点
+      function hasTranslationNodes(element: Element): boolean {
+        if (element.classList?.contains('read-frog-translated-content-wrapper')
+          || element.classList?.contains('read-frog-translated-inline-content')
+          || element.classList?.contains('read-frog-translated-block-content')) {
+          return true
+        }
+        return Array.from(element.children || []).some(child => hasTranslationNodes(child))
+      }
+
+      Element.prototype.remove = function () {
+        if (hasTranslationNodes(this)) {
+          logger.warn('[Read Frog] Prevented removal of element containing translation nodes:', this.className)
+          return
+        }
+        return originalRemove.call(this)
+      }
+
+      Node.prototype.removeChild = function<T extends Node>(child: T): T {
+        if (child.nodeType === Node.ELEMENT_NODE && hasTranslationNodes(child as unknown as Element)) {
+          logger.warn('[Read Frog] Prevented removeChild of element containing translation nodes:', (child as unknown as Element).className)
+          return child
+        }
+        return originalRemoveChild.call(this, child) as T
+      }
+
+      Node.prototype.replaceChild = function<T extends Node>(newChild: Node, oldChild: T): T {
+        if (oldChild.nodeType === Node.ELEMENT_NODE && hasTranslationNodes(oldChild as unknown as Element)) {
+          logger.warn('[Read Frog] Prevented replaceChild of element containing translation nodes:', (oldChild as unknown as Element).className)
+          return oldChild
+        }
+        return originalReplaceChild.call(this, newChild, oldChild) as T
+      }
+
+      // 保护 innerHTML 设置不清除翻译节点
+      Object.defineProperty(Element.prototype, 'innerHTML', {
+        get: originalInnerHTML.get,
+        set(value: string) {
+          const hasTranslations = hasTranslationNodes(this)
+          if (hasTranslations) {
+            logger.warn('[Read Frog] Prevented innerHTML change that would remove translation nodes')
+            return
+          }
+          return originalInnerHTML.set!.call(this, value)
+        },
+        configurable: true,
+      })
+
+      // 保护 textContent 设置不清除翻译节点
+      Object.defineProperty(Node.prototype, 'textContent', {
+        get: originalTextContent.get,
+        set(value: string | null) {
+          if (this.nodeType === Node.ELEMENT_NODE && hasTranslationNodes(this as Element)) {
+            logger.warn('[Read Frog] Prevented textContent change that would remove translation nodes')
+            return
+          }
+          return originalTextContent.set!.call(this, value)
+        },
+        configurable: true,
+      })
+
+      // 导出一些实用函数供其他脚本使用
+      ;(window as any).__readFrogBypass = {
+        // 安全地设置 read-frog 属性
+        setReadFrogAttribute(element: Element, name: string, value: string) {
+          const internalName = `__read_frog_${name.replace('data-read-frog-', '')}`
+          Object.defineProperty(element, internalName, {
+            value,
+            configurable: true,
+            enumerable: false,
+            writable: true,
+          })
+        },
+
+        // 安全地获取 read-frog 属性
+        getReadFrogAttribute(element: Element, name: string) {
+          const internalName = `__read_frog_${name.replace('data-read-frog-', '')}`
+          return (element as any)[internalName]
+        },
+
+        // 检查元素是否有特定的 read-frog 标记
+        hasReadFrogAttribute(element: Element, name: string) {
+          const internalName = `__read_frog_${name.replace('data-read-frog-', '')}`
+          return internalName in element
+        },
+
+        // 保护翻译节点不被意外删除
+        protectTranslationNodes() {
+          const translationNodes = document.querySelectorAll('.read-frog-translated-content-wrapper')
+          translationNodes.forEach((node) => {
+            // 添加一个隐藏的保护标记
+            ;(node as any).__read_frog_protected = true
+          })
+        },
+
+        // 获取所有翻译节点（用于清理时使用）
+        getAllTranslationNodes(): Element[] {
+          return Array.from(document.querySelectorAll('.read-frog-translated-content-wrapper'))
+        },
+      }
+
+      logger.info('[Read Frog] Bypass utilities exported to window.__readFrogBypass')
+    })()
+  },
+})

--- a/apps/extension/src/utils/host/dom/traversal.ts
+++ b/apps/extension/src/utils/host/dom/traversal.ts
@@ -11,6 +11,7 @@ import {
   INVALID_TRANSLATE_TAGS,
   MAIN_CONTENT_IGNORE_TAGS,
 } from '@/utils/constants/dom-tags'
+import { safeGetAttribute, safeHasAttribute, safeSetAttribute } from '@/utils/notion-bypass'
 
 import { translateNodes } from '../translate/node-manipulation'
 import {
@@ -56,7 +57,7 @@ export function walkAndLabelElement(
   element: HTMLElement,
   walkId: string,
 ): 'isOrHasBlockNode' | 'isShallowInlineNode' | false {
-  element.setAttribute(WALKED_ATTRIBUTE, walkId)
+  safeSetAttribute(element, WALKED_ATTRIBUTE, walkId)
 
   if (isDontWalkIntoElement(element)) {
     return false
@@ -113,15 +114,15 @@ export function walkAndLabelElement(
   }
 
   if (hasInlineNodeChild) {
-    element.setAttribute(PARAGRAPH_ATTRIBUTE, '')
+    safeSetAttribute(element, PARAGRAPH_ATTRIBUTE, '')
   }
 
   if (hasBlockNodeChild || isShallowBlockHTMLElement(element)) {
-    element.setAttribute(BLOCK_ATTRIBUTE, '')
+    safeSetAttribute(element, BLOCK_ATTRIBUTE, '')
     return 'isOrHasBlockNode'
   }
   else if (isShallowInlineHTMLElement(element)) {
-    element.setAttribute(INLINE_ATTRIBUTE, '')
+    safeSetAttribute(element, INLINE_ATTRIBUTE, '')
     return 'isShallowInlineNode'
   }
 
@@ -142,14 +143,14 @@ export async function translateWalkedElement(
   const promises: Promise<void>[] = []
 
   // if the walkId is not the same, return
-  if (element.getAttribute(WALKED_ATTRIBUTE) !== walkId)
+  if (safeGetAttribute(element, WALKED_ATTRIBUTE) !== walkId)
     return
 
-  if (element.hasAttribute(PARAGRAPH_ATTRIBUTE)) {
+  if (safeHasAttribute(element, PARAGRAPH_ATTRIBUTE)) {
     let hasBlockNodeChild = false
 
     for (const child of element.childNodes) {
-      if (isHTMLElement(child) && child.hasAttribute(BLOCK_ATTRIBUTE)) {
+      if (isHTMLElement(child) && safeHasAttribute(child, BLOCK_ATTRIBUTE)) {
         hasBlockNodeChild = true
         break
       }
@@ -215,7 +216,7 @@ async function dealWithConsecutiveInlineNodes(nodes: TransNode[], toggle: boolea
     // give attribute to the last node
     const lastNode = nodes[nodes.length - 1]
     if (isHTMLElement(lastNode)) {
-      lastNode.setAttribute(CONSECUTIVE_INLINE_END_ATTRIBUTE, '')
+      safeSetAttribute(lastNode, CONSECUTIVE_INLINE_END_ATTRIBUTE, '')
     }
   }
   await translateNodes(nodes, toggle)

--- a/apps/extension/src/utils/host/translate/node-manipulation.ts
+++ b/apps/extension/src/utils/host/translate/node-manipulation.ts
@@ -52,11 +52,25 @@ export async function hideOrShowNodeTranslation(point: Point) {
 export function removeAllTranslatedWrapperNodes(
   root: Document | ShadowRoot = document,
 ) {
-  const translatedNodes = deepQueryTopLevelSelector(root, isTranslatedWrapperNode)
-  translatedNodes.forEach((node) => {
-    removeShadowHostInTranslatedWrapper(node)
-    node.remove()
-  })
+  // 在 Notion 域名下使用绕过 API 查找翻译节点
+  if (window.location.hostname.includes('notion.') && typeof (window as any).__readFrogBypass === 'object') {
+    const bypass = (window as any).__readFrogBypass
+    const translatedNodes = bypass.getAllTranslationNodes()
+    translatedNodes.forEach((node: Element) => {
+      if (isHTMLElement(node)) {
+        removeShadowHostInTranslatedWrapper(node)
+        node.remove()
+      }
+    })
+  }
+  else {
+    // 在非 Notion 域名下使用常规方式
+    const translatedNodes = deepQueryTopLevelSelector(root, isTranslatedWrapperNode)
+    translatedNodes.forEach((node) => {
+      removeShadowHostInTranslatedWrapper(node)
+      node.remove()
+    })
+  }
 }
 
 /**

--- a/apps/extension/src/utils/notion-bypass.ts
+++ b/apps/extension/src/utils/notion-bypass.ts
@@ -1,0 +1,112 @@
+/**
+ * Notion bypass utilities for safely setting read-frog attributes
+ * without triggering Notion's DOM lock mechanism
+ */
+
+/**
+ * Check if we're on a Notion domain
+ */
+export function isNotionDomain(): boolean {
+  const hostname = window.location.hostname.toLowerCase()
+  return hostname.includes('notion.so')
+    || hostname.includes('notion.site')
+    || hostname.includes('notion.com')
+}
+
+/**
+ * Check if bypass utilities are available
+ */
+function isBypassAvailable(): boolean {
+  return typeof (window as any).__readFrogBypass === 'object'
+}
+
+/**
+ * Safely set a read-frog attribute on an element
+ * Uses bypass API on Notion domains, regular setAttribute elsewhere
+ */
+export function safeSetAttribute(element: Element, name: string, value: string): void {
+  const shouldUseBypass = isNotionDomain() && isBypassAvailable() && name.includes('read-frog')
+  if (shouldUseBypass) {
+    const bypass = (window as any).__readFrogBypass
+    bypass.setReadFrogAttribute(element, name, value)
+  }
+  else {
+    element.setAttribute(name, value)
+  }
+}
+
+/**
+ * Safely get a read-frog attribute from an element
+ */
+export function safeGetAttribute(element: Element, name: string): string | null {
+  const shouldUseBypass = isNotionDomain() && isBypassAvailable() && name.includes('read-frog')
+  if (shouldUseBypass) {
+    const bypass = (window as any).__readFrogBypass
+    return bypass.getReadFrogAttribute(element, name) || null
+  }
+  else {
+    return element.getAttribute(name)
+  }
+}
+
+/**
+ * Safely check if element has a read-frog attribute
+ */
+export function safeHasAttribute(element: Element, name: string): boolean {
+  const shouldUseBypass = isNotionDomain() && isBypassAvailable() && name.includes('read-frog')
+  if (shouldUseBypass) {
+    const bypass = (window as any).__readFrogBypass
+    return bypass.hasReadFrogAttribute(element, name)
+  }
+  else {
+    return element.hasAttribute(name)
+  }
+}
+
+/**
+ * Safely remove a read-frog attribute from an element
+ */
+export function safeRemoveAttribute(element: Element, name: string): void {
+  const shouldUseBypass = isNotionDomain() && isBypassAvailable() && name.includes('read-frog')
+  if (shouldUseBypass) {
+    // Remove the internal property
+    const internalName = `__read_frog_${name.replace('data-read-frog-', '')}`
+    delete (element as any)[internalName]
+  }
+  else {
+    element.removeAttribute(name)
+  }
+}
+
+/**
+ * Wait for bypass utilities to be available (with timeout)
+ */
+export function waitForBypass(timeout: number = 1000): Promise<boolean> {
+  return new Promise((resolve) => {
+    if (!isNotionDomain()) {
+      resolve(true) // Not on Notion, no bypass needed
+      return
+    }
+
+    if (isBypassAvailable()) {
+      resolve(true)
+      return
+    }
+
+    let attempts = 0
+    const maxAttempts = timeout / 50
+
+    const checkInterval = setInterval(() => {
+      attempts++
+      if (isBypassAvailable()) {
+        clearInterval(checkInterval)
+        resolve(true)
+      }
+      else if (attempts >= maxAttempts) {
+        clearInterval(checkInterval)
+        console.warn('[Read Frog] Bypass utilities not available, falling back to regular DOM API')
+        resolve(false)
+      }
+    }, 50)
+  })
+}

--- a/apps/extension/src/utils/react-shadow-host/css-registry.ts
+++ b/apps/extension/src/utils/react-shadow-host/css-registry.ts
@@ -1,4 +1,5 @@
 import { Sha256Hex } from '../hash'
+import { safeSetAttribute } from '../notion-bypass'
 
 export class CSSRegistry {
   private registry = new Map<string, { node: HTMLStyleElement, count: number }>()
@@ -18,7 +19,7 @@ export class CSSRegistry {
 
     const style = document.createElement('style')
     style.textContent = css
-    style.setAttribute('data-read-frog-react-shadow-css-key', key)
+    safeSetAttribute(style, 'data-read-frog-react-shadow-css-key', key)
     document.head.appendChild(style)
     this.registry.set(key, { node: style, count: 1 })
 


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #294 

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

## Summary by Sourcery

Implement a Notion-specific DOM bypass to prevent Notion’s DOM locking from removing translation nodes, update attribute operations to use safe helpers on Notion domains, and ensure proper translation cleanup on Notion pages.

New Features:
- Add a Notion bypass content script that monkey-patches DOM APIs and filters mutations to protect translation nodes and expose a bypass API

Bug Fixes:
- Fix translation cleanup on Notion by using bypass.getAllTranslationNodes in removeAllTranslatedWrapperNodes

Enhancements:
- Introduce safeSetAttribute, safeGetAttribute, safeHasAttribute, safeRemoveAttribute and waitForBypass utilities for Notion domains
- Replace direct setAttribute/getAttribute/hasAttribute calls across node manipulation, DOM traversal, page translation, and CSS registry with safe attribute helpers

Documentation:
- Document the logger usage in the extension README

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Enhanced Notion compatibility so translations persist on Notion pages and avoid site DOM restrictions.

- Bug Fixes
  - Safer attribute handling to reduce interference with page scripts and stabilize translation markers.
  - Prevented accidental removal or clearing of translated content and wrappers, reducing flicker and loss of annotations.

- Documentation
  - Added guidance on logging in the extension with info/warn examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->