### PR TITLE
fix: change default key

### DIFF
--- a/.changeset/mighty-spiders-flash.md
+++ b/.changeset/mighty-spiders-flash.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: change default shortcut for translation

--- a/apps/extension/src/entrypoints/options/pages/api-providers/provider-config-form/config-header.tsx
+++ b/apps/extension/src/entrypoints/options/pages/api-providers/provider-config-form/config-header.tsx
@@ -1,4 +1,5 @@
 import type { APIProviderTypes } from '@/types/config/provider'
+import { i18n } from '#imports'
 import ProviderIcon from '@/components/provider-icon'
 import { PROVIDER_GROUPS, PROVIDER_ITEMS, SPECIFIC_TUTORIAL_PROVIDER_TYPES } from '@/utils/constants/providers'
 import { WEBSITE_URL } from '@/utils/constants/url'
@@ -20,7 +21,7 @@ export function ConfigHeader({ providerType }: { providerType: APIProviderTypes 
       </a>
       {tutorialUrl && (
         <a href={tutorialUrl} className="text-xs text-link hover:opacity-90" target="_blank" rel="noreferrer">
-          How to configure?
+          {i18n.t('options.apiProviders.howToConfigure')}
         </a>
       )}
     </div>

--- a/apps/extension/src/entrypoints/popup/components/node-translation-hotkey-selector.tsx
+++ b/apps/extension/src/entrypoints/popup/components/node-translation-hotkey-selector.tsx
@@ -44,6 +44,7 @@ export default function NodeTranslationHotkeySelector() {
               {i18n.t('popup.hover')}
               {' '}
               +
+              {' '}
               {HOTKEY_ITEMS[item].icon}
               {' '}
               {HOTKEY_ITEMS[item].label}

--- a/apps/extension/src/locales/en.yml
+++ b/apps/extension/src/locales/en.yml
@@ -104,6 +104,7 @@ options:
         vercel: Optimized AI models for web content translation and analysis
     apiKey:
       showAPIKey: Show API Key
+    howToConfigure: How to configure?
     testConnection:
       button: Test Connection
       testing: Testing...

--- a/apps/extension/src/locales/ja.yml
+++ b/apps/extension/src/locales/ja.yml
@@ -103,6 +103,7 @@ options:
         vercel: ウェブコンテンツの翻訳と分析に最適化されたAIモデル
     apiKey:
       showAPIKey: APIキーを表示
+    howToConfigure: 設定方法は?
     testConnection:
       button: 接続テスト
       testing: テスト中...

--- a/apps/extension/src/locales/ko.yml
+++ b/apps/extension/src/locales/ko.yml
@@ -103,6 +103,7 @@ options:
         vercel: 웹 콘텐츠 번역과 분석에 최적화된 AI 모델
     apiKey:
       showAPIKey: API Key 표시
+    howToConfigure: 구성 방법은?
     testConnection:
       button: 연결 테스트
       testing: 테스트 중...

--- a/apps/extension/src/locales/zh-CN.yml
+++ b/apps/extension/src/locales/zh-CN.yml
@@ -104,6 +104,7 @@ options:
         vercel: 针对网页内容翻译和分析优化的 AI 模型
     apiKey:
       showAPIKey: 显示 API Key
+    howToConfigure: 如何配置?
     testConnection:
       button: 测试连接
       testing: 测试中...

--- a/apps/extension/src/locales/zh-TW.yml
+++ b/apps/extension/src/locales/zh-TW.yml
@@ -104,6 +104,7 @@ options:
         vercel: 針對網頁內容翻譯和分析優化的 AI 模型
     apiKey:
       showAPIKey: 顯示 API Key
+    howToConfigure: 如何配置?
     testConnection:
       button: 測試連接
       testing: 測試中...

--- a/apps/extension/src/utils/constants/config.ts
+++ b/apps/extension/src/utils/constants/config.ts
@@ -27,7 +27,7 @@ export const DEFAULT_CONFIG: Config = {
     mode: 'bilingual',
     node: {
       enabled: true,
-      hotkey: 'Control',
+      hotkey: 'Shift',
     },
     page: {
       range: 'main',

--- a/apps/extension/src/utils/constants/providers.ts
+++ b/apps/extension/src/utils/constants/providers.ts
@@ -7,6 +7,7 @@ import tensdaqLogoColor from '@/assets/providers/tensdaq-color.svg'
 import { API_PROVIDER_TYPES, CUSTOM_LLM_PROVIDER_TYPES, NON_API_TRANSLATE_PROVIDERS, NON_API_TRANSLATE_PROVIDERS_MAP, NON_CUSTOM_LLM_PROVIDER_TYPES, PURE_API_PROVIDER_TYPES, PURE_TRANSLATE_PROVIDERS, READ_PROVIDER_TYPES, TRANSLATE_PROVIDER_TYPES } from '@/types/config/provider'
 import { omit, pick } from '@/types/utils'
 import { getLobeIconsCDNUrlFn } from '../logo'
+import { WEBSITE_URL } from './url'
 
 export const DEFAULT_READ_MODELS: ReadModels = {
   siliconflow: {
@@ -269,7 +270,7 @@ export const PROVIDER_ITEMS: Record<AllProviderTypes, { logo: (isDark: boolean) 
     openaiCompatible: {
       logo: () => customProviderLogo,
       name: 'Custom Provider',
-      website: 'http://www.readfrog.app/tutorial/providers/openai-compatible',
+      website: `${WEBSITE_URL}/tutorial/providers/openai-compatible`,
     },
     openai: {
       logo: getLobeIconsCDNUrlFn('openai'),

--- a/apps/extension/src/utils/constants/translate.ts
+++ b/apps/extension/src/utils/constants/translate.ts
@@ -4,7 +4,7 @@ export const MIN_TRANSLATE_CAPACITY = 1
 export const DEFAULT_REQUEST_RATE = 8
 export const DEFAULT_REQUEST_CAPACITY = 60
 
-export const DEFAULT_AUTO_TRANSLATE_SHORTCUT_KEY = ['alt', 'q']
+export const DEFAULT_AUTO_TRANSLATE_SHORTCUT_KEY = ['alt', 't']
 
 export const CUSTOM_DONT_WALK_INTO_ELEMENT_SELECTOR_MAP: Record<string, string[]> = {
   'chatgpt.com': [


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated default translation shortcuts to reduce conflicts and improve usability. Also localized the “How to configure?” text and fixed the custom provider tutorial link.

- **Bug Fixes**
  - Changed node translation hotkey default from Control to Shift.
  - Changed auto-translate shortcut from Alt+Q to Alt+T.
  - Localized “How to configure?” in the provider config header.
  - Used WEBSITE_URL for the custom provider tutorial link to avoid hard-coded URLs.

<!-- End of auto-generated description by cubic. -->

