### PR TITLE
fix: no new line when translating twitter in translation only mode

### DIFF
--- a/.changeset/thick-squids-cough.md
+++ b/.changeset/thick-squids-cough.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: no new line when translating twitter in translation only mode

--- a/src/entrypoints/host.content/style.css
+++ b/src/entrypoints/host.content/style.css
@@ -13,6 +13,7 @@
   margin: 8px 0 !important; /* 上下边距设置为8px，并强制覆盖其他样式 */
   color: inherit; /* 保持文本颜色与周围文本一致 */
   font-family: inherit;
+  white-space: pre-wrap; /* 保留换行符 */
 }
 
 .read-frog-translated-inline-content {
@@ -20,6 +21,7 @@
   color: inherit;
   font-family: inherit;
   text-decoration: inherit;
+  white-space: pre-wrap; /* 保留换行符 */
 }
 
 /* Simplified Chinese - macOS > Windows > Cross-platform > Fallback */

--- a/src/utils/host/dom/traversal.ts
+++ b/src/utils/host/dom/traversal.ts
@@ -23,6 +23,11 @@ export function extractTextContent(node: TransNode, config: Config): string {
     return node.textContent ?? ''
   }
 
+  // Handle <br> elements as line breaks
+  if (isHTMLElement(node) && node.tagName === 'BR') {
+    return '\n'
+  }
+
   // We already don't walk and label the element which isDontWalkIntoElement
   // for the parent element we already walk and label, if we have a notranslate element inside this parent element,
   // we should extract the text content of the parent.

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -74,7 +74,7 @@ export async function translateNodesBilingualMode(
       }
     }
 
-    const textContent = transNodes.map(node => extractTextContent(node, config)).join(' ').trim()
+    const textContent = transNodes.map(node => extractTextContent(node, config)).join('').trim()
     if (!textContent || isNumericContent(textContent))
       return
 
@@ -213,7 +213,7 @@ export async function translateNodeTranslationOnlyMode(
       }
     }
 
-    const innerTextContent = transNodes.map(node => extractTextContent(node, config)).join(' ')
+    const innerTextContent = transNodes.map(node => extractTextContent(node, config)).join('')
     if (!innerTextContent.trim() || isNumericContent(innerTextContent))
       return
 
@@ -223,7 +223,11 @@ export async function translateNodeTranslationOnlyMode(
 
       let cleanedContent = content.replace(MARK_ATTRIBUTES_REGEX, '')
       cleanedContent = cleanedContent.replace(/<!--[\s\S]*?-->/g, ' ')
-      cleanedContent = cleanedContent.replace(/\s+/g, ' ').trim()
+      // Preserve newlines, only collapse horizontal whitespace (spaces/tabs)
+      cleanedContent = cleanedContent.replace(/[^\S\n]+/g, ' ')
+      // Trim spaces at start/end of each line, but preserve newlines
+      cleanedContent = cleanedContent.split('\n').map(line => line.trim()).join('\n')
+      cleanedContent = cleanedContent.trim()
 
       return cleanedContent
     }
@@ -276,7 +280,8 @@ export async function translateNodeTranslationOnlyMode(
       return
     }
 
-    translatedWrapperNode.innerHTML = translatedText
+    // Convert newlines to <br> for proper rendering in innerHTML
+    translatedWrapperNode.innerHTML = translatedText.replace(/\n/g, '<br>')
 
     // Batch final DOM mutations to reduce layout thrashing
     batchDOMOperation(() => {


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #531 

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing line breaks in X/Twitter posts when using translation-only mode. Newlines are preserved end-to-end so translations keep the original formatting.

- **Bug Fixes**
  - Treat <br> elements as line breaks during text extraction.
  - Preserve newlines when cleaning content (only collapse spaces/tabs; trim per line).
  - Render newlines as <br> and apply white-space: pre-wrap to translated elements.
  - Avoid inserting extra spaces when joining text nodes in translation-only (and bilingual) modes.

<sup>Written for commit 8c14e4f0a5d4b40268092b658a8b232981b8ce0e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

