### PR TITLE
fix: avoid recursive translate on translation only

### DIFF
--- a/.changeset/yummy-swans-hear.md
+++ b/.changeset/yummy-swans-hear.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: avoid recursive translate on translation only

--- a/apps/extension/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/apps/extension/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -1,4 +1,5 @@
 import { globalConfig } from '@/utils/config/config'
+import { CONTENT_WRAPPER_CLASS } from '@/utils/constants/dom-labels'
 import { isDontWalkIntoElement, isHTMLElement, isIFrameElement } from '@/utils/host/dom/filter'
 import { deepQueryTopLevelSelector } from '@/utils/host/dom/find'
 import { walkAndLabelElement } from '@/utils/host/dom/traversal'
@@ -93,7 +94,9 @@ export class PageTranslationManager implements IPageTranslationManager {
               console.warn('Global config is not initialized')
               return
             }
-            translateWalkedElement(entry.target, walkId, globalConfig.translate.mode)
+            if (!entry.target.closest(`.${CONTENT_WRAPPER_CLASS}`)) {
+              translateWalkedElement(entry.target, walkId, globalConfig.translate.mode)
+            }
           }
           observer.unobserve(entry.target)
         }


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a DOM guard to skip translating elements inside the extension’s content wrapper, preventing recursive translation in translation-only mode. This stops re-processing already translated nodes and eliminates loops and duplicate work.

<!-- End of auto-generated description by cubic. -->

