### PR TITLE
i18n(extension): update the translation of 'always translate' for options page

### DIFF
--- a/.changeset/shy-rules-bathe.md
+++ b/.changeset/shy-rules-bathe.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(docs): update the translation of 'always translate' for options page

--- a/.changeset/shy-rules-bathe.md
+++ b/.changeset/shy-rules-bathe.md
@@ -2,4 +2,4 @@
 "@read-frog/extension": patch
 ---
 
-feat(docs): update the translation of 'always translate' for options page
+i18n(extension): update the translation of 'always translate' for options page

--- a/apps/extension/src/entrypoints/options/pages/translation/always-translate.tsx
+++ b/apps/extension/src/entrypoints/options/pages/translation/always-translate.tsx
@@ -65,7 +65,7 @@ function PatternTable() {
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-2">
         <Input
-          placeholder="Enter URL Pattern"
+          placeholder={i18n.t('options.translation.alwaysTranslate.enterUrlPattern')}
           value={inputValue}
           onChange={e => setInputValue(e.target.value)}
           onKeyDown={handleKeyPress}
@@ -77,7 +77,7 @@ function PatternTable() {
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead className="w-[100px]">URL Pattern</TableHead>
+            <TableHead className="w-[100px]">{i18n.t('options.translation.alwaysTranslate.urlPattern')}</TableHead>
             <TableHead className="text-right"></TableHead>
           </TableRow>
         </TableHeader>

--- a/apps/extension/src/entrypoints/options/pages/translation/always-translate.tsx
+++ b/apps/extension/src/entrypoints/options/pages/translation/always-translate.tsx
@@ -1,3 +1,4 @@
+import { i18n } from '#imports'
 import { Icon } from '@iconify/react'
 import { Button } from '@repo/ui/components/button'
 import { Input } from '@repo/ui/components/input'
@@ -16,7 +17,7 @@ import { ConfigCard } from '../../components/config-card'
 
 export function AlwaysTranslate() {
   return (
-    <ConfigCard title="Always Translate" description="Always translate the webpage">
+    <ConfigCard title={i18n.t('options.translation.alwaysTranslate.title')} description={i18n.t('options.translation.alwaysTranslate.description')}>
       <PatternTable />
     </ConfigCard>
   )

--- a/apps/extension/src/locales/en.yml
+++ b/apps/extension/src/locales/en.yml
@@ -83,6 +83,8 @@ options:
     alwaysTranslate:
       title: Always Translate
       description: Always translate this website
+      urlPattern: URL Pattern
+      enterUrlPattern: Enter URL Pattern
     personalizedPrompt:
       title: Personalized Prompt
       description: Customizing different types of Prompts allows you to adjust the Prompt type yourself during translation. A Prompt represents the text that the user sends to the LLM, where {{input}} denotes the text content of the paragraph and {{targetLang}} denotes the target language.

--- a/apps/extension/src/locales/en.yml
+++ b/apps/extension/src/locales/en.yml
@@ -80,6 +80,9 @@ options:
       rate:
         title: Average Requests Per Second
         description: Average requests per second, but allows configuring a maximum burst count to temporarily send excess requests
+    alwaysTranslate:
+      title: Always Translate
+      description: Always translate this website
     personalizedPrompt:
       title: Personalized Prompt
       description: Customizing different types of Prompts allows you to adjust the Prompt type yourself during translation. A Prompt represents the text that the user sends to the LLM, where {{input}} denotes the text content of the paragraph and {{targetLang}} denotes the target language.

--- a/apps/extension/src/locales/ja.yml
+++ b/apps/extension/src/locales/ja.yml
@@ -79,6 +79,9 @@ options:
       rate:
         title: 秒間平均リクエスト数
         description: 平均秒間リクエスト数（ただし、最大バーストリクエスト数を設定し一時的な超過リクエスト送信を許可）
+    alwaysTranslate:
+      title: 常に翻訳
+      description: このサイトを常に翻訳する
     personalizedPrompt:
       title: 個人化プロンプト
       description: 異なるタイプのプロンプトをカスタマイズすることで、翻訳時にプロンプトタイプを自ら調整できます。プロンプトとは、ユーザーがLLMに送信するテキストを指し、その中で {{input}} は段落のテキスト内容を、{{targetLang}} はターゲット言語を表します。

--- a/apps/extension/src/locales/ja.yml
+++ b/apps/extension/src/locales/ja.yml
@@ -82,6 +82,8 @@ options:
     alwaysTranslate:
       title: 常に翻訳
       description: このサイトを常に翻訳する
+      urlPattern: URL パターン
+      enterUrlPattern: URL パターンを入力
     personalizedPrompt:
       title: 個人化プロンプト
       description: 異なるタイプのプロンプトをカスタマイズすることで、翻訳時にプロンプトタイプを自ら調整できます。プロンプトとは、ユーザーがLLMに送信するテキストを指し、その中で {{input}} は段落のテキスト内容を、{{targetLang}} はターゲット言語を表します。

--- a/apps/extension/src/locales/ko.yml
+++ b/apps/extension/src/locales/ko.yml
@@ -83,6 +83,8 @@ options:
     alwaysTranslate:
       title: 항상 번역
       description: 이 사이트를 항상 번역합니다
+      urlPattern: URL 패턴
+      enterUrlPattern: URL 패턴 입력
     personalizedPrompt:
       title: 개인화된 프롬프트
       description: 다양한 유형의 프롬프트를 사용자 정의하여, 번역 시 프롬프트 유형을 직접 조정할 수 있습니다. 프롬프트는 사용자가 LLM에게 보내는 텍스트를 나타내며, 여기서 {{input}}은 문단의 텍스트 내용을, {{targetLang}}은 목표 언어를 나타냅니다.

--- a/apps/extension/src/locales/ko.yml
+++ b/apps/extension/src/locales/ko.yml
@@ -82,7 +82,7 @@ options:
         description: 초당 평균 요청 수 (단, 최대 버스트 요청 수 설정을 통한 일시적 초과 요청 전송 허용)
     alwaysTranslate:
       title: 항상 번역
-      description: 이 사이트 항상 번역
+      description: 이 사이트를 항상 번역합니다
     personalizedPrompt:
       title: 개인화된 프롬프트
       description: 다양한 유형의 프롬프트를 사용자 정의하여, 번역 시 프롬프트 유형을 직접 조정할 수 있습니다. 프롬프트는 사용자가 LLM에게 보내는 텍스트를 나타내며, 여기서 {{input}}은 문단의 텍스트 내용을, {{targetLang}}은 목표 언어를 나타냅니다.

--- a/apps/extension/src/locales/ko.yml
+++ b/apps/extension/src/locales/ko.yml
@@ -80,6 +80,9 @@ options:
       rate:
         title: 초당 평균 요청 수
         description: 초당 평균 요청 수 (단, 최대 버스트 요청 수 설정을 통한 일시적 초과 요청 전송 허용)
+    alwaysTranslate:
+      title: 항상 번역
+      description: 이 사이트 항상 번역
     personalizedPrompt:
       title: 개인화된 프롬프트
       description: 다양한 유형의 프롬프트를 사용자 정의하여, 번역 시 프롬프트 유형을 직접 조정할 수 있습니다. 프롬프트는 사용자가 LLM에게 보내는 텍스트를 나타내며, 여기서 {{input}}은 문단의 텍스트 내용을, {{targetLang}}은 목표 언어를 나타냅니다.

--- a/apps/extension/src/locales/zh-CN.yml
+++ b/apps/extension/src/locales/zh-CN.yml
@@ -83,6 +83,8 @@ options:
     alwaysTranslate:
       title: 总是翻译
       description: 总是翻译这个网站
+      urlPattern: URL 模式
+      enterUrlPattern: 输入 URL 模式
     personalizedPrompt:
       title: 个性化 Prompt
       description: 自定义不同类型的 Prompt，可以在翻译时自行调整 Prompt 类型。Prompt 表示以用户身份发送给 llm 的文本，其中 {{input}} 表示段落的文本内容，{{targetLang}} 表示目标语言。

--- a/apps/extension/src/locales/zh-CN.yml
+++ b/apps/extension/src/locales/zh-CN.yml
@@ -80,6 +80,9 @@ options:
       rate:
         title: 每秒平均请求数量
         description: 平均每秒的请求数量，不过允许配置最大突发请求数来短暂发送超量请求。
+    alwaysTranslate:
+      title: 总是翻译
+      description: 总是翻译这个网站
     personalizedPrompt:
       title: 个性化 Prompt
       description: 自定义不同类型的 Prompt，可以在翻译时自行调整 Prompt 类型。Prompt 表示以用户身份发送给 llm 的文本，其中 {{input}} 表示段落的文本内容，{{targetLang}} 表示目标语言。

--- a/apps/extension/src/locales/zh-TW.yml
+++ b/apps/extension/src/locales/zh-TW.yml
@@ -83,6 +83,8 @@ options:
     alwaysTranslate:
       title: 總是翻譯
       description: 總是翻譯這個網站
+      urlPattern: URL 模式
+      enterUrlPattern: 輸入 URL 模式
     personalizedPrompt:
       title: 個人化 Prompt
       description: 自訂不同類型的 Prompt，可以在翻譯時自行調整 Prompt 類型。Prompt 表示以用戶身份發送給 LLM 的文字，其中 {{input}} 表示段落的文字內容，{{targetLang}} 表示目標語言。

--- a/apps/extension/src/locales/zh-TW.yml
+++ b/apps/extension/src/locales/zh-TW.yml
@@ -80,6 +80,9 @@ options:
       rate:
         title: 每秒平均請求數量
         description: 平均每秒的請求數量，但允許設定最大突發請求數來短暫發送超量請求
+    alwaysTranslate:
+      title: 總是翻譯
+      description: 總是翻譯這個網站
     personalizedPrompt:
       title: 個人化 Prompt
       description: 自訂不同類型的 Prompt，可以在翻譯時自行調整 Prompt 類型。Prompt 表示以用戶身份發送給 LLM 的文字，其中 {{input}} 表示段落的文字內容，{{targetLang}} 表示目標語言。


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [x] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->
<img width="1899" height="920" alt="image" src="https://github.com/user-attachments/assets/9fd3ef2c-7cf1-42ce-8cb5-f33b81de337e" />


## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Internationalized the “Always Translate” card on the Options > Translation page. The title and description now use i18n keys with new strings for en, ja, ko, zh-CN, and zh-TW.

<!-- End of auto-generated description by cubic. -->

