### PR TITLE
refactor(extension): use React Activity API for model selector state preservation

### DIFF
--- a/.changeset/refactor-activity-api-model-selectors.md
+++ b/.changeset/refactor-activity-api-model-selectors.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+refactor(extension): use React Activity API for model selector state preservation

--- a/apps/extension/src/entrypoints/options/pages/api-providers/provider-config-form/read-model-selector.tsx
+++ b/apps/extension/src/entrypoints/options/pages/api-providers/provider-config-form/read-model-selector.tsx
@@ -5,6 +5,7 @@ import { SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } fr
 import { cn } from '@repo/ui/lib/utils'
 import { useStore } from '@tanstack/react-form'
 import { useSetAtom } from 'jotai'
+import { Activity } from 'react'
 import { toast } from 'sonner'
 import { isReadProviderConfig, READ_PROVIDER_MODELS } from '@/types/config/provider'
 import { providerConfigAtom, updateLLMProviderConfig } from '@/utils/atoms/provider'
@@ -17,45 +18,43 @@ export const ReadModelSelector = withForm({
     const setProviderConfig = useSetAtom(providerConfigAtom(providerConfig.id))
     if (!isReadProviderConfig(providerConfig))
       return <></>
-    const { isCustomModel, customModel } = providerConfig.models.read
+    const { isCustomModel, customModel, model } = providerConfig.models.read
 
     return (
       <div>
-        {
-          isCustomModel
-            ? (
-                <form.AppField name="models.read.customModel">
-                  {field => <field.InputField formForSubmit={form} label={i18n.t('options.apiProviders.form.models.read.customTitle')} value={customModel ?? ''} />}
-                </form.AppField>
-              )
-            : (
-                <form.AppField name="models.read.model">
-                  {field => (
-                    <field.SelectField formForSubmit={form} label={i18n.t('options.apiProviders.form.models.read.title')}>
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder={i18n.t('options.apiProviders.form.models.read.placeholder')} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          {READ_PROVIDER_MODELS[providerConfig.provider].map(model => (
-                            <SelectItem key={model} value={model}>
-                              {model}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      </SelectContent>
-                    </field.SelectField>
-                  )}
-                </form.AppField>
-              )
-        }
+        <Activity mode={isCustomModel ? 'visible' : 'hidden'}>
+          <form.AppField name="models.read.customModel">
+            {field => <field.InputField formForSubmit={form} label={i18n.t('options.apiProviders.form.models.read.customTitle')} value={customModel ?? ''} />}
+          </form.AppField>
+        </Activity>
+
+        <Activity mode={isCustomModel ? 'hidden' : 'visible'}>
+          <form.AppField name="models.read.model">
+            {field => (
+              <field.SelectField formForSubmit={form} label={i18n.t('options.apiProviders.form.models.read.title')}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder={i18n.t('options.apiProviders.form.models.read.placeholder')} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {READ_PROVIDER_MODELS[providerConfig.provider].map(model => (
+                      <SelectItem key={model} value={model}>
+                        {model}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </field.SelectField>
+            )}
+          </form.AppField>
+        </Activity>
         <div className="mt-2.5 flex items-center space-x-2">
-          <form.Field name="models.read">
+          <form.Field name="models.read.isCustomModel">
             { field => (
               <div className={cn('flex items-center space-x-2', providerConfig.provider === 'openaiCompatible' && 'hidden')}>
                 <Checkbox
                   id="isCustomModel-read"
-                  checked={field.state.value.isCustomModel}
+                  checked={field.state.value}
                   onCheckedChange={(checked) => {
                     try {
                       if (checked === false) {
@@ -75,7 +74,7 @@ export const ReadModelSelector = withForm({
                           updateLLMProviderConfig(providerConfig, {
                             models: {
                               read: {
-                                customModel: field.state.value.model,
+                                customModel: model,
                                 isCustomModel: true,
                               },
                             },

--- a/apps/extension/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
+++ b/apps/extension/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
@@ -5,6 +5,7 @@ import { SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } fr
 import { cn } from '@repo/ui/lib/utils'
 import { useStore } from '@tanstack/react-form'
 import { useSetAtom } from 'jotai'
+import { Activity } from 'react'
 import { toast } from 'sonner'
 import { isLLMTranslateProviderConfig, TRANSLATE_PROVIDER_MODELS } from '@/types/config/provider'
 import { providerConfigAtom, updateLLMProviderConfig } from '@/utils/atoms/provider'
@@ -18,45 +19,43 @@ export const TranslateModelSelector = withForm({
     if (!isLLMTranslateProviderConfig(providerConfig))
       return <></>
 
-    const { isCustomModel, customModel } = providerConfig.models.translate
+    const { isCustomModel, customModel, model } = providerConfig.models.translate
 
     return (
       <div>
-        {
-          isCustomModel
-            ? (
-                <form.AppField name="models.translate.customModel">
-                  {field => <field.InputField formForSubmit={form} label={i18n.t('options.apiProviders.form.models.translate.customTitle')} value={customModel ?? ''} />}
-                </form.AppField>
-              )
-            : (
-                <form.AppField name="models.translate.model">
-                  {field => (
-                    <field.SelectField formForSubmit={form} label={i18n.t('options.apiProviders.form.models.translate.title')}>
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder={i18n.t('options.apiProviders.form.models.translate.placeholder')} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          {TRANSLATE_PROVIDER_MODELS[providerConfig.provider].map(model => (
-                            <SelectItem key={model} value={model}>
-                              {model}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      </SelectContent>
-                    </field.SelectField>
-                  )}
-                </form.AppField>
-              )
-        }
+        <Activity mode={isCustomModel ? 'visible' : 'hidden'}>
+          <form.AppField name="models.translate.customModel">
+            {field => <field.InputField formForSubmit={form} label={i18n.t('options.apiProviders.form.models.translate.customTitle')} value={customModel ?? ''} />}
+          </form.AppField>
+        </Activity>
+
+        <Activity mode={isCustomModel ? 'hidden' : 'visible'}>
+          <form.AppField name="models.translate.model">
+            {field => (
+              <field.SelectField formForSubmit={form} label={i18n.t('options.apiProviders.form.models.translate.title')}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder={i18n.t('options.apiProviders.form.models.translate.placeholder')} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {TRANSLATE_PROVIDER_MODELS[providerConfig.provider].map(model => (
+                      <SelectItem key={model} value={model}>
+                        {model}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </field.SelectField>
+            )}
+          </form.AppField>
+        </Activity>
         <div className="mt-2.5 flex items-center space-x-2">
-          <form.Field name="models.translate">
+          <form.Field name="models.translate.isCustomModel">
             { field => (
               <div className={cn('flex items-center space-x-2', providerConfig.provider === 'openaiCompatible' && 'hidden')}>
                 <Checkbox
                   id="isCustomModel-translate"
-                  checked={field.state.value.isCustomModel}
+                  checked={field.state.value}
                   onCheckedChange={(checked) => {
                     try {
                       if (checked === false) {
@@ -76,7 +75,7 @@ export const TranslateModelSelector = withForm({
                           updateLLMProviderConfig(providerConfig, {
                             models: {
                               translate: {
-                                customModel: field.state.value.model,
+                                customModel: model,
                                 isCustomModel: true,
                               },
                             },


### PR DESCRIPTION
## Type of Changes

- [x] ♻️ Code refactoring (refactor)

## Description

This PR refactors the model selector components to use React's `<Activity>` API instead of conditional mounting. This addresses a bug where the SelectTrigger value would not display properly after toggling the custom model checkbox.

### Changes Made

1. **Replaced conditional mounting with Activity boundaries**
   - Both custom model input and standard model selector now stay mounted
   - Use `<Activity mode="visible|hidden">` to show/hide components instead of ternary operators

2. **Fixed form state preservation**
   - Form state is now preserved when toggling between custom and standard model modes
   - Prevents loss of selected model value when switching modes

3. **Improved form field specificity**
   - Changed `form.Field name="models.translate"` to `form.Field name="models.translate.isCustomModel"`
   - Changed `form.Field name="models.read"` to `form.Field name="models.read.isCustomModel"`
   - Fixed checkbox state binding to use `field.state.value` directly instead of `field.state.value.isCustomModel`

4. **Fixed onCheckedChange handler**
   - Use destructured `model` variable instead of `field.state.value.model`
   - More consistent with the component's data flow

### Benefits

- **Better UX**: Selected model values persist when toggling custom mode on/off
- **Better Performance**: No mounting/unmounting overhead when toggling
- **Modern React**: Leverages React 19's Activity API for cleaner state management
- **Cleaner Code**: More declarative approach to showing/hiding components

## Related Issue

Fixes the issue where SelectTrigger wouldn't display the model value after toggling custom model checkbox.

## How Has This Been Tested?

- [x] Verified through manual testing
- [x] All existing unit tests pass (348 tests)
- [x] Lint and type-check pass
- [x] Build succeeds

### Manual Testing Steps

1. Open extension options page
2. Navigate to API providers settings
3. Select a standard model from the dropdown
4. Toggle "Custom Model" checkbox on
5. Toggle "Custom Model" checkbox off
6. Verify the previously selected model is still displayed in the dropdown

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This refactoring applies to both:
- `translate-model-selector.tsx` (Translation model configuration)
- `read-model-selector.tsx` (Reading model configuration)

The implementation follows React's Activity API best practices as demonstrated in other parts of the codebase.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch model selectors to the React Activity API to keep fields mounted and preserve state when toggling between standard and custom models. Fixes the dropdown value not showing after toggling the Custom Model checkbox.

- **Refactors**
  - Replace conditional mounting with Activity boundaries in read/translate selectors.
  - Keep both fields mounted; toggle visibility via Activity mode.
  - Move checkbox field to models.*.isCustomModel and bind it to a boolean.
  - Use the local model variable in onCheckedChange for consistency.

- **Bug Fixes**
  - Selected model now persists and displays correctly after toggling Custom Model.

<!-- End of auto-generated description by cubic. -->

