### PR TITLE
fix(extension): prevent spinner distortion into ellipse by host page CSS

### DIFF
--- a/.changeset/fix-spinner-ellipse.md
+++ b/.changeset/fix-spinner-ellipse.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(extension): prevent spinner from being distorted into ellipse by host page CSS

--- a/src/utils/host/translate/ui/spinner.ts
+++ b/src/utils/host/translate/ui/spinner.ts
@@ -23,12 +23,21 @@ export function createLightweightSpinner(ownerDoc: Document): HTMLElement {
     display: inline-block !important;
     width: 6px !important;
     height: 6px !important;
+    min-width: 6px !important;
+    min-height: 6px !important;
+    max-width: 6px !important;
+    max-height: 6px !important;
+    aspect-ratio: 1 / 1 !important;
     margin: 0 4px !important;
+    padding: 0 !important;
     vertical-align: middle !important;
     border: 3px solid var(--read-frog-muted) !important;
     border-top: 3px solid var(--read-frog-primary) !important;
     border-radius: 50% !important;
     box-sizing: content-box !important;
+    flex-shrink: 0 !important;
+    flex-grow: 0 !important;
+    align-self: center !important;
   `
 
   // Use Web Animations API instead of CSS keyframes - no DOM manipulation needed


### PR DESCRIPTION
Add defensive CSS properties (min/max dimensions, aspect-ratio, padding reset, flex-shrink/grow, align-self) to the lightweight spinner to prevent host page styles from distorting its circular shape.

Closes #965

## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #965

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the lightweight spinner from being stretched into an ellipse by host page CSS; it now stays circular in all layouts. Closes #965.

- **Bug Fixes**
  - Lock diameter at 6px with min/max and aspect-ratio: 1/1.
  - Reset padding to 0.
  - Prevent flex distortion with

<sup>Written for commit 29c2880e00b161d48f1e78af84df5b660d78cd3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

