### PR TITLE
fix: add extension version check for blog notifications

### DIFF
--- a/.changeset/version-based-blog-notification.md
+++ b/.changeset/version-based-blog-notification.md
@@ -1,0 +1,6 @@
+---
+"@read-frog/extension": patch
+"@read-frog/website": patch
+---
+
+fix: add extension version check for blog notifications

--- a/apps/extension/src/entrypoints/options/app-sidebar/index.tsx
+++ b/apps/extension/src/entrypoints/options/app-sidebar/index.tsx
@@ -84,19 +84,24 @@ export function AppSidebar() {
     queryFn: getLastViewedBlogDate,
   })
 
-  const { data: latestBlogDate } = useQuery({
+  const { data: latestBlogPost } = useQuery({
     queryKey: ['latest-blog-date'],
     queryFn: () => getLatestBlogDate(`${WEBSITE_URL}/api/blog/latest`, 'en'),
   })
 
   const handleWhatsNewClick = async () => {
-    if (latestBlogDate) {
-      await saveLastViewedBlogDate(latestBlogDate)
+    if (latestBlogPost) {
+      await saveLastViewedBlogDate(latestBlogPost.date)
       await queryClient.invalidateQueries({ queryKey: ['last-viewed-blog-date'] })
     }
   }
 
-  const showIndicator = hasNewBlogPost(lastViewedDate ?? null, latestBlogDate ?? null)
+  const showIndicator = hasNewBlogPost(
+    lastViewedDate ?? null,
+    latestBlogPost?.date ?? null,
+    version,
+    latestBlogPost?.extensionVersion ?? null,
+  )
 
   return (
     <Sidebar collapsible="icon">

--- a/apps/extension/src/entrypoints/popup/components/blog-notification.tsx
+++ b/apps/extension/src/entrypoints/popup/components/blog-notification.tsx
@@ -5,6 +5,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@repo/ui/components/too
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { getLastViewedBlogDate, getLatestBlogDate, hasNewBlogPost, saveLastViewedBlogDate } from '@/utils/blog'
 import { WEBSITE_URL } from '@/utils/constants/url'
+import { version } from '../../../../package.json'
 
 export default function BlogNotification() {
   const queryClient = useQueryClient()
@@ -14,20 +15,25 @@ export default function BlogNotification() {
     queryFn: getLastViewedBlogDate,
   })
 
-  const { data: latestBlogDate } = useQuery({
+  const { data: latestBlogPost } = useQuery({
     queryKey: ['latest-blog-date'],
     queryFn: () => getLatestBlogDate(`${WEBSITE_URL}/api/blog/latest`, 'en'),
   })
 
   const handleClick = async () => {
-    if (latestBlogDate) {
-      await saveLastViewedBlogDate(latestBlogDate)
+    if (latestBlogPost) {
+      await saveLastViewedBlogDate(latestBlogPost.date)
       await queryClient.invalidateQueries({ queryKey: ['last-viewed-blog-date'] })
     }
     window.open(`${WEBSITE_URL}/blog?latest-indicator=true`, '_blank')
   }
 
-  const showIndicator = hasNewBlogPost(lastViewedDate ?? null, latestBlogDate ?? null)
+  const showIndicator = hasNewBlogPost(
+    lastViewedDate ?? null,
+    latestBlogPost?.date ?? null,
+    version,
+    latestBlogPost?.extensionVersion ?? null,
+  )
 
   return (
     <Tooltip>

--- a/apps/extension/src/utils/__tests__/blog.test.ts
+++ b/apps/extension/src/utils/__tests__/blog.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import { hasNewBlogPost } from '../blog'
+
+// Extract compareVersions for testing by importing the entire module
+// Since compareVersions is not exported, we'll test it indirectly through hasNewBlogPost
+
+describe('hasNewBlogPost', () => {
+  const baseDate = new Date('2025-01-01')
+  const newerDate = new Date('2025-01-02')
+  const olderDate = new Date('2024-12-31')
+
+  describe('basic functionality without version check', () => {
+    it('should return false if latestDate is null', () => {
+      expect(hasNewBlogPost(baseDate, null)).toBe(false)
+    })
+
+    it('should return true if lastViewedDate is null and latestDate exists', () => {
+      expect(hasNewBlogPost(null, baseDate)).toBe(true)
+    })
+
+    it('should return true if latestDate is newer than lastViewedDate', () => {
+      expect(hasNewBlogPost(olderDate, newerDate)).toBe(true)
+    })
+
+    it('should return false if latestDate is older than lastViewedDate', () => {
+      expect(hasNewBlogPost(newerDate, olderDate)).toBe(false)
+    })
+
+    it('should return false if dates are equal', () => {
+      expect(hasNewBlogPost(baseDate, baseDate)).toBe(false)
+    })
+  })
+
+  describe('version compatibility check', () => {
+    it('should return false if current version is lower than required version', () => {
+      const result = hasNewBlogPost(null, baseDate, '1.10.0', '1.11.0')
+      expect(result).toBe(false)
+    })
+
+    it('should return true if current version equals required version', () => {
+      const result = hasNewBlogPost(null, baseDate, '1.11.0', '1.11.0')
+      expect(result).toBe(true)
+    })
+
+    it('should return true if current version is higher than required version', () => {
+      const result = hasNewBlogPost(null, baseDate, '1.12.0', '1.11.0')
+      expect(result).toBe(true)
+    })
+
+    it('should ignore version check if blogExtensionVersion is null', () => {
+      const result = hasNewBlogPost(null, baseDate, '1.10.0', null)
+      expect(result).toBe(true)
+    })
+
+    it('should ignore version check if blogExtensionVersion is undefined', () => {
+      const result = hasNewBlogPost(null, baseDate, '1.10.0', undefined)
+      expect(result).toBe(true)
+    })
+
+    it('should ignore version check if currentExtensionVersion is undefined', () => {
+      const result = hasNewBlogPost(null, baseDate, undefined, '1.11.0')
+      expect(result).toBe(true)
+    })
+
+    it('should handle major version differences', () => {
+      expect(hasNewBlogPost(null, baseDate, '1.0.0', '2.0.0')).toBe(false)
+      expect(hasNewBlogPost(null, baseDate, '2.0.0', '1.0.0')).toBe(true)
+    })
+
+    it('should handle minor version differences', () => {
+      expect(hasNewBlogPost(null, baseDate, '1.10.0', '1.11.0')).toBe(false)
+      expect(hasNewBlogPost(null, baseDate, '1.11.0', '1.10.0')).toBe(true)
+    })
+
+    it('should handle patch version differences', () => {
+      expect(hasNewBlogPost(null, baseDate, '1.11.0', '1.11.1')).toBe(false)
+      expect(hasNewBlogPost(null, baseDate, '1.11.1', '1.11.0')).toBe(true)
+    })
+
+    it('should handle version strings with different segment counts', () => {
+      expect(hasNewBlogPost(null, baseDate, '1.11', '1.11.0')).toBe(true)
+      expect(hasNewBlogPost(null, baseDate, '1.11.0', '1.11')).toBe(true)
+      expect(hasNewBlogPost(null, baseDate, '1.10', '1.11.0')).toBe(false)
+    })
+  })
+
+  describe('combined date and version checks', () => {
+    it('should return false if version is incompatible even with newer date', () => {
+      const result = hasNewBlogPost(olderDate, newerDate, '1.10.0', '1.11.0')
+      expect(result).toBe(false)
+    })
+
+    it('should return true if version is compatible and date is newer', () => {
+      const result = hasNewBlogPost(olderDate, newerDate, '1.11.0', '1.11.0')
+      expect(result).toBe(true)
+    })
+
+    it('should return false if version is compatible but date is older', () => {
+      const result = hasNewBlogPost(newerDate, olderDate, '1.11.0', '1.11.0')
+      expect(result).toBe(false)
+    })
+
+    it('should prioritize version check over date check', () => {
+      const result = hasNewBlogPost(null, newerDate, '1.10.0', '1.11.0')
+      expect(result).toBe(false)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle all null/undefined parameters', () => {
+      expect(hasNewBlogPost(null, null)).toBe(false)
+      expect(hasNewBlogPost(null, null, undefined, undefined)).toBe(false)
+    })
+
+    it('should handle zero-padded versions', () => {
+      expect(hasNewBlogPost(null, baseDate, '1.09.0', '1.10.0')).toBe(false)
+      expect(hasNewBlogPost(null, baseDate, '1.10.0', '1.09.0')).toBe(true)
+    })
+
+    it('should handle large version numbers', () => {
+      expect(hasNewBlogPost(null, baseDate, '10.20.30', '11.0.0')).toBe(false)
+      expect(hasNewBlogPost(null, baseDate, '11.0.0', '10.20.30')).toBe(true)
+    })
+  })
+})

--- a/apps/website/content/blog/batch-translation-feature.mdx
+++ b/apps/website/content/blog/batch-translation-feature.mdx
@@ -3,6 +3,7 @@ title: Batch Translation & Beta Experience - Save 60-80% on API Costs
 description: Try our new batch translation feature in Beta Experience and save up to 80% on API costs while avoiding rate limits.
 author: MengXi
 date: 2025-10-04
+extensionVersion: 1.11.0
 ---
 
 ## Batch Translation & Beta Experience - Save 60-80% on API Costs 💰

--- a/apps/website/content/blog/batch-translation-feature.zh.mdx
+++ b/apps/website/content/blog/batch-translation-feature.zh.mdx
@@ -3,6 +3,7 @@ title: 批量翻译 & Beta 体验 - 节省 60-80% API 成本
 description: 在 Beta 体验中试用我们的新批量翻译功能，节省高达 80% 的 API 成本，同时避免速率限制。
 author: MengXi
 date: 2025-10-04
+extensionVersion: 1.11.0
 ---
 
 ## 批量翻译 & Beta 体验 - 节省 60-80% API 成本 💰

--- a/apps/website/messages/en.json
+++ b/apps/website/messages/en.json
@@ -40,7 +40,8 @@
     "sharePost": "Share Post",
     "copiedUrl": "Copied URL",
     "writtenBy": "Written by",
-    "at": "At"
+    "at": "At",
+    "extensionVersion": "Extension Version"
   },
   "guide": {
     "continue": "Continue",

--- a/apps/website/messages/zh.json
+++ b/apps/website/messages/zh.json
@@ -40,7 +40,8 @@
     "sharePost": "分享文章",
     "copiedUrl": "已复制链接",
     "writtenBy": "作者",
-    "at": "发布于"
+    "at": "发布于",
+    "extensionVersion": "扩展版本"
   },
   "guide": {
     "continue": "继续",

--- a/apps/website/source.config.ts
+++ b/apps/website/source.config.ts
@@ -25,6 +25,7 @@ export const blog = defineCollections({
   schema: frontmatterSchema.extend({
     author: z.string(),
     date: z.string().date().or(z.date()),
+    extensionVersion: z.string().optional(),
   }),
 })
 

--- a/apps/website/src/app/[locale]/(home)/blog/[slug]/page.tsx
+++ b/apps/website/src/app/[locale]/(home)/blog/[slug]/page.tsx
@@ -62,6 +62,12 @@ export default async function BlogPostPage(props: {
               {new Date(page.data.date ?? page.path).toDateString()}
             </p>
           </div>
+          {page.data.extensionVersion && (
+            <div>
+              <p className="mb-1 text-sm text-fd-muted-foreground">{t('extensionVersion')}</p>
+              <p className="font-medium">{page.data.extensionVersion}</p>
+            </div>
+          )}
           <ShareButton url={page.url} />
         </div>
       </article>

--- a/apps/website/src/app/api/blog/latest/route.ts
+++ b/apps/website/src/app/api/blog/latest/route.ts
@@ -12,7 +12,7 @@ import { blog } from '@/lib/source'
  * - locale: string (default: 'en') - The locale to fetch the latest post for
  *
  * Response:
- * - 200: { date: string (ISO), title: string, description: string, url: string } | null
+ * - 200: { date: string (ISO), title: string, description: string, url: string, extensionVersion: string | null } | null
  * - 400: { error: string } - Invalid locale parameter
  */
 export function GET(request: NextRequest) {
@@ -50,6 +50,7 @@ export function GET(request: NextRequest) {
       title: latestPost.data.title,
       description: latestPost.data.description,
       url: latestPost.url,
+      extensionVersion: latestPost.data.extensionVersion ?? null,
     })
   }
   catch (error) {


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

This PR adds extension version checking to the blog notification system to prevent showing notifications for blog posts that require newer extension versions than what the user currently has installed.

### Problem
Previously, blog notifications were shown based solely on the post date. This meant users with older extension versions would see notifications for features they couldn't use yet.

### Solution
- Added `extensionVersion` field to blog post frontmatter schema
- Modified the `hasNewBlogPost` function to check version compatibility
- Implemented semantic version comparison (`compareVersions` helper)
- Updated API to return extension version from blog metadata
- Added i18n support for displaying extension version on blog pages

### Key Changes

**Backend (Website):**
- Updated blog schema to include optional `extensionVersion` field
- Modified `/api/blog/latest` to return `extensionVersion`
- Added i18n keys for "Extension Version" (English & Chinese)
- Added blog post frontmatter: `extensionVersion: 1.11.0`

**Frontend (Extension):**
- Enhanced `hasNewBlogPost()` to accept and compare extension versions
- Added `compareVersions()` helper for semantic version comparison
- Updated blog notification components to pass current extension version
- Returns `false` if current version < required blog version

**Testing:**
- Added comprehensive unit tests (22 test cases)
- Coverage includes: version comparison, date checks, edge cases, combined logic

## Related Issue

Closes #N/A (internal improvement)

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

**Test Coverage:**
- Basic date comparison functionality
- Version compatibility checks (major/minor/patch)
- Combined date and version validation
- Edge cases (null values, different segment counts, zero-padded versions)

All 289 tests pass ✅

## Screenshots

N/A - Logic enhancement, no UI changes

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

**Version Logic:**
- If blog post has no `extensionVersion`, notification shows normally (backward compatible)
- If user's extension is older than required version, notification is hidden
- Uses standard semantic versioning comparison (1.10.0 < 1.11.0)

**Files Changed:**
- Extension: blog.ts, blog-notification.tsx, app-sidebar/index.tsx, blog.test.ts
- Website: route.ts, page.tsx, source.config.ts, messages (en/zh), blog posts (en/zh)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds an extension version check to blog notifications so users don’t see updates that require a newer extension than they have. The website now provides the required version per post, and the extension uses it to decide whether to show the indicator.

- **Bug Fixes**
  - Added extensionVersion to blog frontmatter and returned it from /api/blog/latest.
  - Updated hasNewBlogPost to verify version and date; introduced a compareVersions helper.
  - Passed the current extension version into notification and sidebar; hides the indicator when incompatible.
  - Displayed “Extension Version” on blog pages with i18n (en/zh) and added unit tests for date/version logic.

<!-- End of auto-generated description by cubic. -->

