### PR TITLE
fix: handle config migration errors gracefully

### DIFF
--- a/.changeset/fix-config-migration-error.md
+++ b/.changeset/fix-config-migration-error.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: treat last synced config as null if it is invalid to unlock sync flow

--- a/src/utils/config/storage.ts
+++ b/src/utils/config/storage.ts
@@ -79,8 +79,14 @@ export async function getLastSyncedConfigAndMeta(): Promise<LastSyncedConfigValu
     return null
   }
 
-  const value = await migrateConfig(rawValue, meta.schemaVersion)
-  return { value, meta }
+  try {
+    const value = await migrateConfig(rawValue, meta.schemaVersion)
+    return { value, meta }
+  }
+  catch (error) {
+    logger.error('Failed to migrate last synced config', error)
+    return null
+  }
 }
 
 export async function setLastSyncConfigAndMeta(value: Config, meta: Partial<LastSyncedConfigMeta>): Promise<void> {


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Previously, if `getLastSyncedConfigAndMeta()` failed during config migration (e.g., due to corrupt or incompatible stored data), it would throw an unhandled error that could crash the sync flow.

This PR adds proper error handling:
- Wraps `migrateConfig` call in try-catch in `src/utils/config/storage.ts`
- Returns `null` on migration failure instead of throwing, allowing the sync flow to continue
- Logs the error for debugging purposes

This ensures users aren't blocked from syncing if their locally cached config becomes invalid.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Verified through manual testing

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle config migration errors so invalid cached config no longer crashes sync. On migration failure, we return null and log the error, allowing the sync flow to continue.

- **Bug Fixes**
  - Wrap migrateConfig in try/catch in src/utils/config/storage.ts.
  - Return null on failure instead of throwing.
  - Log the error for easier debugging.

<sup>Written for commit a533a56480d441dd528e1577c5c2b364345882ce. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

