### PR TITLE
fix: migrate default prompt to the new one

### DIFF
--- a/.changeset/new-suits-teach.md
+++ b/.changeset/new-suits-teach.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: migrate default prompt to the new one

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -17,14 +17,14 @@ jobs:
     #   github.event.pull_request.user.login == 'external-contributor' ||
     #   github.event.pull_request.user.login == 'new-developer' ||
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
+
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -43,12 +43,11 @@ jobs:
             - Performance considerations
             - Security concerns
             - Test coverage
-            
+
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
-          
+
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
@@ -47,4 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
           # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
-

--- a/apps/extension/src/utils/config/__tests__/example/v019.ts
+++ b/apps/extension/src/utils/config/__tests__/example/v019.ts
@@ -1,6 +1,8 @@
-export const description = 'Implement customize translation shortcut key'
+import type { Config } from '@/types/config/config'
 
-export const configExample = {
+export const description = 'Migrate to new default prompt'
+
+export const configExample: Config = {
   language: {
     detectedCode: 'eng',
     sourceCode: 'auto',
@@ -91,9 +93,7 @@ export const configExample = {
 4. For content that should not be translated (such as proper nouns, code, etc.), keep the original text.
 
 Translate to {{targetLang}}:
-\`\`\`
 {{input}}
-\`\`\`
 `,
         },
       ],

--- a/apps/extension/src/utils/config/migration-scripts/v017-to-v018.ts
+++ b/apps/extension/src/utils/config/migration-scripts/v017-to-v018.ts
@@ -1,11 +1,9 @@
-import { DEFAULT_AUTO_TRANSLATE_SHORTCUT_KEY } from '@/utils/constants/translate'
-
 export function migrate(oldConfig: any): any {
   return {
     ...oldConfig,
     translate: {
       ...oldConfig.translate,
-      customAutoTranslateShortcutKey: DEFAULT_AUTO_TRANSLATE_SHORTCUT_KEY,
+      customAutoTranslateShortcutKey: ['alt', 'q'],
     },
   }
 }

--- a/apps/extension/src/utils/config/migration-scripts/v018-to-v019.ts
+++ b/apps/extension/src/utils/config/migration-scripts/v018-to-v019.ts
@@ -1,0 +1,32 @@
+export function migrate(oldConfig: any): any {
+  const newPromptConfig = {
+    ...oldConfig.translate.promptsConfig,
+    patterns: oldConfig.translate.promptsConfig.patterns.map((pattern: any) => {
+      if (pattern.id === 'default') {
+        return {
+          ...pattern,
+          prompt: `You are a professional {{targetLang}} native translator who needs to fluently translate text into {{targetLang}}.
+
+## Translation Rules
+1. Output only the translated content, without explanations or additional content (such as "Here's the translation:" or "Translation as follows:")
+2. The returned translation must maintain exactly the same number of paragraphs and format as the original text.
+3. If the text contains HTML tags, consider where the tags should be placed in the translation while maintaining fluency.
+4. For content that should not be translated (such as proper nouns, code, etc.), keep the original text.
+
+Translate to {{targetLang}}:
+{{input}}
+`,
+        }
+      }
+      return pattern
+    }),
+  }
+
+  return {
+    ...oldConfig,
+    translate: {
+      ...oldConfig.translate,
+      promptsConfig: newPromptConfig,
+    },
+  }
+}

--- a/apps/extension/src/utils/constants/config.ts
+++ b/apps/extension/src/utils/constants/config.ts
@@ -14,7 +14,7 @@ import { DEFAULT_AUTO_TRANSLATE_SHORTCUT_KEY, DEFAULT_REQUEST_CAPACITY, DEFAULT_
 import { DEFAULT_TRANSLATION_NODE_STYLE } from './translation-node-style'
 
 export const CONFIG_STORAGE_KEY = 'config'
-export const CONFIG_SCHEMA_VERSION = 18
+export const CONFIG_SCHEMA_VERSION = 19
 
 export const DEFAULT_PROVIDER_CONFIG: ProvidersConfig = {
   openai: {


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update the default translation prompt to the new template and migrate user configs to schema v19. This makes translations cleaner and preserves paragraph structure.

- **Migration**
  - Bump config schema to 19 and add v018→v019 migration that updates only the “default” prompt pattern.
  - Keep all custom prompt patterns unchanged.
  - Add v019 config example; adjust v018 example and v017→v018 migration to inline ['alt', 'q'] for the shortcut key.
  - No user action needed; migration runs automatically.

<!-- End of auto-generated description by cubic. -->

