### PR TITLE
fix: clear translation state when navigating to a new URL in same tab

### DIFF
--- a/.changeset/clear-translation-state-on-navigation.md
+++ b/.changeset/clear-translation-state-on-navigation.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: clear translation state when navigating to a new URL in the same tab

--- a/src/entrypoints/background/translation-signal.ts
+++ b/src/entrypoints/background/translation-signal.ts
@@ -80,4 +80,13 @@ export function translationMessage() {
   browser.tabs.onRemoved.addListener(async (tabId) => {
     await storage.removeItem(getTranslationStateKey(tabId))
   })
+
+  // Clear translation state when navigating to a new page in the same tab
+  browser.webNavigation.onCommitted.addListener(async (details) => {
+    // Only handle main frame navigations, not iframes
+    if (details.frameId !== 0)
+      return
+
+    await storage.removeItem(getTranslationStateKey(details.tabId))
+  })
 }


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

When full-page translation was enabled on a page and the user navigated to a new URL in the same tab (via address bar), the new page would automatically start translating. This happened because the translation state was stored per-tab in session storage and only cleared when the tab was closed.

**Root Cause**: Translation state is stored in session storage with key `session:translationState.{tabId}`, but only cleared on `browser.tabs.onRemoved`. Same-tab navigations don't trigger this cleanup.

**Solution**: Added `browser.webNavigation.onCommitted` listener to clear translation state when navigating to a new page in the same tab.

## How Has This Been Tested?

- [x] Verified through manual testing

**Test steps:**
1. Open a webpage and enable full-page translation
2. Type a different URL in the address bar (same tab)
3. Verify the new page does NOT auto-translate
4. Verify auto-translation rules still work (if configured)

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes carry-over of full-page translation when navigating to a new URL in the same tab. Translation state is now cleared on navigation, so new pages don’t auto-translate unless rules apply.

- **Bug Fixes**
  - Clear session translation state on browser.webNavigation.onCommitted (main frame only).
  - Keeps configured auto-translation rules; only removes per-tab manual state.

<sup>Written for commit 0b8bc78b8a5acde5dbb44cc081a8c5c0cb40e4e3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

