### PR TITLE
test: add TLD boundary test for domain pattern matching

### DIFF
--- a/src/utils/host/translate/__tests__/auto-translation.test.ts
+++ b/src/utils/host/translate/__tests__/auto-translation.test.ts
@@ -77,6 +77,11 @@ describe('matchDomainPattern', () => {
       expect(result).toBe(false)
     })
 
+    it('should not match similar TLD (x.com vs x.co)', () => {
+      const result = matchDomainPattern('https://x.com', 'x.co')
+      expect(result).toBe(false)
+    })
+
     it('should not match when pattern is longer than hostname', () => {
       const result = matchDomainPattern('https://x.com', 'www.x.com')
       expect(result).toBe(false)


### PR DESCRIPTION
## Type of Changes

- [x] ✅ Test related (test)

## Description

Add a test case to verify that similar TLDs are correctly distinguished in domain pattern matching.

The test ensures `matchDomainPattern('https://x.com', 'x.co')` returns `false`, confirming the existing implementation correctly handles TLD boundaries via the `.` prefix check in `hostname.endsWith('.${pattern}')`.

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unit test to ensure domain pattern matching respects TLD boundaries and doesn’t confuse similar TLDs (x.com vs x.co). Confirms the logic correctly requires a dot boundary, preventing false positives.

<sup>Written for commit 657913f588f151c8949f108b2ffb0e227021aa8d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

