### PR TITLE
build: check google client id before pnpm zip

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "test:cov": "vitest run --coverage",
     "test:watch": "vitest",
     "type-check": "tsc --noEmit",
-    "zip": "wxt zip",
-    "zip:firefox": "wxt zip -b firefox",
+    "zip": "WXT_ZIP_MODE=true wxt zip",
+    "zip:firefox": "WXT_ZIP_MODE=true wxt zip -b firefox",
     "release": "changeset tag && git push origin --tags",
     "prepare": "husky"
   },

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -71,6 +71,20 @@ export default defineConfig({
                   + `Please unset these variables before building for production.\n`,
                 )
               }
+
+              // Check required env vars only for zip builds
+              if (process.env.WXT_ZIP_MODE) {
+                const requiredEnvVars = ['WXT_GOOGLE_CLIENT_ID']
+                const missing = requiredEnvVars.filter(key => !process.env[key])
+
+                if (missing.length > 0) {
+                  throw new Error(
+                    `\n\nMissing required environment variables for zip:\n`
+                    + `${missing.map(k => `   - ${k}`).join('\n')}\n\n`
+                    + `Set them in .env.production or your environment.\n`,
+                  )
+                }
+              }
             },
           },
         ]


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [x] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a build-time check for WXT_GOOGLE_CLIENT_ID when creating extension zips to prevent invalid production builds. Zip scripts now set WXT_ZIP_MODE=true to enable the check.

- **Migration**
  - Set WXT_GOOGLE_CLIENT_ID in .env.production or your environment before running pnpm zip or pnpm zip:firefox.
  - Only zip builds are checked; dev builds remain unchanged.

<sup>Written for commit 96126fe2852fd9c074df4c9c2c762fc54160703d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

