### PR TITLE
build: fail production build when WXT_*_API_KEY env vars detected

### DIFF
--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -56,4 +56,25 @@ export default defineConfig({
       port: 3333,
     },
   },
+  vite: configEnv => ({
+    plugins: configEnv.mode === 'production'
+      ? [
+          {
+            name: 'check-api-key-env',
+            buildStart() {
+              const apiKeyVars = Object.keys(process.env)
+                .filter(key => /^WXT_.*API_KEY/.test(key))
+
+              if (apiKeyVars.length > 0) {
+                throw new Error(
+                  `\n\nFound WXT_*_API_KEY environment variables that may be bundled:\n`
+                  + `${apiKeyVars.map(k => `   - ${k}`).join('\n')}\n\n`
+                  + `Please unset these variables before building for production.\n`,
+                )
+              }
+            },
+          },
+        ]
+      : [],
+  }),
 })


### PR DESCRIPTION
## Type of Changes

- [x] 🔧 Build or dependencies update (build)

## Description

Add a Vite plugin that checks for `WXT_*_API_KEY` environment variables at build start and fails with a clear error if any are found. This prevents accidental bundling of API keys into production builds.

**How it works:**
- Adds a `check-api-key-env` Vite plugin in `wxt.config.ts`
- Only runs in production mode (`pnpm build` / `pnpm zip`)
- Fails immediately at build start with a clear error listing all problematic variables

**Example error output:**
```
Found WXT_*_API_KEY environment variables that may be bundled:
   - WXT_OPENAI_API_KEY
   - WXT_DEEPSEEK_API_KEY

Please unset these variables before building for production.
```

## Related Issue

N/A

## How Has This Been Tested?

- [x] Verified through manual testing

Tested by running `WXT_TEST_API_KEY=test123 pnpm build` - build fails immediately with clear error message.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Production builds now fail if any WXT_*_API_KEY environment variables are detected, preventing accidental bundling of API keys. A production-only Vite plugin stops the build at start and prints a clear error listing the offending variables.

<sup>Written for commit ea06c9f2cb9a0fb7afabf6f34c262ed5b5eb22df. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

