### PR TITLE
fix: prevent infinite loop in MutationObserver causing browser freeze

### DIFF
--- a/.changeset/fix-mutation-observer-freeze.md
+++ b/.changeset/fix-mutation-observer-freeze.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: prevent infinite loop in MutationObserver causing browser freeze

--- a/apps/extension/src/entrypoints/side.content/index.tsx
+++ b/apps/extension/src/entrypoints/side.content/index.tsx
@@ -14,7 +14,7 @@ import { DEFAULT_CONFIG } from '@/utils/constants/config'
 import { protectSelectAllShadowRoot } from '@/utils/select-all'
 import { insertShadowRootUIWrapperInto } from '@/utils/shadow-root'
 import { queryClient } from '@/utils/trpc/client'
-import { addStyleToShadow, mirrorDynamicStyles } from '../../utils/styles'
+import { addStyleToShadow, mirrorDynamicStyles, protectInternalStyles } from '../../utils/styles'
 import App from './app'
 import { enablePageTranslationAtom, store, translationPortAtom } from './atoms'
 import '@/assets/tailwind/theme.css'
@@ -46,6 +46,10 @@ export default defineContentScript({
         //   shadow,
         //   ".with-scroll-bars-hidden22"
         // );
+
+        // Protect internal style elements from being removed
+        protectInternalStyles()
+
         protectSelectAllShadowRoot(shadowHost, wrapper)
 
         const HydrateAtoms = ({


### PR DESCRIPTION
## Summary
- Fixed infinite loop in styles.ts where removed style elements were immediately re-added
- Refactored code to follow single responsibility principle
- Added safeguards to prevent recursive mutations

closes #440 

## Problem
The extension was causing browser freezes due to an infinite loop in the MutationObserver callback. When internal style elements were removed from the document head, the code immediately re-added them, triggering the same MutationObserver again, creating an endless cycle.

## Solution
1. **Separated concerns**: Split `mirrorDynamicStyles` into two functions:
   - `mirrorDynamicStyles()`: Only handles mirroring styles to Shadow DOM
   - `protectInternalStyles()`: Handles protecting internal style elements

2. **Added loop prevention mechanisms**:
   - Re-entry flag to skip processing during node re-addition
   - WeakSet to track already processed nodes
   - Async processing with requestAnimationFrame to break synchronous loops
   - Verification that nodes are detached before re-adding

3. **Improved resource management**:
   - Disconnect previous observers when switching style sources
   - Return cleanup function from `protectInternalStyles()`

## Testing
- [x] Verified the extension no longer freezes the browser
- [x] Confirmed style mirroring still works correctly
- [x] Tested that internal styles are protected from removal
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a browser freeze caused by a MutationObserver loop when internal style elements were re-added. Styles are now mirrored safely without triggering recursive mutations.

- **Bug Fixes**
  - Prevent infinite re-add/remove loop for internal style tags in document head.
  - Add safeguards: re-entry flag, WeakSet to skip processed nodes, rAF deferral, and detached check before re-adding.
  - Disconnect previous observers when the source style element changes.

- **Refactors**
  - Split responsibilities: mirrorDynamicStyles (mirroring) and protectInternalStyles (protection with cleanup).
  - Call protectInternalStyles during content script init (index.tsx).

<!-- End of auto-generated description by cubic. -->

