### PR TITLE
fix: don't print floating button on web page

### DIFF
--- a/.changeset/cold-gifts-judge.md
+++ b/.changeset/cold-gifts-judge.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: don't print floating button on web page

--- a/.changeset/cold-gifts-judge.md
+++ b/.changeset/cold-gifts-judge.md
@@ -1,5 +1,0 @@
----
-"@read-frog/extension": patch
----
-
-fix: don't print floating button on web page

--- a/.changeset/ready-schools-behave.md
+++ b/.changeset/ready-schools-behave.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: hide floating button when printing web

--- a/apps/extension/src/entrypoints/side.content/components/floating-button/index.tsx
+++ b/apps/extension/src/entrypoints/side.content/components/floating-button/index.tsx
@@ -100,7 +100,7 @@ export default function FloatingButton() {
 
   return (
     <div
-      className="group fixed z-[2147483647] flex flex-col items-end gap-2"
+      className="group fixed z-[2147483647] flex flex-col items-end gap-2 print:hidden"
       style={{
         right: isSideOpen
           ? `calc(${sideContent.width}px + var(--removed-body-scroll-bar-size, 0px))`

--- a/apps/extension/src/entrypoints/side.content/components/floating-button/index.tsx
+++ b/apps/extension/src/entrypoints/side.content/components/floating-button/index.tsx
@@ -100,7 +100,7 @@ export default function FloatingButton() {
 
   return (
     <div
-      className="group fixed z-[2147483647] flex flex-col items-end gap-2 print:hidden"
+      className="group fixed z-[2147483647] flex flex-col items-end gap-2"
       style={{
         right: isSideOpen
           ? `calc(${sideContent.width}px + var(--removed-body-scroll-bar-size, 0px))`


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #329 

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

## Summary by Sourcery

Hide the floating button when printing the web page by adding a print-hidden CSS utility

Bug Fixes:
- Prevent the extension’s floating button from appearing in print views

Chores:
- Add changeset for a patch release