### PR TITLE
fix(ui): fix slider track collapse on wide screen

### DIFF
--- a/.changeset/fix-slider-track-wide-screen.md
+++ b/.changeset/fix-slider-track-wide-screen.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(ui): fix slider track collapse on wide screen in video subtitles settings

--- a/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/general-settings.tsx
+++ b/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/general-settings.tsx
@@ -112,7 +112,7 @@ export function GeneralSettings() {
 
         <Field orientation="responsive-compact">
           <FieldLabel className="text-sm whitespace-nowrap">{i18n.t('options.videoSubtitles.style.backgroundOpacity')}</FieldLabel>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-1 min-w-0 items-center gap-2">
             <Slider
               min={MIN_BACKGROUND_OPACITY}
               max={MAX_BACKGROUND_OPACITY}

--- a/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/subtitles-text-style-form.tsx
+++ b/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/subtitles-text-style-form.tsx
@@ -57,7 +57,7 @@ export function SubtitlesTextStyleForm({ type }: SubtitlesTextStyleFormProps) {
 
       <Field orientation="responsive-compact">
         <FieldLabel className="text-sm whitespace-nowrap">{i18n.t('options.videoSubtitles.style.fontScale')}</FieldLabel>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-1 min-w-0 items-center gap-2">
           <Slider
             min={MIN_FONT_SCALE}
             max={MAX_FONT_SCALE}
@@ -75,7 +75,7 @@ export function SubtitlesTextStyleForm({ type }: SubtitlesTextStyleFormProps) {
 
       <Field orientation="responsive-compact">
         <FieldLabel className="text-sm whitespace-nowrap">{i18n.t('options.videoSubtitles.style.fontWeight')}</FieldLabel>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-1 min-w-0 items-center gap-2">
           <Slider
             min={MIN_FONT_WEIGHT}
             max={MAX_FONT_WEIGHT}


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Fix slider track collapsing to zero width on wide screens in the video subtitles style settings page (`#/video-subtitles`).

**Root cause:** The `Field` component's `responsive-compact` orientation applies `@xs/field-group:[&>*]:w-auto` to all direct children when the container exceeds `@xs` breakpoint. This causes slider wrapper divs to shrink-wrap their content, giving the slider track zero width.

**Fix:** Add `flex-1 min-w-0` to the 3 slider wrapper divs (font size, font weight, background opacity) so they grow to fill remaining space in the flex row.

## How Has This Been Tested?

- [x] Verified through manual testing

- Wide screen (3-column layout): slider tracks render correctly
- Narrow screen (1-column layout): sliders still work as before

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes slider tracks collapsing on wide screens in the Video Subtitles style settings. Sliders now expand properly and still work on narrow screens.

- **Bug Fixes**
  - Root cause: responsive-compact Field applied w-auto, making slider wrappers shrink.
  - Fix: add flex-1 min-w-0 to font scale, font weight, and background opacity slider wrappers.
  - Verified manually on wide (3-column) and narrow (1-column) layouts.

<sup>Written for commit ac3286fc9cd7fecb7bb8b9f4fa9c02c25e948d76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

