### PR TITLE
feat: add official volcengine and doubao support

### DIFF
--- a/.changeset/thick-trains-swim.md
+++ b/.changeset/thick-trains-swim.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat: add official volcengine and doubao support

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -114,6 +114,7 @@ options:
         replicate: Access to diverse open-source models for specialized translation tasks
         perplexity: Real-time knowledge-enhanced AI for contextual translations and reading assistance
         vercel: Optimized AI models for web content translation and analysis
+        volcengine: ByteDance's cloud AI platform offering Doubao models for translation and reading
     apiKey:
       showAPIKey: Show API Key
     howToConfigure: How to configure?

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -113,6 +113,7 @@ options:
         replicate: 専門的な翻訳タスクのための多様なオープンソースモデルへのアクセス
         perplexity: 文脈的翻訳と読解支援のためのリアルタイム知識強化AI
         vercel: ウェブコンテンツの翻訳と分析に最適化されたAIモデル
+        volcengine: ByteDanceのクラウドAIプラットフォーム、Doubaoモデルを提供
     apiKey:
       showAPIKey: APIキーを表示
     howToConfigure: 設定方法は?

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -113,6 +113,7 @@ options:
         replicate: 전문적인 번역 작업을 위한 다양한 오픈소스 모델 액세스
         perplexity: 맥락적 번역과 읽기 지원을 위한 실시간 지식 강화 AI
         vercel: 웹 콘텐츠 번역과 분석에 최적화된 AI 모델
+        volcengine: ByteDance의 클라우드 AI 플랫폼, Doubao 모델 제공
     apiKey:
       showAPIKey: API Key 표시
     howToConfigure: 구성 방법은?

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -114,6 +114,7 @@ options:
         replicate: 访问多样化开源模型，适合专业翻译任务
         perplexity: 实时知识增强 AI，提供语境化翻译和阅读辅助
         vercel: 针对网页内容翻译和分析优化的 AI 模型
+        volcengine: 字节跳动旗下云平台，提供豆包系列大模型
     apiKey:
       showAPIKey: 显示 API Key
     howToConfigure: 如何配置?

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -114,6 +114,7 @@ options:
         replicate: 存取多樣化開源模型，適合專業翻譯任務
         perplexity: 即時知識增強 AI，提供語境化翻譯和閱讀輔助
         vercel: 針對網頁內容翻譯和分析優化的 AI 模型
+        volcengine: 字節跳動旗下雲平台，提供豆包系列大模型
     apiKey:
       showAPIKey: 顯示 API Key
     howToConfigure: 如何配置?

--- a/src/types/config/provider.ts
+++ b/src/types/config/provider.ts
@@ -25,6 +25,7 @@ export const READ_PROVIDER_MODELS = {
   vercel: ['v0-1.5-md', 'v0-1.5-lg', 'v0-1.0-md'],
   openrouter: ['deepseek/deepseek-chat-v3.1:free', 'openai/gpt-4.1-mini'],
   ollama: ['gemma3:27b', 'deepseek-v3'],
+  volcengine: ['doubao-seed-1-6-251015', 'doubao-seed-1-6-lite-251015', 'doubao-seed-1-6-flash-250828'],
 } as const
 export const TRANSLATE_PROVIDER_MODELS = {
   openai: ['gpt-5-mini', 'gpt-4.1-mini', 'gpt-4o-mini', 'gpt-5-nano', 'gpt-4.1-nano', 'gpt-5', 'gpt-4.1', 'gpt-4o'],
@@ -49,6 +50,7 @@ export const TRANSLATE_PROVIDER_MODELS = {
   vercel: ['v0-1.5-md', 'v0-1.0-md'],
   openrouter: ['x-ai/grok-4-fast:free', 'openai/gpt-4.1-mini'],
   ollama: ['gemma3:4b', 'llama3.2:3b'],
+  volcengine: ['doubao-seed-1-6-flash-250828', 'doubao-seed-1-6-lite-251015', 'doubao-seed-1-6-251015'],
 } as const
 export const NON_API_TRANSLATE_PROVIDERS = ['google', 'microsoft'] as const
 export const NON_API_TRANSLATE_PROVIDERS_MAP: Record<typeof NON_API_TRANSLATE_PROVIDERS[number], string> = {
@@ -64,7 +66,7 @@ export const THINKING_MODELS = ['gemini-2.5-pro'] as const
   ────────────────────────────── */
 
 // read provider names
-export const READ_PROVIDER_TYPES = ['openai', 'deepseek', 'gemini', 'anthropic', 'grok', 'openaiCompatible', 'siliconflow', 'tensdaq', 'ai302', 'amazonBedrock', 'groq', 'deepinfra', 'mistral', 'togetherai', 'cohere', 'fireworks', 'cerebras', 'replicate', 'perplexity', 'vercel', 'openrouter', 'ollama'] as const satisfies Readonly<
+export const READ_PROVIDER_TYPES = ['openai', 'deepseek', 'gemini', 'anthropic', 'grok', 'openaiCompatible', 'siliconflow', 'tensdaq', 'ai302', 'amazonBedrock', 'groq', 'deepinfra', 'mistral', 'togetherai', 'cohere', 'fireworks', 'cerebras', 'replicate', 'perplexity', 'vercel', 'openrouter', 'ollama', 'volcengine'] as const satisfies Readonly<
   (keyof typeof READ_PROVIDER_MODELS)[]
 >
 export type ReadProviderTypes = typeof READ_PROVIDER_TYPES[number]
@@ -76,7 +78,7 @@ export function isReadProviderConfig(config: ProviderConfig): config is ReadProv
 }
 
 // translate provider names
-export const TRANSLATE_PROVIDER_TYPES = ['google', 'microsoft', 'deeplx', 'openai', 'deepseek', 'gemini', 'anthropic', 'grok', 'openaiCompatible', 'siliconflow', 'tensdaq', 'ai302', 'amazonBedrock', 'groq', 'deepinfra', 'mistral', 'togetherai', 'cohere', 'fireworks', 'cerebras', 'replicate', 'perplexity', 'vercel', 'openrouter', 'ollama'] as const satisfies Readonly<
+export const TRANSLATE_PROVIDER_TYPES = ['google', 'microsoft', 'deeplx', 'openai', 'deepseek', 'gemini', 'anthropic', 'grok', 'openaiCompatible', 'siliconflow', 'tensdaq', 'ai302', 'amazonBedrock', 'groq', 'deepinfra', 'mistral', 'togetherai', 'cohere', 'fireworks', 'cerebras', 'replicate', 'perplexity', 'vercel', 'openrouter', 'ollama', 'volcengine'] as const satisfies Readonly<
   (keyof typeof TRANSLATE_PROVIDER_MODELS | typeof PURE_TRANSLATE_PROVIDERS[number])[]
 >
 export type TranslateProviderTypes = typeof TRANSLATE_PROVIDER_TYPES[number]
@@ -88,7 +90,7 @@ export function isTranslateProviderConfig(config: ProviderConfig): config is Tra
 }
 
 // translate provider names that support LLM
-export const LLM_TRANSLATE_PROVIDER_TYPES = ['openai', 'deepseek', 'gemini', 'anthropic', 'grok', 'openaiCompatible', 'siliconflow', 'tensdaq', 'ai302', 'amazonBedrock', 'groq', 'deepinfra', 'mistral', 'togetherai', 'cohere', 'fireworks', 'cerebras', 'replicate', 'perplexity', 'vercel', 'openrouter', 'ollama'] as const satisfies Readonly<
+export const LLM_TRANSLATE_PROVIDER_TYPES = ['openai', 'deepseek', 'gemini', 'anthropic', 'grok', 'openaiCompatible', 'siliconflow', 'tensdaq', 'ai302', 'amazonBedrock', 'groq', 'deepinfra', 'mistral', 'togetherai', 'cohere', 'fireworks', 'cerebras', 'replicate', 'perplexity', 'vercel', 'openrouter', 'ollama', 'volcengine'] as const satisfies Readonly<
   (keyof typeof TRANSLATE_PROVIDER_MODELS)[]
 >
 export type LLMTranslateProviderTypes = typeof LLM_TRANSLATE_PROVIDER_TYPES[number]
@@ -99,7 +101,7 @@ export function isLLMTranslateProviderConfig(config: ProviderConfig): config is 
   return isLLMTranslateProvider(config.provider)
 }
 
-export const LLM_PROVIDER_TYPES = ['openai', 'deepseek', 'gemini', 'anthropic', 'grok', 'openaiCompatible', 'siliconflow', 'tensdaq', 'ai302', 'amazonBedrock', 'groq', 'deepinfra', 'mistral', 'togetherai', 'cohere', 'fireworks', 'cerebras', 'replicate', 'perplexity', 'vercel', 'openrouter', 'ollama'] as const satisfies Readonly<
+export const LLM_PROVIDER_TYPES = ['openai', 'deepseek', 'gemini', 'anthropic', 'grok', 'openaiCompatible', 'siliconflow', 'tensdaq', 'ai302', 'amazonBedrock', 'groq', 'deepinfra', 'mistral', 'togetherai', 'cohere', 'fireworks', 'cerebras', 'replicate', 'perplexity', 'vercel', 'openrouter', 'ollama', 'volcengine'] as const satisfies Readonly<
   (keyof typeof READ_PROVIDER_MODELS | keyof typeof TRANSLATE_PROVIDER_MODELS)[]
 >
 export type LLMProviderTypes = typeof LLM_PROVIDER_TYPES[number]
@@ -110,7 +112,7 @@ export function isLLMProviderConfig(config: ProviderConfig): config is LLMProvid
   return isLLMProvider(config.provider)
 }
 
-export const CUSTOM_LLM_PROVIDER_TYPES = ['openaiCompatible', 'tensdaq', 'siliconflow', 'ai302'] as const satisfies Readonly<
+export const CUSTOM_LLM_PROVIDER_TYPES = ['openaiCompatible', 'tensdaq', 'siliconflow', 'ai302', 'volcengine'] as const satisfies Readonly<
   (keyof typeof READ_PROVIDER_MODELS | keyof typeof TRANSLATE_PROVIDER_MODELS)[]
 >
 export type CustomLLMProviderTypes = typeof CUSTOM_LLM_PROVIDER_TYPES[number]
@@ -132,7 +134,7 @@ export function isNonCustomLLMProviderConfig(config: ProviderConfig): config is 
   return isNonCustomLLMProvider(config.provider)
 }
 
-export const API_PROVIDER_TYPES = ['siliconflow', 'tensdaq', 'ai302', 'openaiCompatible', 'openai', 'deepseek', 'gemini', 'anthropic', 'grok', 'deeplx', 'amazonBedrock', 'groq', 'deepinfra', 'mistral', 'togetherai', 'cohere', 'fireworks', 'cerebras', 'replicate', 'perplexity', 'vercel', 'openrouter', 'ollama'] as const satisfies Readonly<
+export const API_PROVIDER_TYPES = ['siliconflow', 'tensdaq', 'ai302', 'openaiCompatible', 'openai', 'deepseek', 'gemini', 'anthropic', 'grok', 'deeplx', 'amazonBedrock', 'groq', 'deepinfra', 'mistral', 'togetherai', 'cohere', 'fireworks', 'cerebras', 'replicate', 'perplexity', 'vercel', 'openrouter', 'ollama', 'volcengine'] as const satisfies Readonly<
   (keyof typeof READ_PROVIDER_MODELS | keyof typeof TRANSLATE_PROVIDER_MODELS | 'deeplx')[]
 >
 export type APIProviderTypes = typeof API_PROVIDER_TYPES[number]
@@ -174,7 +176,7 @@ export function isTTSProviderConfig(config: ProviderConfig): config is TTSProvid
 }
 
 // all provider names
-export const ALL_PROVIDER_TYPES = ['google', 'microsoft', 'deeplx', 'siliconflow', 'tensdaq', 'ai302', 'openaiCompatible', 'openai', 'deepseek', 'gemini', 'anthropic', 'grok', 'amazonBedrock', 'groq', 'deepinfra', 'mistral', 'togetherai', 'cohere', 'fireworks', 'cerebras', 'replicate', 'perplexity', 'vercel', 'openrouter', 'ollama'] as const satisfies Readonly<
+export const ALL_PROVIDER_TYPES = ['google', 'microsoft', 'deeplx', 'siliconflow', 'tensdaq', 'ai302', 'openaiCompatible', 'openai', 'deepseek', 'gemini', 'anthropic', 'grok', 'amazonBedrock', 'groq', 'deepinfra', 'mistral', 'togetherai', 'cohere', 'fireworks', 'cerebras', 'replicate', 'perplexity', 'vercel', 'openrouter', 'ollama', 'volcengine'] as const satisfies Readonly<
   (typeof READ_PROVIDER_TYPES[number] | typeof TRANSLATE_PROVIDER_TYPES[number])[]
 >
 export type AllProviderTypes = typeof ALL_PROVIDER_TYPES[number]
@@ -235,6 +237,10 @@ const llmProviderConfigSchemaList = [
   baseCustomLLMProviderConfigSchema.extend({
     provider: z.literal('ai302'),
     models: createProviderModelsSchema<'ai302'>('ai302'),
+  }),
+  baseCustomLLMProviderConfigSchema.extend({
+    provider: z.literal('volcengine'),
+    models: createProviderModelsSchema<'volcengine'>('volcengine'),
   }),
   baseCustomLLMProviderConfigSchema.extend({
     provider: z.literal('openaiCompatible'),

--- a/src/utils/constants/providers.ts
+++ b/src/utils/constants/providers.ts
@@ -121,6 +121,11 @@ export const DEFAULT_READ_MODELS: ReadModels = {
     isCustomModel: false,
     customModel: null,
   },
+  volcengine: {
+    model: 'doubao-seed-1-6-251015',
+    isCustomModel: false,
+    customModel: null,
+  },
 }
 
 export const DEFAULT_TRANSLATE_MODELS: TranslateLLMModels = {
@@ -231,6 +236,11 @@ export const DEFAULT_TRANSLATE_MODELS: TranslateLLMModels = {
   },
   ollama: {
     model: 'gemma3:4b',
+    isCustomModel: false,
+    customModel: null,
+  },
+  volcengine: {
+    model: 'doubao-seed-1-6-flash-250828',
     isCustomModel: false,
     customModel: null,
   },
@@ -362,6 +372,11 @@ export const PROVIDER_ITEMS: Record<AllProviderTypes, { logo: (theme: Theme) => 
       logo: getLobeIconsCDNUrlFn('ollama'),
       name: 'Ollama',
       website: 'https://ollama.ai',
+    },
+    volcengine: {
+      logo: getLobeIconsCDNUrlFn('volcengine-color'),
+      name: 'Volcengine',
+      website: 'https://www.volcengine.com/product/doubao',
     },
   }
 
@@ -630,6 +645,18 @@ export const DEFAULT_PROVIDER_CONFIG = {
     models: {
       read: DEFAULT_READ_MODELS.ollama,
       translate: DEFAULT_TRANSLATE_MODELS.ollama,
+    },
+  },
+  volcengine: {
+    id: 'volcengine-default',
+    name: PROVIDER_ITEMS.volcengine.name,
+    description: i18n.t('options.apiProviders.providers.description.volcengine'),
+    enabled: true,
+    provider: 'volcengine',
+    baseURL: 'https://ark.cn-beijing.volces.com/api/v3',
+    models: {
+      read: DEFAULT_READ_MODELS.volcengine,
+      translate: DEFAULT_TRANSLATE_MODELS.volcengine,
     },
   },
 } as const satisfies Record<AllProviderTypes, ProviderConfig>

--- a/src/utils/providers/model.ts
+++ b/src/utils/providers/model.ts
@@ -27,6 +27,7 @@ interface ProviderFactoryMap {
   siliconflow: typeof createOpenAICompatible
   tensdaq: typeof createOpenAICompatible
   ai302: typeof createOpenAICompatible
+  volcengine: typeof createOpenAICompatible
   openrouter: typeof createOpenRouter
   openaiCompatible: typeof createOpenAICompatible
   openai: typeof createOpenAI
@@ -52,6 +53,7 @@ const CREATE_AI_MAPPER: ProviderFactoryMap = {
   siliconflow: createOpenAICompatible,
   tensdaq: createOpenAICompatible,
   ai302: createOpenAICompatible,
+  volcengine: createOpenAICompatible,
   openrouter: createOpenRouter,
   openaiCompatible: createOpenAICompatible,
   openai: createOpenAI,


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds official Volcengine (Doubao) provider for reading and translation. Includes default models, provider config, and i18n, wired through the OpenAI-compatible client.

- New Features
  - Added volcengine to read/translate/LLM/API provider types and schemas
  - Default models: doubao-seed-1-6-251015 (read), doubao-seed-1-6-flash-250828 (translate) plus lite/flash variants
  - Default provider config with Ark v3 base URL and provider card (logo/name/website)
  - Provider factory mapping via createOpenAICompatible; i18n strings in EN/JA/KO/ZH

- Migration
  - No migration needed. Add your Volcengine API key; base URL defaults to https://ark.cn-beijing.volces.com/api/v3.

<sup>Written for commit a7d78500266e2959e89e7d21bc8bb8bcfd675e44. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

