### PR TITLE
feat: add translation mode selector to popup

### DIFF
--- a/.changeset/two-cloths-raise.md
+++ b/.changeset/two-cloths-raise.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat: add translation mode selector to popup

--- a/apps/extension/src/entrypoints/popup/app.tsx
+++ b/apps/extension/src/entrypoints/popup/app.tsx
@@ -9,16 +9,15 @@ import { version } from '../../../package.json'
 import { initIsIgnoreTabAtom } from './atoms/ignore'
 import { AlwaysTranslate } from './components/always-translate'
 import BlogNotification from './components/blog-notification'
-import FloatingButton from './components/floating-button'
 import LanguageOptionsSelector from './components/language-options-selector'
 import Hotkey from './components/node-translation-hotkey-selector'
 import QuickLinks from './components/quick-links'
 import ReadButton from './components/read-button'
 import ReadProviderField from './components/read-provider-field'
-import SelectionToolbar from './components/text-selection-tooltip'
 import TranslateButton from './components/translate-button'
 import TranslatePromptSelector from './components/translate-prompt-selector'
 import TranslateProviderField from './components/translate-provider-field'
+import TranslationModeSelector from './components/translation-mode-selector'
 
 function App() {
   const initIsIgnoreTab = useSetAtom(initIsIgnoreTabAtom)
@@ -36,6 +35,7 @@ function App() {
         </div>
         <LanguageOptionsSelector />
         {/* <LanguageLevelSelector /> */}
+        <TranslationModeSelector />
         <TranslateProviderField />
         <TranslatePromptSelector />
         <ReadProviderField />
@@ -45,8 +45,8 @@ function App() {
         </div>
         <AlwaysTranslate />
         <Hotkey />
-        <FloatingButton />
-        <SelectionToolbar />
+        {/* <FloatingButton />
+        <SelectionToolbar /> */}
         <QuickLinks />
       </div>
       <div className="flex items-center justify-between bg-neutral-200 px-2 py-1 dark:bg-neutral-800">

--- a/apps/extension/src/entrypoints/popup/components/translation-mode-selector.tsx
+++ b/apps/extension/src/entrypoints/popup/components/translation-mode-selector.tsx
@@ -1,0 +1,96 @@
+import type { TranslationMode as TranslationModeType } from '@/types/config/translate'
+import { i18n } from '#imports'
+import { Icon } from '@iconify/react'
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@repo/ui/components/select'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@repo/ui/components/tooltip'
+import { deepmerge } from 'deepmerge-ts'
+import { useAtom, useAtomValue } from 'jotai'
+import { TRANSLATION_MODES } from '@/types/config/translate'
+import { configFieldsAtomMap } from '@/utils/atoms/config'
+import { filterEnabledProvidersConfig, getLLMTranslateProvidersConfig, getProviderConfigById } from '@/utils/config/helpers'
+
+export default function TranslationModeSelector() {
+  const [translateConfig, setTranslateConfig] = useAtom(configFieldsAtomMap.translate)
+  const providersConfig = useAtomValue(configFieldsAtomMap.providersConfig)
+  const currentMode = translateConfig.mode
+
+  const handleModeChange = (mode: TranslationModeType) => {
+    const currentProvider = getProviderConfigById(providersConfig, translateConfig.providerId)
+
+    if (mode === 'translationOnly' && currentProvider && currentProvider.provider === 'google') {
+      const enabledProviders = filterEnabledProvidersConfig(providersConfig)
+
+      const microsoftProvider = enabledProviders.find(p => p.provider === 'microsoft')
+      if (microsoftProvider) {
+        void setTranslateConfig(
+          deepmerge(translateConfig, {
+            mode,
+            providerId: microsoftProvider.id,
+          }),
+        )
+        return
+      }
+
+      const llmProviders = getLLMTranslateProvidersConfig(enabledProviders)
+      if (llmProviders.length > 0) {
+        void setTranslateConfig(
+          deepmerge(translateConfig, {
+            mode,
+            providerId: llmProviders[0].id,
+          }),
+        )
+        return
+      }
+    }
+
+    void setTranslateConfig(
+      deepmerge(translateConfig, { mode }),
+    )
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="text-[13px] font-medium flex items-center gap-1.5">
+        {i18n.t('options.translation.translationMode.title')}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Icon icon="tabler:help" className="size-3 text-blue-300 dark:text-blue-700/70" />
+          </TooltipTrigger>
+          <TooltipContent className="w-36">
+            <p>
+              {i18n.t('options.translation.translationMode.description')}
+            </p>
+          </TooltipContent>
+        </Tooltip>
+      </span>
+      <Select
+        value={currentMode}
+        onValueChange={handleModeChange}
+      >
+        <SelectTrigger className="!h-7 w-31 pr-1.5 pl-2.5">
+          <SelectValue asChild>
+            <span>
+              {i18n.t(`options.translation.translationMode.mode.${currentMode}`)}
+            </span>
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            {TRANSLATION_MODES.map(mode => (
+              <SelectItem key={mode} value={mode}>
+                {i18n.t(`options.translation.translationMode.mode.${mode}`)}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #662

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a translation mode selector to the popup so users can choose how translations run. Automatically switches to a supported provider when “Translation only” is selected and the current provider doesn’t support it. Closes #662.

- **New Features**
  - Popup selector with localized labels for all modes.
  - Smart fallback: if switching to “translationOnly” on Google, auto-switch to Microsoft (if enabled) or the first enabled LLM provider.

<!-- End of auto-generated description by cubic. -->

