### PR TITLE
fix: don't translate not walk element

### DIFF
--- a/.changeset/weak-goats-live.md
+++ b/.changeset/weak-goats-live.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: don't translate some element which should not be walked

--- a/apps/extension/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/apps/extension/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -1,6 +1,6 @@
 import { globalConfig } from '@/utils/config/config'
 import { CONTENT_WRAPPER_CLASS } from '@/utils/constants/dom-labels'
-import { isDontWalkIntoElement, isHTMLElement, isIFrameElement } from '@/utils/host/dom/filter'
+import { isDontWalkIntoButTranslateAsChildElement, isHTMLElement, isIFrameElement } from '@/utils/host/dom/filter'
 import { deepQueryTopLevelSelector } from '@/utils/host/dom/find'
 import { walkAndLabelElement } from '@/utils/host/dom/traversal'
 import { removeAllTranslatedWrapperNodes, translateWalkedElement } from '@/utils/host/translate/node-manipulation'
@@ -261,7 +261,7 @@ export class PageTranslationManager implements IPageTranslationManager {
    */
   private didChangeToWalkable(element: HTMLElement): boolean {
     const wasDontWalkInto = this.dontWalkIntoElementsCache.has(element)
-    const isDontWalkIntoNow = isDontWalkIntoElement(element)
+    const isDontWalkIntoNow = isDontWalkIntoButTranslateAsChildElement(element)
 
     // Update cache with current state
     if (isDontWalkIntoNow) {
@@ -281,7 +281,7 @@ export class PageTranslationManager implements IPageTranslationManager {
    * Initialize walkability state for an element and its descendants
    */
   private addDontWalkIntoElements(element: HTMLElement): void {
-    const dontWalkIntoElements = deepQueryTopLevelSelector(element, isDontWalkIntoElement)
+    const dontWalkIntoElements = deepQueryTopLevelSelector(element, isDontWalkIntoButTranslateAsChildElement)
     dontWalkIntoElements.forEach(el => this.dontWalkIntoElementsCache.add(el))
   }
 

--- a/apps/extension/src/hooks/read/extract.tsx
+++ b/apps/extension/src/hooks/read/extract.tsx
@@ -8,13 +8,13 @@ import { franc } from 'franc-min'
 import { useSetAtom } from 'jotai'
 import { flattenToParagraphs } from '@/entrypoints/side.content/utils/article'
 import { configFields } from '@/utils/atoms/config'
-import { isDontWalkIntoElement } from '@/utils/host/dom/filter'
+import { isDontWalkIntoButTranslateAsChildElement } from '@/utils/host/dom/filter'
 import { logger } from '@/utils/logger'
 
 function removeDummyNodes(root: Document) {
   const elements = root.querySelectorAll('*')
   elements.forEach((element) => {
-    if (element instanceof HTMLElement && isDontWalkIntoElement(element)) {
+    if (element instanceof HTMLElement && isDontWalkIntoButTranslateAsChildElement(element)) {
       element.remove()
     }
   })

--- a/apps/extension/src/utils/host/dom/filter.ts
+++ b/apps/extension/src/utils/host/dom/filter.ts
@@ -1,4 +1,5 @@
 import type { TransNode } from '@/types/dom'
+import { globalConfig } from '@/utils/config/config'
 import {
   BLOCK_ATTRIBUTE,
   BLOCK_CONTENT_CLASS,
@@ -7,7 +8,7 @@ import {
   INLINE_CONTENT_CLASS,
   NOTRANSLATE_CLASS,
 } from '@/utils/constants/dom-labels'
-import { FORCE_BLOCK_TAGS } from '@/utils/constants/dom-tags'
+import { FORCE_BLOCK_TAGS, INVALID_TRANSLATE_TAGS, MAIN_CONTENT_IGNORE_TAGS } from '@/utils/constants/dom-tags'
 
 export function isEditable(element: HTMLElement): boolean {
   const tag = element.tagName
@@ -79,18 +80,24 @@ export function isShallowBlockHTMLElement(element: HTMLElement): boolean {
   )
 }
 
-export function isDontWalkIntoElement(element: HTMLElement): boolean {
+export function isDontWalkIntoButTranslateAsChildElement(element: HTMLElement): boolean {
   const dontWalkClass = [NOTRANSLATE_CLASS, 'sr-only'].some(className =>
     element.classList.contains(className),
   )
 
+  const dontWalkAttr = element.getAttribute('translate') === 'no'
+
+  return dontWalkClass || dontWalkAttr
+}
+
+export function isDontWalkIntoAndDontTranslateAsChildElement(element: HTMLElement): boolean {
+  const dontWalkContent = globalConfig && globalConfig.translate.page.range !== 'all' && MAIN_CONTENT_IGNORE_TAGS.has(element.tagName)
+  const dontWalkInvalidTag = INVALID_TRANSLATE_TAGS.has(element.tagName)
   const dontWalkCSS
     = window.getComputedStyle(element).display === 'none'
       || window.getComputedStyle(element).visibility === 'hidden'
 
-  const dontWalkAttr = element.getAttribute('translate') === 'no'
-
-  return dontWalkClass || dontWalkCSS || dontWalkAttr
+  return dontWalkContent || dontWalkInvalidTag || dontWalkCSS
 }
 
 export function isInlineTransNode(node: TransNode): boolean {

--- a/apps/extension/src/utils/host/translate/node-manipulation.ts
+++ b/apps/extension/src/utils/host/translate/node-manipulation.ts
@@ -229,6 +229,10 @@ export async function translateNodeTranslationOnlyMode(nodes: ChildNode[], walkI
       }
     }
 
+    const innerTextContent = transNodes.map(node => extractTextContent(node)).join(' ')
+    if (!innerTextContent)
+      return
+
     const cleanTextContent = (content: string): string => {
       if (!content)
         return content


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #446 

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fix element walking and translation so non-walkable elements aren’t translated, while “notranslate” containers are skipped for walking but handled correctly. Addresses Linear #446 by preventing translations in hidden/ignored sections.

- **Bug Fixes**
  - Split filtering into two paths: don’t-walk-but-translate-as-child (notranslate, sr-only, translate="no") and don’t-walk-and-don’t-translate (hidden CSS, invalid tags, out-of-range main-content tags).
  - Updated walker and text extraction to respect the new rules (skip traversal where needed; skip extraction for the non-translatable group).
  - Switched PageTranslationManager and read extractor to the new predicates.
  - Avoid translation calls when extracted inner text is empty.

<!-- End of auto-generated description by cubic. -->

