### PR TITLE
fix: support amazon bedrock region-based model setup

### DIFF
--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/connection-button.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/connection-button.tsx
@@ -38,7 +38,9 @@ const ConnectionTestResultIconMap = {
 }
 
 export function ConnectionTestButton({ providerConfig }: { providerConfig: APIProviderConfig }) {
-  const { apiKey, baseURL, provider } = providerConfig
+  const { apiKey, baseURL, provider, region } = providerConfig
+  const requiresApiKey = provider !== "deeplx" && provider !== "ollama"
+  const missingBedrockRegion = provider === "bedrock" && !baseURL && !region?.trim()
 
   const mutation = useMutation({
     // for safety, we should not include apiKey in the mutationKey
@@ -55,7 +57,7 @@ export function ConnectionTestButton({ providerConfig }: { providerConfig: APIPr
   useEffect(() => {
     mutation.reset()
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [provider, apiKey, baseURL])
+  }, [provider, apiKey, baseURL, region])
 
   const testResult = mutation.isSuccess ? "success" : mutation.isError ? "error" : null
   const ConnectionTestResultIcon = testResult ? ConnectionTestResultIconMap[testResult] : null
@@ -67,7 +69,7 @@ export function ConnectionTestButton({ providerConfig }: { providerConfig: APIPr
         size="xs"
         variant="outline"
         onClick={handleTestConnection}
-        disabled={mutation.isPending || (!apiKey && provider !== "deeplx" && provider !== "ollama")}
+        disabled={mutation.isPending || (requiresApiKey && !apiKey) || missingBedrockRegion}
       >
         {mutation.isPending
           ? (

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
@@ -147,6 +147,11 @@ export function ProviderConfigForm() {
 
           <APIKeyField form={form} />
           <BaseURLField form={form} />
+          {providerType === "bedrock" && (
+            <form.AppField name="region">
+              {field => <field.InputFieldAutoSave formForSubmit={form} label={i18n.t("options.apiProviders.form.fields.region")} />}
+            </form.AppField>
+          )}
           {isTranslateProviderType && (
             <TranslateModelSelector form={form} />
           )}

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -102,6 +102,7 @@ options:
         description: Description
         apiKey: API Key
         baseURL: Base URL
+        region: Region
         optional: Optional
       delete: Delete
       deleteDialog:

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -102,6 +102,7 @@ options:
         description: 描述
         apiKey: API Key
         baseURL: Base URL
+        region: 区域
         optional: 可选
       delete: 删除
       deleteDialog:

--- a/src/types/config/provider.ts
+++ b/src/types/config/provider.ts
@@ -121,6 +121,8 @@ export const baseProviderConfigSchema = z.object({
 export const baseAPIProviderConfigSchema = baseProviderConfigSchema.extend({
   apiKey: z.string().optional(),
   baseURL: z.string().optional(),
+  // Used by Bedrock; ignored by providers that don't need region-based routing.
+  region: z.string().optional(),
   temperature: z.number().min(0).optional(),
   providerOptions: z.record(z.string(), z.any()).optional(),
 })

--- a/src/utils/batch-request-record.ts
+++ b/src/utils/batch-request-record.ts
@@ -4,6 +4,7 @@ import { isLLMProviderConfig } from "@/types/config/provider"
 import { db } from "@/utils/db/dexie/db"
 import { getDateFromDaysBack, numberToPercentage } from "@/utils/utils"
 import { logger } from "./logger"
+import { resolveModelId } from "./providers/model"
 
 export async function getRangeBatchRequestRecords(startDay: number, endDay?: number) {
   const startDate = getDateFromDaysBack(startDay)
@@ -26,7 +27,7 @@ export async function putBatchRequestRecord(
     return
 
   const { provider, model: providerModel } = providerConfig
-  const modelName = providerModel.isCustomModel ? providerModel.customModel : providerModel.model
+  const modelName = resolveModelId(providerModel)
 
   try {
     await db.batchRequestRecord.put({

--- a/src/utils/providers/__tests__/model.test.ts
+++ b/src/utils/providers/__tests__/model.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import { resolveModelId } from "../model"
+
+describe("resolveModelId", () => {
+  it("uses the selected model when custom mode is off", () => {
+    expect(resolveModelId({
+      model: "claude-3-7-sonnet-latest",
+      isCustomModel: false,
+      customModel: " us.anthropic.claude-3-7-sonnet-20250219-v1:0 ",
+    })).toBe("claude-3-7-sonnet-latest")
+  })
+
+  it("uses the custom model when custom mode is on", () => {
+    expect(resolveModelId({
+      model: "claude-3-7-sonnet-latest",
+      isCustomModel: true,
+      customModel: " us.anthropic.claude-3-7-sonnet-20250219-v1:0 ",
+    })).toBe("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+  })
+
+  it("falls back to the configured model when the custom model is empty", () => {
+    expect(resolveModelId({
+      model: "claude-3-7-sonnet-latest",
+      isCustomModel: true,
+      customModel: "   ",
+    })).toBe("claude-3-7-sonnet-latest")
+  })
+
+  it("falls back to the custom model when the primary resolved model is missing", () => {
+    expect(resolveModelId({
+      model: "   " as never,
+      isCustomModel: false,
+      customModel: " us.anthropic.claude-3-7-sonnet-20250219-v1:0 ",
+    })).toBe("us.anthropic.claude-3-7-sonnet-20250219-v1:0")
+  })
+})

--- a/src/utils/providers/model.ts
+++ b/src/utils/providers/model.ts
@@ -57,9 +57,13 @@ const CUSTOM_HEADER_MAP: Partial<Record<keyof typeof CREATE_AI_MAPPER, Record<st
 }
 
 export function resolveModelId(providerModel: LLMProviderConfig["model"]) {
-  return providerModel.isCustomModel
+  const resolvedModelId = providerModel.isCustomModel
     ? providerModel.customModel?.trim()
     : providerModel.model?.trim()
+
+  return resolvedModelId
+    || providerModel.customModel?.trim()
+    || providerModel.model?.trim()
 }
 
 async function getLanguageModelById(providerId: string) {
@@ -75,6 +79,29 @@ async function getLanguageModelById(providerId: string) {
   }
 
   const customHeaders = CUSTOM_HEADER_MAP[providerConfig.provider]
+  const modelId = resolveModelId(providerConfig.model)
+
+  if (!modelId) {
+    throw new Error("Model is undefined")
+  }
+
+  if (providerConfig.provider === "bedrock") {
+    const region = providerConfig.region?.trim()
+    const baseURL = providerConfig.baseURL?.trim()
+
+    if (!region && !baseURL) {
+      throw new Error("Amazon Bedrock requires a region or Base URL")
+    }
+
+    const provider = createAmazonBedrock({
+      ...(region && { region }),
+      ...(baseURL && { baseURL }),
+      ...(providerConfig.apiKey && { apiKey: providerConfig.apiKey }),
+      ...(customHeaders && { headers: customHeaders }),
+    })
+
+    return provider(modelId)
+  }
 
   const provider = isCustomLLMProvider(providerConfig.provider)
     ? CREATE_AI_MAPPER[providerConfig.provider]({
@@ -89,12 +116,6 @@ async function getLanguageModelById(providerId: string) {
         ...(providerConfig.apiKey && { apiKey: providerConfig.apiKey }),
         ...(customHeaders && { headers: customHeaders }),
       })
-
-  const modelId = resolveModelId(providerConfig.model)
-
-  if (!modelId) {
-    throw new Error("Model is undefined")
-  }
 
   return provider.languageModel(modelId)
 }


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [x] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

This PR fixes the Amazon Bedrock provider setup so Bedrock can be configured with a region and initialized through `createAmazonBedrock` correctly.

It also aligns model resolution behavior across runtime and request logging:
- add optional `region` support to API provider config
- expose a Bedrock-only `Region` field in the provider config form
- initialize Bedrock models via `createAmazonBedrock({ region, baseURL, apiKey })` and return `provider(modelId)`
- disable connection testing when a Bedrock provider has neither `region` nor `baseURL`
- reuse `resolveModelId` in batch request logging
- make `resolveModelId` prefer the currently selected source and only fall back to `customModel` when the primary resolved model is missing
- add unit tests for model resolution behavior

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [x] Added unit tests
- [ ] Verified through manual testing

Tested with:
- `pnpm type-check`
- `pnpm exec vitest run src/utils/providers/__tests__/model.test.ts`
- `pnpm exec eslint src/utils/providers/model.ts src/utils/batch-request-record.ts src/utils/providers/__tests__/model.test.ts`

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

N/A

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

- This PR intentionally focuses on the `region + apiKey/baseURL` Bedrock path only.
- AWS SigV4 credential fields such as `accessKeyId`, `secretAccessKey`, and `sessionToken` are not included in this change.
- `AGENTS.md` is not part of this PR.
- 
<img width="2530" height="1796" alt="38788" src="https://github.com/user-attachments/assets/88375965-8f6d-4ca5-9b7a-4af8061b7216" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Amazon Bedrock setup to support region-based configuration and proper model initialization via `createAmazonBedrock`. Also unifies model ID resolution and updates request logging to use it.

- **Bug Fixes**
  - Added optional `region` to API provider config and a Bedrock-only Region field in the form.
  - Initialize Bedrock with `createAmazonBedrock({ region, baseURL, apiKey })` and return `provider(modelId)`.
  - Disable connection testing when Bedrock has neither `region` nor `baseURL`.
  - Reworked `resolveModelId` to prefer the selected source and fall back to `customModel` if needed; reuse it in batch request logging.
  - Added unit tests for `resolveModelId`.

<sup>Written for commit 892284f102dbf5f9b67e7f8254890c7fcc66def3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

