### PR TITLE
fix: crash when delete the first provider

### DIFF
--- a/.changeset/odd-clocks-report.md
+++ b/.changeset/odd-clocks-report.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: crash when delete the first provider

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -56,6 +56,4 @@ jobs:
           PUBLIC_REPO_GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_GITHUB_TOKEN }}
 
       - name: Run tests
-        run: pnpm test
-        env:
-          SKIP_FREE_API: true
+        run: pnpm test -- --exclude="**/free-api.test.ts"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -57,3 +57,5 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+        env:
+          SKIP_FREE_API: true

--- a/apps/extension/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
+++ b/apps/extension/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
@@ -69,10 +69,10 @@ export function ProviderConfigForm() {
     }
 
     if (readConfig.providerId === providerConfig.id) {
-      void setReadConfig({ providerId: updatedAllReadProviders[0].id })
+      await setReadConfig({ providerId: updatedAllReadProviders[0].id })
     }
     if (translateConfig.providerId === providerConfig.id) {
-      void setTranslateConfig({ providerId: chooseNextProviderConfig(updatedAllTranslateProviders).id })
+      await setTranslateConfig({ providerId: chooseNextProviderConfig(updatedAllTranslateProviders).id })
     }
     await setAllProvidersConfig(updatedAllProviders)
     setSelectedProviderId(chooseNextProviderConfig(updatedAllProviders).id)

--- a/apps/extension/src/entrypoints/options/pages/api-providers/providers-config.tsx
+++ b/apps/extension/src/entrypoints/options/pages/api-providers/providers-config.tsx
@@ -32,10 +32,10 @@ export function ProvidersConfig() {
         </div>
       )}
       description={(
-        <p className="text-sm text-muted-foreground">
+        <>
           {i18n.t('options.apiProviders.description')}
           <Promotion className="mt-2" />
-        </p>
+        </>
       )}
       className="lg:flex-col"
     >

--- a/apps/extension/src/utils/atoms/storage-adapter.ts
+++ b/apps/extension/src/utils/atoms/storage-adapter.ts
@@ -1,12 +1,25 @@
+import type { ZodSchema } from 'zod'
 import { storage } from '#imports'
 
 export const storageAdapter = {
-  async get<T>(key: string, fallback: T): Promise<T> {
+  async get<T>(key: string, fallback: T, schema: ZodSchema<T>): Promise<T> {
     const value = await storage.getItem<T>(`local:${key}`)
-    return value ?? fallback
+    if (value) {
+      const parsedValue = schema.safeParse(value)
+      if (parsedValue.success) {
+        return parsedValue.data
+      }
+    }
+    return fallback
   },
-  async set<T>(key: string, value: T) {
-    await storage.setItem(`local:${key}`, value)
+  async set<T>(key: string, value: T, schema: ZodSchema<T>) {
+    const parsedValue = schema.safeParse(value)
+    if (parsedValue.success) {
+      await storage.setItem(`local:${key}`, parsedValue.data)
+    }
+    else {
+      throw new Error(parsedValue.error.message)
+    }
   },
   watch<T>(key: string, callback: (newValue: T) => void) {
     const unwatch = storage.watch<T>(`local:${key}`, (newValue) => {

--- a/apps/extension/src/utils/host/translate/node-manipulation.ts
+++ b/apps/extension/src/utils/host/translate/node-manipulation.ts
@@ -76,12 +76,6 @@ export async function translateNodes(nodes: ChildNode[], walkId: string, toggle:
   }
 }
 
-/**
- * Translate the node
- * @param nodes - The nodes to translate
- * @param walkId - The walk ID for the translation
- * @param toggle - Whether to toggle the translation, if true, the translation will be removed if it already exists
- */
 export async function translateNodesBilingualMode(nodes: ChildNode[], walkId: string, config: Config, toggle: boolean = false) {
   const transNodes = nodes.filter(node => isTransNode(node))
   if (transNodes.length === 0) {


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes a crash when deleting the first API provider by correctly reassigning the active provider and saving a valid config. Also adds schema-validated config storage and stabilizes tests.

- **Bug Fixes**
  - On delete, await updates to read/translate provider IDs and select the next available provider.
  - Validate config reads/writes with Zod; rollback atom state if persistence fails and ensure validated loads on mount/visibility change.
  - Minor UI cleanup in the Providers page description.
  - CI: set SKIP_FREE_API=true by default to avoid flaky external calls in tests.

<!-- End of auto-generated description by cubic. -->

