### PR TITLE
perf: improve the performance of smash style

### DIFF
--- a/.changeset/pink-spies-change.md
+++ b/.changeset/pink-spies-change.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+perf: Use requestIdleCallback or requestAnimationFrame to delay the application of smash style to improve the performance of the walk element.

--- a/.github/workflows/stale-issue-pr.yml
+++ b/.github/workflows/stale-issue-pr.yml
@@ -15,7 +15,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
           # ---- Issue settings ----
-          days-before-issue-stale: 30  # Issues become stale after 30 days inactive
+          days-before-issue-stale: 30 # Issues become stale after 30 days inactive
           days-before-issue-close: 180 # Close Issues 180 days after stale
           stale-issue-message: |
             This issue has been inactive for 30 days and is now marked as stale.
@@ -25,8 +25,8 @@ jobs:
             If you need to continue, please reopen or create a new issue.
 
           # ---- PR settings ----
-          days-before-pr-stale: 7   # PRs become stale after 7 days inactive
-          days-before-pr-close: 30  # Close PRs 30 days after stale
+          days-before-pr-stale: 7 # PRs become stale after 7 days inactive
+          days-before-pr-close: 30 # Close PRs 30 days after stale
           stale-pr-message: |
             This PR has been inactive for 7 days and is now marked as stale.
             It will be automatically closed in 30 days if no further activity occurs.

--- a/apps/extension/src/utils/host/dom/style.ts
+++ b/apps/extension/src/utils/host/dom/style.ts
@@ -3,7 +3,7 @@
  * @param element - The node to smash the truncation style
  */
 export function smashTruncationStyle(element: HTMLElement) {
-  const scheduleIdleTask = requestIdleCallback ?? requestAnimationFrame
+  const scheduleIdleTask = window.requestIdleCallback ?? window.requestAnimationFrame
 
   scheduleIdleTask(() => {
     const computedStyle = window.getComputedStyle(element)

--- a/apps/extension/src/utils/host/dom/style.ts
+++ b/apps/extension/src/utils/host/dom/style.ts
@@ -3,22 +3,26 @@
  * @param element - The node to smash the truncation style
  */
 export function smashTruncationStyle(element: HTMLElement) {
-  const computedStyle = window.getComputedStyle(element)
+  const scheduleIdleTask = requestIdleCallback ?? requestAnimationFrame
 
-  if (computedStyle.webkitLineClamp && computedStyle.webkitLineClamp !== 'none') {
-    element.style.webkitLineClamp = 'unset'
-  }
+  scheduleIdleTask(() => {
+    const computedStyle = window.getComputedStyle(element)
 
-  if (computedStyle.maxHeight && computedStyle.maxHeight !== 'none') {
-    element.style.maxHeight = 'unset'
-  }
+    if (computedStyle.webkitLineClamp && computedStyle.webkitLineClamp !== 'none') {
+      element.style.webkitLineClamp = 'unset'
+    }
 
-  // fix this issue: https://github.com/mengxi-ream/read-frog/issues/222
-  // if (computedStyle.overflow === 'hidden') {
-  //   element.style.overflow = 'visible'
-  // }
+    if (computedStyle.maxHeight && computedStyle.maxHeight !== 'none') {
+      element.style.maxHeight = 'unset'
+    }
 
-  if (computedStyle.textOverflow === 'ellipsis') {
-    element.style.textOverflow = 'unset'
-  }
+    // fix this issue: https://github.com/mengxi-ream/read-frog/issues/222
+    // if (computedStyle.overflow === 'hidden') {
+    //   element.style.overflow = 'visible'
+    // }
+
+    if (computedStyle.textOverflow === 'ellipsis') {
+      element.style.textOverflow = 'unset'
+    }
+  })
 }


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [x] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->
Use requestIdleCallback or requestAnimationFrame to delay the application of smash style to improve the performance of the walk element.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #421 

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

https://github.com/user-attachments/assets/361f04ec-aef0-4e9e-9873-5f2b2b2ee534

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Defers smashTruncationStyle changes to requestIdleCallback (with requestAnimationFrame fallback) to cut main-thread work and reduce jank when walking the DOM. Addresses #421.

- **Performance**
  - Schedule unsetting webkitLineClamp, maxHeight, and textOverflow in an idle/RAF callback instead of immediately.
  - No behavior change, only the timing of style application is deferred.

<!-- End of auto-generated description by cubic. -->

