### PR TITLE
feat(extension): support drag translation popup

### DIFF
--- a/.changeset/puny-tools-call.md
+++ b/.changeset/puny-tools-call.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(extension): support drag translation popup

--- a/apps/extension/src/entrypoints/selection.content/selection-toolbar/translate-button.tsx
+++ b/apps/extension/src/entrypoints/selection.content/selection-toolbar/translate-button.tsx
@@ -5,6 +5,7 @@ import { readUIMessageStream, streamText } from 'ai'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
+import { useDraggable } from '@/hooks/use-draggable'
 import { ISO6393_TO_6391, LANG_CODE_TO_EN_NAME } from '@/types/config/languages'
 import { isPureTranslateProvider } from '@/types/config/provider'
 import { authClient } from '@/utils/auth/auth-client'
@@ -48,6 +49,10 @@ export function TranslatePopover() {
   const selectionContent = useAtomValue(selectionContentAtom)
   const popoverRef = useRef<HTMLDivElement>(null)
   const { data: session } = authClient.useSession()
+
+  const { ref: dragRef, style: dragStyle } = useDraggable({
+    initialPosition: mouseClickPosition || { x: 0, y: 0 },
+  })
 
   const createVocabulary = useMutation({
     ...trpc.vocabulary.create.mutationOptions(),
@@ -179,12 +184,12 @@ export function TranslatePopover() {
     <div
       ref={popoverRef}
       className="fixed z-[2147483647] bg-white dark:bg-zinc-800 border rounded-lg w-[300px] shadow-lg"
-      style={{
-        left: mouseClickPosition.x,
-        top: mouseClickPosition.y,
-      }}
+      style={dragStyle}
     >
-      <div className="flex items-center justify-between p-4 border-b">
+      <div
+        ref={dragRef as React.RefObject<HTMLDivElement>}
+        className="flex items-center justify-between p-4 border-b hover:cursor-grab active:cursor-grabbing select-none"
+      >
         <div className="flex items-center gap-2">
           <Icon icon="ri:translate" strokeWidth={0.8} className="size-4.5 text-zinc-600 dark:text-zinc-400" />
           <h2 className="text-base font-medium text-zinc-900 dark:text-zinc-100">Translation</h2>

--- a/apps/extension/src/hooks/use-draggable.ts
+++ b/apps/extension/src/hooks/use-draggable.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
+
+interface Position {
+  x: number
+  y: number
+}
+
+interface UseDraggableOptions {
+  initialPosition?: Position
+  onPositionChange?: (position: Position) => void
+}
+
+interface UseDraggableReturn {
+  position: Position
+  isDragging: boolean
+  ref: React.RefObject<HTMLElement | null>
+  style: {
+    left: number
+    top: number
+  }
+}
+
+/**
+ * Custom hook for making elements draggable
+ * @param options - Configuration options for draggable behavior
+ * @returns Object containing position, drag state, ref and styles
+ */
+export function useDraggable(options: UseDraggableOptions = {}): UseDraggableReturn {
+  const { initialPosition = { x: 0, y: 0 }, onPositionChange } = options
+
+  const [isDragging, setIsDragging] = useState(false)
+  const [dragOffset, setDragOffset] = useState<Position>({ x: 0, y: 0 })
+  const [position, setPosition] = useState<Position>(initialPosition)
+  const ref = useRef<HTMLElement>(null)
+
+  useLayoutEffect(() => {
+    setPosition({
+      x: initialPosition.x,
+      y: initialPosition.y,
+    })
+  }, [initialPosition.x, initialPosition.y])
+
+  // Handle mouse move during drag
+  const handleMouseMove = useCallback((event: MouseEvent) => {
+    if (isDragging) {
+      const newPosition = {
+        x: event.clientX - dragOffset.x,
+        y: event.clientY - dragOffset.y,
+      }
+      setPosition(newPosition)
+      onPositionChange?.(newPosition)
+    }
+  }, [isDragging, dragOffset, onPositionChange])
+
+  // Handle mouse up to end drag
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false)
+  }, [])
+
+  // Handle mouse down to start drag
+  const handleMouseDown = useCallback((event: MouseEvent) => {
+    if (!ref.current)
+      return
+
+    const rect = ref.current.getBoundingClientRect()
+    setDragOffset({
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    })
+    setIsDragging(true)
+
+    // Prevent text selection during drag
+    event.preventDefault()
+  }, [])
+
+  // Add/remove event listeners for drag
+  useEffect(() => {
+    if (isDragging) {
+      document.addEventListener('mousemove', handleMouseMove)
+      document.addEventListener('mouseup', handleMouseUp)
+      return () => {
+        document.removeEventListener('mousemove', handleMouseMove)
+        document.removeEventListener('mouseup', handleMouseUp)
+      }
+    }
+  }, [isDragging, handleMouseMove, handleMouseUp])
+
+  // Add/remove mousedown listener to the ref element
+  useEffect(() => {
+    const element = ref.current
+    if (element) {
+      element.addEventListener('mousedown', handleMouseDown)
+      return () => {
+        element.removeEventListener('mousedown', handleMouseDown)
+      }
+    }
+  // ref.current may be null. Add the listener when it becomes available and update it on ref changes.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [handleMouseDown, ref.current])
+
+  return {
+    position,
+    isDragging,
+    ref,
+    style: {
+      left: position.x,
+      top: position.y,
+    },
+  }
+}

--- a/apps/extension/src/hooks/use-draggable.ts
+++ b/apps/extension/src/hooks/use-draggable.ts
@@ -59,7 +59,7 @@ export function useDraggable(options: UseDraggableOptions = {}): UseDraggableRet
 
   // Handle mouse down to start drag
   const handleMouseDown = useCallback((event: MouseEvent) => {
-    if (!ref.current)
+    if (!ref.current || event.button !== 0)
       return
 
     const rect = ref.current.getBoundingClientRect()


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [x] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description
Sometimes the translation window appears in an unusable place. For Example:
<img width="1920" height="932" alt="截屏2025-08-26 21 49 37" src="https://github.com/user-attachments/assets/9421a214-57dd-4697-b489-1ddaf11421d1" />


<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Make the translation popover draggable so you can move it when it appears in a bad spot. Adds a reusable useDraggable hook and starts the popover at the click position.

- **New Features**
  - Added useDraggable hook (tracks position, exposes ref and left/top style).
  - Made Translation popover draggable; header acts as the drag handle with grab/grabbing cursor.
  - Popover now initializes at mouseClickPosition for better placement.

<!-- End of auto-generated description by cubic. -->

