### PR TITLE
fix: make comment in youtube as block

### DIFF
--- a/.changeset/legal-parrots-eat.md
+++ b/.changeset/legal-parrots-eat.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: make comment in youtube as block

--- a/src/utils/constants/dom-rules.ts
+++ b/src/utils/constants/dom-rules.ts
@@ -157,4 +157,7 @@ export const CUSTOM_FORCE_BLOCK_TRANSLATION_SELECTOR_MAP: Record<string, string[
   "engoo.com": [
     "#windowexercise-2 > div > div > div.css-ep7xq6 > div > div > div.css-19m2fbm *",
   ],
+  "www.youtube.com": [
+    "yt-attributed-string > span",
+  ],
 }


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #913

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forces YouTube comments to render as block elements so translation and formatting are correct. Fixes #913 by treating yt-attributed-string spans as blocks.

- **Bug Fixes**
  - Added www.youtube.com selector (yt-attributed-string > span) to CUSTOM_FORCE_BLOCK_TRANSLATION_SELECTOR_MAP.

<sup>Written for commit 213a68519f8cd73d9a3d07a7e1a3a6d087d25f7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

