### PR TITLE
fix: remove image type

### DIFF
--- a/apps/website/src/app/[locale]/(home)/blog/[slug]/opengraph-image.tsx
+++ b/apps/website/src/app/[locale]/(home)/blog/[slug]/opengraph-image.tsx
@@ -11,8 +11,6 @@ export const size = {
   height: 630,
 }
 
-export const contentType = 'image/png'
-
 export default async function Image(props: {
   params: Promise<{ slug: string, locale: string }>
 }) {

--- a/apps/website/src/app/[locale]/(home)/blog/[slug]/twitter-image.tsx
+++ b/apps/website/src/app/[locale]/(home)/blog/[slug]/twitter-image.tsx
@@ -1,6 +1,5 @@
-import Image, { alt as ogAlt, contentType as ogContentType, size as ogSize } from './opengraph-image'
+import Image, { alt as ogAlt, size as ogSize } from './opengraph-image'
 
 export const alt = ogAlt
 export const size = ogSize
-export const contentType = ogContentType
 export default Image


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the contentType export from the blog Open Graph and Twitter image routes to rely on Next.js defaults. This simplifies the handlers and avoids potential header mismatches.

<!-- End of auto-generated description by cubic. -->

