### PR TITLE
fix: disable Zod JIT to avoid CSP eval violation in MV3 extensions

### DIFF
--- a/.changeset/fix-zod-csp-eval.md
+++ b/.changeset/fix-zod-csp-eval.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: disable Zod JIT to avoid CSP eval violation in MV3 extensions

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,6 +30,30 @@ export default antfu({
     "unused-imports/no-unused-imports": "error",
     "no-inner-declarations": "error",
     "antfu/consistent-list-newline": "off",
+    "perfectionist/sort-imports": ["error", {
+      groups: [
+        "setup",
+        "type-import",
+        ["type-parent", "type-sibling", "type-index", "type-internal"],
+        "value-builtin",
+        "value-external",
+        "value-internal",
+        ["value-parent", "value-sibling", "value-index"],
+        "side-effect",
+        "ts-equals-import",
+        "unknown",
+      ],
+      customGroups: [
+        {
+          groupName: "setup",
+          elementNamePattern: "@/utils/zod-config",
+        },
+      ],
+      newlinesBetween: "ignore",
+      newlinesInside: "ignore",
+      order: "asc",
+      type: "natural",
+    }],
   },
   react: {
     overrides: {

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -1,3 +1,4 @@
+import "@/utils/zod-config"
 import { browser, defineBackground } from "#imports"
 import { WEBSITE_URL } from "@/utils/constants/url"
 import { logger } from "@/utils/logger"

--- a/src/entrypoints/host.content/index.tsx
+++ b/src/entrypoints/host.content/index.tsx
@@ -1,3 +1,4 @@
+import "@/utils/zod-config"
 import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { Config } from "@/types/config/config"
 import { createShadowRootUi, defineContentScript, storage } from "#imports"

--- a/src/entrypoints/options/main.tsx
+++ b/src/entrypoints/options/main.tsx
@@ -1,3 +1,4 @@
+import "@/utils/zod-config"
 import type { Config } from "@/types/config/config"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { Provider as JotaiProvider } from "jotai"

--- a/src/entrypoints/popup/main.tsx
+++ b/src/entrypoints/popup/main.tsx
@@ -1,3 +1,4 @@
+import "@/utils/zod-config"
 import type { Config } from "@/types/config/config"
 import { browser } from "#imports"
 import { QueryClientProvider } from "@tanstack/react-query"

--- a/src/entrypoints/selection.content/index.tsx
+++ b/src/entrypoints/selection.content/index.tsx
@@ -1,3 +1,4 @@
+import "@/utils/zod-config"
 import { createShadowRootUi, defineContentScript } from "#imports"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { kebabCase } from "case-anything"

--- a/src/entrypoints/side.content/index.tsx
+++ b/src/entrypoints/side.content/index.tsx
@@ -1,3 +1,4 @@
+import "@/utils/zod-config"
 import type { Config } from "@/types/config/config"
 import { createShadowRootUi, defineContentScript } from "#imports"
 import { QueryClientProvider } from "@tanstack/react-query"

--- a/src/entrypoints/subtitles.content/index.tsx
+++ b/src/entrypoints/subtitles.content/index.tsx
@@ -1,3 +1,4 @@
+import "@/utils/zod-config"
 import { defineContentScript } from "#imports"
 import { getLocalConfig } from "@/utils/config/storage"
 import { initYoutubeSubtitles } from "./init-youtube-subtitles"

--- a/src/utils/zod-config.ts
+++ b/src/utils/zod-config.ts
@@ -1,0 +1,5 @@
+import { z } from "zod"
+
+// Disable Zod JIT (new Function) to avoid CSP eval violation in MV3 extensions
+// https://github.com/colinhacks/zod/issues/4360
+z.config({ jitless: true })


### PR DESCRIPTION
Zod v4 uses `new Function("")` to detect eval support, which triggers CSP violations in Manifest V3 extensions. Set `z.config({ jitless: true })` in all entrypoints to skip JIT and prevent `new Function` from executing.

Also add ESLint perfectionist custom group "setup" to ensure the zod-config side-effect import stays at the top of import lists.

## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable Zod JIT to avoid CSP eval violations in MV3 extensions. Prevents Zod’s new Function check from running in all entrypoints.

- **Bug Fixes**
  - Added a global zod-config (z.config({ jitless: true })) and imported it as a side effect at the top of every entrypoint.
  - Updated ESLint (perfectionist sort-imports) to keep the zod-config setup import first.

<sup>Written for commit 3a0d3944ffde5759f9c60b6e521be45a24dc89d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

