### PR TITLE
fix: modify the border style name to avoid conflicts (#225)

### DIFF
--- a/.changeset/tough-breads-ask.md
+++ b/.changeset/tough-breads-ask.md
@@ -1,0 +1,7 @@
+---
+"@read-frog/extension": patch
+---
+
+Fix border style conflict issue with Figma
+
+Change the border style name to `read-frog-border` to avoid conflicts with Figma styles.

--- a/packages/ui/src/styles/theme.css
+++ b/packages/ui/src/styles/theme.css
@@ -23,7 +23,7 @@
   --color-chart-1: var(--chart-1);
   --color-ring: var(--ring);
   --color-input: var(--input);
-  --color-border: var(--border);
+  --color-border: var(--read-frog-border);
   --color-warning: var(--warning);
   --color-warning-border: var(--warning-border);
   --color-destructive: var(--destructive);
@@ -64,7 +64,7 @@
   --warning: oklch(97.3% 0.071 103.193);
   --warning-border: oklch(85.2% 0.199 91.936);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
+  --read-frog-border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
   --chart-1: oklch(0.646 0.222 41.116);
@@ -100,7 +100,7 @@
   --warning: oklch(42.1% 0.095 57.708);
   --warning-border: oklch(68.1% 0.162 75.834);
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
+  --read-frog-border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
   --chart-1: oklch(0.488 0.243 264.376);


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Change the border style name to `read-frog-border` to avoid conflicts with Figma styles.

## Related Issue

Closes [#225](https://github.com/mengxi-ream/read-frog/issues/225)

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

<img width="837" height="879" alt="modified_figma_page_effect" src="https://github.com/user-attachments/assets/dad650a5-d930-4c44-b7a4-e75ed2963d68" />

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->
