### PR TITLE
fix: reinsert when an internal node is removed

### DIFF
--- a/.changeset/icy-bottles-film.md
+++ b/.changeset/icy-bottles-film.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: reinsert when an internal node is removed.

--- a/apps/extension/src/utils/styles.ts
+++ b/apps/extension/src/utils/styles.ts
@@ -27,7 +27,7 @@ function isInnerDom(node: Node) {
     return true
   }
 
-  if (node.textContent?.includes('[data-sonner-toaster]')) {
+  if (node instanceof HTMLStyleElement && node.textContent.includes('[data-sonner-toaster]')) {
     return true
   }
 
@@ -77,6 +77,7 @@ export function mirrorDynamicStyles(selector: string, shadowRoot: ShadowRoot, co
   // Observe the head for added style elements
   const headObserver = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
+      console.log(mutation.addedNodes)
       mutation.addedNodes.forEach((node) => {
         if (node instanceof HTMLStyleElement && node.matches(selector)) {
           // Only check content if contentMatch is provided

--- a/apps/extension/src/utils/styles.ts
+++ b/apps/extension/src/utils/styles.ts
@@ -77,7 +77,6 @@ export function mirrorDynamicStyles(selector: string, shadowRoot: ShadowRoot, co
   // Observe the head for added style elements
   const headObserver = new MutationObserver((mutations) => {
     mutations.forEach((mutation) => {
-      console.log(mutation.addedNodes)
       mutation.addedNodes.forEach((node) => {
         if (node instanceof HTMLStyleElement && node.matches(selector)) {
           // Only check content if contentMatch is provided

--- a/apps/extension/src/utils/styles.ts
+++ b/apps/extension/src/utils/styles.ts
@@ -15,7 +15,7 @@ export function addStyleToShadow(shadow: ShadowRoot) {
   })
 }
 
-function isInnerDom(node: Node) {
+function isInternalStyleElement(node: Node) {
   if (!node)
     return false
 
@@ -89,7 +89,7 @@ export function mirrorDynamicStyles(selector: string, shadowRoot: ShadowRoot, co
       })
       // protect inner dom
       mutation.removedNodes.forEach((node) => {
-        if (isInnerDom(node)) {
+        if (isInternalStyleElement(node)) {
           document.head.append(node)
         }
       })

--- a/apps/extension/src/utils/styles.ts
+++ b/apps/extension/src/utils/styles.ts
@@ -27,7 +27,7 @@ function isInnerDom(node: Node) {
     return true
   }
 
-  if (node instanceof HTMLStyleElement && node.textContent.includes('[data-sonner-toaster]')) {
+  if (node instanceof HTMLStyleElement && node.textContent?.includes('[data-sonner-toaster]')) {
     return true
   }
 

--- a/apps/extension/src/utils/styles.ts
+++ b/apps/extension/src/utils/styles.ts
@@ -15,6 +15,25 @@ export function addStyleToShadow(shadow: ShadowRoot) {
   })
 }
 
+function isInnerDom(node: Node) {
+  if (!node)
+    return false
+
+  if (node instanceof HTMLStyleElement && node.attributes.getNamedItem('wxt-shadow-root-document-styles')) {
+    return true
+  }
+
+  if (node instanceof HTMLStyleElement && node.id === '_goober') {
+    return true
+  }
+
+  if (node.textContent?.includes('[data-sonner-toaster]')) {
+    return true
+  }
+
+  return false
+}
+
 export function mirrorDynamicStyles(selector: string, shadowRoot: ShadowRoot, contentMatch?: string) {
   // TODO: 目前函数只会把找到的第一个 style 放进来，但是可能存在多个 style 匹配，那其实要全部放进来，并且对应不同的 mirrorSheet
   const mirrorSheet = new CSSStyleSheet()
@@ -68,7 +87,12 @@ export function mirrorDynamicStyles(selector: string, shadowRoot: ShadowRoot, co
           }
         }
       })
-      // TODO: handle removed nodes
+      // protect inner dom
+      mutation.removedNodes.forEach((node) => {
+        if (isInnerDom(node)) {
+          document.head.append(node)
+        }
+      })
     })
   })
 


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->
 reinsert when an internal node is removed in side.content

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #410 #170 

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevents style loss when internal extension style nodes are removed by reinserting them, fixing side content auto-expand styling issues.

- **Bug Fixes**
  - Detects extension-owned style nodes (wxt shadow styles, _goober, sonner toaster) with a new isInnerDom check.
  - On DOM changes, reattaches any removed internal nodes to document.head within mirrorDynamicStyles.

<!-- End of auto-generated description by cubic. -->

