### PR TITLE
feat: add export confirmation dialog for config backup items

### DIFF
--- a/.changeset/export-backup-dialog.md
+++ b/.changeset/export-backup-dialog.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat: add export confirmation dialog for config backup items

--- a/src/entrypoints/options/pages/config/config-backup/components/backup-config-item.tsx
+++ b/src/entrypoints/options/pages/config/config-backup/components/backup-config-item.tsx
@@ -118,6 +118,7 @@ function RestoreButton({ backup }: { backup: ConfigBackup }) {
 
 function MoreOptions({ backupId, backup }: { backupId: string, backup: ConfigBackup }) {
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
+  const [showExportDialog, setShowExportDialog] = useState(false)
 
   const { mutate: deleteBackup, isPending: isDeleting } = useMutation({
     mutationFn: async (backupId: string) => {
@@ -142,7 +143,7 @@ function MoreOptions({ backupId, backup }: { backupId: string, backup: ConfigBac
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-40" align="end">
-          <DropdownMenuItem onSelect={() => exportConfig(false)} disabled={isExporting}>
+          <DropdownMenuItem onSelect={() => setShowExportDialog(true)} disabled={isExporting}>
             <Icon icon="tabler:file-export" />
             {i18n.t('options.config.backup.item.export')}
           </DropdownMenuItem>
@@ -164,6 +165,28 @@ function MoreOptions({ backupId, backup }: { backupId: string, backup: ConfigBac
             <AlertDialogAction variant="destructive" onClick={() => deleteBackup(backupId)} disabled={isDeleting}>
               {i18n.t('options.config.backup.delete.confirm')}
             </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog open={showExportDialog} onOpenChange={setShowExportDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{i18n.t('options.config.sync.exportOptions.title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {i18n.t('options.config.sync.exportOptions.description')}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex justify-between!">
+            <AlertDialogCancel>{i18n.t('options.config.sync.exportOptions.cancel')}</AlertDialogCancel>
+            <div className="flex gap-2">
+              <AlertDialogAction variant="secondary" onClick={() => exportConfig(true)} disabled={isExporting}>
+                {i18n.t('options.config.sync.exportOptions.includeAPIKeys')}
+              </AlertDialogAction>
+              <AlertDialogAction onClick={() => exportConfig(false)} disabled={isExporting}>
+                {i18n.t('options.config.sync.exportOptions.excludeAPIKeys')}
+              </AlertDialogAction>
+            </div>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)

## Description

Add a confirmation dialog when exporting config backup items that prompts users to choose whether to include or exclude API keys. This brings consistency with the existing export behavior in the sync settings page.

### Changes:
- Added `showExportDialog` state to manage dialog visibility
- Replaced direct `exportConfig(false)` call with dialog trigger
- Added AlertDialog with options to include or exclude API keys
- Reused existing i18n keys from sync export options

## Related Issue

Closes #693


## How Has This Been Tested?

- [x] Verified through manual testing

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)