### PR TITLE
ci(release): fix zip env handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag to rebuild assets for (e.g., v1.30.1)"
+        required: true
+        type: string
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -16,7 +22,14 @@ jobs:
       HUSKY: 0
     steps:
       - name: Checkout Repo
+        if: github.event_name != 'workflow_dispatch'
         uses: actions/checkout@v4
+
+      - name: Checkout Release Tag
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -31,6 +44,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Create Release Pull Request or Tag
+        if: github.event_name != 'workflow_dispatch'
         id: changesets
         uses: changesets/action@v1
         with:
@@ -105,16 +119,24 @@ jobs:
           fi
 
       - name: Build and Zip Extension
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: pnpm zip:all
         env:
-          WXT_GOOGLE_CLIENT_ID: ${{ secrets.WXT_GOOGLE_CLIENT_ID }}
+          WXT_GOOGLE_CLIENT_ID: ${{ secrets.WXT_GOOGLE_CLIENT_ID || vars.WXT_GOOGLE_CLIENT_ID }}
+          WXT_POSTHOG_API_KEY: ${{ secrets.WXT_POSTHOG_API_KEY || vars.WXT_POSTHOG_API_KEY }}
+          WXT_POSTHOG_HOST: ${{ secrets.WXT_POSTHOG_HOST || vars.WXT_POSTHOG_HOST }}
 
       - name: Upload Extension Zip to Release
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.changesets.outputs.published == 'true' || github.event_name == 'workflow_dispatch'
         run: |
-          VERSION=$(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[0].version')
-          gh release upload "v$VERSION" .output/*-chrome.zip .output/*-edge.zip .output/*-firefox.zip .output/*-sources.zip --clobber
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+          else
+            VERSION=$(echo '${{ steps.changesets.outputs.publishedPackages }}' | jq -r '.[0].version')
+            TAG="v$VERSION"
+          fi
+
+          gh release upload "$TAG" .output/*-chrome.zip .output/*-edge.zip .output/*-firefox.zip .output/*-sources.zip --clobber
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -41,7 +41,9 @@ jobs:
       - name: Build and Zip Extension
         run: pnpm zip
         env:
-          WXT_GOOGLE_CLIENT_ID: ${{ secrets.WXT_GOOGLE_CLIENT_ID }}
+          WXT_GOOGLE_CLIENT_ID: ${{ secrets.WXT_GOOGLE_CLIENT_ID || vars.WXT_GOOGLE_CLIENT_ID }}
+          WXT_POSTHOG_API_KEY: ${{ secrets.WXT_POSTHOG_API_KEY || vars.WXT_POSTHOG_API_KEY }}
+          WXT_POSTHOG_HOST: ${{ secrets.WXT_POSTHOG_HOST || vars.WXT_POSTHOG_HOST }}
 
       - name: Upload Extension Zip to Release
         run: gh release upload "${{ inputs.tag }}" .output/*-chrome.zip --clobber

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -3,6 +3,9 @@ import process from "node:process"
 import { defineConfig } from "wxt"
 
 const WXT_API_KEY_PATTERN = /^WXT_.*API_KEY/
+const ALLOWED_BUNDLED_API_KEYS = new Set([
+  "WXT_POSTHOG_API_KEY",
+])
 
 // See https://wxt.dev/api/config.html
 export default defineConfig({
@@ -79,6 +82,7 @@ export default defineConfig({
             buildStart() {
               const apiKeyVars = Object.keys(process.env)
                 .filter(key => WXT_API_KEY_PATTERN.test(key))
+                .filter(key => !ALLOWED_BUNDLED_API_KEYS.has(key))
 
               if (apiKeyVars.length > 0) {
                 throw new Error(


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [x] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

This PR fixes release packaging in GitHub Actions by wiring the required PostHog environment variables into the zip steps and by allowing the public PostHog key through the WXT production env guard.

It also adds a manual `workflow_dispatch` path to the release workflow so an existing tag can be checked out, rebuilt, and have its release assets re-uploaded without publishing a new version.

## Related Issue

Closes #

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

Manual verification:

- Ran `env WXT_GOOGLE_CLIENT_ID=dummy-google-client-id WXT_POSTHOG_API_KEY=dummy-posthog-key WXT_POSTHOG_HOST=https://app.posthog.com pnpm zip:all`
- Confirmed Chrome, Edge, Firefox, and sources zip artifacts were generated successfully
- Ran `git diff --check`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- `Release Extension` now supports a manual run with a `tag` input for rebuilding assets on an existing GitHub release.
- The workflow reads `WXT_GOOGLE_CLIENT_ID`, `WXT_POSTHOG_API_KEY`, and `WXT_POSTHOG_HOST` from either GitHub Actions Secrets or Variables.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes release packaging by passing required PostHog env vars into zip steps and allowing the public PostHog key in production builds. Adds a manual rebuild path to regenerate and re-upload zips for an existing tag.

- **New Features**
  - Add `workflow_dispatch` with a `tag` input to rebuild and re-upload release zips without publishing a new version.

- **Bug Fixes**
  - Pass `WXT_GOOGLE_CLIENT_ID`, `WXT_POSTHOG_API_KEY`, and `WXT_POSTHOG_HOST` to zip steps in release and submit workflows (read from Secrets or Variables).
  - Whitelist `WXT_POSTHOG_API_KEY` in `wxt` production env guard to allow bundling the public PostHog key.

<sup>Written for commit a68cea2dde4c8f8d622970b33b93aa62bc50c14d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

