### PR TITLE
feat(extension): add node translation shortcut setting on option page

### DIFF
--- a/.changeset/feat-node-translation-shortcut-option-page.md
+++ b/.changeset/feat-node-translation-shortcut-option-page.md
@@ -1,0 +1,5 @@
+---
+'@read-frog/extension': patch
+---
+
+feat: add node translation shortcut setting on option page

--- a/apps/extension/src/entrypoints/options/pages/translation/index.tsx
+++ b/apps/extension/src/entrypoints/options/pages/translation/index.tsx
@@ -3,8 +3,9 @@ import { PageLayout } from '../../components/page-layout'
 import { AutoTranslateLanguages } from './auto-translate-languages'
 import { AutoTranslateWebsitePatterns } from './auto-translate-website-patterns'
 import { ClearCacheConfig } from './clear-cache-config'
-import { CustomAutoTranslateShortcutKey } from './custom-auto-translate-shortcut-key'
 import { CustomTranslationStyle } from './custom-translation-style'
+import { NodeTranslationHotkey } from './node-translation-hotkey'
+import { PageTranslationShortcut } from './page-translation-shortcut'
 import { PersonalizedPrompts } from './personalized-prompt'
 import { RequestBatch } from './request-batch'
 import { RequestRate } from './request-rate'
@@ -14,7 +15,8 @@ export function TranslationPage() {
   return (
     <PageLayout title={i18n.t('options.translation.title')} innerClassName="[&>*]:border-b [&>*:last-child]:border-b-0">
       <TranslationMode />
-      <CustomAutoTranslateShortcutKey />
+      <PageTranslationShortcut />
+      <NodeTranslationHotkey />
       <RequestRate />
       <RequestBatch />
       <CustomTranslationStyle />

--- a/apps/extension/src/entrypoints/options/pages/translation/node-translation-hotkey.tsx
+++ b/apps/extension/src/entrypoints/options/pages/translation/node-translation-hotkey.tsx
@@ -1,0 +1,56 @@
+import { i18n } from '#imports'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@repo/ui/components/select'
+import { deepmerge } from 'deepmerge-ts'
+import { useAtom } from 'jotai'
+import { configFieldsAtomMap } from '@/utils/atoms/config'
+import { HOTKEY_ITEMS, HOTKEYS } from '@/utils/constants/hotkeys'
+import { ConfigCard } from '../../components/config-card'
+
+export function NodeTranslationHotkey() {
+  const [translateConfig, setTranslateConfig] = useAtom(
+    configFieldsAtomMap.translate,
+  )
+
+  return (
+    <ConfigCard
+      title={i18n.t('options.translation.nodeTranslationHotkey.title')}
+      description={i18n.t('options.translation.nodeTranslationHotkey.description')}
+    >
+      <Select
+        value={translateConfig.node.hotkey}
+        onValueChange={(value: typeof HOTKEYS[number]) =>
+          setTranslateConfig(
+            deepmerge(translateConfig, { node: { hotkey: value } }),
+          )}
+      >
+        <SelectTrigger className="w-full">
+          <SelectValue asChild>
+            <span>
+              {HOTKEY_ITEMS[translateConfig.node.hotkey].icon}
+              {' '}
+              {HOTKEY_ITEMS[translateConfig.node.hotkey].label}
+            </span>
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {HOTKEYS.map(item => (
+              <SelectItem key={item} value={item}>
+                {HOTKEY_ITEMS[item].icon}
+                {' '}
+                {HOTKEY_ITEMS[item].label}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    </ConfigCard>
+  )
+}

--- a/apps/extension/src/entrypoints/options/pages/translation/page-translation-shortcut.tsx
+++ b/apps/extension/src/entrypoints/options/pages/translation/page-translation-shortcut.tsx
@@ -5,7 +5,7 @@ import { configFieldsAtomMap } from '@/utils/atoms/config'
 import { DEFAULT_AUTO_TRANSLATE_SHORTCUT_KEY } from '@/utils/constants/translate'
 import { ConfigCard } from '../../components/config-card'
 
-export function CustomAutoTranslateShortcutKey() {
+export function PageTranslationShortcut() {
   const [translateConfig, setTranslateConfig] = useAtom(configFieldsAtomMap.translate)
   const shortcut = translateConfig.page.shortcut ?? DEFAULT_AUTO_TRANSLATE_SHORTCUT_KEY
 
@@ -20,7 +20,7 @@ export function CustomAutoTranslateShortcutKey() {
   }
 
   return (
-    <ConfigCard title={i18n.t('options.translation.customAutoTranslateShortcutKey.title')} description={i18n.t('options.translation.customAutoTranslateShortcutKey.description')}>
+    <ConfigCard title={i18n.t('options.translation.pageTranslationShortcut.title')} description={i18n.t('options.translation.pageTranslationShortcut.description')}>
       <ShortcutKeyRecorder shortcutKey={shortcut} onChange={updateShortcut} />
     </ConfigCard>
   )

--- a/apps/extension/src/locales/en.yml
+++ b/apps/extension/src/locales/en.yml
@@ -241,9 +241,12 @@ options:
       mode:
         bilingual: Bilingual
         translationOnly: Translation Only
-    customAutoTranslateShortcutKey:
-      title: Customize translation shortcut
-      description: Allows you to customize the full-text translation shortcut
+    pageTranslationShortcut:
+      title: Page translation shortcut
+      description: Customize the shortcut key for translating entire web pages
+    nodeTranslationHotkey:
+      title: Hover translation shortcut
+      description: Customize the modifier key for hovering over text to translate paragraphs
     autoTranslateLanguages:
       title: Auto translate based on language
       description: Automatically translate page content when specific languages are detected

--- a/apps/extension/src/locales/ja.yml
+++ b/apps/extension/src/locales/ja.yml
@@ -239,9 +239,12 @@ options:
       mode:
         bilingual: バイリンガル
         translationOnly: 翻訳のみ
-    customAutoTranslateShortcutKey:
-      title: 翻訳ショートカットキーをカスタマイズ
-      description: ウェブページ翻訳のショートカットキーをカスタマイズできます
+    pageTranslationShortcut:
+      title: ページ翻訳ショートカットキー
+      description: ウェブページ全体を翻訳するショートカットキーをカスタマイズします
+    nodeTranslationHotkey:
+      title: ホバー翻訳ショートカットキー
+      description: テキストにホバーして段落を翻訳する際の修飾キーをカスタマイズします
     autoTranslateLanguages:
       title: 言語に基づく自動翻訳
       description: 特定の言語が検出された場合にページコンテンツを自動翻訳します

--- a/apps/extension/src/locales/ko.yml
+++ b/apps/extension/src/locales/ko.yml
@@ -240,9 +240,12 @@ options:
       mode:
         bilingual: 이중 언어
         translationOnly: 번역만
-    customAutoTranslateShortcutKey:
-      title: 번역 단축키 사용자 지정
-      description: 웹페이지 번역 단축키를 사용자 지정할 수 있습니다
+    pageTranslationShortcut:
+      title: 페이지 번역 단축키
+      description: 전체 웹페이지를 번역하는 단축키를 사용자 지정합니다
+    nodeTranslationHotkey:
+      title: 호버 번역 단축키
+      description: 텍스트 위에 호버하여 단락을 번역할 때 사용할 수정 키를 사용자 지정합니다
     autoTranslateLanguages:
       title: 언어에 기반한 자동 번역
       description: 특정 언어가 감지되면 페이지 콘텐츠를 자동으로 번역합니다

--- a/apps/extension/src/locales/zh-CN.yml
+++ b/apps/extension/src/locales/zh-CN.yml
@@ -241,9 +241,12 @@ options:
       mode:
         bilingual: 双语对照
         translationOnly: 仅显示翻译
-    customAutoTranslateShortcutKey:
-      title: 自定义翻译快捷键
-      description: 允许您自定义网页翻译快捷键
+    pageTranslationShortcut:
+      title: 网页翻译快捷键
+      description: 自定义翻译整个网页的快捷键
+    nodeTranslationHotkey:
+      title: 悬停翻译快捷键
+      description: 自定义悬停在文本上翻译段落的修饰键
     autoTranslateLanguages:
       title: 基于语言的自动翻译
       description: 当检测到指定语言时自动翻译页面内容

--- a/apps/extension/src/locales/zh-TW.yml
+++ b/apps/extension/src/locales/zh-TW.yml
@@ -241,9 +241,12 @@ options:
       mode:
         bilingual: 雙語對照
         translationOnly: 僅顯示翻譯
-    customAutoTranslateShortcutKey:
-      title: 自訂翻譯快捷鍵
-      description: 允許您自訂全文翻譯快捷鍵
+    pageTranslationShortcut:
+      title: 網頁翻譯快捷鍵
+      description: 自訂翻譯整個網頁的快捷鍵
+    nodeTranslationHotkey:
+      title: 懸停翻譯快捷鍵
+      description: 自訂懸停在文字上翻譯段落的修飾鍵
     autoTranslateLanguages:
       title: 基於語言的自動翻譯
       description: 當檢測到特定語言時自動翻譯頁面內容


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

This PR adds the node translation (hover translation) shortcut setting to the options page, making it accessible alongside other translation settings. Previously, this setting was only available in the popup.

### Changes Made

1. **New Component**: Created `NodeTranslationHotkey` component that provides a clean selector for choosing the modifier key (Control, Alt, Shift, or Backtick) used for hover translation
2. **Component Rename**: Renamed `CustomAutoTranslateShortcutKey` to `PageTranslationShortcut` to better distinguish between page translation and node translation settings
3. **Updated i18n**: Updated all locale files to reflect the new naming convention and added translations for the hover translation shortcut
4. **UI Layout**: Positioned the node translation setting directly below the page translation shortcut in the options page for better organization

### Key Improvements

- Better discoverability: Users can now configure node translation shortcut from the options page
- Clearer naming: "Page translation shortcut" vs "Hover translation shortcut" makes the distinction obvious
- Consistent UX: Both shortcut settings use similar patterns (ConfigCard with appropriate selectors)
- Full i18n support: All 5 languages supported (en, zh-CN, zh-TW, ja, ko)

## Related Issue

Closes #370

## How Has This Been Tested?

- [x] Added unit tests (existing tests cover the functionality)
- [x] Verified through manual testing
- [x] All existing tests pass
- [x] Build succeeds without errors
- [x] Lint and type-check pass

## Screenshots

N/A - This is a settings UI enhancement. The new setting appears in the Translation section of the options page, below the page translation shortcut.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The implementation follows the existing patterns in the options page:
- Uses `ConfigCard` for consistent styling
- Uses `Select` component with `SelectTrigger` and `SelectValue` for the dropdown
- Reuses the `HOTKEYS` and `HOTKEY_ITEMS` constants from the popup implementation
- Maintains the same state management approach using Jotai atoms

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hover (node) translation shortcut setting to the Options page, placed under the page translation shortcut. Renames the page shortcut component and updates i18n for clearer labels.

- **New Features**
  - New NodeTranslationHotkey with a dropdown to choose the modifier key (Ctrl, Alt, Shift, `).
  - Renamed CustomAutoTranslateShortcutKey to PageTranslationShortcut and grouped both settings together.
  - Updated all locales with distinct labels for page vs hover shortcuts; reused existing ConfigCard and HOTKEY constants.

<!-- End of auto-generated description by cubic. -->

