### PR TITLE
fix: load css before spin

### DIFF
--- a/.changeset/social-parents-yawn.md
+++ b/.changeset/social-parents-yawn.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: load css before spin

--- a/src/entrypoints/host.content/index.tsx
+++ b/src/entrypoints/host.content/index.tsx
@@ -4,6 +4,7 @@ import { defineContentScript, storage } from "#imports"
 import { getLocalConfig } from "@/utils/config/storage"
 import { DEFAULT_CONFIG, DETECTED_CODE_STORAGE_KEY } from "@/utils/constants/config"
 import { getDocumentInfo } from "@/utils/content/analyze"
+import { ensurePresetStyles } from "@/utils/host/translate/ui/style-injector"
 import { logger } from "@/utils/logger"
 import { onMessage, sendMessage } from "@/utils/message"
 import { isSiteEnabled } from "@/utils/site-control"
@@ -35,6 +36,8 @@ export default defineContentScript({
       window.__READ_FROG_HOST_INJECTED__ = false
       return
     }
+
+    ensurePresetStyles(document)
 
     const cleanupUrlListener = setupUrlChangeListener()
 

--- a/src/utils/host/translate/ui/__tests__/spinner.test.ts
+++ b/src/utils/host/translate/ui/__tests__/spinner.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { ensurePresetStylesMock } = vi.hoisted(() => ({
+  ensurePresetStylesMock: vi.fn(),
+}))
+
+vi.mock("@/utils/host/translate/ui/style-injector", () => ({
+  ensurePresetStyles: ensurePresetStylesMock,
+}))
+
+describe("spinner", () => {
+  beforeEach(() => {
+    document.head.innerHTML = ""
+    document.body.innerHTML = ""
+    ensurePresetStylesMock.mockReset()
+  })
+
+  it("ensures preset styles on the document before appending the spinner", async () => {
+    const wrapper = document.createElement("span")
+    document.body.appendChild(wrapper)
+
+    ensurePresetStylesMock.mockImplementation((root: Document | ShadowRoot) => {
+      expect(root).toBe(document)
+      expect(wrapper.querySelector(".read-frog-spinner")).toBeNull()
+
+      const style = document.createElement("style")
+      style.id = "read-frog-preset-styles"
+      document.head.appendChild(style)
+    })
+
+    const { createSpinnerInside } = await import("../spinner")
+    const spinner = createSpinnerInside(wrapper)
+
+    expect(ensurePresetStylesMock).toHaveBeenCalledOnce()
+    expect(document.head.querySelector("#read-frog-preset-styles")).not.toBeNull()
+    expect(wrapper.lastElementChild).toBe(spinner)
+    expect(spinner.className).toBe("read-frog-spinner")
+  })
+
+  it("ensures preset styles on the containing shadow root before appending the spinner", async () => {
+    const host = document.createElement("div")
+    const shadow = host.attachShadow({ mode: "open" })
+    const wrapper = document.createElement("span")
+    shadow.appendChild(wrapper)
+
+    ensurePresetStylesMock.mockImplementation((root: Document | ShadowRoot) => {
+      expect(root).toBe(shadow)
+      expect(wrapper.querySelector(".read-frog-spinner")).toBeNull()
+
+      const style = document.createElement("style")
+      style.id = "read-frog-preset-styles"
+      shadow.appendChild(style)
+    })
+
+    const { createSpinnerInside } = await import("../spinner")
+    const spinner = createSpinnerInside(wrapper)
+
+    expect(ensurePresetStylesMock).toHaveBeenCalledOnce()
+    expect(shadow.querySelector("#read-frog-preset-styles")).not.toBeNull()
+    expect(wrapper.lastElementChild).toBe(spinner)
+    expect(spinner.className).toBe("read-frog-spinner")
+  })
+})

--- a/src/utils/host/translate/ui/spinner.ts
+++ b/src/utils/host/translate/ui/spinner.ts
@@ -5,8 +5,9 @@ import themeCSS from "@/assets/styles/theme.css?inline"
 import { TranslationError } from "@/components/translation/error"
 import { createReactShadowHost } from "@/utils/react-shadow-host/create-shadow-host"
 import { TRANSLATION_ERROR_CONTAINER_CLASS } from "../../../constants/dom-labels"
-import { getOwnerDocument } from "../../dom/node"
+import { getContainingShadowRoot, getOwnerDocument } from "../../dom/node"
 import { translateTextForPage } from "../translate-variants"
+import { ensurePresetStyles } from "./style-injector"
 
 /**
  * Create a lightweight spinner element without React/Shadow DOM overhead
@@ -68,6 +69,8 @@ export function createLightweightSpinner(ownerDoc: Document): HTMLElement {
 
 export function createSpinnerInside(translatedWrapperNode: HTMLElement): HTMLElement {
   const ownerDoc = getOwnerDocument(translatedWrapperNode)
+  const root = getContainingShadowRoot(translatedWrapperNode) ?? ownerDoc
+  ensurePresetStyles(root)
   const spinner = createLightweightSpinner(ownerDoc)
   translatedWrapperNode.appendChild(spinner)
   return spinner


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure preset CSS loads before the spinner renders to prevent unstyled flashes and layout shifts. Works in both the document and Shadow DOM.

- **Bug Fixes**
  - Call `ensurePresetStyles` at content init and right before mounting the spinner, targeting the document or containing shadow root.
  - Added tests to verify styles are injected before the spinner is appended in both environments.

<sup>Written for commit e5c73bdd80c0bffb41ca111c0cff48744b90c0d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

