### PR TITLE
fix: skip empty nodes in translation traversal to fix Inoreader style issue

### DIFF
--- a/.changeset/empty-nodes-inoreader-fix.md
+++ b/.changeset/empty-nodes-inoreader-fix.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: skip empty nodes in translation traversal to fix Inoreader style issue

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,5 +45,8 @@
     "scss",
     "pcss",
     "postcss"
-  ]
+  ],
+
+  // Vitest extension configuration
+  "vitest.rootConfig": "./vitest.config.ts"
 }

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "nx": "^22.1.0",
     "postcss": "^8.5.6",
     "postcss-rem-to-responsive-pixel": "^6.0.2",
+    "postcss-value-parser": "^4.2.0",
     "tailwindcss": "^4.1.15",
     "typescript": "^5.9.3",
     "vitest": "^4.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,9 @@ importers:
       postcss-rem-to-responsive-pixel:
         specifier: ^6.0.2
         version: 6.1.0
+      postcss-value-parser:
+        specifier: ^4.2.0
+        version: 4.2.0
       tailwindcss:
         specifier: ^4.1.15
         version: 4.1.17

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -956,6 +956,30 @@ describe('translate', () => {
       })
     })
   })
+  describe('empty nodes in multiple child nodes', () => {
+    it('bilingual mode: should not insert translation wrapper', async () => {
+      // https://github.com/mengxi-ream/read-frog/issues/717
+      render(
+        <div data-testid="test-node">
+          <div><div style={{ display: 'inline' }}>{MOCK_ORIGINAL_TEXT}</div></div>
+          <div></div>
+        </div>,
+      )
+
+      const node = screen.getByTestId('test-node')
+      await removeOrShowPageTranslation('bilingual', true)
+
+      expectNodeLabels(node.children[0], [BLOCK_ATTRIBUTE])
+      expectNodeLabels(node.children[0].children[0], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
+      const wrapper = expectTranslationWrapper(node.children[0].children[0], 'bilingual')
+      expect(wrapper).toBe(node.children[0].children[0].lastChild)
+      expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+
+      await removeOrShowPageTranslation('bilingual', true)
+      expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+      expect(node.textContent).toBe(`${MOCK_ORIGINAL_TEXT}`)
+    })
+  })
   describe('empty text nodes with only one inline node in middle', () => {
     it('bilingual mode: should insert translation wrapper in inline node', async () => {
       render(

--- a/src/utils/host/dom/traversal.ts
+++ b/src/utils/host/dom/traversal.ts
@@ -110,6 +110,14 @@ export function walkAndLabelElement(
 
   // force block will force the current and ancestor elements to be block node
   forceBlock = forceBlock || (blockChildCount >= 1 && translateChildCount > 1) || FORCE_BLOCK_TAGS.has(element.tagName)
+
+  if (element.textContent?.trim() === '' && !forceBlock) {
+    return {
+      forceBlock: false,
+      isInlineNode: false,
+    }
+  }
+
   const isInlineNode = isShallowInlineHTMLElement(element)
 
   if (isShallowBlockHTMLElement(element) || forceBlock) {


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

This PR fixes a translation style issue in Inoreader where empty nodes were causing layout disruptions in column mode. The problem occurred when translation wrappers were being inserted into empty DOM nodes, leading to visual inconsistencies.

The fix adds a check in the DOM traversal logic to skip empty text nodes that aren't explicitly forced to be block elements, preventing unnecessary translation wrapper insertion.

## Related Issue

Closes #717

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

### Testing Details

- Added integration test case `empty nodes in multiple child nodes` in [translate.integration.test.tsx](src/utils/host/__tests__/translate.integration.test.tsx#L959-L981) to verify that empty nodes don't receive translation wrappers in bilingual mode
- Test validates that only nodes with actual content get translation wrappers
- All existing tests continue to pass

## Key Changes

1. **Core Fix** ([traversal.ts:113-120](src/utils/host/dom/traversal.ts#L113-L120)): Added early return for empty text nodes
   ```typescript
   if (element.textContent?.trim() === '' && !forceBlock) {
     return {
       forceBlock: false,
       isInlineNode: false,
     }
   }
   ```

2. **Test Coverage**: Added regression test for issue #717

3. **Dependencies**: Added missing `postcss-value-parser` dependency used by [postcss-rename-custom-props.cjs](src/utils/styles/postcss-rename-custom-props.cjs)

4. **Dev Config**: Updated VSCode settings with Vitest root config

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This fix specifically addresses the Inoreader column mode layout issue, but the logic improvement applies to all translation scenarios - ensuring empty nodes are never unnecessarily wrapped or processed during translation.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip empty nodes during translation traversal to fix Inoreader column mode layout issues. Prevents adding translation wrappers to empty elements.

- **Bug Fixes**
  - Skip empty text nodes unless forced block.
  - Resolves Inoreader column mode spacing/style issue (Fixes #717).
  - Added integration test to ensure empty nodes aren’t wrapped in bilingual mode.

- **Dependencies**
  - Added postcss-value-parser for postcss-rename-custom-props.
  - Updated VSCode settings with Vitest root config.

<sup>Written for commit 3dffb8bde55708711aa6094f3e3c63fc24855e56. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



