### PR TITLE
feat(extension): support border style

### DIFF
--- a/.changeset/six-spiders-sit.md
+++ b/.changeset/six-spiders-sit.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(extension): support border style

--- a/apps/extension/src/assets/tailwind/custom-translation-node.css
+++ b/apps/extension/src/assets/tailwind/custom-translation-node.css
@@ -32,5 +32,4 @@
   border: 1px solid var(--read-frog-primary);
   padding: 4px;
   border-radius: 2px;
-  background-color: var(--read-frog-muted);
 }

--- a/apps/extension/src/assets/tailwind/custom-translation-node.css
+++ b/apps/extension/src/assets/tailwind/custom-translation-node.css
@@ -32,5 +32,5 @@
   border: 1px solid var(--read-frog-primary);
   padding: 4px;
   border-radius: 2px;
-  background-color: var(--read-frog-accent);
+  background-color: var(--read-frog-muted);
 }

--- a/apps/extension/src/assets/tailwind/custom-translation-node.css
+++ b/apps/extension/src/assets/tailwind/custom-translation-node.css
@@ -27,3 +27,10 @@
   text-decoration: underline dashed var(--read-frog-primary);
   text-underline-offset: 5px;
 }
+
+[data-read-frog-custom-translation-style='border'] {
+  border: 1px solid var(--read-frog-primary);
+  padding: 4px;
+  border-radius: 2px;
+  background-color: var(--read-frog-accent);
+}

--- a/apps/extension/src/locales/en.yml
+++ b/apps/extension/src/locales/en.yml
@@ -112,6 +112,7 @@ options:
         blockquote: Blockquote
         weakened: Weakened
         dashedLine: Dashed Line
+        border: Border
     translationMode:
       title: Translation Mode
       description: 'Choose how the translated text is displayed: bilingual or translation only.'

--- a/apps/extension/src/locales/ja.yml
+++ b/apps/extension/src/locales/ja.yml
@@ -111,6 +111,7 @@ options:
         blockquote: 引用
         weakened: 弱化
         dashedLine: 破線
+        border: 枠線
     translationMode:
       title: 翻訳モード
       description: 翻訳テキストの表示方法を選択：バイリンガルまたは翻訳のみ

--- a/apps/extension/src/locales/ko.yml
+++ b/apps/extension/src/locales/ko.yml
@@ -112,6 +112,7 @@ options:
         blockquote: 인용
         weakened: 약화
         dashedLine: 점선
+        border: 테두리
     translationMode:
       title: 번역 모드
       description: '번역된 텍스트 표시 방법 선택: 이중 언어 또는 번역만'

--- a/apps/extension/src/locales/zh-CN.yml
+++ b/apps/extension/src/locales/zh-CN.yml
@@ -112,6 +112,7 @@ options:
         blockquote: 引用
         weakened: 弱化
         dashedLine: 虚线
+        border: 边框
     translationMode:
       title: 翻译模式
       description: 选择翻译文本的显示方式：双语对照或仅显示翻译

--- a/apps/extension/src/locales/zh-TW.yml
+++ b/apps/extension/src/locales/zh-TW.yml
@@ -112,6 +112,7 @@ options:
         blockquote: 引用
         weakened: 弱化
         dashedLine: 虛線
+        border: 邊框
     translationMode:
       title: 翻譯模式
       description: 選擇翻譯文字的顯示方式：雙語對照或僅顯示翻譯

--- a/apps/extension/src/utils/constants/translation-node-style.ts
+++ b/apps/extension/src/utils/constants/translation-node-style.ts
@@ -1,5 +1,5 @@
 export const DEFAULT_TRANSLATION_NODE_STYLE = 'default'
 
-export const TRANSLATION_NODE_STYLE = [DEFAULT_TRANSLATION_NODE_STYLE, 'blur', 'blockquote', 'weakened', 'dashedLine'] as const
+export const TRANSLATION_NODE_STYLE = [DEFAULT_TRANSLATION_NODE_STYLE, 'blur', 'blockquote', 'weakened', 'dashedLine', 'border'] as const
 
 export const CUSTOM_TRANSLATION_NODE_ATTRIBUTE = 'read-frog-custom-translation-style'


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #339

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a new “Border” translation style to highlight translated text with a bordered accent. Registers the style, adds CSS, and updates locale labels.

- New Features
  - Added "border" to translation styles and constants.
  - CSS for [data-read-frog-custom-translation-style='border']: 1px primary border, 4px padding, 2px radius, accent background.
  - Locales updated (en, ja, ko, zh-CN, zh-TW) with a "Border" label.

<!-- End of auto-generated description by cubic. -->

