### PR TITLE
feat: add site-specific force block translation support

### DIFF
--- a/.changeset/custom-force-block-translation.md
+++ b/.changeset/custom-force-block-translation.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat: add site-specific force block translation support

--- a/src/utils/constants/dom-rules.ts
+++ b/src/utils/constants/dom-rules.ts
@@ -129,3 +129,9 @@ export const CUSTOM_DONT_WALK_INTO_ELEMENT_SELECTOR_MAP: Record<string, string[]
     '#badges *',
   ],
 }
+
+export const CUSTOM_FORCE_BLOCK_TRANSLATION_SELECTOR_MAP: Record<string, string[]> = {
+  'github.com': [
+    '.react-directory-row-commit-cell *',
+  ],
+}

--- a/src/utils/host/dom/__tests__/custom-force-block.test.ts
+++ b/src/utils/host/dom/__tests__/custom-force-block.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest'
+import { isCustomForceBlockTranslation } from '../filter'
+
+function setHost(host: string) {
+  // jsdom exposes location as read-only; override via defineProperty
+  Object.defineProperty(window, 'location', {
+    value: new URL(`https://${host}/some/path`),
+    writable: true,
+  })
+}
+
+describe('isCustomForceBlockTranslation', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('matches child element inside configured parent on github.com', () => {
+    setHost('github.com')
+
+    const commitCell = document.createElement('div')
+    commitCell.classList.add('react-directory-row-commit-cell')
+    const child = document.createElement('span')
+    commitCell.appendChild(child)
+    document.body.appendChild(commitCell)
+
+    // Child matches `.react-directory-row-commit-cell *`
+    expect(isCustomForceBlockTranslation(child)).toBe(true)
+    // Parent itself does not match (selector is `* ` for descendants)
+    expect(isCustomForceBlockTranslation(commitCell)).toBe(false)
+  })
+
+  it('does not match on non-configured host', () => {
+    setHost('example.com')
+
+    const commitCell = document.createElement('div')
+    commitCell.classList.add('react-directory-row-commit-cell')
+    const child = document.createElement('span')
+    commitCell.appendChild(child)
+    document.body.appendChild(commitCell)
+
+    expect(isCustomForceBlockTranslation(child)).toBe(false)
+  })
+
+  it('does not match element outside configured parent on configured host', () => {
+    setHost('github.com')
+
+    const other = document.createElement('div')
+    document.body.appendChild(other)
+
+    expect(isCustomForceBlockTranslation(other)).toBe(false)
+  })
+
+  it('uses hostname when host includes port', () => {
+    setHost('github.com:3000')
+
+    const commitCell = document.createElement('div')
+    commitCell.classList.add('react-directory-row-commit-cell')
+    const child = document.createElement('span')
+    commitCell.appendChild(child)
+    document.body.appendChild(commitCell)
+
+    expect(window.location.host).toContain(':')
+    expect(window.location.hostname).toBe('github.com')
+
+    expect(isCustomForceBlockTranslation(child)).toBe(true)
+  })
+
+  it('does not match on non-configured host when host !== hostname', () => {
+    setHost('example.com:8080')
+
+    const commitCell = document.createElement('div')
+    commitCell.classList.add('react-directory-row-commit-cell')
+    const child = document.createElement('span')
+    commitCell.appendChild(child)
+    document.body.appendChild(commitCell)
+
+    expect(window.location.host).toContain(':')
+    expect(window.location.hostname).toBe('example.com')
+
+    expect(isCustomForceBlockTranslation(child)).toBe(false)
+  })
+})

--- a/src/utils/host/dom/filter.ts
+++ b/src/utils/host/dom/filter.ts
@@ -8,7 +8,7 @@ import {
   INLINE_CONTENT_CLASS,
   NOTRANSLATE_CLASS,
 } from '@/utils/constants/dom-labels'
-import { CUSTOM_DONT_WALK_INTO_ELEMENT_SELECTOR_MAP, DONT_WALK_AND_TRANSLATE_TAGS, DONT_WALK_BUT_TRANSLATE_TAGS, FORCE_BLOCK_TAGS, MAIN_CONTENT_IGNORE_TAGS } from '@/utils/constants/dom-rules'
+import { CUSTOM_DONT_WALK_INTO_ELEMENT_SELECTOR_MAP, CUSTOM_FORCE_BLOCK_TRANSLATION_SELECTOR_MAP, DONT_WALK_AND_TRANSLATE_TAGS, DONT_WALK_BUT_TRANSLATE_TAGS, FORCE_BLOCK_TAGS, MAIN_CONTENT_IGNORE_TAGS } from '@/utils/constants/dom-rules'
 
 export function isEditable(element: HTMLElement): boolean {
   const tag = element.tagName
@@ -95,6 +95,17 @@ export function isCustomDontWalkIntoElement(element: HTMLElement): boolean {
     return false
 
   return element.matches(dontWalkSelector)
+}
+
+export function isCustomForceBlockTranslation(element: HTMLElement): boolean {
+  const forceBlockSelectorList = CUSTOM_FORCE_BLOCK_TRANSLATION_SELECTOR_MAP[window.location.hostname] ?? []
+
+  const forceBlockSelector = forceBlockSelectorList.join(',')
+
+  if (!forceBlockSelector)
+    return false
+
+  return element.matches(forceBlockSelector)
 }
 
 export function isDontWalkIntoButTranslateAsChildElement(element: HTMLElement): boolean {

--- a/src/utils/host/translate/dom/translation-insertion.ts
+++ b/src/utils/host/translate/dom/translation-insertion.ts
@@ -1,7 +1,7 @@
 import type { TranslationNodeStyleConfig } from '@/types/config/translate'
 import type { TransNode } from '@/types/dom'
 import { BLOCK_CONTENT_CLASS, INLINE_CONTENT_CLASS, NOTRANSLATE_CLASS } from '../../../constants/dom-labels'
-import { isBlockTransNode, isInlineTransNode } from '../../dom/filter'
+import { isBlockTransNode, isCustomForceBlockTranslation, isHTMLElement, isInlineTransNode } from '../../dom/filter'
 import { getOwnerDocument } from '../../dom/node'
 import { decorateTranslationNode } from '../decorate-translation'
 import { isForceInlineTranslation } from '../ui/translation-utils'
@@ -30,9 +30,13 @@ export async function insertTranslatedNodeIntoWrapper(
   const ownerDoc = getOwnerDocument(translatedWrapperNode)
   const translatedNode = ownerDoc.createElement('span')
   const forceInlineTranslation = isForceInlineTranslation(targetNode)
+  const customForceBlock = isHTMLElement(targetNode) && isCustomForceBlockTranslation(targetNode)
 
-  // priority: forceInlineTranslation > forceBlockTranslation > isInlineTransNode > isBlockTransNode
-  if (forceInlineTranslation) {
+  // priority: customForceBlock > forceInlineTranslation > forceBlockTranslation > isInlineTransNode > isBlockTransNode
+  if (customForceBlock) {
+    addBlockTranslation(ownerDoc, translatedWrapperNode, translatedNode)
+  }
+  else if (forceInlineTranslation) {
     addInlineTranslation(ownerDoc, translatedWrapperNode, translatedNode)
   }
   else if (forceBlockTranslation) {


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)

## Description

Add `CUSTOM_FORCE_BLOCK_TRANSLATION_SELECTOR_MAP` for configuring site-specific CSS selectors that force block-style translation (translation appears on a new line below original text, instead of inline).

**Changes:**
- Added `CUSTOM_FORCE_BLOCK_TRANSLATION_SELECTOR_MAP` constant in `dom-rules.ts`
- Added `isCustomForceBlockTranslation()` function in `filter.ts`
- Modified translation priority in `translation-insertion.ts`: `customForceBlock > forceInlineTranslation > forceBlockTranslation > isInlineTransNode > isBlockTransNode`
- Initial configuration for GitHub: `.react-directory-row-commit-cell *` to display commit messages with block translation style

## Related Issue

Closes #374

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added site-specific selectors to force block-style translation, starting with GitHub commit cells, so translations appear on a new line under the original. Updated translation priority to honor these selectors before other rules.

- **New Features**
  - Added CUSTOM_FORCE_BLOCK_TRANSLATION_SELECTOR_MAP (per-host CSS selectors).
  - Implemented isCustomForceBlockTranslation() and set new priority: custom block > force inline > force block > inline > block.
  - Initial GitHub config: ".react-directory-row-commit-cell *" to render commit messages with block translation.

<sup>Written for commit 26362d6abe39a2067c2c864001ee9ee73fa9a66e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

