### PR TITLE
fix: force <task-list> to be block in github website

### DIFF
--- a/.changeset/cyan-sides-kick.md
+++ b/.changeset/cyan-sides-kick.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: force <task-list> to be block in github website

--- a/src/utils/constants/dom-rules.ts
+++ b/src/utils/constants/dom-rules.ts
@@ -139,6 +139,7 @@ export const CUSTOM_DONT_WALK_INTO_ELEMENT_SELECTOR_MAP: Record<string, string[]
 export const CUSTOM_FORCE_BLOCK_TRANSLATION_SELECTOR_MAP: Record<string, string[]> = {
   'github.com': [
     '.react-directory-row-commit-cell *',
+    'task-lists', // https://github.com/mengxi-ream/read-frog/issues/867
   ],
   'engoo.com': [
     '#windowexercise-2 > div > div > div.css-ep7xq6 > div > div > div.css-19m2fbm *',

--- a/src/utils/host/dom/traversal.ts
+++ b/src/utils/host/dom/traversal.ts
@@ -8,6 +8,7 @@ import {
 } from '@/utils/constants/dom-labels'
 import { FORCE_BLOCK_TAGS } from '@/utils/constants/dom-rules'
 import {
+  isCustomForceBlockTranslation,
   isDontWalkIntoAndDontTranslateAsChildElement,
   isDontWalkIntoButTranslateAsChildElement,
   isHTMLElement,
@@ -134,7 +135,7 @@ export function walkAndLabelElement(
 
   const isInlineNode = isShallowInlineHTMLElement(element)
 
-  if (isShallowBlockHTMLElement(element) || forceBlock) {
+  if (isShallowBlockHTMLElement(element) || forceBlock || isCustomForceBlockTranslation(element)) {
     element.setAttribute(BLOCK_ATTRIBUTE, '')
   }
   else if (isInlineNode) {


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #867 

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force GitHub task lists to be treated as block elements so comments render and translate correctly. Fixes #867.

- **Bug Fixes**
  - Added "task-lists" to the github.com force-block selector map.
  - Updated DOM traversal to set the block attribute when an element matches the custom force-block rule.

<sup>Written for commit d43ed96c9f3cdec847a94d90f39c4182ac5aa377. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

