### PR TITLE
refactor(subtitles): unify noise filtering to fetcher layer

### DIFF
--- a/.changeset/unify-noise-filter.md
+++ b/.changeset/unify-noise-filter.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+refactor(subtitles): unify noise filtering to fetcher layer

--- a/src/utils/subtitles/__tests__/noise-filter.test.ts
+++ b/src/utils/subtitles/__tests__/noise-filter.test.ts
@@ -1,0 +1,114 @@
+import type { YoutubeTimedText } from '../fetchers/youtube/types'
+import { describe, expect, it } from 'vitest'
+import { filterNoiseFromEvents } from '../fetchers/youtube/noise-filter'
+
+describe('noise Filter', () => {
+  describe('filterNoiseFromEvents', () => {
+    it('should filter out [Music] annotations', () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: '[Music]' }] },
+      ]
+      const result = filterNoiseFromEvents(events)
+      expect(result[0].segs).toHaveLength(0)
+    })
+
+    it('should filter out (Applause) annotations', () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: '(Applause)' }] },
+      ]
+      const result = filterNoiseFromEvents(events)
+      expect(result[0].segs).toHaveLength(0)
+    })
+
+    it('should filter out music note annotations', () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: '♪ Music ♪' }] },
+        { tStartMs: 1000, dDurationMs: 1000, segs: [{ utf8: '🎵 Song 🎵' }] },
+        { tStartMs: 2000, dDurationMs: 1000, segs: [{ utf8: '🎶 Melody 🎶' }] },
+      ]
+      const result = filterNoiseFromEvents(events)
+      expect(result[0].segs).toHaveLength(0)
+      expect(result[1].segs).toHaveLength(0)
+      expect(result[2].segs).toHaveLength(0)
+    })
+
+    it('should keep text after removing speaker annotation', () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: '[Speaker 1] Hello world' }] },
+      ]
+      const result = filterNoiseFromEvents(events)
+      expect(result[0].segs).toHaveLength(1)
+      expect(result[0].segs![0].utf8).toBe(' Hello world')
+    })
+
+    it('should remove noise in the middle of text', () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: 'Hello [Music] World' }] },
+      ]
+      const result = filterNoiseFromEvents(events)
+      expect(result[0].segs).toHaveLength(1)
+      expect(result[0].segs![0].utf8).toBe('Hello  World')
+    })
+
+    it('should handle multiple noise patterns in one segment', () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: '[Music] Hello (Applause)' }] },
+      ]
+      const result = filterNoiseFromEvents(events)
+      expect(result[0].segs).toHaveLength(1)
+      expect(result[0].segs![0].utf8).toBe(' Hello ')
+    })
+
+    it('should preserve events without segs', () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 0, dDurationMs: 1000 },
+      ]
+      const result = filterNoiseFromEvents(events)
+      expect(result).toHaveLength(1)
+      expect(result[0].segs).toBeUndefined()
+    })
+
+    it('should preserve timing information', () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 1234, dDurationMs: 5678, segs: [{ utf8: '[Music]', tOffsetMs: 100 }] },
+      ]
+      const result = filterNoiseFromEvents(events)
+      expect(result[0].tStartMs).toBe(1234)
+      expect(result[0].dDurationMs).toBe(5678)
+    })
+
+    it('should handle empty events array', () => {
+      const result = filterNoiseFromEvents([])
+      expect(result).toEqual([])
+    })
+
+    it('should handle multiple segs in one event', () => {
+      const events: YoutubeTimedText[] = [
+        {
+          tStartMs: 0,
+          dDurationMs: 1000,
+          segs: [
+            { utf8: '[Music]' },
+            { utf8: 'Hello' },
+            { utf8: '(Applause)' },
+          ],
+        },
+      ]
+      const result = filterNoiseFromEvents(events)
+      expect(result[0].segs).toHaveLength(1)
+      expect(result[0].segs![0].utf8).toBe('Hello')
+    })
+
+    it('should preserve tOffsetMs in segs', () => {
+      const events: YoutubeTimedText[] = [
+        {
+          tStartMs: 0,
+          dDurationMs: 1000,
+          segs: [{ utf8: 'Hello', tOffsetMs: 500 }],
+        },
+      ]
+      const result = filterNoiseFromEvents(events)
+      expect(result[0].segs![0].tOffsetMs).toBe(500)
+    })
+  })
+})

--- a/src/utils/subtitles/fetchers/youtube/noise-filter.ts
+++ b/src/utils/subtitles/fetchers/youtube/noise-filter.ts
@@ -1,0 +1,37 @@
+import type { YoutubeTimedText } from './types'
+
+/**
+ * Patterns to filter out noise annotations from subtitles
+ * Uses partial matching to handle mixed content like "[Speaker 1] Hello"
+ */
+const NOISE_PATTERNS = [
+  /\[.*?\]/g, // [Music], [Applause], [Speaker 1], etc.
+  /\(.*?\)/g, // (Music), (Applause), etc.
+  /♪.*?♪/g, // ♪ Music ♪
+  /🎵.*?🎵/g, // 🎵 Music 🎵
+  /🎶.*?🎶/g, // 🎶 Music 🎶
+]
+
+function filterNoiseText(text: string): string {
+  let result = text
+  for (const pattern of NOISE_PATTERNS) {
+    result = result.replace(pattern, '')
+  }
+  return result
+}
+
+export function filterNoiseFromEvents(events: YoutubeTimedText[]): YoutubeTimedText[] {
+  return events.map((event) => {
+    if (!event.segs)
+      return event
+
+    const filteredSegs = event.segs
+      .map(seg => ({
+        ...seg,
+        utf8: filterNoiseText(seg.utf8),
+      }))
+      .filter(seg => seg.utf8.trim().length > 0)
+
+    return { ...event, segs: filteredSegs }
+  })
+}

--- a/src/utils/subtitles/processor/ai-segmentation.ts
+++ b/src/utils/subtitles/processor/ai-segmentation.ts
@@ -2,35 +2,13 @@ import type { SubtitlesFragment } from '../types'
 import type { Config } from '@/types/config/config'
 import { sendMessage } from '@/utils/message'
 
-/**
- * Patterns to filter out from subtitles (non-speech annotations)
- */
-const NOISE_PATTERNS = [
-  /^\[.*\]$/, // [Music], [Applause], [Laughter], etc.
-  /^\(.*\)$/, // (Music), (Applause), etc.
-  /^♪.*♪$/, // ♪ Music ♪
-  /^🎵.*🎵$/, // 🎵 Music 🎵
-  /^🎶.*🎶$/, // 🎶 Music 🎶
-]
-
-/**
- * Check if text is a noise annotation that should be filtered out
- */
-function isNoiseText(text: string): boolean {
-  const trimmed = text.trim()
-  return NOISE_PATTERNS.some(pattern => pattern.test(trimmed))
-}
-
 export function cleanFragmentsForAi(fragments: SubtitlesFragment[]): SubtitlesFragment[] {
   return fragments
     .map(fragment => ({
       ...fragment,
       text: fragment.text.replace(/\n/g, ' ').replace(/\s+/g, ' ').trim(),
     }))
-    .filter(fragment =>
-      fragment.text.length > 0
-      && !isNoiseText(fragment.text),
-    )
+    .filter(fragment => fragment.text.length > 0)
 }
 
 export function formatFragmentsToJson(fragments: SubtitlesFragment[]): string {


### PR DESCRIPTION
## Type of Changes

- [x] ♻️ Code refactoring (refactor)

## Description

Extracts and unifies noise filtering logic from AI segmentation module to the fetcher layer. Now noise (like `[Music]`, `(Applause)`, `♪ Song ♪`) is filtered at the earliest stage in `processRawEvents()`, ensuring all subtitle processing branches receive clean data.

**Changes:**
- Create `noise-filter.ts` with `filterNoiseFromEvents()` function
- Apply noise filtering to raw `YoutubeTimedText[]` events before parsing
- Remove duplicated noise filtering logic from `ai-segmentation.ts`
- All branches (karaoke, standard, scrolling-asr, AI segmentation) now receive clean data

**Behavior:**
- Partial matching: `[Speaker 1] Hello` → ` Hello` (keeps speech, removes annotation)
- Full noise: `[Music]` → seg removed if empty after filtering
- Preserves whitespace for word boundaries

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move noise filtering for YouTube subtitles to the fetcher layer so all parsing paths get clean, speech-only data. Removes duplicated filtering in AI segmentation and adds tests for common annotations.

- **Refactors**
  - Apply filtering in processRawEvents before format detection using filterNoiseFromEvents.
  - Remove noise filtering from ai-segmentation; karaoke, standard, scrolling-asr, and AI segmentation now consume filtered events.
  - Preserve timing and tOffsetMs; trim bracketed/parenthesized and music-note annotations; drop segments that become empty.

<sup>Written for commit 4d41471260e3043079aa46ab4019c52710f255fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

