### PR TITLE
fix(ui): workaround base-ui Select/Field update loop bug

### DIFF
--- a/src/entrypoints/options/pages/general/translation-config.tsx
+++ b/src/entrypoints/options/pages/general/translation-config.tsx
@@ -4,9 +4,6 @@ import { Activity } from 'react'
 import { toast } from 'sonner'
 import { Field, FieldLabel } from '@/components/base-ui/field'
 import { Input } from '@/components/base-ui/input'
-import TranslateProviderSelector from '@/components/llm-providers/translate-provider-selector'
-// TODO: use base-ui/checkbox has the bug Maximum update depth, report to base-ui
-import { Checkbox } from '@/components/shadcn/checkbox'
 import {
   Select,
   SelectContent,
@@ -14,7 +11,10 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/shadcn/select'
+} from '@/components/base-ui/select'
+import TranslateProviderSelector from '@/components/llm-providers/translate-provider-selector'
+// TODO: use base-ui/checkbox has the bug Maximum update depth, report to base-ui
+import { Checkbox } from '@/components/shadcn/checkbox'
 import { isAPIProviderConfig, isLLMTranslateProviderConfig, TRANSLATE_PROVIDER_MODELS } from '@/types/config/provider'
 import { translateProviderConfigAtom, updateLLMProviderConfig } from '@/utils/atoms/provider'
 import { ConfigCard } from '../../components/config-card'
@@ -61,57 +61,59 @@ function TranslateModelSelector() {
   const modelConfig = translateProviderConfig.models.translate
 
   return (
-    <Field>
-      <FieldLabel nativeLabel={false} render={<div />}>
-        {i18n.t('options.general.translationConfig.model.title')}
-      </FieldLabel>
-      <Activity mode={modelConfig.isCustomModel ? 'visible' : 'hidden'}>
-        <Input
-          value={modelConfig.customModel ?? ''}
-          onChange={(e) => {
-            void setTranslateProviderConfig(
-              updateLLMProviderConfig(translateProviderConfig, {
-                models: {
-                  translate: {
-                    customModel: e.target.value === '' ? null : e.target.value,
+    <>
+      <Field>
+        <FieldLabel nativeLabel={false} render={<div />}>
+          {i18n.t('options.general.translationConfig.model.title')}
+        </FieldLabel>
+        <Activity mode={modelConfig.isCustomModel ? 'visible' : 'hidden'}>
+          <Input
+            value={modelConfig.customModel ?? ''}
+            onChange={(e) => {
+              void setTranslateProviderConfig(
+                updateLLMProviderConfig(translateProviderConfig, {
+                  models: {
+                    translate: {
+                      customModel: e.target.value === '' ? null : e.target.value,
+                    },
                   },
-                },
-              }),
-            )
-          }}
-        />
-      </Activity>
-      <Activity mode={modelConfig.isCustomModel ? 'hidden' : 'visible'}>
-        <Select
-          value={modelConfig.model}
-          onValueChange={(value) => {
-            if (!value)
-              return
-            void setTranslateProviderConfig(
-              updateLLMProviderConfig(translateProviderConfig, {
-                models: {
-                  translate: {
-                    model: value as any,
+                }),
+              )
+            }}
+          />
+        </Activity>
+        <Activity mode={modelConfig.isCustomModel ? 'hidden' : 'visible'}>
+          <Select
+            value={modelConfig.model}
+            onValueChange={(value) => {
+              if (!value)
+                return
+              void setTranslateProviderConfig(
+                updateLLMProviderConfig(translateProviderConfig, {
+                  models: {
+                    translate: {
+                      model: value as any,
+                    },
                   },
-                },
-              }),
-            )
-          }}
-        >
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder="Select a model" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectGroup>
-              {TRANSLATE_PROVIDER_MODELS[provider].map(model => (
-                <SelectItem key={model} value={model}>
-                  {model}
-                </SelectItem>
-              ))}
-            </SelectGroup>
-          </SelectContent>
-        </Select>
-      </Activity>
+                }),
+              )
+            }}
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select a model" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {TRANSLATE_PROVIDER_MODELS[provider].map(model => (
+                  <SelectItem key={model} value={model}>
+                    {model}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </Activity>
+      </Field>
       <Activity mode={provider === 'openai-compatible' ? 'hidden' : 'visible'}>
         <div className="mt-0.5 flex items-center space-x-2">
           <Checkbox
@@ -157,6 +159,6 @@ function TranslateModelSelector() {
           </label>
         </div>
       </Activity>
-    </Field>
+    </>
   )
 }


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

This PR migrates the Select component in the translation config page from shadcn to base-ui, with a workaround for a known base-ui issue.

**The problem:** When `Select` and `Checkbox` components are wrapped under the same `<Field.Root>`, changing the Select value causes an infinite "Maximum update depth exceeded" error.

**The workaround:** Wrap the `<Field>` containing the Select in a React fragment (`<>...</>`) so it's no longer a sibling of the Checkbox's Field under a single parent component.

## Related Issue

Related upstream issue: https://github.com/mui/base-ui/issues/3928

We are waiting for this issue to be resolved by the base-ui team. Once fixed, we can remove the fragment workaround.

## How Has This Been Tested?

- [x] Verified through manual testing

Tested by:
1. Opening the extension options page
2. Navigating to General settings → Translation Config
3. Changing the model selection - no crash occurs
4. Toggling the custom model checkbox - works correctly

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This is a temporary workaround. The TODO comment in the code references the upstream issue. Once https://github.com/mui/base-ui/issues/3928 is resolved, we should revisit and potentially simplify this code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the Translation Config model Select to base-ui and added a small workaround to stop an update loop with Field + Checkbox. This fixes the “Maximum update depth exceeded” crash when changing models.

- **Bug Fixes**
  - Replaced shadcn Select with base-ui Select in translation-config.
  - Wrapped the Select’s Field in a fragment so it doesn’t share a Field.Root with the Checkbox, preventing the loop.
  - Kept Checkbox on shadcn; remove the fragment workaround once base-ui issue 3928 is fixed.

<sup>Written for commit 7117f4ffb8476b56d4bd61641d978d1274a34ed9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

