### PR TITLE
feat: add right-click context menu for text selection translation

### DIFF
--- a/.changeset/chubby-ads-count.md
+++ b/.changeset/chubby-ads-count.md
@@ -2,4 +2,4 @@
 "@read-frog/extension": patch
 ---
 
-fix: popup ui
+feat: add right-click context menu for text selection translation

--- a/.changeset/chubby-ads-count.md
+++ b/.changeset/chubby-ads-count.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: popup ui

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -51,7 +51,6 @@ export default defineBackground(() => {
 
   // Create context menus for selection translation and page translation toggle
   try {
-    browser.contextMenus.removeAll()
     browser.contextMenus.create({
       id: 'readfrog-translate-selection',
       title: i18n.t('rightClickMenu.translateSelection'),

--- a/apps/extension/src/entrypoints/background/index.ts
+++ b/apps/extension/src/entrypoints/background/index.ts
@@ -1,4 +1,4 @@
-import { browser, defineBackground } from '#imports'
+import { browser, defineBackground, i18n } from '#imports'
 import { WEBSITE_URL } from '@/utils/constants/url'
 import { logger } from '@/utils/logger'
 import { onMessage, sendMessage } from '@/utils/message'
@@ -48,4 +48,28 @@ export default defineBackground(() => {
   setUpCacheCleanup()
 
   proxyFetch()
+
+  // Create context menus for selection translation and page translation toggle
+  try {
+    browser.contextMenus.removeAll()
+    browser.contextMenus.create({
+      id: 'readfrog-translate-selection',
+      title: i18n.t('rightClickMenu.translateSelection'),
+      contexts: ['selection'],
+    })
+
+    browser.contextMenus.onClicked.addListener(async (info, tab) => {
+      const tabId = tab?.id
+      if (typeof tabId !== 'number')
+        return
+
+      if (info.menuItemId === 'readfrog-translate-selection') {
+        // Notify selection.content to open translate popover for current selection
+        sendMessage('triggerSelectionTranslate', undefined, tabId)
+      }
+    })
+  }
+  catch (err) {
+    logger.error('Failed to create context menus', err)
+  }
 })

--- a/apps/extension/src/entrypoints/host.content/index.tsx
+++ b/apps/extension/src/entrypoints/host.content/index.tsx
@@ -75,7 +75,8 @@ export default defineContentScript({
         return
       // Let SelectionToolbar logic react to selection change and show UI
       const ev = new Event('selectionchange')
-      document.dispatchEvent(ev)
+      // Directly trigger selection translation logic instead of dispatching synthetic event
+      triggerSelectionTranslation()
     })
 
     // ! Temporary code for browser has no port.onMessage.addListener api like Orion

--- a/apps/extension/src/entrypoints/host.content/index.tsx
+++ b/apps/extension/src/entrypoints/host.content/index.tsx
@@ -3,7 +3,7 @@ import { browser, defineContentScript } from '#imports'
 import { globalConfig, loadGlobalConfig } from '@/utils/config/config'
 import { shouldEnableAutoTranslation } from '@/utils/host/translate/auto-translation'
 import { logger } from '@/utils/logger'
-import { sendMessage } from '@/utils/message'
+import { onMessage, sendMessage } from '@/utils/message'
 import { registerNodeTranslationTriggers } from './translation-control/node-translation'
 import { PageTranslationManager } from './translation-control/page-translation'
 import './listen'
@@ -66,6 +66,16 @@ export default defineContentScript({
       if (msg.type !== 'STATUS_PUSH' || msg.enabled === manager.isActive)
         return
       msg.enabled ? manager.start() : manager.stop()
+    })
+
+    // Listen for background context-menu action: trigger selection translate
+    onMessage('triggerSelectionTranslate', () => {
+      const selection = window.getSelection()
+      if (!selection || selection.rangeCount === 0)
+        return
+      // Let SelectionToolbar logic react to selection change and show UI
+      const ev = new Event('selectionchange')
+      document.dispatchEvent(ev)
     })
 
     // ! Temporary code for browser has no port.onMessage.addListener api like Orion

--- a/apps/extension/src/entrypoints/selection.content/selection-toolbar/index.tsx
+++ b/apps/extension/src/entrypoints/selection.content/selection-toolbar/index.tsx
@@ -168,7 +168,7 @@ export function SelectionToolbar() {
       setSelectionContent(selectedText)
       const range = selection.getRangeAt(0)
       const rect = range.getBoundingClientRect()
-      const scrollX = window.scrollX
+      const {scrollX} = window
       const scrollY = window.scrollY
       const x = rect.left + scrollX
       const y = rect.top + scrollY

--- a/apps/extension/src/entrypoints/selection.content/selection-toolbar/index.tsx
+++ b/apps/extension/src/entrypoints/selection.content/selection-toolbar/index.tsx
@@ -169,7 +169,7 @@ export function SelectionToolbar() {
       const range = selection.getRangeAt(0)
       const rect = range.getBoundingClientRect()
       const {scrollX} = window
-      const scrollY = window.scrollY
+      const {scrollY} = window
       const x = rect.left + scrollX
       const y = rect.top + scrollY
       setMouseClickPosition({ x, y })

--- a/apps/extension/src/locales/en.yml
+++ b/apps/extension/src/locales/en.yml
@@ -140,3 +140,5 @@ noConfig:
     firstOnThe: first on the
     optionsPage: options
     page: page
+rightClickMenu:
+  translateSelection: Translate selected content

--- a/apps/extension/src/locales/ja.yml
+++ b/apps/extension/src/locales/ja.yml
@@ -138,3 +138,5 @@ noConfig:
     firstOnThe: する必要があります（
     optionsPage: オプションページ
     page: ）
+rightClickMenu:
+  translateSelection: 選択した内容を翻訳

--- a/apps/extension/src/locales/ko.yml
+++ b/apps/extension/src/locales/ko.yml
@@ -140,3 +140,5 @@ noConfig:
     firstOnThe: 먼저
     optionsPage: 옵션
     page: 페이지에서
+rightClickMenu:
+  translateSelection: 선택한 내용 번역

--- a/apps/extension/src/locales/zh-CN.yml
+++ b/apps/extension/src/locales/zh-CN.yml
@@ -141,3 +141,5 @@ noConfig:
     firstOnThe: 在
     optionsPage: 选项
     page: 页
+rightClickMenu:
+  translateSelection: 翻译选中内容

--- a/apps/extension/src/locales/zh-TW.yml
+++ b/apps/extension/src/locales/zh-TW.yml
@@ -140,3 +140,5 @@ noConfig:
     firstOnThe: 在
     optionsPage: 選項
     page: 頁
+rightClickMenu:
+  translateSelection: 翻譯選中內容

--- a/apps/extension/src/utils/message.ts
+++ b/apps/extension/src/utils/message.ts
@@ -11,6 +11,8 @@ interface ProtocolMap {
   setEnablePageTranslation: (data: { tabId: number, enabled: boolean }) => void
   setEnablePageTranslationOnContentScript: (data: { enabled: boolean }) => void
   resetPageTranslationOnNavigation: (data: { url: string }) => void
+  // context-menu actions
+  triggerSelectionTranslate: () => void
   // read article
   readArticle: () => void
   popupRequestReadArticle: (data: { tabId: number }) => void

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     name: '__MSG_extName__',
     description: '__MSG_extDescription__',
     default_locale: 'en',
-    permissions: ['storage', 'tabs', 'alarms', 'cookies'],
+    permissions: ['storage', 'tabs', 'alarms', 'cookies', 'contextMenus'],
     host_permissions:
       mode === 'development'
         ? [


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description
Add right-click menu entry for text selection translation

## Related Issue

[FEATURE] 希望能添加右键菜单功能 #292
Only the word selection translation has been completed so far, while the right-click page translation remains to be added.

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing


## Screenshots

![PixPin_2025-08-14_16-29-29](https://github.com/user-attachments/assets/c204fc5f-4bdd-4e40-a2fa-29efdc78eec4)

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

## Summary by Sourcery

Add a right-click context menu option to translate selected text by sending a message to content scripts and showing the translation popover at the selection position.

New Features:
- Introduce a context menu item for translating selected text in the background script
- Support a triggerSelectionTranslate message in content scripts to open the translation UI for the current text selection

Enhancements:
- Extend the selection toolbar to position and display the translate popover upon receiving the context-menu trigger
- Implement message handling across background, host content, and toolbar to coordinate the right-click translation flow

Build:
- Grant the extension the contextMenus permission in the manifest configuration

Documentation:
- Add localization entries for the 'Translate selected content' menu label in all supported languages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a right-click "Translate selected content" menu option to translate highlighted text and open the translate popover positioned at the selection.
  - Menu action now triggers translation for the current selection.

- Localization
  - Localized the new menu label in English, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

- Chores
  - Added context menu permission to the extension.
  - Added a changeset to publish a patch update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->