### PR TITLE
fix: translate attribute is no

### DIFF
--- a/.changeset/warm-moles-dig.md
+++ b/.changeset/warm-moles-dig.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: translate dom with translate attribute no"

--- a/apps/extension/src/utils/host/dom/filter.ts
+++ b/apps/extension/src/utils/host/dom/filter.ts
@@ -97,9 +97,10 @@ export function isDontWalkIntoButTranslateAsChildElement(element: HTMLElement): 
     element.classList.contains(className),
   )
 
-  const dontWalkAttr = element.getAttribute('translate') === 'no'
+  // issue: https://github.com/mengxi-ream/read-frog/issues/459
+  // const dontWalkAttr = element.getAttribute('translate') === 'no'
 
-  return dontWalkClass || dontWalkAttr
+  return dontWalkClass
 }
 
 export function isDontWalkIntoAndDontTranslateAsChildElement(element: HTMLElement): boolean {


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #459

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Stop translating elements marked translate="no" by removing the attribute check from the DOM filter. This fixes unwanted translations and aligns with issue #459.

- **Bug Fixes**
  - Removed translate="no" handling in isDontWalkIntoButTranslateAsChildElement; only class-based rules apply now.

<!-- End of auto-generated description by cubic. -->

