### PR TITLE
fix(extension): prevent translation of MathML elements

### DIFF
--- a/.changeset/fix-mathml-translation.md
+++ b/.changeset/fix-mathml-translation.md
@@ -1,0 +1,5 @@
+---
+'@read-frog/extension': patch
+---
+
+fix(extension): prevent translation of MathML elements and improve academic content handling

--- a/apps/extension/src/utils/constants/config.ts
+++ b/apps/extension/src/utils/constants/config.ts
@@ -32,7 +32,7 @@ export const DEFAULT_CONFIG: Config = {
       hotkey: 'Control',
     },
     page: {
-      range: 'all',
+      range: 'main',
       autoTranslatePatterns: ['news.ycombinator.com'],
       autoTranslateLanguages: [],
       shortcut: DEFAULT_AUTO_TRANSLATE_SHORTCUT_KEY,

--- a/apps/extension/src/utils/constants/dom-rules.ts
+++ b/apps/extension/src/utils/constants/dom-rules.ts
@@ -26,6 +26,41 @@ export const FORCE_BLOCK_TAGS = new Set([
   'NAV',
 ])
 
+export const MATH_TAGS = new Set([
+  'math',
+  'maction',
+  'annotation',
+  'annotation-xml',
+  'menclose',
+  'merror',
+  'mfenced',
+  'mfrac',
+  'mi',
+  'mmultiscripts',
+  'mn',
+  'mo',
+  'mover',
+  'mpadded',
+  'mphantom',
+  'mprescripts',
+  'mroot',
+  'mrow',
+  'ms',
+  'mspace',
+  'msqrt',
+  'mstyle',
+  'msub',
+  'msubsup',
+  'msup',
+  'mtable',
+  'mtd',
+  'mtext',
+  'mtr',
+  'munder',
+  'munderover',
+  'semantics',
+])
+
 // Don't walk into these tags
 export const DONT_WALK_AND_TRANSLATE_TAGS = new Set([
   'HEAD',
@@ -44,6 +79,7 @@ export const DONT_WALK_AND_TRANSLATE_TAGS = new Set([
   'LINK',
   'PRE',
   'svg',
+  ...MATH_TAGS,
 ])
 
 export const DONT_WALK_BUT_TRANSLATE_TAGS = new Set([
@@ -59,3 +95,12 @@ export const FORCE_INLINE_TRANSLATION_TAGS = new Set([
 ])
 
 export const MAIN_CONTENT_IGNORE_TAGS = new Set(['HEADER', 'FOOTER', 'NAV', 'NOSCRIPT'])
+
+export const CUSTOM_DONT_WALK_INTO_ELEMENT_SELECTOR_MAP: Record<string, string[]> = {
+  'chatgpt.com': [
+    '.ProseMirror',
+  ],
+  'arxiv.org': [
+    '.ltx_listing',
+  ],
+}

--- a/apps/extension/src/utils/constants/translate.ts
+++ b/apps/extension/src/utils/constants/translate.ts
@@ -15,9 +15,3 @@ export const DEFAULT_BATCH_CONFIG = {
 }
 
 export const DEFAULT_AUTO_TRANSLATE_SHORTCUT_KEY = ['alt', 'e']
-
-export const CUSTOM_DONT_WALK_INTO_ELEMENT_SELECTOR_MAP: Record<string, string[]> = {
-  'chatgpt.com': [
-    '.ProseMirror',
-  ],
-}

--- a/apps/extension/src/utils/host/dom/filter.ts
+++ b/apps/extension/src/utils/host/dom/filter.ts
@@ -8,8 +8,7 @@ import {
   INLINE_CONTENT_CLASS,
   NOTRANSLATE_CLASS,
 } from '@/utils/constants/dom-labels'
-import { DONT_WALK_AND_TRANSLATE_TAGS, DONT_WALK_BUT_TRANSLATE_TAGS, FORCE_BLOCK_TAGS, MAIN_CONTENT_IGNORE_TAGS } from '@/utils/constants/dom-tags'
-import { CUSTOM_DONT_WALK_INTO_ELEMENT_SELECTOR_MAP } from '@/utils/constants/translate'
+import { CUSTOM_DONT_WALK_INTO_ELEMENT_SELECTOR_MAP, DONT_WALK_AND_TRANSLATE_TAGS, DONT_WALK_BUT_TRANSLATE_TAGS, FORCE_BLOCK_TAGS, MAIN_CONTENT_IGNORE_TAGS } from '@/utils/constants/dom-rules'
 
 export function isEditable(element: HTMLElement): boolean {
   const tag = element.tagName

--- a/apps/extension/src/utils/host/dom/traversal.ts
+++ b/apps/extension/src/utils/host/dom/traversal.ts
@@ -6,7 +6,7 @@ import {
   PARAGRAPH_ATTRIBUTE,
   WALKED_ATTRIBUTE,
 } from '@/utils/constants/dom-labels'
-import { FORCE_BLOCK_TAGS } from '@/utils/constants/dom-tags'
+import { FORCE_BLOCK_TAGS } from '@/utils/constants/dom-rules'
 import {
   isDontWalkIntoAndDontTranslateAsChildElement,
   isDontWalkIntoButTranslateAsChildElement,

--- a/apps/extension/src/utils/host/translate/node-manipulation.ts
+++ b/apps/extension/src/utils/host/translate/node-manipulation.ts
@@ -21,7 +21,7 @@ import {
   TRANSLATION_MODE_ATTRIBUTE,
   WALKED_ATTRIBUTE,
 } from '../../constants/dom-labels'
-import { FORCE_INLINE_TRANSLATION_TAGS } from '../../constants/dom-tags'
+import { FORCE_INLINE_TRANSLATION_TAGS } from '../../constants/dom-rules'
 import { isBlockTransNode, isHTMLElement, isInlineTransNode, isTextNode, isTranslatedWrapperNode, isTransNode } from '../dom/filter'
 import { deepQueryTopLevelSelector, findNearestAncestorBlockNodeAt, unwrapDeepestOnlyHTMLChild } from '../dom/find'
 import { getOwnerDocument } from '../dom/node'


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [ ] ✨ New feature (feat)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

This PR fixes issue #555 where mathematical formulas in academic papers were being incorrectly translated. The root cause was that MathML elements were not properly excluded from translation.

### Changes Made:

1. **Added complete MathML tag support (32 elements)**:
   - Previously, MathML tags were not defined at all
   - Now includes all MathML Core elements: `math`, `mi`, `mo`, `mn`, `mfrac`, `msub`, `msup`, `mrow`, etc.
   - All tags are in **lowercase** (correct for XML namespaces like MathML/SVG)

2. **Renamed file for better organization**:
   - Renamed `dom-tags.ts` to `dom-rules.ts` to better reflect its purpose
   - Consolidated DOM-related translation rules in one place

3. **Consolidated custom element selectors**:
   - Moved `CUSTOM_DONT_WALK_INTO_ELEMENT_SELECTOR_MAP` from `translate.ts` to `dom-rules.ts`
   - Added arxiv.org code listing exclusion (`.ltx_listing`)

4. **Changed default translation range**:
   - Default range changed from `'all'` to `'main'` content
   - Improves translation quality by focusing on main content

### Technical Details:

**Why lowercase?**
- HTML elements have uppercase `tagName` (e.g., `DIV`, `SPAN`)
- SVG and MathML elements (XML namespaces) have lowercase `tagName` (e.g., `svg`, `math`, `mi`)
- This follows browser DOM specifications

## Related Issue

Closes #555

## How Has This Been Tested?

- [x] Verified through manual testing
- [x] All existing tests pass (352 tests)

Tested on:
- https://www.sciencedirect.com/science/article/pii/S2666165924000188
- https://arxiv.org/html/2412.12154v1

## Screenshots

Before: Math formulas were being translated (causing broken rendering)
After: Math formulas are properly preserved

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This fix ensures that all MathML elements are properly excluded from translation, which is critical for academic and scientific content where mathematical notation must be preserved exactly as written.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents translation of MathML so formulas render correctly, and shifts default translation to main content for better results on academic pages. Also excludes arXiv code listings from traversal.

- **Bug Fixes**
  - Exclude all MathML Core tags from traversal/translation (32 lowercase tags).
  - Add arxiv.org .ltx_listing to “don’t walk” rules.
  - Fixes #555 where formulas were altered.

- **Refactors**
  - Rename dom-tags.ts to dom-rules.ts and centralize DOM rules.
  - Move CUSTOM_DONT_WALK_INTO_ELEMENT_SELECTOR_MAP to dom-rules.ts.
  - Change default page range from all to main.

<!-- End of auto-generated description by cubic. -->

