### PR TITLE
fix(subtitles): fast detect no-subtitles before fetching

### DIFF
--- a/.changeset/fix-fast-no-subtitles-detection.md
+++ b/.changeset/fix-fast-no-subtitles-detection.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(subtitles): fast detect no-subtitles before fetching

--- a/src/entrypoints/subtitles.content/ui/state-message.tsx
+++ b/src/entrypoints/subtitles.content/ui/state-message.tsx
@@ -4,16 +4,14 @@ import { useAtomValue } from 'jotai'
 import { STATE_MESSAGE_CLASS } from '@/utils/constants/subtitles'
 import { subtitlesStateAtom } from '../atoms'
 
-const STATE_CONFIG: Record<Exclude<SubtitlesState, 'idle'>, { color: string, getText: () => string, position: string }> = {
+const STATE_CONFIG: Record<Exclude<SubtitlesState, 'idle'>, { color: string, getText: () => string }> = {
   loading: {
     color: 'oklch(70% 0.19 250)',
     getText: () => i18n.t('subtitles.state.loading'),
-    position: 'bottom-20',
   },
   error: {
     color: 'oklch(63% 0.24 25)',
     getText: () => i18n.t('subtitles.state.error'),
-    position: 'top-1/2 -translate-y-1/2',
   },
 }
 
@@ -24,12 +22,12 @@ export function StateMessage() {
     return null
   }
 
-  const { color, getText, position } = STATE_CONFIG[stateData.state]
+  const { color, getText } = STATE_CONFIG[stateData.state]
   const message = stateData.message || getText()
 
   return (
     <div
-      className={`${STATE_MESSAGE_CLASS} absolute left-1/2 -translate-x-1/2 pointer-events-auto ${position}`}
+      className={`${STATE_MESSAGE_CLASS} absolute left-1/2 -translate-x-1/2 bottom-1/6 pointer-events-auto`}
       style={{
         fontFamily: 'Roboto, "Arial Unicode Ms", Arial, Helvetica, Verdana, "PT Sans Caption", sans-serif',
       }}

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -199,6 +199,12 @@ export class UniversalVideoAdapter {
       this.processedFragments = []
       this.segmentationPipeline = null
       this.subtitlesScheduler?.reset()
+
+      if (!await this.subtitlesFetcher.hasAvailableSubtitles()) {
+        this.subtitlesScheduler?.setState('error', { message: i18n.t('subtitles.errors.noSubtitlesFound') })
+        return
+      }
+
       this.subtitlesScheduler?.setState('loading')
 
       this.originalSubtitles = await this.subtitlesFetcher.fetch()

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -673,7 +673,7 @@ subtitles:
     networkError: Network error occurred when fetching captions
     fetchSubTimeout: Fetching youtube captions timed out
     buttonNotFound: Subtitle button not found
-    noSubtitlesFound: No subtitles found
+    noSubtitlesFound: No subtitles available for this video
     videoNotFound: Video element not found
     controlsBarNotFound: Controls bar not found
     aiRateLimited: Too many requests, please try again later

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -670,7 +670,7 @@ subtitles:
     networkError: 字幕取得時にネットワークエラーが発生しました
     fetchSubTimeout: YouTube字幕の取得がタイムアウトしました
     buttonNotFound: 字幕ボタンが見つかりません
-    noSubtitlesFound: 字幕が見つかりません
+    noSubtitlesFound: この動画には字幕がありません
     videoNotFound: 動画要素が見つかりません
     controlsBarNotFound: コントロールバーが見つかりません
     aiRateLimited: リクエストが多すぎます。後でもう一度お試しください

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -670,7 +670,7 @@ subtitles:
     networkError: 자막을 가져오는 도중 네트워크 오류가 발생했습니다
     fetchSubTimeout: 유튜브 자막 가져오기 시간이 초과되었습니다
     buttonNotFound: 자막 버튼을 찾을 수 없습니다
-    noSubtitlesFound: 자막을 찾을 수 없습니다
+    noSubtitlesFound: 현재 영상에 자막이 없습니다
     videoNotFound: 비디오 요소를 찾을 수 없습니다
     controlsBarNotFound: 컨트롤 바를 찾을 수 없습니다
     aiRateLimited: 요청이 너무 많습니다. 나중에 다시 시도해 주세요

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -671,7 +671,7 @@ subtitles:
     networkError: Произошла сетевая ошибка при получении субтитров
     fetchSubTimeout: Получение субтитров YouTube завершилось с ошибкой
     buttonNotFound: Кнопка субтитров не найдена
-    noSubtitlesFound: Субтитры не найдены
+    noSubtitlesFound: Для этого видео нет субтитров
     videoNotFound: Видео элемент не найден
     controlsBarNotFound: Панель управления не найдена
     aiRateLimited: Слишком много запросов, пожалуйста, повторите позже

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -671,7 +671,7 @@ subtitles:
     networkError: YouTube altyazılar alınırken ağ hatası oluştu.
     fetchSubTimeout: YouTube altyazılar alınırken zaman aşımı oluştu.
     buttonNotFound: Altyazı butonu bulunamadı
-    noSubtitlesFound: Altyazı bulunamadı
+    noSubtitlesFound: Bu video için altyazı bulunmuyor
     videoNotFound: Video öğesi bulunamadı
     controlsBarNotFound: Kontrol çubuğu bulunamadı
     aiRateLimited: Çok fazla istek, lütfen daha sonra tekrar deneyin

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -671,7 +671,7 @@ subtitles:
     networkError: Xảy ra lỗi mạng khi lấy phụ đề
     fetchSubTimeout: Quá thời gian lấy phụ đề Youtube
     buttonNotFound: Không tìm thấy nút phụ đề
-    noSubtitlesFound: Không tìm thấy phụ đề
+    noSubtitlesFound: Video hiện tại không có phụ đề
     videoNotFound: Không tìm thấy phần tử video
     controlsBarNotFound: Không tìm thấy thanh điều khiển
     aiRateLimited: Quá nhiều yêu cầu, vui lòng thử lại sau

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -673,7 +673,7 @@ subtitles:
     networkError: 获取字幕时发生网络错误
     fetchSubTimeout: 获取 youtube 字幕超时
     buttonNotFound: 字幕按钮未找到
-    noSubtitlesFound: 未找到字幕
+    noSubtitlesFound: 当前视频没有字幕
     videoNotFound: 视频元素未找到
     controlsBarNotFound: 控制栏未找到
     aiRateLimited: 请求过于频繁，请稍后再试

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -673,7 +673,7 @@ subtitles:
     networkError: 取得字幕時發生網路錯誤
     fetchSubTimeout: 取得 youtube 字幕逾時
     buttonNotFound: 字幕按鈕未找到
-    noSubtitlesFound: 未找到字幕
+    noSubtitlesFound: 當前影片沒有字幕
     videoNotFound: 影片元素未找到
     controlsBarNotFound: 控制列未找到
     aiRateLimited: 請求過於頻繁，請稍後再試

--- a/src/utils/subtitles/fetchers/types.ts
+++ b/src/utils/subtitles/fetchers/types.ts
@@ -5,4 +5,5 @@ export interface SubtitlesFetcher {
   cleanup: () => void
   shouldUseSameTrack: () => Promise<boolean>
   getSourceLanguage: () => string
+  hasAvailableSubtitles: () => Promise<boolean>
 }

--- a/src/utils/subtitles/fetchers/youtube/index.ts
+++ b/src/utils/subtitles/fetchers/youtube/index.ts
@@ -111,6 +111,18 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     this.cachedTrackHash = null
   }
 
+  async hasAvailableSubtitles(): Promise<boolean> {
+    const videoId = getYoutubeVideoId()
+    if (!videoId) {
+      return false
+    }
+
+    const response = await this.requestPlayerData(videoId)
+    return response.success === true
+      && response.data != null
+      && response.data.captionTracks.length > 0
+  }
+
   async shouldUseSameTrack(): Promise<boolean> {
     if (this.subtitles.length === 0 || !this.cachedTrackHash) {
       return false
@@ -166,6 +178,10 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     let playerData = response.data
 
     if (this.hasPotInAudioTracks(playerData) || playerData.cachedTimedtextUrl) {
+      return playerData
+    }
+
+    if (playerData.captionTracks.length === 0) {
       return playerData
     }
 


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

- Add `hasAvailableSubtitles()` method to `SubtitlesFetcher` interface and `YoutubeSubtitlesFetcher` — checks subtitle availability before starting the full fetch pipeline
- Check availability early in `startTranslation()` to show error immediately for videos without subtitles, avoiding unnecessary wait
- Early return in `getPlayerDataWithPot()` when `captionTracks` is empty — skip POT token waiting for videos with no subtitles
- Simplify `StateMessage` position handling (remove per-state position, use unified `bottom-1/6`)
- Improve "no subtitles" error messages across all 8 locales to be more user-friendly

## How Has This Been Tested?

- [x] Verified through manual testing

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects when a video has no subtitles before starting the fetch pipeline. Shows an immediate, clearer error and skips unnecessary POT waits.

- Bug Fixes
  - Add hasAvailableSubtitles() to SubtitlesFetcher; implement for YouTube.
  - Check availability early in UniversalVideoAdapter.startTranslation() and set error state right away.
  - Short-circuit getPlayerDataWithPot when captionTracks is empty to avoid POT polling.
  - Simplify StateMessage positioning to a single bottom-1/6.
  - Improve “no subtitles” copy across all locales.

<sup>Written for commit 79c70ef0ad60ba25fcc8db816d5b9fd74a0436c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

