### PR TITLE
ai: improve writing prompt with originLanguage detection

### DIFF
--- a/.changeset/improve-writing-prompt.md
+++ b/.changeset/improve-writing-prompt.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+ai: improve writing prompt with language detection and diverse examples

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -446,9 +446,10 @@ options:
               Given selected text and its surrounding paragraphs, analyze writing issues and produce an improved version.
 
               ## Language Policy (critical)
-              1. The "Error Analysis" field must be written in {{targetLanguage}}.
-              2. The "Improved Version" field must stay in the original language of Selection.
-              3. Never translate "Improved Version" into {{targetLanguage}} unless Selection is already in {{targetLanguage}}.
+              1. Detect the original language of Selection as {{originLanguage}}.
+              2. The "Error Analysis" field must be written in {{targetLanguage}}.
+              3. The "Improved Version" field must stay in {{originLanguage}}.
+              4. Never translate "Improved Version" into {{targetLanguage}} unless {{originLanguage}} is already {{targetLanguage}}.
 
               ## Writing Rules
               1. Identify grammar, spelling, punctuation, and word choice errors.
@@ -458,16 +459,18 @@ options:
 
               ## Examples
               Example A:
-              - Selection (English): "He go to school yesterday, and he don't finish his homework."
-              - targetLanguage: Chinese
-              - Error Analysis (Chinese): 存在主谓一致和时态错误：go 应改为 went，don't 应改为 didn't，finish 应改为 finish 的过去时语境搭配。
-              - Improved Version (English): He went to school yesterday, and he didn't finish his homework.
+              - Selection: "He go to school yesterday, and he don't finish his homework."
+              - Detected {{originLanguage}}: English
+              - {{targetLanguage}}: Chinese
+              - Error Analysis (Chinese — {{targetLanguage}}): 存在主谓一致和时态错误：go 应改为 went，don't 应改为 didn't，finish 应改为 finish 的过去时语境搭配。
+              - Improved Version (English — {{originLanguage}}): He went to school yesterday, and he didn't finish his homework.
 
               Example B:
-              - Selection (English): "The service attitude of this store is very good."
-              - targetLanguage: Japanese
-              - Error Analysis (Japanese): 文法はほぼ正しいですが、「service attitude」は不自然な直訳です。英語ではスタッフの対応を直接表現する方が自然です。
-              - Improved Version (English): The staff at this store are very friendly.
+              - Selection: "昨日私は友達に会いて、一緒に映画を見るました。"
+              - Detected {{originLanguage}}: Japanese
+              - {{targetLanguage}}: English
+              - Error Analysis (English — {{targetLanguage}}): There are verb conjugation errors: "会いて" should be "会って" (te-form of 会う), and "見るました" should be "見ました" (past tense of 見る in masu-form).
+              - Improved Version (Japanese — {{originLanguage}}): 昨日私は友達に会って、一緒に映画を見ました。
             prompt: |-
               ## Input
               Selection: {{selection}}

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -446,28 +446,31 @@ options:
               根据选中的文本及其周围段落，分析写作问题并给出改进版本。
 
               ## 语言规则（必须遵守）
-              1. “错误分析”字段必须使用 {{targetLanguage}}。
-              2. “改进版本”字段必须保持 Selection 的原文语言。
-              3. 除非 Selection 本身就是 {{targetLanguage}}，否则不要把“改进版本”翻译成 {{targetLanguage}}。
+              1. 检测 Selection 的原文语言，记为 {{originLanguage}}。
+              2. “错误分析”字段必须使用 {{targetLanguage}}。
+              3. “改进版本”字段必须保持 {{originLanguage}}。
+              4. 除非 {{originLanguage}} 就是 {{targetLanguage}}，否则不要把”改进版本”翻译成 {{targetLanguage}}。
 
               ## 写作规则
               1. 识别语法、拼写、标点和用词错误。
               2. 保持改写自然，尽量保留作者原意和语气。
-              3. 如果没有明显错误，请在“错误分析”中明确说明，并给出轻度润色后的“改进版本”。
+              3. 如果没有明显错误，请在”错误分析”中明确说明，并给出轻度润色后的”改进版本”。
               4. “改进版本”应简洁、可直接使用。
 
               ## 示例
               示例 A：
-              - Selection（英文）: "He go to school yesterday, and he don't finish his homework."
-              - targetLanguage: 中文
-              - 错误分析（中文）: 存在主谓一致和时态错误：go 应改为 went，don't 应改为 didn't，finish 应改为 finish 的过去时语境搭配。
-              - 改进版本（英文）: He went to school yesterday, and he didn't finish his homework.
+              - Selection: “He go to school yesterday, and he don't finish his homework.”
+              - 检测到 {{originLanguage}}: 英文
+              - {{targetLanguage}}: 中文
+              - 错误分析（中文 — {{targetLanguage}}）: 存在主谓一致和时态错误：go 应改为 went，don't 应改为 didn't，finish 应改为 finish 的过去时语境搭配。
+              - 改进版本（英文 — {{originLanguage}}）: He went to school yesterday, and he didn't finish his homework.
 
               示例 B：
-              - Selection（英文）: "The service attitude of this store is very good."
-              - targetLanguage: 日文
-              - 错误分析（日文）: 文法はほぼ正しいですが、「service attitude」は不自然な直訳です。英語ではスタッフの対応を直接表現する方が自然です。
-              - 改进版本（英文）: The staff at this store are very friendly.
+              - Selection: “昨日私は友達に会いて、一緒に映画を見るました。”
+              - 检测到 {{originLanguage}}: 日文
+              - {{targetLanguage}}: 英文
+              - 错误分析（英文 — {{targetLanguage}}）: There are verb conjugation errors: “会いて” should be “会って” (te-form of 会う), and “見るました” should be “見ました” (past tense of 見る in masu-form).
+              - 改进版本（日文 — {{originLanguage}}）: 昨日私は友達に会って、一緒に映画を見ました。
             prompt: |-
               ## 输入
               选中文本：{{selection}}


### PR DESCRIPTION
- Add {{originLanguage}} detection step in Language Policy
- Replace Example B with Japanese original text
- Diversify targetLanguage across examples
- Update both en.yml and zh-CN.yml locales

## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add originLanguage detection to the writing-improvement prompt so the “Improved Version” stays in the source language while “Error Analysis” uses the target language. Updated `en.yml` and `zh-CN.yml` with clearer rules and diversified examples, including a Japanese selection.

- **New Features**
  - Added {{originLanguage}} detection and clarified: keep “Improved Version” in {{originLanguage}}; write “Error Analysis” in {{targetLanguage}}; don’t translate unless languages match.
  - Replaced Example B with a Japanese source sentence and varied {{targetLanguage}} across examples.
  - Synced changes in both locales and added a patch changeset for `@read-frog/extension`.

<sup>Written for commit ef04b9ece64b63f057dae687e3bafa40c7369610. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

