### PR TITLE
fix(extension): improve BR tag handling and inline element processing

### DIFF
--- a/apps/extension/src/utils/constants/dom-tags.ts
+++ b/apps/extension/src/utils/constants/dom-tags.ts
@@ -6,6 +6,7 @@ export const FORCE_BLOCK_TAGS = new Set([
   'H4',
   'H5',
   'H6',
+  'BR',
   'FORM',
   'SELECT',
   'BUTTON',
@@ -35,7 +36,6 @@ export const VALID_TRANSLATE_NODES = new Set([
 // Don't walk into these tags
 export const INVALID_TRANSLATE_TAGS = new Set([
   'HEAD',
-  'BR',
   'HR',
   'INPUT',
   'TEXTAREA',

--- a/apps/extension/src/utils/host/__tests__/bilingual-translate.test.tsx
+++ b/apps/extension/src/utils/host/__tests__/bilingual-translate.test.tsx
@@ -183,6 +183,32 @@ describe('translatePage', () => {
     expect(node.childNodes[1].childNodes[1]).toHaveClass(BLOCK_CONTENT_CLASS)
   })
 
+  it('should handle inline elements separated by br tags correctly', async () => {
+    render(
+      <div data-testid="test-node">
+        <span style={{ display: 'inline' }}>First inline text</span>
+        <span style={{ display: 'inline' }}>Second inline text</span>
+        <br />
+        <span style={{ display: 'inline' }}>Third inline text</span>
+        <span style={{ display: 'inline' }}>Fourth inline text</span>
+        <br />
+        <span style={{ display: 'inline' }}>Fifth inline text</span>
+      </div>,
+    )
+
+    const node = screen.getByTestId('test-node')
+    await hideOrShowPageTranslation()
+
+    // Should have multiple translation wrappers due to br tags breaking inline sequences
+    const wrappers = node.querySelectorAll(`.${CONTENT_WRAPPER_CLASS}`)
+    expect(wrappers.length).toBeGreaterThan(1)
+
+    // Each wrapper should contain inline content
+    wrappers.forEach((wrapper) => {
+      expect(wrapper.childNodes[1]).toHaveClass(INLINE_CONTENT_CLASS)
+    })
+  })
+
   it('should translate floating element as inline node', async () => {
     render(
       <div data-testid="test-node">

--- a/apps/extension/src/utils/host/dom/filter.ts
+++ b/apps/extension/src/utils/host/dom/filter.ts
@@ -31,10 +31,6 @@ export function isShallowInlineTransNode(node: Node): boolean {
 }
 
 export function isShallowInlineHTMLElement(element: HTMLElement): boolean {
-  if (!element.textContent?.trim()) {
-    return false
-  }
-
   const computedStyle = window.getComputedStyle(element)
 
   // treat large floating letter on some news websites as inline node
@@ -61,10 +57,6 @@ export function isShallowBlockTransNode(node: Node): boolean {
 }
 
 export function isShallowBlockHTMLElement(element: HTMLElement): boolean {
-  if (!element.textContent?.trim()) {
-    return false
-  }
-
   const computedStyle = window.getComputedStyle(element)
 
   // treat large floating letter on some news websites as block node

--- a/apps/extension/src/utils/host/translate/node-manipulation.ts
+++ b/apps/extension/src/utils/host/translate/node-manipulation.ts
@@ -379,9 +379,9 @@ export async function translateWalkedElement(
       const children = Array.from(element.childNodes)
       let consecutiveInlineNodes: TransNode[] = []
       for (const child of children) {
-        if (!child.textContent?.trim()) {
-          continue
-        }
+        // if (!child.textContent?.trim()) {
+        //   continue
+        // }
         if (!(isTextNode(child) || isHTMLElement(child))) {
           continue
         }


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

This PR improves how the extension handles BR tags and inline elements in DOM processing:

1. **BR tag classification**: Moved BR tags from `INVALID_TRANSLATE_TAGS` to `FORCE_BLOCK_TAGS` so they properly interrupt inline sequences and create translation boundaries
2. **Element processing**: Removed text content trimming checks in DOM filtering to ensure all elements are processed consistently
3. **Translation grouping**: Inline elements separated by BR tags are now correctly grouped into separate translation units instead of being treated as one continuous sequence

## Related Issue

This addresses issues where inline content separated by `<br>` tags was incorrectly grouped together, leading to poor translation boundaries.

## How Has This Been Tested?

- [x] Added unit tests - comprehensive test case for inline elements separated by BR tags
- [x] Verified through manual testing - all existing tests pass

The new test `should handle inline elements separated by br tags correctly` verifies that:
- Multiple translation wrappers are created when BR tags break inline sequences
- Each wrapper contains the correct inline content class
- Translation boundaries are properly established

## Screenshots

N/A - This is a logic fix without UI changes

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary  
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This change ensures that content like:
```html
<div>
  <span>First text</span>
  <span>Second text</span>
  <br />
  <span>Third text</span>
</div>
```

Will create separate translation groups before and after the BR tag, providing more accurate translation boundaries and better user experience.