### PR TITLE
fix: don't retranslate the whole ancestor node when auto transla

### DIFF
--- a/.changeset/witty-ads-pick.md
+++ b/.changeset/witty-ads-pick.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(extension): don't retranslate the whole ancestor node when auto translate

--- a/apps/extension/src/utils/host/translate/node-manipulation.ts
+++ b/apps/extension/src/utils/host/translate/node-manipulation.ts
@@ -23,7 +23,7 @@ import {
 } from '../../constants/dom-labels'
 import { FORCE_INLINE_TRANSLATION_TAGS } from '../../constants/dom-tags'
 import { isBlockTransNode, isHTMLElement, isInlineTransNode, isTextNode, isTranslatedWrapperNode, isTransNode } from '../dom/filter'
-import { deepQueryTopLevelSelector, findNearestAncestorBlockNodeAt, findNearestAncestorBlockNodeFor, unwrapDeepestOnlyHTMLChild } from '../dom/find'
+import { deepQueryTopLevelSelector, findNearestAncestorBlockNodeAt, unwrapDeepestOnlyHTMLChild } from '../dom/find'
 import { getOwnerDocument } from '../dom/node'
 import {
   extractTextContent,
@@ -210,7 +210,7 @@ export async function translateNodeTranslationOnlyMode(nodes: ChildNode[], walkI
       console.error('targetNode.parentElement is not HTMLElement', targetNode.parentElement)
       return
     }
-    const existedTranslatedWrapper = findPreviousTranslatedWrapper(findNearestAncestorBlockNodeFor(targetNode.parentElement), walkId)
+    const existedTranslatedWrapper = findPreviousTranslatedWrapper(targetNode.parentElement, walkId)
     if (existedTranslatedWrapper) {
       removeTranslatedWrapperWithRestore(existedTranslatedWrapper)
       if (toggle) {


### PR DESCRIPTION
…ranslate

## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

fix the issue:
1. turn on auto translate, translationOnly mode
2. toggle this node, can't toggle the translation
```
<p>Join our <a href="https://discord.gg/ej45e3PezJ" rel="noreferrer noopener" target="_blank">Discord</a> community to discuss the project, share your ideas, and get help.</p>
```

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevented auto-translate from reprocessing entire ancestor blocks. It now targets the direct parent, avoiding duplicate wrappers and reducing unnecessary DOM work.

- **Bug Fixes**
  - Look up the existing translated wrapper from targetNode.parentElement instead of the nearest ancestor block node.
  - Removed the unused findNearestAncestorBlockNodeFor import.

<!-- End of auto-generated description by cubic. -->

