### PR TITLE
ci: add zip:all script and upload Chrome + Edge zips to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,19 +104,19 @@ jobs:
             echo "❌ Discord notification failed (HTTP $HTTP_CODE)"
           fi
 
-      # - name: Build and Zip Extension
-      #   if: steps.changesets.outputs.published == 'true'
-      #   run: pnpm zip
-      #   env:
-      #     WXT_GOOGLE_CLIENT_ID: ${{ secrets.WXT_GOOGLE_CLIENT_ID }}
+      - name: Build and Zip Extension
+        if: steps.changesets.outputs.published == 'true'
+        run: pnpm zip:all
+        env:
+          WXT_GOOGLE_CLIENT_ID: ${{ secrets.WXT_GOOGLE_CLIENT_ID }}
 
-      # - name: Upload Extension Zip to Release
-      #   if: steps.changesets.outputs.published == 'true'
-      #   run: |
-      #     VERSION=$(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[0].version')
-      #     gh release upload "v$VERSION" .output/*-chrome.zip --clobber
-      #   env:
-      #     GH_TOKEN: ${{ github.token }}
+      - name: Upload Extension Zip to Release
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          VERSION=$(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[0].version')
+          gh release upload "v$VERSION" .output/*-chrome.zip .output/*-edge.zip --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       # - name: Submit to Chrome & Edge Stores
       #   if: steps.changesets.outputs.published == 'true'

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "test:watch": "vitest",
     "type-check": "tsc --noEmit",
     "zip": "WXT_ZIP_MODE=true wxt zip",
+    "zip:edge": "WXT_ZIP_MODE=true wxt zip -b edge",
     "zip:firefox": "WXT_ZIP_MODE=true wxt zip -b firefox",
+    "zip:all": "pnpm zip && pnpm zip:edge",
     "release": "changeset tag && git push origin --tags",
     "prepare": "husky"
   },


### PR DESCRIPTION
## Type of Changes

- [x] 🔄 CI/CD related (ci)

## Description

Add `zip:all` command that builds both Chrome and Edge extension zips, and update the release workflow to upload both to GitHub releases.

Changes:
- Add `zip:edge` script for Edge browser builds
- Add `zip:all` script to build both Chrome and Edge zips sequentially
- Enable and update release workflow to use `pnpm zip:all`
- Upload both `*-chrome.zip` and `*-edge.zip` to GitHub releases

## Related Issue

N/A

## How Has This Been Tested?

- [x] Verified through manual testing

Scripts verified locally:
- `pnpm zip:edge` creates Edge zip successfully
- `pnpm zip:all` creates both Chrome and Edge zips

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add zip:all to build both Chrome and Edge extension zips and update the release workflow to upload both to GitHub releases. This makes releases include both browser builds automatically.

- **New Features**
  - Added zip:edge and zip:all scripts.
  - Release workflow runs pnpm zip:all after publish.
  - Uploads both *-chrome.zip and *-edge.zip to the GitHub release.

<sup>Written for commit b90032a983ed3d14af768523d782db4ae8d7a936. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

