### PR TITLE
fix(firefox): hide TTS toolbar button and options page entry

### DIFF
--- a/src/entrypoints/options/app-sidebar/nav-items.ts
+++ b/src/entrypoints/options/app-sidebar/nav-items.ts
@@ -21,7 +21,7 @@ export const ROUTE_CONFIG = [
   { path: "/selection-toolbar", component: SelectionToolbarPage },
   { path: "/context-menu", component: ContextMenuPage },
   { path: "/input-translation", component: InputTranslationPage },
-  { path: "/tts", component: TextToSpeechPage },
+  ...(import.meta.env.BROWSER === "firefox" ? [] : [{ path: "/tts", component: TextToSpeechPage }]),
   { path: "/statistics", component: StatisticsPage },
   { path: "/config", component: ConfigPage },
 ] as const

--- a/src/entrypoints/options/app-sidebar/settings-nav.tsx
+++ b/src/entrypoints/options/app-sidebar/settings-nav.tsx
@@ -23,6 +23,7 @@ const OVERLAY_TOOLS_PATHS = ["/floating-button", "/selection-toolbar", "/context
 export function SettingsNav() {
   const { pathname } = useLocation()
   const isOverlayToolsActive = OVERLAY_TOOLS_PATHS.includes(pathname)
+  const isFirefox = import.meta.env.BROWSER === "firefox"
 
   return (
     <SidebarGroup>
@@ -103,12 +104,14 @@ export function SettingsNav() {
             </SidebarMenuItem>
           </Collapsible>
 
-          <SidebarMenuItem>
-            <SidebarMenuButton render={<Link to="/tts" />} isActive={pathname === "/tts"}>
-              <Icon icon="tabler:speakerphone" />
-              <span>{i18n.t("options.tts.title")}</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
+          {!isFirefox && (
+            <SidebarMenuItem>
+              <SidebarMenuButton render={<Link to="/tts" />} isActive={pathname === "/tts"}>
+                <Icon icon="tabler:speakerphone" />
+                <span>{i18n.t("options.tts.title")}</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          )}
 
           <SidebarMenuItem>
             <SidebarMenuButton render={<Link to="/statistics" />} isActive={pathname === "/statistics"}>

--- a/src/entrypoints/options/command-palette/search-items.ts
+++ b/src/entrypoints/options/command-palette/search-items.ts
@@ -6,6 +6,8 @@ export interface SearchItem {
   pageKey: string
 }
 
+const IS_FIREFOX = import.meta.env.BROWSER === "firefox"
+
 export const SEARCH_ITEMS: SearchItem[] = [
   // General page
   {
@@ -262,13 +264,15 @@ export const SEARCH_ITEMS: SearchItem[] = [
   },
 
   // Text to Speech page
-  {
-    sectionId: "tts-config",
-    route: "/tts",
-    titleKey: "options.tts.title",
-    descriptionKey: "options.tts.description",
-    pageKey: "options.tts.title",
-  },
+  ...(!IS_FIREFOX
+    ? [{
+        sectionId: "tts-config",
+        route: "/tts",
+        titleKey: "options.tts.title",
+        descriptionKey: "options.tts.description",
+        pageKey: "options.tts.title",
+      }]
+    : []),
 
   // Config page
   {

--- a/src/entrypoints/selection.content/selection-toolbar/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/index.tsx
@@ -58,6 +58,7 @@ function applyDirectionOffset(
 }
 
 export function SelectionToolbar() {
+  const isFirefox = import.meta.env.BROWSER === "firefox"
   const tooltipRef = useRef<HTMLDivElement>(null)
   const tooltipContainerRef = useRef<HTMLDivElement>(null)
   const selectionPositionRef = useRef<{ x: number, y: number } | null>(null) // store selection position (base position without direction offset)
@@ -248,7 +249,7 @@ export function SelectionToolbar() {
           <div className="flex items-center overflow-x-auto overflow-y-hidden rounded-sm max-w-[420px] no-scrollbar">
             <AiButton />
             <TranslateButton />
-            <SpeakButton />
+            {!isFirefox && <SpeakButton />}
             <SelectionToolbarCustomFeatureButtons />
           </div>
           <CloseButton />


### PR DESCRIPTION
### Motivation
- Firefox currently has a TTS-related issue that can cause incorrect behavior when the selection toolbar TTS button or TTS settings page are available, so hide those UI entry points on Firefox builds to avoid the bug.

### Description
- Conditionally hide the selection-toolbar `SpeakButton` on Firefox by checking `import.meta.env.BROWSER === "firefox"` in `src/entrypoints/selection.content/selection-toolbar/index.tsx`.
- Remove the `/tts` route from the main `ROUTE_CONFIG` on Firefox so the TTS settings page is not registered (`src/entrypoints/options/app-sidebar/nav-items.ts`).
- Hide the TTS sidebar item in settings navigation on Firefox by adding an `isFirefox` guard in `src/entrypoints/options/app-sidebar/settings-nav.tsx`.
- Remove the TTS command-palette/search entry on Firefox by excluding the search item when `IS_FIREFOX` (`src/entrypoints/options/command-palette/search-items.ts`).

### Testing
- Ran lint on modified files with `pnpm -s eslint` and it completed successfully.
- Ran type checking with `pnpm -s type-check` and it completed successfully.
- `pnpm dev` started the dev server successfully, and pre-commit hooks ran `pnpm lint:fix` during the change preparation.
- Attempted a Playwright navigation to capture the options UI, but `page.goto` failed with `ERR_EMPTY_RESPONSE`, so automated screenshot validation could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a94669dc88832dae0ded822ab75732)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide TTS UI on Firefox to prevent incorrect behavior caused by a Firefox-specific TTS issue. Removes the TTS button and settings entries on Firefox builds.

- **Bug Fixes**
  - Selection toolbar: wrap SpeakButton with a Firefox check in selection-toolbar/index.tsx.
  - Options routing: conditionally omit /tts route in app-sidebar/nav-items.ts.
  - Settings nav: hide the TTS menu item when on Firefox in settings-nav.tsx.
  - Command palette: exclude the TTS search item on Firefox in search-items.ts.

<sup>Written for commit ccfd316e47448d9919686e7223035036d32149b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

