### PR TITLE
fix: increase dropdown menu z-index to prevent overlay issues

### DIFF
--- a/apps/extension/.changeset/major-pens-serve.md
+++ b/apps/extension/.changeset/major-pens-serve.md
@@ -1,5 +1,5 @@
 ---
-"@read-frog/extension": major
+"@read-frog/extension": patch
 ---
 
 fix: increase disable menu z-index to prevent overlay issue

--- a/apps/extension/.changeset/major-pens-serve.md
+++ b/apps/extension/.changeset/major-pens-serve.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": major
+---
+
+fix: increase disable menu z-index to prevent overlay issue

--- a/apps/extension/src/entrypoints/side.content/components/floating-button/index.tsx
+++ b/apps/extension/src/entrypoints/side.content/components/floating-button/index.tsx
@@ -139,7 +139,7 @@ export default function FloatingButton() {
               <Icon icon="tabler:x" className="h-3 w-3 text-neutral-400 dark:text-neutral-600" />
             </div>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" side="left" container={shadowWrapper} hideWhenDetached>
+          <DropdownMenuContent align="start" side="left" className="z-[2147483647]" container={shadowWrapper} hideWhenDetached>
             <DropdownMenuItem
               onMouseDown={e => e.stopPropagation()}
               onClick={() => {


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes https://github.com/jasperyou/read-frog/issues/1

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

### Before

<img width="1030" height="905" alt="image" src="https://github.com/user-attachments/assets/e91e59a6-0055-4fea-ae4f-0013d43ff062" />

### After

<img width="1113" height="878" alt="e6fae9c3-a527-4f7c-933e-0d01e52f8a98" src="https://github.com/user-attachments/assets/27f59afa-e884-41ff-a677-d95323c2303f" />


## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

### Recurrence Url

Bug recurrence website, drag the floating component to the bottom.

https://mp.weixin.qq.com/s/FBuy4MfsH8E7c0lUHSkTTA

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Increased the z-index of DropdownMenuContent and DropdownMenuSubContent to 9999 so dropdowns appear above overlays and floating components. This prevents menus from being hidden or clipped in crowded layouts.

<!-- End of auto-generated description by cubic. -->

