### PR TITLE
fix(extension): add Firefox data collection consent metadata

### DIFF
--- a/.changeset/firefox-data-collection-consent.md
+++ b/.changeset/firefox-data-collection-consent.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(extension): add Firefox data collection consent metadata

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -60,7 +60,10 @@ export default defineConfig({
       browser_specific_settings: {
         gecko: {
           id: "{bd311a81-4530-4fcc-9178-74006155461b}",
-          strict_min_version: "109.0",
+          strict_min_version: "112.0",
+          data_collection_permissions: {
+            optional: ["technicalAndInteraction"],
+          },
         },
       },
     }),


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Updates the Firefox MV3 manifest metadata to satisfy AMO compatibility checks for analytics consent and background script support.

- Adds `browser_specific_settings.gecko.data_collection_permissions.optional = ["technicalAndInteraction"]` for PostHog analytics disclosure
- Raises `browser_specific_settings.gecko.strict_min_version` from `109.0` to `112.0` so it matches support for `background.type`
- Adds a patch changeset for the extension package

## Related Issue

Closes #

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

Manual verification:
- `pnpm build:firefox`
- `nx run @read-frog/extension:lint`
- `nx run @read-frog/extension:type-check`
- `nx run @read-frog/extension:test`
- Confirmed `.output/firefox-mv3/manifest.json` contains the new `data_collection_permissions` field and `strict_min_version: "112.0"`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The push hook reused cached `lint`, `type-check`, and `test` results, and all checks passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare Firefox data collection consent and update the minimum supported version to 112 to satisfy AMO checks. This aligns with MV3 background script support and unblocks publishing.

- **Bug Fixes**
  - Add `browser_specific_settings.gecko.data_collection_permissions.optional = ["technicalAndInteraction"]` for PostHog analytics.
  - Set `browser_specific_settings.gecko.strict_min_version` to `112.0`; add a patch changeset for `@read-frog/extension`.

<sup>Written for commit 38eaf46de8d83e33cf28aecc9b200ffde4750269. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

