### PR TITLE
refactor: move detectedCode from config to separate storage

### DIFF
--- a/.changeset/move-detected-code-storage.md
+++ b/.changeset/move-detected-code-storage.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+refactor: move detectedCode from config to separate storage location

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -1,4 +1,4 @@
-import { getConfigFromStorage } from '@/utils/config/config'
+import { getConfigFromStorage, getDetectedCodeFromStorage } from '@/utils/config/config'
 import { CONTENT_WRAPPER_CLASS } from '@/utils/constants/dom-labels'
 import { hasNoWalkAncestor, isDontWalkIntoButTranslateAsChildElement, isHTMLElement, isIFrameElement } from '@/utils/host/dom/filter'
 import { deepQueryTopLevelSelector } from '@/utils/host/dom/find'
@@ -81,11 +81,13 @@ export class PageTranslationManager implements IPageTranslationManager {
       return
     }
 
+    const detectedCode = await getDetectedCodeFromStorage()
+
     if (!validateTranslationConfigAndToast({
       providersConfig: config.providersConfig,
       translate: config.translate,
       language: config.language,
-    })) {
+    }, detectedCode)) {
       return
     }
 

--- a/src/entrypoints/popup/components/language-options-selector.tsx
+++ b/src/entrypoints/popup/components/language-options-selector.tsx
@@ -6,7 +6,7 @@ import {
   LANG_CODE_TO_LOCALE_NAME,
   langCodeISO6393Schema,
 } from '@read-frog/definitions'
-import { useAtom } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 import {
   Select,
   SelectContent,
@@ -15,6 +15,7 @@ import {
   SelectValue,
 } from '@/components/shadcn/select'
 import { configFieldsAtomMap } from '@/utils/atoms/config'
+import { detectedCodeAtom } from '@/utils/atoms/detected-code'
 
 function langCodeLabel(langCode: LangCodeISO6393) {
   return `${LANG_CODE_TO_EN_NAME[langCode]} (${LANG_CODE_TO_LOCALE_NAME[langCode]})`
@@ -26,6 +27,7 @@ const langSelectorContentClasses = 'flex flex-col items-start text-base font-med
 
 export default function LanguageOptionsSelector() {
   const [language, setLanguage] = useAtom(configFieldsAtomMap.language)
+  const detectedCode = useAtomValue(detectedCodeAtom)
 
   const handleSourceLangChange = (newLangCode: LangCodeISO6393) => {
     void setLanguage({ sourceCode: newLangCode })
@@ -37,7 +39,7 @@ export default function LanguageOptionsSelector() {
 
   const sourceLangLabel
     = language.sourceCode === 'auto'
-      ? `${langCodeLabel(language.detectedCode)} (auto)`
+      ? `${langCodeLabel(detectedCode)} (auto)`
       : langCodeLabel(language.sourceCode)
 
   const targetLangLabel = langCodeLabel(language.targetCode)
@@ -60,7 +62,7 @@ export default function LanguageOptionsSelector() {
         </SelectTrigger>
         <SelectContent className="rounded-lg shadow-md w-72">
           <SelectItem value="auto">
-            {langCodeLabel(language.detectedCode)}
+            {langCodeLabel(detectedCode)}
             <AutoLangCell />
           </SelectItem>
           {langCodeISO6393Schema.options.map(key => (

--- a/src/entrypoints/selection.content/selection-toolbar/ai-button.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/ai-button.tsx
@@ -7,6 +7,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { Activity } from 'react'
 import { MarkdownRenderer } from '@/components/markdown-renderer'
 import { configAtom, configFieldsAtomMap } from '@/utils/atoms/config'
+import { detectedCodeAtom } from '@/utils/atoms/detected-code'
 import { readProviderConfigAtom } from '@/utils/atoms/provider'
 import { getFinalSourceCode } from '@/utils/config/languages'
 import { getIsFirefoxExtensionEnv } from '@/utils/firefox/firefox-compat'
@@ -49,6 +50,7 @@ export function AiPopover() {
   const [isVisible, setIsVisible] = useAtom(isAiPopoverVisibleAtom)
   const selectionRange = useAtomValue(selectionRangeAtom)
   const config = useAtomValue(configAtom)
+  const detectedCode = useAtomValue(detectedCodeAtom)
   const readProviderConfig = useAtomValue(readProviderConfigAtom)
   const popoverRef = useRef<PopoverWrapperRef>(null)
   const [aiResponse, setAiResponse] = useState('')
@@ -86,7 +88,7 @@ export function AiPopover() {
           return false
         }
 
-        const actualSourceCode = getFinalSourceCode(config.language.sourceCode, config.language.detectedCode)
+        const actualSourceCode = getFinalSourceCode(config.language.sourceCode, detectedCode)
         const systemPrompt = getWordExplainPrompt(
           actualSourceCode,
           config.language.targetCode,

--- a/src/entrypoints/side.content/components/side-content/top-bar.tsx
+++ b/src/entrypoints/side.content/components/side-content/top-bar.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/shadcn/select'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/shadcn/tooltip'
 import { configFieldsAtomMap } from '@/utils/atoms/config'
+import { detectedCodeAtom } from '@/utils/atoms/detected-code'
 import { readProviderConfigAtom } from '@/utils/atoms/provider'
 import { getFinalSourceCode } from '@/utils/config/languages'
 import { READ_PROVIDER_ITEMS } from '@/utils/constants/providers'
@@ -141,6 +142,7 @@ function TargetLangSelect() {
 
 function SourceLangSelect() {
   const [language, setLanguage] = useAtom(configFieldsAtomMap.language)
+  const detectedCode = useAtomValue(detectedCodeAtom)
 
   return (
     <Select
@@ -153,15 +155,15 @@ function SourceLangSelect() {
         className="border-border flex !h-7 w-auto items-center gap-2 rounded-md border px-2"
       >
         <div className="max-w-15 min-w-0 truncate">
-          {LANG_CODE_TO_EN_NAME[getFinalSourceCode(language.sourceCode, language.detectedCode)]}
+          {LANG_CODE_TO_EN_NAME[getFinalSourceCode(language.sourceCode, detectedCode)]}
         </div>
       </SelectTrigger>
       <SelectContent container={shadowWrapper}>
         <SelectGroup>
           <SelectLabel>{i18n.t('side.sourceLang')}</SelectLabel>
           <SelectItem value="auto">
-            {`${LANG_CODE_TO_EN_NAME[language.detectedCode]} (${
-              LANG_CODE_TO_LOCALE_NAME[language.detectedCode]
+            {`${LANG_CODE_TO_EN_NAME[detectedCode]} (${
+              LANG_CODE_TO_LOCALE_NAME[detectedCode]
             })`}
             <span className="rounded-full bg-neutral-200 px-1 text-xs dark:bg-neutral-800">
               auto

--- a/src/hooks/read/extract.tsx
+++ b/src/hooks/read/extract.tsx
@@ -1,12 +1,12 @@
 import type { ExtractedContent } from '@/types/content'
 import { useQuery } from '@tanstack/react-query'
 import { useSetAtom } from 'jotai'
-import { configFieldsAtomMap } from '@/utils/atoms/config'
+import { detectedCodeAtom } from '@/utils/atoms/detected-code'
 import { getDocumentInfo } from '@/utils/content/analyze'
 import { logger } from '@/utils/logger'
 
 export function useExtractContent() {
-  const setLanguage = useSetAtom(configFieldsAtomMap.language)
+  const setDetectedCode = useSetAtom(detectedCodeAtom)
 
   return useQuery<ExtractedContent | null>({
     queryKey: ['extractContent'],
@@ -17,7 +17,7 @@ export function useExtractContent() {
 
         logger.log('detected lang', detectedCodeOrUnd)
 
-        void setLanguage({ detectedCode: detectedCodeOrUnd === 'und' ? 'eng' : detectedCodeOrUnd })
+        void setDetectedCode(detectedCodeOrUnd === 'und' ? 'eng' : detectedCodeOrUnd)
 
         return {
           article: {

--- a/src/types/config/config.ts
+++ b/src/types/config/config.ts
@@ -8,7 +8,6 @@ import { translateConfigSchema } from './translate'
 import { ttsConfigSchema } from './tts'
 // Language schema
 const languageSchema = z.object({
-  detectedCode: langCodeISO6393Schema,
   sourceCode: langCodeISO6393Schema.or(z.literal('auto')),
   targetCode: langCodeISO6393Schema,
   level: langLevel,

--- a/src/utils/atoms/detected-code.ts
+++ b/src/utils/atoms/detected-code.ts
@@ -1,0 +1,44 @@
+import type { LangCodeISO6393 } from '@read-frog/definitions'
+import { langCodeISO6393Schema } from '@read-frog/definitions'
+import { atom } from 'jotai'
+import { DEFAULT_DETECTED_CODE, DETECTED_CODE_STORAGE_KEY } from '../constants/config'
+import { logger } from '../logger'
+import { storageAdapter } from './storage-adapter'
+
+// Private base atom - not exported to prevent direct writes
+const baseDetectedCodeAtom = atom<LangCodeISO6393>(DEFAULT_DETECTED_CODE)
+
+// Public atom with read/write - write always goes through storageAdapter
+export const detectedCodeAtom = atom(
+  get => get(baseDetectedCodeAtom),
+  async (get, set, newValue: LangCodeISO6393) => {
+    const prev = get(baseDetectedCodeAtom)
+    set(baseDetectedCodeAtom, newValue)
+    try {
+      await storageAdapter.set(DETECTED_CODE_STORAGE_KEY, newValue, langCodeISO6393Schema)
+    }
+    catch (error) {
+      console.error('Failed to set detectedCode to storage:', newValue, error)
+      set(baseDetectedCodeAtom, prev)
+    }
+  },
+)
+
+// onMount on base atom - gets triggered when derived atom subscribes
+baseDetectedCodeAtom.onMount = (setAtom: (newValue: LangCodeISO6393) => void) => {
+  void storageAdapter.get<LangCodeISO6393>(DETECTED_CODE_STORAGE_KEY, DEFAULT_DETECTED_CODE, langCodeISO6393Schema).then(setAtom)
+  const unwatch = storageAdapter.watch<LangCodeISO6393>(DETECTED_CODE_STORAGE_KEY, setAtom)
+
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === 'visible') {
+      logger.info('detectedCodeAtom onMount handleVisibilityChange when: ', new Date())
+      void storageAdapter.get<LangCodeISO6393>(DETECTED_CODE_STORAGE_KEY, DEFAULT_DETECTED_CODE, langCodeISO6393Schema).then(setAtom)
+    }
+  }
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+
+  return () => {
+    unwatch()
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
+  }
+}

--- a/src/utils/config/__tests__/example/v037.ts
+++ b/src/utils/config/__tests__/example/v037.ts
@@ -1,0 +1,286 @@
+import type { TestSeriesObject } from './types'
+
+export const testSeries: TestSeriesObject = {
+  'complex-config-from-v020': {
+    description: 'Remove detectedCode from language config',
+    config: {
+      language: {
+        sourceCode: 'spa',
+        targetCode: 'eng',
+        level: 'advanced',
+      },
+      providersConfig: [
+        {
+          id: 'google-default',
+          enabled: true,
+          name: 'Google Translate',
+          provider: 'google',
+        },
+        {
+          id: 'microsoft-default',
+          enabled: true,
+          name: 'Microsoft Translator',
+          provider: 'microsoft',
+        },
+        {
+          id: 'openai-default',
+          enabled: true,
+          name: 'OpenAI',
+          provider: 'openai',
+          apiKey: 'sk-custom-prompt-key',
+          baseURL: 'https://api.openai.com/v1',
+          models: {
+            read: {
+              model: 'gpt-4o-mini',
+              isCustomModel: true,
+              customModel: 'gpt-5-custom',
+            },
+            translate: {
+              model: 'gpt-4o-mini',
+              isCustomModel: true,
+              customModel: 'translate-gpt-custom',
+            },
+          },
+        },
+        {
+          id: 'deepseek-default',
+          enabled: true,
+          name: 'DeepSeek',
+          provider: 'deepseek',
+          apiKey: 'ds-custom',
+          baseURL: 'https://api.custom.com/v1',
+          models: {
+            read: {
+              model: 'deepseek-chat',
+              isCustomModel: true,
+              customModel: 'deepseek-v4-pro',
+            },
+            translate: {
+              model: 'deepseek-chat',
+              isCustomModel: false,
+              customModel: '',
+            },
+          },
+        },
+        {
+          id: 'gemini-default',
+          enabled: true,
+          name: 'Gemini',
+          provider: 'gemini',
+          apiKey: undefined,
+          baseURL: undefined,
+          models: {
+            read: {
+              model: 'gemini-2.5-pro',
+              isCustomModel: false,
+              customModel: '',
+            },
+            translate: {
+              model: 'gemini-2.5-pro',
+              isCustomModel: false,
+              customModel: '',
+            },
+          },
+        },
+        {
+          id: 'deeplx-default',
+          enabled: true,
+          name: 'DeepLX',
+          provider: 'deeplx',
+          apiKey: undefined,
+          baseURL: 'https://deeplx.vercel.app',
+        },
+      ],
+      read: {
+        providerId: 'deepseek-default',
+      },
+      translate: {
+        providerId: 'openai-default',
+        mode: 'translationOnly',
+        enableAIContentAware: false,
+        node: {
+          enabled: true,
+          hotkey: 'Alt',
+        },
+        page: {
+          range: 'all',
+          autoTranslatePatterns: ['spanish-news.com', 'elmundo.es'],
+          autoTranslateLanguages: [],
+          shortcut: ['alt', 'b'],
+          enableLLMDetection: false,
+          preload: {
+            margin: 1000,
+            threshold: 0,
+          },
+        },
+        customPromptsConfig: {
+          promptId: '123e4567-e89b-12d3-a456-426614174000',
+          patterns: [
+            {
+              id: '123e4567-e89b-12d3-a456-426614174000',
+              name: 'Technical Translation',
+              systemPrompt: '',
+              prompt: 'Technical translation from Spanish to {{targetLang}}. Preserve technical terms and accuracy:\n{{input}}',
+            },
+          ],
+        },
+        requestQueueConfig: {
+          capacity: 400,
+          rate: 8,
+        },
+        batchQueueConfig: {
+          maxCharactersPerBatch: 1000,
+          maxItemsPerBatch: 4,
+        },
+        translationNodeStyle: {
+          preset: 'blur',
+          isCustom: false,
+          customCSS: null,
+        },
+      },
+      tts: {
+        providerId: null,
+        model: 'tts-1',
+        voice: 'alloy',
+        speed: 1,
+      },
+      floatingButton: {
+        enabled: true,
+        position: 0.75,
+        disabledFloatingButtonPatterns: ['github.com'],
+      },
+      sideContent: {
+        width: 700,
+      },
+      selectionToolbar: {
+        enabled: false,
+        disabledSelectionToolbarPatterns: [],
+      },
+      betaExperience: {
+        enabled: false,
+      },
+      contextMenu: {
+        enabled: true,
+      },
+    },
+  },
+  'config-with-no-default-openai-model': {
+    description: 'Remove detectedCode from language config',
+    config: {
+      floatingButton: {
+        disabledFloatingButtonPatterns: [],
+        enabled: true,
+        position: 0.66,
+      },
+      language: {
+        level: 'intermediate',
+        sourceCode: 'auto',
+        targetCode: 'cmn',
+      },
+      providersConfig: [
+        {
+          id: 'google-default',
+          enabled: true,
+          name: 'Google Translate',
+          provider: 'google',
+        },
+        {
+          id: 'microsoft-default',
+          enabled: true,
+          name: 'Microsoft Translator',
+          provider: 'microsoft',
+        },
+        {
+          id: 'gemini-default',
+          enabled: true,
+          apiKey: '1',
+          models: {
+            read: {
+              customModel: null,
+              isCustomModel: false,
+              model: 'gemini-2.5-pro',
+            },
+            translate: {
+              customModel: 'gemini-1.5-pro',
+              isCustomModel: true,
+              model: 'gemini-2.5-pro',
+            },
+          },
+          name: 'Gemini',
+          provider: 'gemini',
+        },
+        {
+          id: 'deeplx-default',
+          enabled: true,
+          apiKey: '11113',
+          name: 'DeepLX',
+          provider: 'deeplx',
+        },
+      ],
+      read: {
+        providerId: 'gemini-default',
+      },
+      selectionToolbar: {
+        enabled: true,
+        disabledSelectionToolbarPatterns: [],
+      },
+      sideContent: {
+        width: 420,
+      },
+      translate: {
+        mode: 'translationOnly',
+        enableAIContentAware: false,
+        node: {
+          enabled: true,
+          hotkey: 'Control',
+        },
+        page: {
+          autoTranslateLanguages: [],
+          autoTranslatePatterns: [
+            'news.ycombinator.com',
+          ],
+          range: 'all',
+          shortcut: [
+            'alt',
+            'q',
+          ],
+          enableLLMDetection: false,
+          preload: {
+            margin: 1000,
+            threshold: 0,
+          },
+        },
+        customPromptsConfig: {
+          patterns: [],
+          promptId: null,
+        },
+        providerId: 'gemini-default',
+        requestQueueConfig: {
+          capacity: 200,
+          rate: 2,
+        },
+        batchQueueConfig: {
+          maxCharactersPerBatch: 1000,
+          maxItemsPerBatch: 4,
+        },
+        translationNodeStyle: {
+          preset: 'default',
+          isCustom: false,
+          customCSS: null,
+        },
+      },
+      tts: {
+        providerId: null,
+        model: 'tts-1',
+        voice: 'alloy',
+        speed: 1,
+      },
+      betaExperience: {
+        enabled: false,
+      },
+      contextMenu: {
+        enabled: true,
+      },
+    },
+  },
+}

--- a/src/utils/config/config.ts
+++ b/src/utils/config/config.ts
@@ -1,3 +1,4 @@
+import type { LangCodeISO6393 } from '@read-frog/definitions'
 import type { Config } from '@/types/config/config'
 import type { ProvidersConfig } from '@/types/config/provider'
 import { storage } from '#imports'
@@ -6,8 +7,14 @@ import { isReadProviderConfig } from '@/types/config/provider'
 import {
   CONFIG_STORAGE_KEY,
   DEFAULT_CONFIG,
+  DEFAULT_DETECTED_CODE,
+  DETECTED_CODE_STORAGE_KEY,
 } from '../constants/config'
 import { logger } from '../logger'
+
+export async function getDetectedCodeFromStorage(): Promise<LangCodeISO6393> {
+  return await storage.getItem<LangCodeISO6393>(`local:${DETECTED_CODE_STORAGE_KEY}`) ?? DEFAULT_DETECTED_CODE
+}
 
 export async function getConfigFromStorage() {
   const config = await storage.getItem<Config>(`local:${CONFIG_STORAGE_KEY}`)

--- a/src/utils/config/migration-scripts/v036-to-v037.ts
+++ b/src/utils/config/migration-scripts/v036-to-v037.ts
@@ -1,0 +1,19 @@
+/**
+ * Migration script from v036 to v037
+ * Removes 'detectedCode' from language config as it's now stored separately
+ *
+ * Before (v036):
+ *   { language: { detectedCode, sourceCode, targetCode, level }, ... }
+ *
+ * After (v037):
+ *   { language: { sourceCode, targetCode, level }, ... }
+ */
+
+export function migrate(oldConfig: any): any {
+  const { detectedCode: _, ...restLanguage } = oldConfig.language ?? {}
+
+  return {
+    ...oldConfig,
+    language: restLanguage,
+  }
+}

--- a/src/utils/config/migration.ts
+++ b/src/utils/config/migration.ts
@@ -38,6 +38,7 @@ import { migrate as migrateV032ToV033 } from './migration-scripts/v032-to-v033'
 import { migrate as migrateV033ToV034 } from './migration-scripts/v033-to-v034'
 import { migrate as migrateV034ToV035 } from './migration-scripts/v034-to-v035'
 import { migrate as migrateV035ToV036 } from './migration-scripts/v035-to-v036'
+import { migrate as migrateV036ToV037 } from './migration-scripts/v036-to-v037'
 
 export const LATEST_SCHEMA_VERSION = CONFIG_SCHEMA_VERSION
 
@@ -80,6 +81,7 @@ export const migrationScripts: Record<number, MigrationFunction> = {
   34: migrateV033ToV034,
   35: migrateV034ToV035,
   36: migrateV035ToV036,
+  37: migrateV036ToV037,
 }
 
 export async function runMigration(version: number, config: any): Promise<any> {

--- a/src/utils/constants/config.ts
+++ b/src/utils/constants/config.ts
@@ -12,13 +12,14 @@ export const CONFIG_SCHEMA_VERSION_STORAGE_KEY = '__configSchemaVersion'
 export const LAST_SYNC_TIME_STORAGE_KEY = '__lastGoogleDriveSyncTime'
 export const LAST_SYNCED_CONFIG_STORAGE_KEY = '__lastSyncedConfig'
 export const GOOGLE_DRIVE_TOKEN_STORAGE_KEY = '__googleDriveToken'
-export const CONFIG_SCHEMA_VERSION = 36
+export const DETECTED_CODE_STORAGE_KEY = 'detectedCode'
+export const DEFAULT_DETECTED_CODE = 'eng' as const
+export const CONFIG_SCHEMA_VERSION = 37
 
 export const DEFAULT_FLOATING_BUTTON_POSITION = 0.66
 
 export const DEFAULT_CONFIG: Config = {
   language: {
-    detectedCode: 'eng',
     sourceCode: 'auto',
     targetCode: 'cmn',
     level: 'intermediate',

--- a/src/utils/host/__tests__/node-translate.test.tsx
+++ b/src/utils/host/__tests__/node-translate.test.tsx
@@ -24,6 +24,7 @@ vi.mock('@/utils/host/translate/translate-text', () => ({
 
 vi.mock('@/utils/config/config', () => ({
   getConfigFromStorage: vi.fn(),
+  getDetectedCodeFromStorage: vi.fn(() => Promise.resolve('eng')),
 }))
 
 describe('node translation', () => {

--- a/src/utils/host/translate/node-manipulation.ts
+++ b/src/utils/host/translate/node-manipulation.ts
@@ -1,5 +1,6 @@
 import type { Config } from '@/types/config/config'
 import type { Point } from '@/types/dom'
+import { getDetectedCodeFromStorage } from '@/utils/config/config'
 import { isHTMLElement } from '../dom/filter'
 import { findNearestAncestorBlockNodeAt } from '../dom/find'
 import { walkAndLabelElement } from '../dom/traversal'
@@ -18,11 +19,13 @@ export async function removeOrShowNodeTranslation(point: Point, config: Config):
   if (!node || !isHTMLElement(node))
     return
 
+  const detectedCode = await getDetectedCodeFromStorage()
+
   if (!validateTranslationConfigAndToast({
     providersConfig: config.providersConfig,
     translate: config.translate,
     language: config.language,
-  })) {
+  }, detectedCode)) {
     return
   }
 

--- a/src/utils/host/translate/translate-text.ts
+++ b/src/utils/host/translate/translate-text.ts
@@ -182,7 +182,10 @@ export async function translateText(text: string) {
   })
 }
 
-export function validateTranslationConfigAndToast(config: Pick<Config, 'providersConfig' | 'translate' | 'language'>): boolean {
+export function validateTranslationConfigAndToast(
+  config: Pick<Config, 'providersConfig' | 'translate' | 'language'>,
+  detectedCode: LangCodeISO6393,
+): boolean {
   const { providersConfig, translate: translateConfig, language: languageConfig } = config
   const providerConfig = getProviderConfigById(providersConfig, translateConfig.providerId)
   if (!providerConfig) {
@@ -194,9 +197,9 @@ export function validateTranslationConfigAndToast(config: Pick<Config, 'provider
     logger.info('validateTranslationConfig: returning false (same language)')
     return false
   }
-  else if (languageConfig.sourceCode === 'auto' && languageConfig.detectedCode === languageConfig.targetCode) {
+  else if (languageConfig.sourceCode === 'auto' && detectedCode === languageConfig.targetCode) {
     toast.warning(i18n.t('translation.autoModeSameLanguage', [
-      LANG_CODE_TO_LOCALE_NAME[languageConfig.detectedCode] ?? languageConfig.detectedCode,
+      LANG_CODE_TO_LOCALE_NAME[detectedCode] ?? detectedCode,
     ]))
   }
 

--- a/src/utils/request/__tests__/batch-queue.test.ts
+++ b/src/utils/request/__tests__/batch-queue.test.ts
@@ -40,7 +40,6 @@ function mockTranslateError(error: Error) {
 const sampleLangConfig: Config['language'] = {
   sourceCode: 'eng',
   targetCode: 'cmn',
-  detectedCode: 'eng',
   level: 'beginner',
 }
 


### PR DESCRIPTION
## Type of Changes

- [x] ♻️ Code refactoring (refactor)

## Description

This PR extracts `detectedCode` from `config.language` into a separate browser storage location, improving separation of concerns and simplifying the config schema.

### Key Changes

1. **New Storage Infrastructure**
   - Added `DETECTED_CODE_STORAGE_KEY` and `DEFAULT_DETECTED_CODE` constants
   - Created `detectedCodeAtom` with single-atom pattern (private base + public derived) to prevent direct writes
   - Added `getDetectedCodeFromStorage()` utility function

2. **Config Migration (v036 → v037)**
   - Removed `detectedCode` from `languageSchema`
   - Added migration script to strip `detectedCode` from existing configs
   - New storage defaults to `'eng'` if empty

3. **Updated All Read/Write Locations**
   - UI components now use `detectedCodeAtom` for reactive state
   - Non-React contexts use `getDetectedCodeFromStorage()` helper
   - Updated `validateTranslationConfigAndToast` signature to accept `detectedCode` as parameter

### Benefits
- Cleaner config schema (detectedCode is transient state, not user configuration)
- Single atom export reduces mental overhead
- Write operations always go through storageAdapter (can't bypass)

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

All 388 tests pass, including:
- Config migration tests
- Node translation tests (updated mocks)

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved detectedCode out of config.language into its own storage and atom to separate transient state from user config. Updated all read/write paths and validation to use the new storage, with a default of 'eng'.

- **Refactors**
  - Added DETECTED_CODE_STORAGE_KEY and DEFAULT_DETECTED_CODE; implemented detectedCodeAtom with storage-backed writes and onMount syncing.
  - Added getDetectedCodeFromStorage; removed detectedCode from languageSchema.
  - Updated UI components, hooks, and translation flows to read detectedCode from atom/storage.
  - Changed validateTranslationConfigAndToast to accept detectedCode.

- **Migration**
  - Bumped schema to v37 and added v036→v037 script that removes detectedCode from language.
  - Added v037 test examples to confirm migration behavior.

<sup>Written for commit fd1ca80f176a5d2df73b476d7019a9b95e33ac6a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

