### PR TITLE
fix: delete provider handler function

### DIFF
--- a/.changeset/small-planets-thank.md
+++ b/.changeset/small-planets-thank.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: choose right read or translate provider when delete the previous one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,8 @@ The code comments should be in English.
 
 ## i18n
 
+Locale files are in `apps/extension/src/locales` for extension app and `apps/website/messages` for website app.
+
 After you updated the locale files for extension app, you need to run `pnpm dev:extension` to update the locale types to pass the ESLint check.
 
 ## Others

--- a/apps/extension/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
+++ b/apps/extension/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
@@ -110,7 +110,7 @@ export function ProviderConfigForm() {
 
           <APIKeyField form={form} />
           <form.AppField name="baseURL">
-            {field => <field.InputField formForSubmit={form} label={`${i18n.t('options.apiProviders.form.fields.baseURL')}${isNonCustomLLMProviderName ? ' (Optional)' : ''}`} value={providerConfig.baseURL ?? ''} />}
+            {field => <field.InputField formForSubmit={form} label={`${i18n.t('options.apiProviders.form.fields.baseURL')}${isNonCustomLLMProviderName ? ` (${i18n.t('options.apiProviders.form.fields.optional')})` : ''}`} value={providerConfig.baseURL ?? ''} />}
           </form.AppField>
           {isTranslateProviderName && (
             <>

--- a/apps/extension/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
+++ b/apps/extension/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
@@ -1,3 +1,4 @@
+import type { ProvidersConfig } from '@/types/config/provider'
 import { i18n } from '#imports'
 import { Button } from '@repo/ui/components/button'
 import { Separator } from '@repo/ui/components/separator'
@@ -6,10 +7,10 @@ import { useStore } from '@tanstack/react-form'
 import { useAtom } from 'jotai'
 import { useEffect } from 'react'
 import { toast } from 'sonner'
-import { isAPIProviderConfig, isReadProvider, isTranslateProvider } from '@/types/config/provider'
+import { isAPIProviderConfig, isNonAPIProvider, isNonCustomLLMProvider, isReadProvider, isTranslateProvider } from '@/types/config/provider'
 import { configFields } from '@/utils/atoms/config'
 import { providerConfigAtom } from '@/utils/atoms/provider'
-import { getAPIProvidersConfig } from '@/utils/config/helpers'
+import { getReadProvidersConfig, getTranslateProvidersConfig } from '@/utils/config/helpers'
 import { selectedProviderIdAtom } from '../atoms'
 import { APIKeyField } from './api-key-field'
 import { DefaultReadProviderSelector, DefaultTranslateProviderSelector } from './default-provider'
@@ -39,6 +40,7 @@ export function ProviderConfigForm() {
   const providerType = useStore(form.store, state => state.values.provider)
   const isReadProviderName = isReadProvider(providerType)
   const isTranslateProviderName = isTranslateProvider(providerType)
+  const isNonCustomLLMProviderName = isNonCustomLLMProvider(providerType)
 
   // Reset form when selectedProviderId changes
   useEffect(() => {
@@ -51,22 +53,29 @@ export function ProviderConfigForm() {
     return null
   }
 
+  const chooseNextProviderConfig = (providersConfig: ProvidersConfig) => {
+    // better not choose non API provider
+    const firstProvider = providersConfig.find(config => !isNonAPIProvider(config.provider))
+    return firstProvider ?? providersConfig[0]
+  }
+
   const handleDelete = async () => {
     const updatedAllProviders = allProvidersConfig.filter(provider => provider.id !== providerConfig.id)
-    const updatedAllAPIProviders = getAPIProvidersConfig(updatedAllProviders)
-    if (updatedAllAPIProviders.length === 0) {
+    const updatedAllReadProviders = getReadProvidersConfig(updatedAllProviders)
+    const updatedAllTranslateProviders = getTranslateProvidersConfig(updatedAllProviders)
+    if (updatedAllReadProviders.length === 0 || updatedAllTranslateProviders.length === 0) {
       toast.error(i18n.t('options.apiProviders.form.atLeastOneProvider'))
       return
     }
 
     if (readConfig.providerId === providerConfig.id) {
-      void setReadConfig({ providerId: updatedAllAPIProviders[0].id })
+      void setReadConfig({ providerId: updatedAllReadProviders[0].id })
     }
     if (translateConfig.providerId === providerConfig.id) {
-      void setTranslateConfig({ providerId: updatedAllAPIProviders[0].id })
+      void setTranslateConfig({ providerId: chooseNextProviderConfig(updatedAllTranslateProviders).id })
     }
     await setAllProvidersConfig(updatedAllProviders)
-    setSelectedProviderId(updatedAllAPIProviders[0].id)
+    setSelectedProviderId(chooseNextProviderConfig(updatedAllProviders).id)
   }
 
   return (
@@ -101,7 +110,7 @@ export function ProviderConfigForm() {
 
           <APIKeyField form={form} />
           <form.AppField name="baseURL">
-            {field => <field.InputField formForSubmit={form} label={i18n.t('options.apiProviders.form.fields.baseURL')} value={providerConfig.baseURL ?? ''} />}
+            {field => <field.InputField formForSubmit={form} label={`${i18n.t('options.apiProviders.form.fields.baseURL')}${isNonCustomLLMProviderName ? ' (Optional)' : ''}`} value={providerConfig.baseURL ?? ''} />}
           </form.AppField>
           {isTranslateProviderName && (
             <>

--- a/apps/extension/src/locales/en.yml
+++ b/apps/extension/src/locales/en.yml
@@ -51,8 +51,9 @@ options:
         description: Description
         apiKey: API Key
         baseURL: Base URL
+        optional: Optional
       delete: Delete
-      atLeastOneProvider: Need at least one provider for reading or translation
+      atLeastOneProvider: At least one read provider and one translation provider are required.
       duplicateProviderName: 'Duplicate provider name "$1"'
       defaultProvider:
         translate: Set as default translate provider

--- a/apps/extension/src/locales/en.yml
+++ b/apps/extension/src/locales/en.yml
@@ -52,7 +52,7 @@ options:
         apiKey: API Key
         baseURL: Base URL
       delete: Delete
-      atLeastOneProvider: You must have at least one API provider
+      atLeastOneProvider: Need at least one provider for reading or translation
       duplicateProviderName: 'Duplicate provider name "$1"'
       defaultProvider:
         translate: Set as default translate provider

--- a/apps/extension/src/locales/ja.yml
+++ b/apps/extension/src/locales/ja.yml
@@ -51,8 +51,9 @@ options:
         description: 説明
         apiKey: APIキー
         baseURL: ベースURL
+        optional: オプション
       delete: 削除
-      atLeastOneProvider: 最低1つの読解または翻訳プロバイダーが必要です
+      atLeastOneProvider: 最低1つの読解プロバイダーと1つの翻訳プロバイダーが必要です。
       duplicateProviderName: '重複するプロバイダー名 "$1"'
       defaultProvider:
         translate: デフォルト翻訳プロバイダーに設定

--- a/apps/extension/src/locales/ja.yml
+++ b/apps/extension/src/locales/ja.yml
@@ -52,7 +52,7 @@ options:
         apiKey: APIキー
         baseURL: ベースURL
       delete: 削除
-      atLeastOneProvider: 最低1つのAPIプロバイダーが必要です
+      atLeastOneProvider: 最低1つの読解または翻訳プロバイダーが必要です
       duplicateProviderName: '重複するプロバイダー名 "$1"'
       defaultProvider:
         translate: デフォルト翻訳プロバイダーに設定

--- a/apps/extension/src/locales/ko.yml
+++ b/apps/extension/src/locales/ko.yml
@@ -52,7 +52,7 @@ options:
         apiKey: API Key
         baseURL: Base URL
       delete: 삭제
-      atLeastOneProvider: 최소 하나의 API 제공업체가 필요합니다
+      atLeastOneProvider: 최소 하나의 읽기 또는 번역 제공업체가 필요합니다
       duplicateProviderName: '중복된 제공업체 이름 "$1"'
       defaultProvider:
         translate: 기본 번역 제공업체로 설정

--- a/apps/extension/src/locales/ko.yml
+++ b/apps/extension/src/locales/ko.yml
@@ -51,8 +51,9 @@ options:
         description: 설명
         apiKey: API Key
         baseURL: Base URL
+        optional: 선택사항
       delete: 삭제
-      atLeastOneProvider: 최소 하나의 읽기 또는 번역 제공업체가 필요합니다
+      atLeastOneProvider: 최소 하나의 읽기 제공업체와 하나의 번역 제공업체가 필요합니다.
       duplicateProviderName: '중복된 제공업체 이름 "$1"'
       defaultProvider:
         translate: 기본 번역 제공업체로 설정

--- a/apps/extension/src/locales/zh-CN.yml
+++ b/apps/extension/src/locales/zh-CN.yml
@@ -52,7 +52,7 @@ options:
         apiKey: API Key
         baseURL: Base URL
       delete: 删除
-      atLeastOneProvider: 您必须至少有一个 API 提供商
+      atLeastOneProvider: 您必须至少有一个阅读或翻译提供商
       duplicateProviderName: '重复的提供商名称 "$1"'
       defaultProvider:
         translate: 设为默认翻译提供商

--- a/apps/extension/src/locales/zh-CN.yml
+++ b/apps/extension/src/locales/zh-CN.yml
@@ -51,8 +51,9 @@ options:
         description: 描述
         apiKey: API Key
         baseURL: Base URL
+        optional: 可选
       delete: 删除
-      atLeastOneProvider: 您必须至少有一个阅读或翻译提供商
+      atLeastOneProvider: 至少需要一个阅读提供商和一个翻译提供商。
       duplicateProviderName: '重复的提供商名称 "$1"'
       defaultProvider:
         translate: 设为默认翻译提供商

--- a/apps/extension/src/locales/zh-TW.yml
+++ b/apps/extension/src/locales/zh-TW.yml
@@ -51,8 +51,9 @@ options:
         description: 描述
         apiKey: API Key
         baseURL: Base URL
+        optional: 可選
       delete: 刪除
-      atLeastOneProvider: 您必須至少有一個閱讀或翻譯提供商
+      atLeastOneProvider: 至少需要一個閱讀提供商和一個翻譯提供商。
       duplicateProviderName: '重複的提供商名稱 "$1"'
       defaultProvider:
         translate: 設為預設翻譯提供商

--- a/apps/extension/src/locales/zh-TW.yml
+++ b/apps/extension/src/locales/zh-TW.yml
@@ -52,7 +52,7 @@ options:
         apiKey: API Key
         baseURL: Base URL
       delete: 刪除
-      atLeastOneProvider: 您必須至少有一個 API 提供商
+      atLeastOneProvider: 您必須至少有一個閱讀或翻譯提供商
       duplicateProviderName: '重複的提供商名稱 "$1"'
       defaultProvider:
         translate: 設為預設翻譯提供商

--- a/apps/extension/src/utils/config/helpers.ts
+++ b/apps/extension/src/utils/config/helpers.ts
@@ -1,6 +1,6 @@
 import type { Config } from '@/types/config/config'
-import type { APIProviderConfig, LLMTranslateProviderConfig, NonAPIProviderConfig, ProviderConfig, ProvidersConfig, PureAPIProviderConfig, ReadProviderConfig } from '@/types/config/provider'
-import { isAPIProviderConfig, isLLMTranslateProviderConfig, isNonAPIProviderConfig, isPureAPIProviderConfig, isReadProviderConfig } from '@/types/config/provider'
+import type { APIProviderConfig, LLMTranslateProviderConfig, NonAPIProviderConfig, ProviderConfig, ProvidersConfig, PureAPIProviderConfig, ReadProviderConfig, TranslateProviderConfig } from '@/types/config/provider'
+import { isAPIProviderConfig, isLLMTranslateProviderConfig, isNonAPIProviderConfig, isPureAPIProviderConfig, isReadProviderConfig, isTranslateProviderConfig } from '@/types/config/provider'
 
 export function getProviderConfigById<T extends ProviderConfig>(providersConfig: T[], providerId: string): T | undefined {
   return providersConfig.find(p => p.id === providerId)
@@ -24,6 +24,10 @@ export function getNonAPIProvidersConfig(providersConfig: ProvidersConfig): NonA
 
 export function getReadProvidersConfig(providersConfig: ProvidersConfig): ReadProviderConfig[] {
   return providersConfig.filter(isReadProviderConfig)
+}
+
+export function getTranslateProvidersConfig(providersConfig: ProvidersConfig): TranslateProviderConfig[] {
+  return providersConfig.filter(isTranslateProviderConfig)
 }
 
 export function filterEnabledProvidersConfig(providersConfig: ProvidersConfig): ProvidersConfig {

--- a/apps/extension/src/utils/host/translate/translate-text.ts
+++ b/apps/extension/src/utils/host/translate/translate-text.ts
@@ -3,7 +3,7 @@ import type { ProviderConfig } from '@/types/config/provider'
 import { i18n } from '#imports'
 import { ISO6393_TO_6391, LANG_CODE_TO_EN_NAME, LANG_CODE_TO_LOCALE_NAME } from '@repo/definitions'
 import { toast } from 'sonner'
-import { isAPIProviderConfig, isLLMTranslateProviderConfig, isNonAPIProvider, isPureAPIProvider, isPureTranslateProvider } from '@/types/config/provider'
+import { isAPIProviderConfig, isLLMTranslateProviderConfig, isNonAPIProvider, isPureAPIProvider } from '@/types/config/provider'
 import { getProviderConfigById } from '@/utils/config/helpers'
 import { logger } from '@/utils/logger'
 import { globalConfig } from '../../config/config'
@@ -85,20 +85,16 @@ export function validateTranslationConfig(config: Pick<Config, 'providersConfig'
   if (!providerConfig) {
     return false
   }
-  const { provider } = providerConfig
 
-  // check if the source language is the same as the target language
-  if (isPureTranslateProvider(provider)) {
-    if (languageConfig.sourceCode === languageConfig.targetCode) {
-      toast.error(i18n.t('translation.sameLanguage'))
-      logger.info('validateTranslationConfig: returning false (same language)')
-      return false
-    }
-    else if (languageConfig.sourceCode === 'auto' && languageConfig.detectedCode === languageConfig.targetCode) {
-      toast.warning(i18n.t('translation.autoModeSameLanguage', [
-        LANG_CODE_TO_LOCALE_NAME[languageConfig.detectedCode] ?? languageConfig.detectedCode,
-      ]))
-    }
+  if (languageConfig.sourceCode === languageConfig.targetCode) {
+    toast.error(i18n.t('translation.sameLanguage'))
+    logger.info('validateTranslationConfig: returning false (same language)')
+    return false
+  }
+  else if (languageConfig.sourceCode === 'auto' && languageConfig.detectedCode === languageConfig.targetCode) {
+    toast.warning(i18n.t('translation.autoModeSameLanguage', [
+      LANG_CODE_TO_LOCALE_NAME[languageConfig.detectedCode] ?? languageConfig.detectedCode,
+    ]))
   }
 
   // check if the API key is configured


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

#246 

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes provider deletion to correctly pick the next default read/translate provider and prevent removing the last provider of either type. Also marks Base URL as optional for non‑custom LLM providers.

- **Bug Fixes**
  - Reassigns default read/translate provider on delete, preferring API providers when auto-selecting.
  - Blocks deletion if it would leave no read or no translate providers; shows a clearer toast message.
  - Adds translate provider config helper and updates i18n copy.

<!-- End of auto-generated description by cubic. -->

