### PR TITLE
fix(extension): improve config handling and page translation initialization

### DIFF
--- a/apps/extension/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/apps/extension/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -69,12 +69,6 @@ export class PageTranslationManager implements IPageTranslationManager {
   }
 
   async start(): Promise<void> {
-    const config = await getConfigFromStorage()
-    if (!config) {
-      console.warn('Config is not initialized')
-      return
-    }
-
     if (this.isAutoTranslating) {
       console.warn('AutoTranslationManager is already active')
       return
@@ -84,6 +78,12 @@ export class PageTranslationManager implements IPageTranslationManager {
     void sendMessage('setEnablePageTranslationOnContentScript', {
       enabled: true,
     })
+
+    const config = await getConfigFromStorage()
+    if (!config) {
+      console.warn('Config is not initialized')
+      return
+    }
 
     // Listen to existing elements when they enter the viewpoint
     const walkId = crypto.randomUUID()

--- a/apps/extension/src/utils/config/config.ts
+++ b/apps/extension/src/utils/config/config.ts
@@ -5,16 +5,22 @@ import { configSchema } from '@/types/config/config'
 import { isReadProviderConfig } from '@/types/config/provider'
 import {
   CONFIG_STORAGE_KEY,
+  DEFAULT_CONFIG,
 } from '../constants/config'
 import { logger } from '../logger'
 
 export async function getConfigFromStorage() {
   const config = await storage.getItem<Config>(`local:${CONFIG_STORAGE_KEY}`)
   if (!config) {
-    logger.warn('No config found in storage, using default config')
+    logger.warn('No config found in storage')
     return null
   }
-  return configSchema.parse(config)
+  const parsedConfig = configSchema.safeParse(config)
+  if (!parsedConfig.success) {
+    logger.error('Config is invalid, using default config')
+    return DEFAULT_CONFIG
+  }
+  return parsedConfig.data
 }
 
 export function isAnyAPIKeyForReadProviders(providersConfig: ProvidersConfig) {


### PR DESCRIPTION
## Summary

- Move config check after state initialization in PageTranslationManager to prevent race conditions
- Add safe parsing for config with fallback to default config when config is invalid
- Improve error handling and logging when config issues occur

## Changes

- **Page Translation**: Move config retrieval after setting translation state to `enabled: true` to avoid potential race conditions during initialization
- **Config Handling**: Replace direct schema parsing with safe parsing that falls back to default config when validation fails
- **Error Logging**: Enhanced error messages to distinguish between missing config and invalid config

## Test Plan

- [x] Verify extension builds successfully
- [x] Verify all tests pass
- [x] Verify linting passes
- [x] Test page translation initialization with valid config
- [x] Test page translation initialization with invalid config (should use default)
- [x] Test page translation initialization with missing config

Generated with Claude Code
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a race in page translation startup and hardens config parsing to avoid crashes and confusing logs. This makes auto-translation more reliable even when stored config is invalid.

- **Bug Fixes**
  - Initialize translation state before fetching config to prevent startup races.
  - Safely parse config; fall back to DEFAULT_CONFIG when validation fails.
  - Clarify logs: distinguish between missing config (warn, return null) and invalid config (error, use default).

<!-- End of auto-generated description by cubic. -->

