### PR TITLE
feat: add engoo.com force block translation rule

### DIFF
--- a/.changeset/engoo-force-block.md
+++ b/.changeset/engoo-force-block.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat: add engoo.com force block translation rule

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ coverage/
 .nx/
 
 tsconfig.local.json
+
+immersive-translate-config-example.txt

--- a/src/utils/constants/dom-rules.ts
+++ b/src/utils/constants/dom-rules.ts
@@ -134,4 +134,7 @@ export const CUSTOM_FORCE_BLOCK_TRANSLATION_SELECTOR_MAP: Record<string, string[
   'github.com': [
     '.react-directory-row-commit-cell *',
   ],
+  'engoo.com': [
+    '#windowexercise-2 > div > div > div.css-ep7xq6 > div > div > div.css-19m2fbm *',
+  ],
 }


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)

## Description

Add site-specific CSS selectors to force block translation for article paragraphs on
engoo.com.

The site uses inline `<span>` elements inside block `<p>` elements which causes the
translation to be displayed inline instead of as a new block. This rule forces block
translation for content in the exercise-2 article section where the main article
content is displayed.

**Selector added:**
```
#windowexercise-2 > div > div > div.css-ep7xq6 > div > div > div.css-19m2fbm *
```

## Related Issue

Closes #102

## How Has This Been Tested?

- [x] Verified through manual testing

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a site-specific selector to force block translation on engoo.com articles, fixing inline translations in the exercise-2 section. Translations now render as separate blocks for better readability. Closes #102.

- **New Features**
  - Force block translation for engoo.com exercise-2 article content to handle inline spans inside paragraphs.
  - Selector: #windowexercise-2 > div > div > div.css-ep7xq6 > div > div > div.css-19m2fbm *

<sup>Written for commit a825a10444bc87570c867f7c0cf5fedeb15fbb9d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

