### PR TITLE
fix(extension): prevent node translation trigger with key combinations

### DIFF
--- a/.changeset/fix-node-translation-key-combination.md
+++ b/.changeset/fix-node-translation-key-combination.md
@@ -1,0 +1,5 @@
+---
+'@read-frog/extension': patch
+---
+
+fix: prevent node translation trigger with key combinations


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

This PR fixes an issue where node translation would incorrectly trigger when users pressed key combinations. Previously, if a user held down another key (e.g., Shift) and then quickly pressed the hotkey, the translation would still be triggered, which was not the intended behavior.

### Changes Made

1. **Introduced `isHotkeySessionPure` flag**: Tracks whether any other key was pressed during the current hotkey session
2. **Simplified state management**: Removed the redundant `isOtherKeyPressed` flag and the `keyState` object
3. **Improved key detection logic**: Now properly detects if other keys were pressed before or during the hotkey press

### How It Works

- When any non-hotkey key is pressed, the session is marked as "impure"
- When the hotkey is pressed, translation only triggers if the session is pure
- The session purity flag is reset when the hotkey is released
- This ensures that pressing other keys before, during, or after the hotkey press will prevent translation

## Related Issue

Closes #637

## How Has This Been Tested?

- [x] Verified through manual testing
- [x] All existing unit tests pass (352 tests)

### Test Scenarios Covered

1. ✅ Press other key → press hotkey → translation does NOT trigger
2. ✅ Press hotkey → press other key → translation does NOT trigger
3. ✅ Press hotkey → hold → release → translation triggers (if no other key pressed)
4. ✅ Press hotkey alone → translation triggers correctly

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This fix improves the user experience by preventing accidental translations when users are typing or using keyboard shortcuts that involve the same key as the translation hotkey.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents node translation from triggering when users press key combinations. Translation now fires only on a clean hotkey press, reducing accidental actions.

- **Bug Fixes**
  - Add hotkey session purity (isHotkeySessionPure) to block translation if any other key is pressed before/during the hotkey.
  - Simplify state by removing isOtherKeyPressed and the keyState object.
  - Cancel the trigger timer when the session becomes impure; only trigger on hotkey release if the session stayed pure.

<!-- End of auto-generated description by cubic. -->

