### PR TITLE
feat(website): add sitemap.xml

### DIFF
--- a/.changeset/calm-meals-behave.md
+++ b/.changeset/calm-meals-behave.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/website": patch
+---
+
+feat: added sitemap.xml

--- a/apps/website/src/app/sitemap.ts
+++ b/apps/website/src/app/sitemap.ts
@@ -1,0 +1,92 @@
+import type { MetadataRoute } from 'next'
+import { routing } from '@/i18n/routing'
+import { SITE_PUBLIC_URL } from '@/lib/constants'
+import { source } from '@/lib/source'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = SITE_PUBLIC_URL
+  const locales = routing.locales
+
+  const createLocalizedUrl = (path: string = '') => {
+    const alternates: Record<string, string> = {}
+    for (const locale of locales) {
+      alternates[locale] = `${baseUrl}/${locale}${path}`
+    }
+    return { languages: alternates }
+  }
+
+  const createUrl = (path: string = '') => {
+    return `${baseUrl}${path}`
+  }
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: createUrl(),
+      changeFrequency: 'weekly',
+      priority: 1,
+      alternates: createLocalizedUrl(),
+    },
+    {
+      url: createUrl('/dashboard'),
+      changeFrequency: 'monthly',
+      priority: 0.9,
+      alternates: createLocalizedUrl('/dashboard'),
+    },
+    {
+      url: createUrl('/log-in'),
+      changeFrequency: 'monthly',
+      priority: 0.6,
+      alternates: createLocalizedUrl('/log-in'),
+    },
+    {
+      url: createUrl('/tutorial'),
+      changeFrequency: 'weekly',
+      priority: 0.9,
+      alternates: createLocalizedUrl('/tutorial'),
+    },
+    {
+      url: createUrl('/privacy-policy'),
+      changeFrequency: 'yearly',
+      priority: 0.1,
+      alternates: createLocalizedUrl('/privacy-policy'),
+    },
+    {
+      url: createUrl('/terms-of-service'),
+      changeFrequency: 'yearly',
+      priority: 0.1,
+      alternates: createLocalizedUrl('/terms-of-service'),
+    },
+  ]
+
+  for (let step = 1; step <= 4; step++) {
+    staticRoutes.push({
+      url: createUrl(`/guide/step-${step}`),
+      changeFrequency: 'weekly',
+      priority: 0.8,
+      alternates: createLocalizedUrl(`/guide/step-${step}`),
+    })
+  }
+
+  // dynamic tutorial routes
+  const dynamicRoutes: MetadataRoute.Sitemap = []
+
+  try {
+    const tutorialPages = source.generateParams('slug')
+    for (const page of tutorialPages) {
+      if (page.slug && Array.isArray(page.slug)) {
+        const slug = page.slug.join('/')
+        dynamicRoutes.push({
+          url: createUrl(`/tutorial/${slug}`),
+          changeFrequency: 'weekly',
+          priority: 0.7,
+          alternates: createLocalizedUrl(`/tutorial/${slug}`),
+        })
+      }
+    }
+  }
+  catch (error) {
+    console.warn('Failed to generate tutorial pages:', error)
+  }
+
+  return [...staticRoutes, ...dynamicRoutes]
+}


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [X] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Added sitemap.xml generation following Next.js documentation. The lastModified field was omitted since we don’t currently track modification dates for page content.

Reference: (https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap)

## Related Issue

[<!--- If this PR closes an issue, please link the issue below -->]

Closes #128 

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [X] Verified through manual testing

## Screenshots

<img width="909" height="910" alt="image" src="https://github.com/user-attachments/assets/c5643ee8-2126-41b2-a589-90931d694ef1" />

## Checklist

<!--- Go over all the following points before requesting a review -->

- [X] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [X] My changes do not break existing functionality
- [X] If my code was generated by AI, I have proofread and improved it as necessary.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds sitemap generation for the website to improve SEO and indexing. Generates localized URLs and includes both static pages and dynamic tutorial routes.

- **New Features**
  - Adds Next.js sitemap.ts using SITE_PUBLIC_URL with i18n alternates; default locale is en.
  - Covers home, dashboard, log-in, tutorial, privacy-policy, terms-of-service, and guide/step-1..4.
  - Dynamically includes /tutorial/[...slug] pages from source.generateParams('slug', 'en') with safe error handling.
  - Sets changeFrequency and priority; omits lastModified until we track content updates.

<!-- End of auto-generated description by cubic. -->

