### PR TITLE
fix(ai): configure reasoning effort per GPT-5 model variant

### DIFF
--- a/.changeset/fix-gpt5-reasoning-effort.md
+++ b/.changeset/fix-gpt5-reasoning-effort.md
@@ -1,0 +1,10 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(ai): configure reasoning effort per GPT-5 model variant
+
+- GPT-5.2 and GPT-5.1+ don't support 'minimal', now use 'none'
+- gpt-5-pro uses 'high', gpt-5.2-pro uses 'medium'
+- gpt-5.x-chat-latest models use 'medium'
+- GPT-5 (before 5.1) and o1/o3 models keep 'minimal'

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -29,12 +29,50 @@ describe('getProviderOptions', () => {
       expect(options.anthropic?.thinking).toEqual({ type: 'disabled' })
     })
 
-    it('should return options for OpenAI reasoning models', () => {
+    it('should return options for OpenAI o1/o3 reasoning models', () => {
       const o1Options = getProviderOptions('o1-preview', 'openai')
       expect(o1Options.openai?.reasoningEffort).toBe('minimal')
 
-      const gpt5Options = getProviderOptions('gpt-5-mini', 'openai')
+      const o3Options = getProviderOptions('o3-mini', 'openai')
+      expect(o3Options.openai?.reasoningEffort).toBe('minimal')
+    })
+
+    it('should return medium for gpt-5.x-chat-latest and gpt-5.2-pro', () => {
+      const gpt52ProOptions = getProviderOptions('gpt-5.2-pro', 'openai')
+      expect(gpt52ProOptions.openai?.reasoningEffort).toBe('medium')
+
+      const gpt52ChatLatestOptions = getProviderOptions('gpt-5.2-chat-latest', 'openai')
+      expect(gpt52ChatLatestOptions.openai?.reasoningEffort).toBe('medium')
+
+      const gpt51ChatLatestOptions = getProviderOptions('gpt-5.1-chat-latest', 'openai')
+      expect(gpt51ChatLatestOptions.openai?.reasoningEffort).toBe('medium')
+    })
+
+    it('should return high for gpt-5-pro', () => {
+      const gpt5ProOptions = getProviderOptions('gpt-5-pro', 'openai')
+      expect(gpt5ProOptions.openai?.reasoningEffort).toBe('high')
+    })
+
+    it('should return none for GPT-5.1+ models', () => {
+      const gpt51Options = getProviderOptions('gpt-5.1', 'openai')
+      expect(gpt51Options.openai?.reasoningEffort).toBe('none')
+
+      const gpt52Options = getProviderOptions('gpt-5.2', 'openai')
+      expect(gpt52Options.openai?.reasoningEffort).toBe('none')
+
+      const gpt51CodexOptions = getProviderOptions('gpt-5.1-codex', 'openai')
+      expect(gpt51CodexOptions.openai?.reasoningEffort).toBe('none')
+    })
+
+    it('should return minimal for GPT-5 models before 5.1 (none not supported)', () => {
+      const gpt5Options = getProviderOptions('gpt-5', 'openai')
       expect(gpt5Options.openai?.reasoningEffort).toBe('minimal')
+
+      const gpt5MiniOptions = getProviderOptions('gpt-5-mini', 'openai')
+      expect(gpt5MiniOptions.openai?.reasoningEffort).toBe('minimal')
+
+      const gpt5NanoOptions = getProviderOptions('gpt-5-nano', 'openai')
+      expect(gpt5NanoOptions.openai?.reasoningEffort).toBe('minimal')
     })
 
     it('should return empty object for non-matching models', () => {

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -94,9 +94,33 @@ export const TRANSLATE_MODEL_OPTIONS: Array<{
     options: { thinking: { type: 'disabled' } } satisfies AnthropicProviderOptions as Record<string, JSONValue>,
   },
 
-  // OpenAI reasoning models
+  // OpenAI o1/o3 reasoning models - use 'minimal'
   {
-    pattern: /^(gpt-5|o1-|o3-)/,
+    pattern: /^(o1-|o3-)/,
+    options: { reasoningEffort: 'minimal' } satisfies OpenAIResponsesProviderOptions as Record<string, JSONValue>,
+  },
+
+  // OpenAI gpt-5.x-chat-latest and gpt-5.2-pro - use 'medium'
+  {
+    pattern: /^gpt-5(\.\d-chat-latest|\.2-pro)/,
+    options: { reasoningEffort: 'medium' } satisfies OpenAIResponsesProviderOptions as Record<string, JSONValue>,
+  },
+
+  // OpenAI gpt-5-pro - use 'high'
+  {
+    pattern: /^gpt-5-pro/,
+    options: { reasoningEffort: 'high' } satisfies OpenAIResponsesProviderOptions as Record<string, JSONValue>,
+  },
+
+  // OpenAI GPT-5.1+ - use 'none' (minimal not supported)
+  {
+    pattern: /^gpt-5\.\d/,
+    options: { reasoningEffort: 'none' } satisfies OpenAIResponsesProviderOptions as Record<string, JSONValue>,
+  },
+
+  // OpenAI GPT-5 models (before 5.1) - use 'minimal' (none not supported)
+  {
+    pattern: /^gpt-5/,
     options: { reasoningEffort: 'minimal' } satisfies OpenAIResponsesProviderOptions as Record<string, JSONValue>,
   },
 


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Fixes GPT-5.2 throwing error: "Unsupported value: 'minimal' is not supported with the 'gpt-5.2' model."

Different GPT-5 model variants support different `reasoningEffort` values. This PR configures the appropriate value for each variant:

| Model Pattern | reasoningEffort | Reason |
|---------------|-----------------|--------|
| o1-*, o3-* | `minimal` | Reasoning models, minimal for cost savings |
| gpt-5.x-chat-latest, gpt-5.2-pro | `medium` | Chat-latest and 5.2-pro models |
| gpt-5-pro | `high` | Only supports high |
| gpt-5.1+  | `none` | Default for 5.1+, minimal not supported |
| gpt-5 (before 5.1) | `minimal` | None not supported, use minimal |

## Related Issue

Closes #899

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configured reasoningEffort per GPT-5 model variant to match supported values and stop the “Unsupported value: 'minimal'” error on gpt-5.2. Updated model pattern matching and added tests to ensure correct defaults.

- **Bug Fixes**
  - o1-*/o3-* → minimal
  - gpt-5.x-chat-latest, gpt-5.2-pro → medium
  - gpt-5-pro → high
  - gpt-5.1+ → none
  - gpt-5 (pre-5.1) → minimal
  - Added unit tests for each case

<sup>Written for commit e1ed4e5f7952f08e82ba65a46c2513ccd3e9a386. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

