### PR TITLE
fix(subtitles): enable text selection and copy in subtitle container

### DIFF
--- a/.changeset/fix-subtitle-text-copy.md
+++ b/.changeset/fix-subtitle-text-copy.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(subtitles): enable text selection and copy in subtitle container

--- a/src/entrypoints/subtitles.content/ui/subtitles-view.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-view.tsx
@@ -29,7 +29,7 @@ function SubtitlesContent() {
   return (
     <div className={`${SUBTITLES_VIEW_CLASS} flex w-full flex-col items-center justify-end pb-3 pointer-events-none`}>
       <div
-        className="flex flex-col gap-2 w-fit max-w-[80%] mx-auto px-2 py-1.5 rounded text-center text-white pointer-events-auto"
+        className="flex flex-col gap-2 w-fit max-w-[80%] mx-auto px-2 py-1.5 rounded text-center text-white pointer-events-auto select-text cursor-text"
         style={containerStyle}
       >
         <Activity mode={showMain ? 'visible' : 'hidden'}>


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Subtitle text inside the video overlay cannot be selected or copied. The Shadow DOM's `all: initial` reset breaks the browser's default text selection inheritance chain, so even though the subtitle content div has `pointer-events-auto`, text selection doesn't work.

**Fix:** Add `select-text` (`user-select: text`) and `cursor-text` (`cursor: text`) to the inner subtitle content div to explicitly re-enable text selection.

## How Has This Been Tested?

- [x] Verified through manual testing

1. Open a video with subtitles
2. Hover over subtitle text → cursor changes to text cursor
3. Click and drag to select subtitle text → text highlights
4. Ctrl+C / Cmd+C → selected text copies to clipboard

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows selecting and copying subtitle text in the video overlay by explicitly enabling text selection in the Shadow DOM. Adds select-text and cursor-text to the subtitle content container to restore native selection behavior.

<sup>Written for commit 644c2f6e07d3f533468a08aa74ff35f184863ba3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

