### PR TITLE
ci(stale): add on-hold exempt label and fix issue close days

### DIFF
--- a/.github/workflows/stale-issue-pr.yml
+++ b/.github/workflows/stale-issue-pr.yml
@@ -17,10 +17,13 @@ jobs:
 
           # ---- Issue settings ----
           days-before-issue-stale: 30
-          days-before-issue-close: 150
+          days-before-issue-close: 60
+          exempt-issue-labels: |
+            pinned
+            on-hold
           stale-issue-message: |
             This issue has been inactive for 30 days and is now marked as stale.
-            It will be automatically closed in 150 days if no further activity occurs.
+            It will be automatically closed in 60 days if no further activity occurs.
           close-issue-message: |
             Since it has been a long time without updates, the issue has been automatically closed.
             If you need to continue, please reopen or create a new issue.
@@ -37,3 +40,4 @@ jobs:
           exempt-pr-labels: |
             pinned
             WIP
+            on-hold


### PR DESCRIPTION
## Type of Changes

- [x] 🔄 CI/CD related (ci)

## Description

- Add `exempt-issue-labels` with `pinned` and `on-hold` so long-term issues are not auto-staled/closed
- Add `on-hold` to existing `exempt-pr-labels` (alongside `pinned` and `WIP`)
- Fix `days-before-issue-close` from 150 to 60 and update `stale-issue-message` to match

## How Has This Been Tested?

- [x] Verified through manual testing

Reviewed YAML syntax validity and confirmed both `exempt-issue-labels` and `exempt-pr-labels` include `on-hold`.

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the stale workflow to respect “on-hold” items and shorten the issue auto-close window. This prevents paused or long-term work from being auto-staled/closed too soon.

- **New Features**
  - Exempt issues with labels: pinned, on-hold.
  - Exempt PRs with on-hold (alongside pinned, WIP).

- **Bug Fixes**
  - Set days-before-issue-close to 60 (was 150).
  - Updated the stale message to reflect the 60-day close.

<sup>Written for commit cd167dec7137f90acc149a6d6a3c1bf90d08c567. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

