### PR TITLE
fix: resolve dark mode flash (FOUC) on options and translation-hub pages

### DIFF
--- a/.changeset/fix-dark-mode-fouc.md
+++ b/.changeset/fix-dark-mode-fouc.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: resolve dark mode flash (FOUC) on options and translation-hub pages

--- a/src/entrypoints/options/main.tsx
+++ b/src/entrypoints/options/main.tsx
@@ -1,5 +1,6 @@
 import "@/utils/zod-config"
 import type { Config } from "@/types/config/config"
+import type { ThemeMode } from "@/types/config/theme"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { Provider as JotaiProvider } from "jotai"
 import { useHydrateAtoms } from "jotai/utils"
@@ -14,9 +15,11 @@ import { RecoveryBoundary } from "@/components/recovery/recovery-boundary"
 import { SidebarProvider } from "@/components/ui/base-ui/sidebar"
 import { TooltipProvider } from "@/components/ui/base-ui/tooltip"
 import { configAtom } from "@/utils/atoms/config"
+import { baseThemeModeAtom } from "@/utils/atoms/theme"
 import { getLocalConfig } from "@/utils/config/storage"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { queryClient } from "@/utils/tanstack-query"
+import { applyTheme, getLocalThemeMode, isDarkMode } from "@/utils/theme"
 import App from "./app"
 import { AppSidebar } from "./app-sidebar"
 import { SettingsSearch } from "./command-palette/settings-search"
@@ -27,7 +30,10 @@ function HydrateAtoms({
   initialValues,
   children,
 }: {
-  initialValues: [[typeof configAtom, Config]]
+  initialValues: [
+    [typeof configAtom, Config],
+    [typeof baseThemeModeAtom, ThemeMode],
+  ]
   children: React.ReactNode
 }) {
   useHydrateAtoms(initialValues)
@@ -38,12 +44,18 @@ async function initApp() {
   const root = document.getElementById("root")!
   root.className = "antialiased bg-background"
 
-  const config = (await getLocalConfig()) ?? DEFAULT_CONFIG
+  const [configValue, themeMode] = await Promise.all([
+    getLocalConfig(),
+    getLocalThemeMode(),
+  ])
+  const config = configValue ?? DEFAULT_CONFIG
+
+  applyTheme(document.documentElement, isDarkMode(themeMode) ? "dark" : "light")
 
   ReactDOM.createRoot(root).render(
     <React.StrictMode>
       <JotaiProvider>
-        <HydrateAtoms initialValues={[[configAtom, config]]}>
+        <HydrateAtoms initialValues={[[configAtom, config], [baseThemeModeAtom, themeMode]]}>
           <QueryClientProvider client={queryClient}>
             <HashRouter>
               <SidebarProvider>

--- a/src/entrypoints/translation-hub/main.tsx
+++ b/src/entrypoints/translation-hub/main.tsx
@@ -1,4 +1,5 @@
 import type { Config } from "@/types/config/config"
+import type { ThemeMode } from "@/types/config/theme"
 import { QueryClientProvider } from "@tanstack/react-query"
 import { Provider as JotaiProvider } from "jotai"
 import { useHydrateAtoms } from "jotai/utils"
@@ -9,14 +10,19 @@ import { HelpButton } from "@/components/help-button"
 import { ThemeProvider } from "@/components/providers/theme-provider"
 import { TooltipProvider } from "@/components/ui/base-ui/tooltip"
 import { configAtom } from "@/utils/atoms/config"
+import { baseThemeModeAtom } from "@/utils/atoms/theme"
 import { getLocalConfig } from "@/utils/config/storage"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { queryClient } from "@/utils/tanstack-query"
+import { applyTheme, getLocalThemeMode, isDarkMode } from "@/utils/theme"
 import App from "./app"
 import "@/assets/styles/theme.css"
 
 interface HydrateAtomsProps {
-  initialValues: [[typeof configAtom, Config]]
+  initialValues: [
+    [typeof configAtom, Config],
+    [typeof baseThemeModeAtom, ThemeMode],
+  ]
   children: React.ReactNode
 }
 
@@ -29,13 +35,19 @@ async function initApp() {
   const root = document.getElementById("root")!
   root.className = "text-base antialiased min-h-screen bg-background"
 
-  const config = (await getLocalConfig()) ?? DEFAULT_CONFIG
+  const [configValue, themeMode] = await Promise.all([
+    getLocalConfig(),
+    getLocalThemeMode(),
+  ])
+  const config = configValue ?? DEFAULT_CONFIG
+
+  applyTheme(document.documentElement, isDarkMode(themeMode) ? "dark" : "light")
 
   ReactDOM.createRoot(root).render(
     <React.StrictMode>
       <QueryClientProvider client={queryClient}>
         <JotaiProvider>
-          <HydrateAtoms initialValues={[[configAtom, config]]}>
+          <HydrateAtoms initialValues={[[configAtom, config], [baseThemeModeAtom, themeMode]]}>
             <ThemeProvider>
               <TooltipProvider>
                 <App />


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Fix dark mode flash (FOUC) on the options page and translation-hub page.

When the OS is in light mode but the extension theme is set to dark, these pages briefly flash white before switching to dark. This happens because the theme is only applied after React mounts and ThemeProvider's `useLayoutEffect` runs — too late to prevent the initial white paint.

**Root cause:** Unlike the popup (which already loads theme before render), options and translation-hub pages only loaded config before React render, leaving theme resolution to ThemeProvider's async `onMount`.

**Fix:** Follow the popup's existing pattern:
- Load `themeMode` in parallel with config via `Promise.all`
- Apply theme class to `<html>` before React render via `applyTheme(document.documentElement, ...)`
- Hydrate `baseThemeModeAtom` so ThemeProvider has the correct value on first render

## Related Issue

## How Has This Been Tested?

- [x] Verified through manual testing
  - Set extension theme to "dark" while OS is in light mode → options page renders dark immediately, no flash
  - Set extension theme to "system" → follows OS preference without flash
  - Translation-hub page behaves the same
- [x] All 766 existing tests pass
- [x] Type-check passes

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the dark mode flash (FOUC) on the options and translation-hub pages. Theme is applied before React renders, so the first paint matches the selected mode.

- **Bug Fixes**
  - Load `themeMode` alongside config with `Promise.all`.
  - Apply theme to `<html>` via `applyTheme` before rendering.
  - Hydrate `baseThemeModeAtom` so `ThemeProvider` has the correct value on first render.
  - Aligns these pages with the popup’s existing theme boot logic.

<sup>Written for commit ed1bfe730b5bc03b4ba2db802f12bfaed7b8f33d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

