### PR TITLE
feat: support manually switch theme (light or dark) in extension

### DIFF
--- a/.changeset/honest-deer-laugh.md
+++ b/.changeset/honest-deer-laugh.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+Add manual theme switching feature with light/dark/system modes

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -1,17 +1,17 @@
-import { createContext, use, useEffect, useMemo, useState } from 'react'
-import { isDarkMode } from '@/utils/theme'
+import type { ThemeMode } from '@/utils/atoms/theme'
+import { useAtom } from 'jotai'
+import { createContext, use, useCallback, useEffect, useMemo, useState } from 'react'
+import { getSystemTheme, themeModeAtom, writeThemeModeAtom } from '@/utils/atoms/theme'
 
 export type Theme = 'light' | 'dark'
 
 interface ThemeContextI {
   theme: Theme
+  themeMode: ThemeMode
+  setThemeMode: (mode: ThemeMode) => Promise<void>
 }
 
 export const ThemeContext = createContext<ThemeContextI | undefined>(undefined)
-
-function getCurrentTheme(): Theme {
-  return isDarkMode() ? 'dark' : 'light'
-}
 
 export function ThemeProvider({
   children,
@@ -20,7 +20,24 @@ export function ThemeProvider({
   children: React.ReactNode
   container?: HTMLElement
 }) {
-  const [theme, setTheme] = useState<Theme>(() => getCurrentTheme())
+  const [themeMode] = useAtom(themeModeAtom)
+  const [, writeThemeMode] = useAtom(writeThemeModeAtom)
+
+  const [systemTheme, setSystemTheme] = useState<'light' | 'dark'>(() => getSystemTheme())
+
+  const theme = useMemo(() => {
+    if (themeMode === 'system') {
+      return systemTheme
+    }
+    return themeMode
+  }, [themeMode, systemTheme])
+
+  const updateThemeMode = useCallback(
+    async (mode: ThemeMode) => {
+      await writeThemeMode(mode)
+    },
+    [writeThemeMode],
+  )
 
   // Apply theme to document or shadow root container
   useEffect(() => {
@@ -35,12 +52,20 @@ export function ThemeProvider({
     const mq = window.matchMedia?.('(prefers-color-scheme: dark)')
     if (!mq)
       return
-    const onChange = (e: MediaQueryListEvent) => setTheme(e.matches ? 'dark' : 'light')
+
+    const onChange = (e: MediaQueryListEvent) => {
+      const newSystemTheme = e.matches ? 'dark' : 'light'
+      setSystemTheme(newSystemTheme)
+    }
+
     mq.addEventListener?.('change', onChange)
     return () => mq.removeEventListener?.('change', onChange)
   }, [])
 
-  const contextValue = useMemo(() => ({ theme }), [theme])
+  const contextValue = useMemo(
+    () => ({ theme, themeMode, setThemeMode: updateThemeMode }),
+    [theme, themeMode, updateThemeMode],
+  )
 
   return (
     <ThemeContext value={contextValue}>

--- a/src/entrypoints/host.content/index.tsx
+++ b/src/entrypoints/host.content/index.tsx
@@ -1,8 +1,10 @@
 import type { Config } from '@/types/config/config'
 import { createShadowRootUi, defineContentScript, storage } from '#imports'
 import { kebabCase } from 'case-anything'
+import { Provider as JotaiProvider } from 'jotai'
 import ReactDOM from 'react-dom/client'
 // import eruda from 'eruda'
+import { ThemeProvider } from '@/components/providers/theme-provider'
 import { getConfigFromStorage } from '@/utils/config/config'
 import { APP_NAME } from '@/utils/constants/app'
 import { CONFIG_STORAGE_KEY } from '@/utils/constants/config'
@@ -38,7 +40,11 @@ export default defineContentScript({
         // Create a root on the UI container and render a component
         const root = ReactDOM.createRoot(wrapper)
         root.render(
-          <App />,
+          <JotaiProvider>
+            <ThemeProvider container={wrapper}>
+              <App />
+            </ThemeProvider>
+          </JotaiProvider>,
         )
         return root
       },

--- a/src/entrypoints/options/pages/general/index.tsx
+++ b/src/entrypoints/options/pages/general/index.tsx
@@ -1,6 +1,7 @@
 import { i18n } from '#imports'
 import { PageLayout } from '../../components/page-layout'
 import { ReadConfig } from './read-config'
+import { ThemeConfig } from './theme-config'
 import TranslationConfig from './translation-config'
 
 export function GeneralPage() {
@@ -8,6 +9,7 @@ export function GeneralPage() {
     <PageLayout title={i18n.t('options.general.title')} innerClassName="[&>*]:border-b [&>*:last-child]:border-b-0">
       <TranslationConfig />
       <ReadConfig />
+      <ThemeConfig />
     </PageLayout>
   )
 }

--- a/src/entrypoints/options/pages/general/theme-config.tsx
+++ b/src/entrypoints/options/pages/general/theme-config.tsx
@@ -1,0 +1,58 @@
+import type { ThemeMode } from '@/utils/atoms/theme'
+import { Icon } from '@iconify/react'
+import { useTheme } from '@/components/providers/theme-provider'
+import { Field, FieldLabel } from '@/components/shadcn/field'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/shadcn/select'
+import { ConfigCard } from '../../components/config-card'
+
+export function ThemeConfig() {
+  const { themeMode, setThemeMode } = useTheme()
+
+  const handleThemeChange = async (value: ThemeMode) => {
+    await setThemeMode(value)
+  }
+
+  return (
+    <ConfigCard
+      title="Theme"
+      description="Choose your preferred color theme for the extension interface."
+    >
+      <Field>
+        <FieldLabel htmlFor="theme-mode">
+          Theme Mode
+        </FieldLabel>
+        <Select value={themeMode} onValueChange={handleThemeChange}>
+          <SelectTrigger id="theme-mode">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="light">
+              <div className="flex items-center gap-2">
+                <Icon icon="tabler:sun" className="size-4" />
+                <span>Light</span>
+              </div>
+            </SelectItem>
+            <SelectItem value="dark">
+              <div className="flex items-center gap-2">
+                <Icon icon="tabler:moon" className="size-4" />
+                <span>Dark</span>
+              </div>
+            </SelectItem>
+            <SelectItem value="system">
+              <div className="flex items-center gap-2">
+                <Icon icon="tabler:device-desktop" className="size-4" />
+                <span>System</span>
+              </div>
+            </SelectItem>
+          </SelectContent>
+        </Select>
+      </Field>
+    </ConfigCard>
+  )
+}

--- a/src/entrypoints/popup/main.tsx
+++ b/src/entrypoints/popup/main.tsx
@@ -35,6 +35,7 @@ function HydrateAtoms({
 async function initApp() {
   const root = document.getElementById('root')!
   root.className = 'text-base antialiased w-[320px] bg-background'
+
   const config = (await getConfigFromStorage()) ?? DEFAULT_CONFIG
 
   const activeTab = await browser.tabs.query({

--- a/src/entrypoints/selection.content/index.tsx
+++ b/src/entrypoints/selection.content/index.tsx
@@ -1,6 +1,7 @@
 import { createShadowRootUi, defineContentScript } from '#imports'
 import { QueryClientProvider } from '@tanstack/react-query'
 import { kebabCase } from 'case-anything'
+import { Provider as JotaiProvider } from 'jotai'
 import ReactDOM from 'react-dom/client'
 import { ThemeProvider } from '@/components/providers/theme-provider'
 import { APP_NAME } from '@/utils/constants/app.ts'
@@ -33,9 +34,11 @@ export default defineContentScript({
         const root = ReactDOM.createRoot(wrapper)
         root.render(
           <QueryClientProvider client={queryClient}>
-            <ThemeProvider container={wrapper}>
-              <App />
-            </ThemeProvider>
+            <JotaiProvider>
+              <ThemeProvider container={wrapper}>
+                <App />
+              </ThemeProvider>
+            </JotaiProvider>
           </QueryClientProvider>,
         )
         return root

--- a/src/utils/atoms/theme.ts
+++ b/src/utils/atoms/theme.ts
@@ -1,0 +1,79 @@
+import { atom } from 'jotai'
+import { z } from 'zod'
+import { THEME_MODE_KEY } from '../constants/storage-keys'
+import { storageAdapter } from './storage-adapter'
+
+export type ThemeMode = 'light' | 'dark' | 'system'
+
+const themeModeSchema = z.enum(['light', 'dark', 'system'])
+
+const DEFAULT_THEME_MODE: ThemeMode = 'system'
+
+export const themeModeAtom = atom<ThemeMode>(DEFAULT_THEME_MODE)
+
+export const writeThemeModeAtom = atom(
+  null,
+  async (get, set, newMode: ThemeMode) => {
+    const modeInStorage = await storageAdapter.get<ThemeMode>(
+      THEME_MODE_KEY,
+      DEFAULT_THEME_MODE,
+      themeModeSchema,
+    )
+    set(themeModeAtom, modeInStorage)
+
+    const prev = get(themeModeAtom)
+    set(themeModeAtom, newMode)
+
+    try {
+      await storageAdapter.set(THEME_MODE_KEY, newMode, themeModeSchema)
+    }
+    catch {
+      set(themeModeAtom, prev)
+    }
+  },
+)
+
+themeModeAtom.onMount = (setAtom: (newValue: ThemeMode) => void) => {
+  void storageAdapter
+    .get<ThemeMode>(THEME_MODE_KEY, DEFAULT_THEME_MODE, themeModeSchema)
+    .then(setAtom)
+
+  const unwatch = storageAdapter.watch<ThemeMode>(THEME_MODE_KEY, setAtom)
+
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === 'visible') {
+      void storageAdapter
+        .get<ThemeMode>(THEME_MODE_KEY, DEFAULT_THEME_MODE, themeModeSchema)
+        .then(setAtom)
+    }
+  }
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+
+  return () => {
+    unwatch()
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
+  }
+}
+
+export function getSystemTheme(): 'light' | 'dark' {
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+  return 'light'
+}
+
+export function getResolvedTheme(themeMode: ThemeMode): 'light' | 'dark' {
+  if (themeMode === 'system') {
+    return getSystemTheme()
+  }
+  return themeMode
+}
+
+export async function getResolvedThemeFromStorage(): Promise<'light' | 'dark'> {
+  const themeMode = await storageAdapter.get<ThemeMode>(
+    THEME_MODE_KEY,
+    DEFAULT_THEME_MODE,
+    themeModeSchema,
+  )
+  return getResolvedTheme(themeMode)
+}

--- a/src/utils/constants/storage-keys.ts
+++ b/src/utils/constants/storage-keys.ts
@@ -1,4 +1,5 @@
 export const TRANSLATION_STATE_KEY_PREFIX = 'session:translationState' as const
+export const THEME_MODE_KEY = 'themeMode' as const
 
 export function getTranslationStateKey(tabId: number): `session:translationState.${number}` {
   return `${TRANSLATION_STATE_KEY_PREFIX}.${tabId}` as const

--- a/src/utils/react-shadow-host/shadow-host-builder.ts
+++ b/src/utils/react-shadow-host/shadow-host-builder.ts
@@ -1,4 +1,3 @@
-import { isDarkMode } from '../theme'
 import { cssRegistry } from './css-registry'
 
 interface ShadowHostOptions {
@@ -60,10 +59,6 @@ export class ShadowHostBuilder {
     wrapper.style.display = position
     if (style) {
       Object.assign(wrapper.style, style)
-    }
-    if (isDarkMode()) {
-      wrapper.classList.add('dark')
-      wrapper.style.colorScheme = 'dark'
     }
     this.shadowRoot.appendChild(wrapper)
 

--- a/src/utils/shadow-root.ts
+++ b/src/utils/shadow-root.ts
@@ -1,13 +1,10 @@
 import { cn } from '@/utils/styles/tailwind'
-import { isDarkMode } from './theme'
 
 export function insertShadowRootUIWrapperInto(container: HTMLElement) {
   const wrapper = document.createElement('div')
   wrapper.className = cn(
     'text-base antialiased font-sans z-[2147483647]',
-    isDarkMode() && 'dark',
   )
-  wrapper.style.colorScheme = isDarkMode() ? 'dark' : 'light'
   container.append(wrapper)
   return wrapper
 }

--- a/src/utils/theme-manager.ts
+++ b/src/utils/theme-manager.ts
@@ -1,0 +1,59 @@
+import { storage } from '#imports'
+import { THEME_MODE_KEY } from './constants/storage-keys'
+
+export type ThemeMode = 'light' | 'dark' | 'system'
+
+let cachedThemeMode: ThemeMode = 'system'
+let isInitialized = false
+
+function getSystemTheme(): 'light' | 'dark' {
+  if (typeof window !== 'undefined' && window.matchMedia) {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+  return 'light'
+}
+
+export async function initThemeManager(): Promise<void> {
+  if (isInitialized)
+    return
+
+  try {
+    const stored = await storage.getItem<ThemeMode>(`local:${THEME_MODE_KEY}`)
+    if (stored && ['light', 'dark', 'system'].includes(stored)) {
+      cachedThemeMode = stored
+    }
+  }
+  catch (error) {
+    console.error('Failed to load theme from storage:', error)
+  }
+
+  isInitialized = true
+
+  storage.watch<ThemeMode>(`local:${THEME_MODE_KEY}`, (newValue) => {
+    if (newValue && ['light', 'dark', 'system'].includes(newValue)) {
+      cachedThemeMode = newValue
+      window.dispatchEvent(new CustomEvent('themechange', { detail: newValue }))
+    }
+  })
+}
+
+export function getThemeMode(): ThemeMode {
+  return cachedThemeMode
+}
+
+export async function setThemeMode(mode: ThemeMode): Promise<void> {
+  cachedThemeMode = mode
+  await storage.setItem(`local:${THEME_MODE_KEY}`, mode)
+  window.dispatchEvent(new CustomEvent('themechange', { detail: mode }))
+}
+
+export function getResolvedTheme(): 'light' | 'dark' {
+  if (cachedThemeMode === 'system') {
+    return getSystemTheme()
+  }
+  return cachedThemeMode
+}
+
+export function isDarkMode(): boolean {
+  return getResolvedTheme() === 'dark'
+}

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,10 +1,1 @@
-export function isDarkMode() {
-  return (
-    // TODO: change this to storage API for browser extension
-    localStorage.theme === 'dark'
-    || (!('theme' in localStorage)
-      && typeof window !== 'undefined'
-      && window.matchMedia
-      && window.matchMedia('(prefers-color-scheme: dark)').matches)
-  )
-}
+export { getResolvedTheme, getSystemTheme, type ThemeMode, themeModeAtom, writeThemeModeAtom } from './atoms/theme'


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)

## Description

Added manual theme switching functionality to the extension, supporting three modes:

## Related Issue

Closes #https://github.com/mengxi-ream/read-frog/issues/639

## How Has This Been Tested?

- [x] Verified through manual testing

## Screenshots

<img width="2559" height="1398" alt="594f65f757a607fd308d06b3fbf1515c" src="https://github.com/user-attachments/assets/dbabb5c1-c572-4a3e-8a72-fbe4246ecfc6" />
<img width="2559" height="1398" alt="8cb474ebe1af88ac0e7c073f5b7edcc5" src="https://github.com/user-attachments/assets/012ea4cd-2279-4e5e-8ab5-d289d06cae3d" />

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.






<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added manual theme switching with light, dark, and system modes. The choice is saved and applied across the popup, options, and content UIs; system mode follows OS changes.

- **New Features**
  - Added a ThemeManager that persists mode to storage and broadcasts updates via a themechange event.
  - Updated ThemeProvider to expose themeMode and setThemeMode, resolve the effective theme, and listen to system changes only in system mode.
  - Added a ThemeConfig section in Options → General with a Light/Dark/System selector.
  - Wrapped content scripts with Jotai and ThemeProvider so UI updates immediately across views.

<sup>Written for commit 564a359eea9cdcc2283057ec20fbf4d14a19b9ee. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





