### PR TITLE
fix: unify selection toolbar inline errors

### DIFF
--- a/.changeset/selection-toolbar-inline-errors.md
+++ b/.changeset/selection-toolbar-inline-errors.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: unify inline error handling for selection toolbar translate and custom actions

--- a/src/components/ui/base-ui/alert.tsx
+++ b/src/components/ui/base-ui/alert.tsx
@@ -11,7 +11,7 @@ const alertVariants = cva(
       variant: {
         default: "bg-card text-card-foreground",
         destructive:
-          "text-destructive bg-card *:data-[slot=alert-description]:text-destructive/90 *:[svg]:text-current",
+          "text-destructive border-destructive bg-destructive/5 *:data-[slot=alert-description]:text-card-foreground *:[svg]:text-current",
       },
     },
     defaultVariants: {
@@ -56,7 +56,7 @@ function AlertDescription({
     <div
       data-slot="alert-description"
       className={cn(
-        "text-muted-foreground [&_a]:hover:text-foreground text-sm text-balance md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4",
+        "text-muted-foreground min-w-0 text-sm text-balance break-words [overflow-wrap:anywhere] md:text-pretty [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4",
         className,
       )}
       {...props}

--- a/src/entrypoints/selection.content/components/selection-toolbar-error-alert.tsx
+++ b/src/entrypoints/selection.content/components/selection-toolbar-error-alert.tsx
@@ -1,0 +1,28 @@
+import type { SelectionToolbarInlineError } from "../selection-toolbar/inline-error"
+import { IconAlertCircle } from "@tabler/icons-react"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/base-ui/alert"
+import { cn } from "@/utils/styles/utils"
+
+export function SelectionToolbarErrorAlert({
+  className,
+  error,
+}: {
+  className?: string
+  error: SelectionToolbarInlineError | null
+}) {
+  if (!error) {
+    return null
+  }
+
+  return (
+    <div className={cn("px-4 pb-4", className)}>
+      <Alert variant="destructive">
+        <IconAlertCircle className="size-4" />
+        <AlertTitle>{error.title}</AlertTitle>
+        <AlertDescription>
+          {error.description}
+        </AlertDescription>
+      </Alert>
+    </div>
+  )
+}

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
@@ -469,7 +469,60 @@ describe("selection toolbar requests", () => {
     })
 
     expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(screen.queryByRole("alert")).toBeNull()
     expect(screen.queryByTestId("translation-content")).toBeNull()
+  })
+
+  it("renders translate errors inline and clears them after a successful rerun", async () => {
+    translateTextCoreMock
+      .mockRejectedValueOnce(new Error("Standard translation failed"))
+      .mockResolvedValueOnce("Recovered translation")
+    getOrFetchArticleDataMock.mockResolvedValue(null)
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    store.set(selectionContentAtom, "Selected text")
+    renderWithProviders(<TranslateButton />, store)
+
+    fireEvent.click(screen.getByRole("button", { name: "action.translation" }))
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("translationHub.translationFailed")
+    expect(alert).toHaveTextContent("Standard translation failed")
+    expect(toastErrorMock).not.toHaveBeenCalled()
+
+    const translationContent = screen.getByTestId("translation-content")
+    expect(translationContent.compareDocumentPosition(alert) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(alert.compareDocumentPosition(screen.getByRole("button", { name: "Change provider" })) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+    fireEvent.click(screen.getByRole("button", { name: "Regenerate" }))
+
+    await waitFor(() => {
+      expect(translateTextCoreMock).toHaveBeenCalledTimes(2)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("translation-result").textContent).toBe("Recovered translation")
+    })
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("shows a precheck alert when the translate provider is unavailable", async () => {
+    const store = createStore()
+    const updatedConfig = cloneConfig(DEFAULT_CONFIG)
+    updatedConfig.selectionToolbar.features.translate.providerId = "missing-provider-id"
+
+    store.set(configAtom, updatedConfig)
+    store.set(selectionContentAtom, "Selected text")
+    renderWithProviders(<TranslateButton />, store)
+
+    fireEvent.click(screen.getByRole("button", { name: "action.translation" }))
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("translationHub.translationFailed")
+    expect(alert).toHaveTextContent("options.floatingButtonAndToolbar.selectionToolbar.errors.providerUnavailable")
+    expect(translateTextCoreMock).not.toHaveBeenCalled()
+    expect(streamBackgroundTextMock).not.toHaveBeenCalled()
   })
 
   it("shows translations identical to the original text", async () => {
@@ -708,5 +761,67 @@ describe("selection toolbar requests", () => {
     await waitFor(() => {
       expect(screen.getByText("{\"summary\":\"fresh\"}")).toBeInTheDocument()
     })
+  })
+
+  it("shows a precheck alert when a custom action has no selected text", async () => {
+    const paragraph = document.createElement("p")
+    paragraph.textContent = "Selected text inside a paragraph."
+    document.body.appendChild(paragraph)
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    store.set(selectionContentAtom, "   ")
+    store.set(selectionRangeAtom, createRangeFor(paragraph))
+    renderWithProviders(<SelectionToolbarCustomActionButtons />, store)
+
+    const actionName = DEFAULT_CONFIG.selectionToolbar.customActions[0]?.name
+    if (!actionName) {
+      throw new Error("Default custom action is missing")
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: actionName }))
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("options.floatingButtonAndToolbar.selectionToolbar.errors.customActionFailed")
+    expect(alert).toHaveTextContent("options.floatingButtonAndToolbar.selectionToolbar.errors.missingSelection")
+    expect(streamBackgroundStructuredObjectMock).not.toHaveBeenCalled()
+  })
+
+  it("renders custom action errors inline and clears them after a successful rerun", async () => {
+    streamBackgroundStructuredObjectMock
+      .mockRejectedValueOnce(new Error("Structured output failed"))
+      .mockResolvedValueOnce(createStructuredObjectSnapshot({ summary: "fresh" }))
+
+    const paragraph = document.createElement("p")
+    paragraph.textContent = "Selected text inside a paragraph."
+    document.body.appendChild(paragraph)
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    store.set(selectionContentAtom, "Selected text")
+    store.set(selectionRangeAtom, createRangeFor(paragraph))
+    renderWithProviders(<SelectionToolbarCustomActionButtons />, store)
+
+    const actionName = DEFAULT_CONFIG.selectionToolbar.customActions[0]?.name
+    if (!actionName) {
+      throw new Error("Default custom action is missing")
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: actionName }))
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("options.floatingButtonAndToolbar.selectionToolbar.errors.customActionFailed")
+    expect(alert).toHaveTextContent("Structured output failed")
+
+    fireEvent.click(screen.getByRole("button", { name: "Regenerate" }))
+
+    await waitFor(() => {
+      expect(streamBackgroundStructuredObjectMock).toHaveBeenCalledTimes(2)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("{\"summary\":\"fresh\"}")).toBeInTheDocument()
+    })
+    expect(screen.queryByRole("alert")).toBeNull()
   })
 })

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/custom-action-content.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/custom-action-content.tsx
@@ -4,7 +4,6 @@ import { SelectionSourceContent } from "../../components/selection-source-conten
 import { StructuredObjectRenderer } from "./structured-object-renderer"
 
 interface CustomActionContentProps {
-  errorMessage: string | null
   isRunning: boolean
   outputSchema: SelectionToolbarCustomActionOutputField[]
   selectionContent: string | null | undefined
@@ -13,7 +12,6 @@ interface CustomActionContentProps {
 }
 
 export function CustomActionContent({
-  errorMessage,
   isRunning,
   outputSchema,
   selectionContent,
@@ -35,12 +33,6 @@ export function CustomActionContent({
           isStreaming={isRunning}
           thinking={thinking}
         />
-
-        {errorMessage && (
-          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900 dark:bg-red-950/30 dark:text-red-300">
-            {errorMessage}
-          </div>
-        )}
       </div>
     </div>
   )

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/custom-action-trigger.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/custom-action-trigger.tsx
@@ -7,6 +7,7 @@ import { isLLMProviderConfig } from "@/types/config/provider"
 import { configFieldsAtomMap, writeConfigAtom } from "@/utils/atoms/config"
 import { filterEnabledProvidersConfig } from "@/utils/config/helpers"
 import { shadowWrapper } from "../.."
+import { SelectionToolbarErrorAlert } from "../../components/selection-toolbar-error-alert"
 import { SelectionToolbarFooterContent } from "../../components/selection-toolbar-footer-content"
 import { SelectionToolbarTitleContent } from "../../components/selection-toolbar-title-content"
 import { SelectionToolbarTooltip } from "../../components/selection-tooltip"
@@ -65,7 +66,7 @@ export function SelectionToolbarCustomActionTrigger({ action }: { action: Select
   const {
     isRunning,
     result,
-    errorMessage,
+    error,
     resetSessionState,
     thinking,
   } = useCustomActionExecution({
@@ -76,7 +77,7 @@ export function SelectionToolbarCustomActionTrigger({ action }: { action: Select
     rerunNonce,
   })
   const displayedResult = executionPlan.executionContext ? result : null
-  const displayedErrorMessage = errorMessage ?? executionPlan.errorMessage
+  const displayedError = error ?? executionPlan.error
   const displayedIsRunning = executionPlan.executionContext ? isRunning : false
   const displayedThinking = executionPlan.executionContext ? thinking : null
 
@@ -139,13 +140,13 @@ export function SelectionToolbarCustomActionTrigger({ action }: { action: Select
 
         <SelectionPopover.Body ref={bodyRef}>
           <CustomActionContent
-            errorMessage={displayedErrorMessage}
             isRunning={displayedIsRunning}
             outputSchema={activeAction.outputSchema}
             selectionContent={selectionContentSnapshot}
             value={displayedResult}
             thinking={displayedThinking}
           />
+          <SelectionToolbarErrorAlert error={displayedError} />
         </SelectionPopover.Body>
         <SelectionToolbarFooterContent
           providers={llmProviders}

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/use-custom-action-execution.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/use-custom-action-execution.ts
@@ -1,5 +1,6 @@
 import type { RefObject } from "react"
 import type { SelectionToolbarCustomActionRequestSlice } from "../atoms"
+import type { SelectionToolbarInlineError } from "../inline-error"
 import type { BackgroundStructuredObjectStreamSnapshot, ThinkingSnapshot } from "@/types/background-stream"
 import type { LLMProviderConfig } from "@/types/config/provider"
 import type { SelectionToolbarCustomAction } from "@/types/config/selection-toolbar"
@@ -10,6 +11,11 @@ import { streamBackgroundStructuredObject } from "@/utils/content-script/backgro
 import { resolveModelId } from "@/utils/providers/model"
 import { getProviderOptionsWithOverride } from "@/utils/providers/options"
 import { buildSelectionToolbarCustomActionSystemPrompt, replaceSelectionToolbarCustomActionPromptTokens } from "../custom-action-prompt"
+import {
+  createSelectionToolbarPrecheckError,
+  createSelectionToolbarRuntimeError,
+  isAbortError,
+} from "../inline-error"
 
 export interface CustomActionExecutionContext {
   action: SelectionToolbarCustomAction
@@ -23,16 +29,8 @@ export interface CustomActionExecutionContext {
 }
 
 interface CustomActionExecutionPlan {
-  errorMessage: string | null
+  error: SelectionToolbarInlineError | null
   executionContext: CustomActionExecutionContext | null
-}
-
-function getCustomActionErrorMessage(error: unknown) {
-  if (error instanceof Error) {
-    return error.message
-  }
-
-  return "Custom action request failed"
 }
 
 function scrollSelectionPopoverBodyToBottom(ref: RefObject<HTMLDivElement | null>) {
@@ -52,14 +50,14 @@ export function buildCustomActionExecutionPlan(
 
   if (!action) {
     return {
-      errorMessage: "Selected action is unavailable",
+      error: createSelectionToolbarPrecheckError("customAction", "actionUnavailable"),
       executionContext: null,
     }
   }
 
   if (!cleanSelection) {
     return {
-      errorMessage: "No selected text available",
+      error: createSelectionToolbarPrecheckError("customAction", "missingSelection"),
       executionContext: null,
     }
   }
@@ -67,20 +65,20 @@ export function buildCustomActionExecutionPlan(
   const providerConfig = customActionRequest.providerConfig
   if (!providerConfig || !isLLMProviderConfig(providerConfig)) {
     return {
-      errorMessage: "Selected provider is unavailable for this action",
+      error: createSelectionToolbarPrecheckError("customAction", "providerUnavailable"),
       executionContext: null,
     }
   }
 
   if (!providerConfig.enabled) {
     return {
-      errorMessage: "Selected provider is disabled",
+      error: createSelectionToolbarPrecheckError("customAction", "providerDisabled"),
       executionContext: null,
     }
   }
 
   return {
-    errorMessage: null,
+    error: null,
     executionContext: {
       action,
       providerConfig,
@@ -109,13 +107,13 @@ export function useCustomActionExecution({
 }) {
   const [isRunning, setIsRunning] = useState(false)
   const [result, setResult] = useState<Record<string, unknown> | null>(null)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [error, setError] = useState<SelectionToolbarInlineError | null>(null)
   const [thinking, setThinking] = useState<ThinkingSnapshot | null>(null)
 
   const resetSessionState = useCallback(() => {
     setIsRunning(false)
     setResult(null)
-    setErrorMessage(null)
+    setError(null)
     setThinking(null)
   }, [])
 
@@ -144,7 +142,7 @@ export function useCustomActionExecution({
 
       setIsRunning(true)
       setResult(null)
-      setErrorMessage(null)
+      setError(null)
       setThinking({
         status: "thinking",
         text: "",
@@ -182,7 +180,7 @@ export function useCustomActionExecution({
         setThinking(finalResult.thinking)
       }
       catch (error) {
-        if (error instanceof DOMException && error.name === "AbortError") {
+        if (isAbortError(error)) {
           return
         }
 
@@ -191,7 +189,7 @@ export function useCustomActionExecution({
         }
 
         setThinking(prev => prev?.text ? { ...prev, status: "complete" } : null)
-        setErrorMessage(getCustomActionErrorMessage(error))
+        setError(createSelectionToolbarRuntimeError("customAction", error))
       }
       finally {
         if (!isCancelled) {
@@ -209,7 +207,7 @@ export function useCustomActionExecution({
   }, [bodyRef, executionContext, open, popoverSessionKey, rerunNonce])
 
   return {
-    errorMessage,
+    error,
     isRunning,
     resetSessionState,
     result,

--- a/src/entrypoints/selection.content/selection-toolbar/inline-error.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/inline-error.ts
@@ -1,0 +1,61 @@
+import { i18n } from "#imports"
+import { extractAISDKErrorMessage } from "@/utils/error/extract-message"
+
+export interface SelectionToolbarInlineError {
+  title: string
+  description: string
+}
+
+type SelectionToolbarErrorKind = "translate" | "customAction"
+type SelectionToolbarPrecheckErrorCode = "actionUnavailable" | "missingSelection" | "providerDisabled" | "providerUnavailable"
+
+const UNEXPECTED_ERROR_MESSAGE = "Unexpected error occurred"
+
+export function isAbortError(error: unknown) {
+  return error instanceof DOMException && error.name === "AbortError"
+}
+
+function getErrorTitle(kind: SelectionToolbarErrorKind) {
+  return kind === "translate"
+    ? i18n.t("translationHub.translationFailed")
+    : i18n.t("options.floatingButtonAndToolbar.selectionToolbar.errors.customActionFailed")
+}
+
+function getErrorFallbackDescription(kind: SelectionToolbarErrorKind) {
+  return kind === "translate"
+    ? i18n.t("translationHub.translationFailedFallback")
+    : i18n.t("options.floatingButtonAndToolbar.selectionToolbar.errors.customActionFailedFallback")
+}
+
+function getPrecheckErrorDescription(code: SelectionToolbarPrecheckErrorCode) {
+  return i18n.t(`options.floatingButtonAndToolbar.selectionToolbar.errors.${code}` as never)
+}
+
+function toErrorDescription(kind: SelectionToolbarErrorKind, error: unknown) {
+  const message = extractAISDKErrorMessage(error)
+  if (!message || message === UNEXPECTED_ERROR_MESSAGE) {
+    return getErrorFallbackDescription(kind)
+  }
+
+  return message
+}
+
+export function createSelectionToolbarPrecheckError(
+  kind: SelectionToolbarErrorKind,
+  code: SelectionToolbarPrecheckErrorCode,
+): SelectionToolbarInlineError {
+  return {
+    title: getErrorTitle(kind),
+    description: getPrecheckErrorDescription(code),
+  }
+}
+
+export function createSelectionToolbarRuntimeError(
+  kind: SelectionToolbarErrorKind,
+  error: unknown,
+): SelectionToolbarInlineError {
+  return {
+    title: getErrorTitle(kind),
+    description: toErrorDescription(kind, error),
+  }
+}

--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/index.tsx
@@ -1,4 +1,5 @@
 import type { SelectionToolbarTranslateRequestSlice } from "../atoms"
+import type { SelectionToolbarInlineError } from "../inline-error"
 import type { BackgroundTextStreamSnapshot, ThinkingSnapshot } from "@/types/background-stream"
 import type { LLMProviderConfig, ProviderConfig } from "@/types/config/provider"
 import { i18n } from "#imports"
@@ -6,7 +7,6 @@ import { LANG_CODE_TO_EN_NAME } from "@read-frog/definitions"
 import { RiTranslate } from "@remixicon/react"
 import { useAtomValue, useSetAtom } from "jotai"
 import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react"
-import { toast } from "sonner"
 import { SelectionPopover } from "@/components/ui/selection-popover"
 import { isLLMProviderConfig, isTranslateProviderConfig } from "@/types/config/provider"
 import { configFieldsAtomMap, writeConfigAtom } from "@/utils/atoms/config"
@@ -20,6 +20,7 @@ import { getTranslatePromptFromConfig } from "@/utils/prompts/translate"
 import { resolveModelId } from "@/utils/providers/model"
 import { getProviderOptionsWithOverride } from "@/utils/providers/options"
 import { shadowWrapper } from "../.."
+import { SelectionToolbarErrorAlert } from "../../components/selection-toolbar-error-alert"
 import { SelectionToolbarFooterContent } from "../../components/selection-toolbar-footer-content"
 import { SelectionToolbarTitleContent } from "../../components/selection-toolbar-title-content"
 import { SelectionToolbarTooltip } from "../../components/selection-tooltip"
@@ -27,23 +28,14 @@ import {
   isSelectionToolbarVisibleAtom,
   selectionToolbarTranslateRequestAtom,
 } from "../atoms"
+import {
+  createSelectionToolbarPrecheckError,
+  createSelectionToolbarRuntimeError,
+  isAbortError,
+} from "../inline-error"
 import { useSelectionPopoverSnapshot } from "../use-selection-popover-snapshot"
 import { TargetLanguageSelector } from "./target-language-selector"
 import { TranslationContent } from "./translation-content"
-
-function isAbortError(error: unknown) {
-  return error instanceof DOMException && error.name === "AbortError"
-}
-
-function getProviderConfigOrThrow(translateRequest: SelectionToolbarTranslateRequestSlice): ProviderConfig {
-  const providerConfig = translateRequest.providerConfig
-
-  if (!providerConfig) {
-    throw new Error("No provider config when translate text")
-  }
-
-  return providerConfig
-}
 
 async function translateWithLlm({
   preparedText,
@@ -121,6 +113,7 @@ export function TranslateButton() {
   const [rerunNonce, setRerunNonce] = useState(0)
   const [translatedText, setTranslatedText] = useState<string | undefined>(undefined)
   const [thinking, setThinking] = useState<ThinkingSnapshot | null>(null)
+  const [error, setError] = useState<SelectionToolbarInlineError | null>(null)
   const translateRequest = useAtomValue(selectionToolbarTranslateRequestAtom)
   const providersConfig = useAtomValue(configFieldsAtomMap.providersConfig)
   const setIsSelectionToolbarVisible = useSetAtom(isSelectionToolbarVisibleAtom)
@@ -143,6 +136,7 @@ export function TranslateButton() {
     setIsTranslating(false)
     setTranslatedText(undefined)
     setThinking(null)
+    setError(null)
   }, [])
 
   const cancelCurrentTranslation = useCallback((runId?: number) => {
@@ -168,10 +162,26 @@ export function TranslateButton() {
     setIsTranslating(true)
     setTranslatedText(undefined)
     setThinking(null)
+    setError(null)
+
+    const providerConfig = translateRequest.providerConfig
+    if (!providerConfig || !isTranslateProviderConfig(providerConfig)) {
+      if (runIdRef.current === runId) {
+        setIsTranslating(false)
+        setError(createSelectionToolbarPrecheckError("translate", "providerUnavailable"))
+      }
+      return
+    }
+
+    if (!providerConfig.enabled) {
+      if (runIdRef.current === runId) {
+        setIsTranslating(false)
+        setError(createSelectionToolbarPrecheckError("translate", "providerDisabled"))
+      }
+      return
+    }
 
     try {
-      const providerConfig = getProviderConfigOrThrow(translateRequest)
-
       let nextTranslatedText = ""
       if (isLLMProviderConfig(providerConfig)) {
         setThinking({
@@ -216,9 +226,7 @@ export function TranslateButton() {
       if (!isAbortError(error) && runIdRef.current === runId) {
         setThinking(prev => prev?.text ? { ...prev, status: "complete" } : null)
         console.error("Translation error:", error)
-        toast.error(i18n.t("translationHub.translationFailed"), {
-          description: error instanceof Error ? error.message : String(error),
-        })
+        setError(createSelectionToolbarRuntimeError("translate", error))
       }
     }
     finally {
@@ -304,6 +312,7 @@ export function TranslateButton() {
             isTranslating={isTranslating}
             thinking={thinking}
           />
+          <SelectionToolbarErrorAlert error={error} className="-mt-3" />
         </SelectionPopover.Body>
         <SelectionToolbarFooterContent
           providers={translateProviders}

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -275,6 +275,13 @@ options:
         description: Configure websites where the selection toolbar should be disabled
         enterUrlPattern: Enter URL pattern
         urlPattern: URL Pattern
+      errors:
+        customActionFailed: Custom Action Failed
+        customActionFailedFallback: Custom action request failed
+        actionUnavailable: Selected action is unavailable
+        missingSelection: No selected text available
+        providerDisabled: Selected provider is disabled
+        providerUnavailable: Selected provider is unavailable
       features:
         provider: Provider
         selectProvider: Select a provider

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -274,6 +274,13 @@ options:
         description: 選択ツールバーを無効化するウェブサイトを設定します
         enterUrlPattern: URL パターンを入力
         urlPattern: URL パターン
+      errors:
+        customActionFailed: カスタムアクションに失敗しました
+        customActionFailedFallback: カスタムアクションのリクエストに失敗しました
+        actionUnavailable: 選択したアクションは利用できません
+        missingSelection: 選択されたテキストがありません
+        providerDisabled: 選択したプロバイダーは無効です
+        providerUnavailable: 選択したプロバイダーは利用できません
       features:
         provider: プロバイダー
         selectProvider: プロバイダーを選択

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -274,6 +274,13 @@ options:
         description: 선택 툴바를 비활성화할 웹사이트를 설정합니다
         enterUrlPattern: URL 패턴 입력
         urlPattern: URL 패턴
+      errors:
+        customActionFailed: 사용자 지정 작업 실패
+        customActionFailedFallback: 사용자 지정 작업 요청에 실패했습니다
+        actionUnavailable: 선택한 작업을 사용할 수 없습니다
+        missingSelection: 선택된 텍스트가 없습니다
+        providerDisabled: 선택한 제공업체가 비활성화되었습니다
+        providerUnavailable: 선택한 제공업체를 사용할 수 없습니다
       features:
         provider: 제공업체
         selectProvider: 제공업체 선택

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -274,6 +274,13 @@ options:
         description: Настройте веб-сайты, где панель выделения должна быть отключена
         enterUrlPattern: Введите URL-шаблон
         urlPattern: URL-шаблон
+      errors:
+        customActionFailed: Не удалось выполнить пользовательское действие
+        customActionFailedFallback: Запрос пользовательского действия не удался
+        actionUnavailable: Выбранное действие недоступно
+        missingSelection: Нет выделенного текста
+        providerDisabled: Выбранный провайдер отключен
+        providerUnavailable: Выбранный провайдер недоступен
       features:
         provider: Провайдер
         selectProvider: Выберите провайдера

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -274,6 +274,13 @@ options:
         description: Seçim araç çubuğunun devre dışı bırakılması gereken web sitelerini yapılandırın
         enterUrlPattern: URL kalıbı girin
         urlPattern: URL Kalıbı
+      errors:
+        customActionFailed: Özel eylem başarısız oldu
+        customActionFailedFallback: Özel eylem isteği başarısız oldu
+        actionUnavailable: Seçilen eylem kullanılamıyor
+        missingSelection: Seçili metin yok
+        providerDisabled: Seçilen sağlayıcı devre dışı
+        providerUnavailable: Seçilen sağlayıcı kullanılamıyor
       features:
         provider: Sağlayıcı
         selectProvider: Sağlayıcı seçin

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -274,6 +274,13 @@ options:
         description: Cấu hình các trang web mà thanh công cụ chọn văn bản nên bị tắt
         enterUrlPattern: Nhập mẫu URL
         urlPattern: Mẫu URL
+      errors:
+        customActionFailed: Hành động tuỳ chỉnh thất bại
+        customActionFailedFallback: Yêu cầu hành động tuỳ chỉnh thất bại
+        actionUnavailable: Hành động đã chọn không khả dụng
+        missingSelection: Không có văn bản được chọn
+        providerDisabled: Nhà cung cấp đã chọn bị tắt
+        providerUnavailable: Nhà cung cấp đã chọn không khả dụng
       features:
         provider: Nhà cung cấp
         selectProvider: Chọn nhà cung cấp

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -275,6 +275,13 @@ options:
         description: 配置需要禁用选择工具栏的网站
         enterUrlPattern: 输入网址模式
         urlPattern: 网址模式
+      errors:
+        customActionFailed: 自定义操作失败
+        customActionFailedFallback: 自定义操作请求失败
+        actionUnavailable: 所选操作不可用
+        missingSelection: 没有可用的选中文本
+        providerDisabled: 所选提供商已被禁用
+        providerUnavailable: 所选提供商不可用
       features:
         provider: 提供商
         selectProvider: 选择提供商

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -274,6 +274,13 @@ options:
         description: 設定需要停用選擇工具列的網站
         enterUrlPattern: 輸入網址模式
         urlPattern: URL 模式
+      errors:
+        customActionFailed: 自訂操作失敗
+        customActionFailedFallback: 自訂操作請求失敗
+        actionUnavailable: 所選操作不可用
+        missingSelection: 沒有可用的選取文字
+        providerDisabled: 所選提供商已被停用
+        providerUnavailable: 所選提供商不可用
       features:
         provider: 提供商
         selectProvider: 選擇提供商


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [x] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies selection toolbar errors by showing inline alerts for Translate and Custom Actions. Adds precheck/runtime handling, improves alert styling and i18n, and updates tests.

- **Bug Fixes**
  - Centralized error creation in `inline-error` and added `SelectionToolbarErrorAlert`.
  - Translate and Custom Action flows now show in-popover alerts, with provider/selection prechecks and abort-safe handling; removed toasts and ad‑hoc error UI.
  - Improved alert UI (destructive border/background, better wrapping).
  - Added localized error strings across all locales.
  - Updated tests for inline error rendering, precheck cases, and clearing after successful reruns; patch bump for `@read-frog/extension`.

<sup>Written for commit a7b08317392258829469bbbcc98a626031836067. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

