### PR TITLE
feat: integrate YouTube subtitle translation survey

### DIFF
--- a/.changeset/tally-survey-integration.md
+++ b/.changeset/tally-survey-integration.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat: replace feature suggestion survey with subtitle translation survey

--- a/src/entrypoints/options/app-sidebar/product-nav.tsx
+++ b/src/entrypoints/options/app-sidebar/product-nav.tsx
@@ -17,7 +17,7 @@ import { getLastViewedSurvey, hasNewSurvey, saveLastViewedSurvey } from '@/utils
 import { version } from '../../../../package.json'
 import { AnimatedIndicator } from './animated-indicator'
 
-const SURVEY_URL = 'https://tally.so/r/nrxr6L'
+const SURVEY_URL = 'https://tally.so/r/kdNN5R'
 
 export function ProductNav() {
   const { open } = useSidebar()

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -582,7 +582,7 @@ options:
   whatsNew:
     title: What's New
   survey:
-    title: New Feature Suggestion
+    title: Subtitle Translation Survey
   rateUs:
     title: Rate Us
 side:

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -578,7 +578,7 @@ options:
   whatsNew:
     title: 新機能
   survey:
-    title: 新機能の提案
+    title: 字幕翻訳アンケート
   rateUs:
     title: レビューを書く
 side:

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -579,7 +579,7 @@ options:
   whatsNew:
     title: 새로운 기능
   survey:
-    title: 새로운 기능 제안
+    title: 자막 번역 설문조사
   rateUs:
     title: 리뷰 남기기
 side:

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -580,7 +580,7 @@ options:
   whatsNew:
     title: Что нового
   survey:
-    title: Предложение новой функции
+    title: Опрос о переводе субтитров
   rateUs:
     title: Оцените нас
 side:

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -580,7 +580,7 @@ options:
   whatsNew:
     title: Yenilikler
   survey:
-    title: Yeni Özellik Önerisi
+    title: Altyazı Çeviri Anketi
   rateUs:
     title: Bizi Değerlendirin
 side:

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -580,7 +580,7 @@ options:
   whatsNew:
     title: Có gì mới
   survey:
-    title: Đề xuất tính năng mới
+    title: Khảo sát dịch phụ đề
   rateUs:
     title: Đánh giá chúng tôi
 side:

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -581,7 +581,7 @@ options:
   whatsNew:
     title: 最近更新
   survey:
-    title: 新功能建议
+    title: 字幕翻译调研
   rateUs:
     title: 好评支持
 side:

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -581,7 +581,7 @@ options:
   whatsNew:
     title: 最近更新
   survey:
-    title: 新功能建議
+    title: 字幕翻譯調研
   rateUs:
     title: 好評支持
 side:


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)

## Description

Replace the "New Feature Suggestion" survey with a new "Subtitle Translation Survey" to gather user feedback on YouTube subtitle translation functionality.

### Changes
- Update survey URL from `nrxr6L` to `kdNN5R`
- Update survey title in all 8 locale files:
  - zh-CN: 字幕翻译调研
  - zh-TW: 字幕翻譯調研
  - en: Subtitle Translation Survey
  - ja: 字幕翻訳アンケート
  - ko: 자막 번역 설문조사
  - ru: Опрос о переводе субтитров
  - tr: Altyazı Çeviri Anketi
  - vi: Khảo sát dịch phụ đề

## How Has This Been Tested?

- [x] Verified through manual testing

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the “New Feature Suggestion” survey with a “Subtitle Translation Survey” to collect feedback on YouTube subtitle translation. Updates the options sidebar link and localized survey titles.

- **New Features**
  - Updated survey URL to https://tally.so/r/kdNN5R.
  - Updated survey title across en, zh-CN, zh-TW, ja, ko, ru, tr, vi.

<sup>Written for commit 5aa26bbbeddd2c14e04727eb2c900878c96e5287. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

