### PR TITLE
feat(aiContentAware): allows AI content awareness capabilities to select their own LLM API provider

### DIFF
--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -1,10 +1,11 @@
 import type { Config } from "@/types/config/config"
-import type { LLMProviderConfig, ProviderConfig } from "@/types/config/provider"
+import type { ProviderConfig } from "@/types/config/provider"
 import type { BatchQueueConfig, RequestQueueConfig } from "@/types/config/translate"
 import type { ArticleContent } from "@/types/content"
 import type { PromptResolver } from "@/utils/host/translate/api/ai"
 import { isLLMProviderConfig } from "@/types/config/provider"
 import { putBatchRequestRecord } from "@/utils/batch-request-record"
+import { getProviderConfigById } from "@/utils/config/helpers"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { BATCH_SEPARATOR } from "@/utils/constants/prompt"
 import { generateArticleSummary } from "@/utils/content/summary"
@@ -27,11 +28,25 @@ export function parseBatchResult(result: string): string[] {
 async function getOrGenerateSummary(
   title: string,
   textContent: string,
-  providerConfig: LLMProviderConfig,
   requestQueue: RequestQueue,
 ): Promise<string | undefined> {
   const preparedText = cleanText(textContent)
   if (!preparedText) {
+    return undefined
+  }
+
+  const runtimeConfig = await ensureInitializedConfig() ?? DEFAULT_CONFIG
+  if (!runtimeConfig.translate.aiContentAware.enabled) {
+    return undefined
+  }
+
+  const providerConfig = getProviderConfigById(
+    runtimeConfig.providersConfig,
+    runtimeConfig.translate.aiContentAware.providerId,
+  )
+
+  if (!providerConfig || !isLLMProviderConfig(providerConfig)) {
+    logger.warn("AI Content Aware provider is missing or not an LLM provider, skipping summary generation. This should not happen. Please submit an issue to report this.")
     return undefined
   }
 
@@ -176,10 +191,8 @@ export async function setUpWebPageTranslationQueue() {
     }
 
     if (isLLMProviderConfig(providerConfig)) {
-      // Generate or fetch cached summary if AI Content Aware is enabled
-      const config = await ensureInitializedConfig()
-      if (config?.translate.enableAIContentAware && articleTitle != null && articleTextContent != null) {
-        content.summary = await getOrGenerateSummary(articleTitle, articleTextContent, providerConfig, requestQueue)
+      if (articleTitle != null && articleTextContent != null) {
+        content.summary = await getOrGenerateSummary(articleTitle, articleTextContent, requestQueue)
       }
 
       const data = { text, langConfig, providerConfig, hash, scheduleAt, content }
@@ -243,9 +256,8 @@ export async function setUpSubtitlesTranslationQueue() {
     }
 
     if (isLLMProviderConfig(providerConfig)) {
-      const runtimeConfig = await ensureInitializedConfig()
-      if (runtimeConfig?.translate.enableAIContentAware && videoTitle && subtitlesContext) {
-        content.summary = await getOrGenerateSummary(videoTitle, subtitlesContext, providerConfig, requestQueue)
+      if (videoTitle && subtitlesContext) {
+        content.summary = await getOrGenerateSummary(videoTitle, subtitlesContext, requestQueue)
       }
 
       const data = { text, langConfig, providerConfig, hash, scheduleAt, content }

--- a/src/entrypoints/options/pages/general/feature-providers-config.tsx
+++ b/src/entrypoints/options/pages/general/feature-providers-config.tsx
@@ -128,6 +128,7 @@ export default function FeatureProvidersConfig() {
         <FeatureProviderField featureKey="selectionToolbar.translate" />
         <FeatureProviderField featureKey="selectionToolbar.vocabularyInsight" />
         <FeatureProviderField featureKey="inputTranslation" />
+        <FeatureProviderField featureKey="translate.aiContentAware" />
         <CustomActionProviderFields />
       </div>
     </ConfigCard>

--- a/src/entrypoints/options/pages/translation/ai-content-aware.tsx
+++ b/src/entrypoints/options/pages/translation/ai-content-aware.tsx
@@ -40,11 +40,13 @@ export function AIContentAware() {
         </FieldContent>
         <Switch
           id="ai-content-aware-toggle"
-          checked={translateConfig.enableAIContentAware}
+          checked={translateConfig.aiContentAware.enabled}
           onCheckedChange={(checked) => {
             void setTranslateConfig(
               deepmerge(translateConfig, {
-                enableAIContentAware: checked,
+                aiContentAware: {
+                  enabled: checked,
+                },
               }),
             )
           }}

--- a/src/entrypoints/popup/components/ai-smart-context.tsx
+++ b/src/entrypoints/popup/components/ai-smart-context.tsx
@@ -17,9 +17,9 @@ export function AISmartContext() {
         </HelpTooltip>
       </span>
       <Switch
-        checked={translateConfig.enableAIContentAware}
+        checked={translateConfig.aiContentAware.enabled}
         onCheckedChange={checked =>
-          setTranslateConfig(deepmerge(translateConfig, { enableAIContentAware: checked }))}
+          setTranslateConfig(deepmerge(translateConfig, { aiContentAware: { enabled: checked } }))}
       />
     </div>
   )

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -191,6 +191,7 @@ options:
         tts: Text to Speech
         inputTranslation: Input Translation
         videoSubtitles: Video Subtitles
+        aiContentAware: AI Smart Context
     translationConfig:
       model:
         title: Model

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -190,6 +190,7 @@ options:
         tts: テキスト読み上げ
         inputTranslation: 入力翻訳
         videoSubtitles: 動画字幕
+        aiContentAware: AI スマートコンテキスト
     translationConfig:
       model:
         title: モデル

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -190,6 +190,7 @@ options:
         tts: 텍스트 음성 변환
         inputTranslation: 입력 번역
         videoSubtitles: 비디오 자막
+        aiContentAware: AI 스마트 컨텍스트
     translationConfig:
       model:
         title: 모델

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -190,6 +190,7 @@ options:
         tts: Озвучивание текста
         inputTranslation: Перевод ввода
         videoSubtitles: Субтитры видео
+        aiContentAware: Умный контекст ИИ
     translationConfig:
       model:
         title: Модель

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -190,6 +190,7 @@ options:
         tts: Metin Okuma
         inputTranslation: Giriş Çevirisi
         videoSubtitles: Video Altyazıları
+        aiContentAware: AI Akıllı Bağlam
     translationConfig:
       model:
         title: Model

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -190,6 +190,7 @@ options:
         tts: Chuyển văn bản thành giọng nói
         inputTranslation: Dịch đầu vào
         videoSubtitles: Phụ đề video
+        aiContentAware: Ngữ cảnh thông minh AI
     translationConfig:
       model:
         title: Mô hình

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -191,6 +191,7 @@ options:
         tts: 文本转语音
         inputTranslation: 输入翻译
         videoSubtitles: 视频字幕
+        aiContentAware: AI 智能上下文
     translationConfig:
       model:
         title: 模型

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -190,6 +190,7 @@ options:
         tts: 文字轉語音
         inputTranslation: 輸入翻譯
         videoSubtitles: 影片字幕
+        aiContentAware: AI 智慧上下文
     translationConfig:
       model:
         title: 模型

--- a/src/types/config/translate.ts
+++ b/src/types/config/translate.ts
@@ -87,7 +87,10 @@ export const translateConfigSchema = z.object({
     minWordsPerNode: z.number().min(MIN_WORDS_PER_NODE),
     skipLanguages: z.array(langCodeISO6393Schema),
   }),
-  enableAIContentAware: z.boolean(),
+  aiContentAware: z.object({
+    enabled: z.boolean(),
+    providerId: z.string().nonempty(),
+  }),
   customPromptsConfig: customPromptsConfigSchema,
   requestQueueConfig: requestQueueConfigSchema,
   batchQueueConfig: batchQueueConfigSchema,

--- a/src/utils/config/__tests__/example/v065.ts
+++ b/src/utils/config/__tests__/example/v065.ts
@@ -1,0 +1,87 @@
+import type { TestSeriesObject } from "./types"
+import { testSeries as v064TestSeries } from "./v064"
+
+const NON_LLM_PROVIDERS = ["google-translate", "microsoft-translate", "deeplx"]
+
+type UnknownRecord = Record<string, unknown>
+
+function asRecord(value: unknown): UnknownRecord {
+  return value != null && typeof value === "object"
+    ? value as UnknownRecord
+    : {}
+}
+
+function asRecordArray(value: unknown): UnknownRecord[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  return value
+    .filter(item => item != null && typeof item === "object")
+    .map(item => item as UnknownRecord)
+}
+
+function isEnabledLLMProvider(provider: unknown): provider is UnknownRecord & { id: string } {
+  const record = asRecord(provider)
+  return record.enabled === true
+    && typeof record.provider === "string"
+    && !NON_LLM_PROVIDERS.includes(record.provider)
+    && typeof record.id === "string"
+    && record.id.length > 0
+}
+
+function resolveAIContentAwareProviderId(config: unknown): string {
+  const configRecord = asRecord(config)
+  const providers = asRecordArray(configRecord.providersConfig)
+  const translate = asRecord(configRecord.translate)
+  const translateProviderId = typeof translate.providerId === "string" && translate.providerId.length > 0
+    ? translate.providerId
+    : undefined
+
+  const translateProvider = providers.find(provider => provider.id === translateProviderId)
+  if (isEnabledLLMProvider(translateProvider) && translateProviderId) {
+    return translateProviderId
+  }
+
+  const fallbackProvider = providers.find(provider => isEnabledLLMProvider(provider))
+  if (fallbackProvider && typeof fallbackProvider.id === "string") {
+    return fallbackProvider.id
+  }
+
+  if (translateProviderId) {
+    return translateProviderId
+  }
+
+  return "openai-default"
+}
+
+function migrateToV065Config(oldConfig: unknown): unknown {
+  const oldConfigRecord = asRecord(oldConfig)
+  const oldTranslate = asRecord(oldConfigRecord.translate)
+
+  const restTranslate: UnknownRecord = { ...oldTranslate }
+  delete restTranslate.enableAIContentAware
+  delete restTranslate.aiContentAware
+
+  return {
+    ...oldConfigRecord,
+    translate: {
+      ...restTranslate,
+      aiContentAware: {
+        enabled: oldTranslate.enableAIContentAware === true,
+        providerId: resolveAIContentAwareProviderId(oldConfig),
+      },
+    },
+  }
+}
+
+export const testSeries: TestSeriesObject = Object.fromEntries(
+  Object.entries(v064TestSeries).map(([seriesId, series]) => {
+    return [
+      seriesId,
+      {
+        ...series,
+        config: migrateToV065Config(series.config),
+      },
+    ]
+  }),
+) as TestSeriesObject

--- a/src/utils/config/migration-scripts/v064-to-v065.ts
+++ b/src/utils/config/migration-scripts/v064-to-v065.ts
@@ -1,0 +1,92 @@
+/**
+ * Migration script from v064 to v065
+ * - Replaces `translate.enableAIContentAware` with `translate.aiContentAware`
+ * - Initializes `translate.aiContentAware.providerId`
+ *
+ * Provider selection strategy:
+ * 1) Prefer `translate.providerId` when it points to an enabled LLM provider
+ * 2) Otherwise use the first enabled LLM provider from `providersConfig`
+ * 3) Fallback to existing translate providerId (or "openai-default") to keep data non-empty
+ *
+ * IMPORTANT: All values are hardcoded inline. Migration scripts are frozen
+ * snapshots — never import constants or helpers that may change.
+ */
+
+const NON_LLM_PROVIDERS = ["google-translate", "microsoft-translate", "deeplx"]
+
+type UnknownRecord = Record<string, unknown>
+
+function asRecord(value: unknown): UnknownRecord {
+  return value != null && typeof value === "object"
+    ? value as UnknownRecord
+    : {}
+}
+
+function asRecordArray(value: unknown): UnknownRecord[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  return value
+    .filter(item => item != null && typeof item === "object")
+    .map(item => item as UnknownRecord)
+}
+
+function isEnabledLLMProvider(provider: unknown): provider is UnknownRecord & { id: string } {
+  const record = asRecord(provider)
+  return record.enabled === true
+    && typeof record.provider === "string"
+    && !NON_LLM_PROVIDERS.includes(record.provider)
+    && typeof record.id === "string"
+    && record.id.length > 0
+}
+
+function resolveAIContentAwareProviderId(oldConfig: unknown): string {
+  const config = asRecord(oldConfig)
+  const providers = asRecordArray(config.providersConfig)
+  const translate = asRecord(config.translate)
+  const translateProviderId = typeof translate.providerId === "string" && translate.providerId.length > 0
+    ? translate.providerId
+    : undefined
+
+  const translateProvider = providers.find(provider => provider.id === translateProviderId)
+  if (isEnabledLLMProvider(translateProvider) && translateProviderId) {
+    return translateProviderId
+  }
+
+  const fallbackProvider = providers.find(provider => isEnabledLLMProvider(provider))
+  if (fallbackProvider && typeof fallbackProvider.id === "string") {
+    return fallbackProvider.id
+  }
+
+  if (translateProviderId) {
+    return translateProviderId
+  }
+
+  return "openai-default"
+}
+
+export function migrate(oldConfig: unknown): unknown {
+  const config = asRecord(oldConfig)
+  const oldTranslate = asRecord(config.translate)
+  const oldAIContentAware = asRecord(oldTranslate.aiContentAware)
+
+  const restTranslate: UnknownRecord = { ...oldTranslate }
+  delete restTranslate.enableAIContentAware
+  delete restTranslate.aiContentAware
+
+  const enabled = oldAIContentAware.enabled === true || oldTranslate.enableAIContentAware === true
+  const providerId = typeof oldAIContentAware.providerId === "string" && oldAIContentAware.providerId.length > 0
+    ? oldAIContentAware.providerId
+    : resolveAIContentAwareProviderId(oldConfig)
+
+  return {
+    ...config,
+    translate: {
+      ...restTranslate,
+      aiContentAware: {
+        enabled,
+        providerId,
+      },
+    },
+  }
+}

--- a/src/utils/constants/config.ts
+++ b/src/utils/constants/config.ts
@@ -17,7 +17,7 @@ export const GOOGLE_DRIVE_TOKEN_STORAGE_KEY = "__googleDriveToken"
 export const THEME_STORAGE_KEY = "theme"
 export const DETECTED_CODE_STORAGE_KEY = "detectedCode"
 export const DEFAULT_DETECTED_CODE = "eng" as const
-export const CONFIG_SCHEMA_VERSION = 64
+export const CONFIG_SCHEMA_VERSION = 65
 
 export const DEFAULT_FLOATING_BUTTON_POSITION = 0.66
 
@@ -69,7 +69,10 @@ export const DEFAULT_CONFIG: Config = {
       minWordsPerNode: DEFAULT_MIN_WORDS_PER_NODE,
       skipLanguages: [],
     },
-    enableAIContentAware: false,
+    aiContentAware: {
+      enabled: false,
+      providerId: "openai-default",
+    },
     customPromptsConfig: DEFAULT_TRANSLATE_PROMPTS_CONFIG,
     requestQueueConfig: {
       capacity: DEFAULT_REQUEST_CAPACITY,

--- a/src/utils/constants/feature-providers.ts
+++ b/src/utils/constants/feature-providers.ts
@@ -10,6 +10,7 @@ export const FEATURE_KEYS = [
   "selectionToolbar.translate",
   "selectionToolbar.vocabularyInsight",
   "inputTranslation",
+  "translate.aiContentAware",
 ] as const
 
 export type FeatureKey = (typeof FEATURE_KEYS)[number]
@@ -46,6 +47,11 @@ export const FEATURE_PROVIDER_DEFS = {
     getProviderId: (c: Config) => c.inputTranslation.providerId,
     configPath: ["inputTranslation", "providerId"],
   },
+  "translate.aiContentAware": {
+    isProvider: isLLMProvider,
+    getProviderId: (c: Config) => c.translate.aiContentAware.providerId,
+    configPath: ["translate", "aiContentAware", "providerId"],
+  },
 } as const satisfies Record<FeatureKey, FeatureProviderDef>
 
 /** Maps FeatureKey (with dots) to i18n-safe key (with underscores) for `options.general.featureProviders.features.*` */
@@ -55,6 +61,7 @@ export const FEATURE_KEY_I18N_MAP: Record<FeatureKey, string> = {
   "selectionToolbar.translate": "selectionToolbar_translate",
   "selectionToolbar.vocabularyInsight": "selectionToolbar_vocabularyInsight",
   "inputTranslation": "inputTranslation",
+  "translate.aiContentAware": "aiContentAware",
 }
 
 export function resolveProviderConfig(config: Config, featureKey: FeatureKey) {

--- a/src/utils/host/translate/translate-variants.ts
+++ b/src/utils/host/translate/translate-variants.ts
@@ -64,7 +64,7 @@ async function translateTextUsingPageConfig(
     text: preparedText,
     langConfig: config.language,
     providerConfig,
-    enableAIContentAware: config.translate.enableAIContentAware,
+    enableAIContentAware: config.translate.aiContentAware.enabled,
     extraHashTags: options.extraHashTags,
     articleContext: options.articleContext,
   })
@@ -76,7 +76,7 @@ async function translateTextUsingPageConfig(
  */
 export async function translateTextForPage(text: string): Promise<string> {
   const config = await getConfigOrThrow()
-  const articleData = await getOrFetchArticleData(config.translate.enableAIContentAware)
+  const articleData = await getOrFetchArticleData(config.translate.aiContentAware.enabled)
   return translateTextUsingPageConfig(config, text, {
     articleContext: articleData ?? undefined,
   })
@@ -88,7 +88,7 @@ export async function translateTextForPage(text: string): Promise<string> {
  */
 export async function translateTextForPageTitle(text: string): Promise<string> {
   const config = await getConfigOrThrow()
-  const articleContext = await getOrFetchArticleData(config.translate.enableAIContentAware)
+  const articleContext = await getOrFetchArticleData(config.translate.aiContentAware.enabled)
 
   return translateTextUsingPageConfig(config, text, {
     extraHashTags: ["pageTitleTranslation"],
@@ -131,7 +131,7 @@ export async function translateTextForInput(
     return ""
   }
 
-  const articleData = await getOrFetchArticleData(config.translate.enableAIContentAware)
+  const articleData = await getOrFetchArticleData(config.translate.aiContentAware.enabled)
 
   return translateTextCore({
     text,
@@ -142,7 +142,7 @@ export async function translateTextForInput(
     },
     extraHashTags: [`inputTranslation:${fromLang}->${toLang}`],
     providerConfig,
-    enableAIContentAware: config.translate.enableAIContentAware,
+    enableAIContentAware: config.translate.aiContentAware.enabled,
     articleContext: articleData ?? undefined,
   })
 }

--- a/src/utils/subtitles/processor/translator.ts
+++ b/src/utils/subtitles/processor/translator.ts
@@ -80,7 +80,7 @@ export async function translateSubtitles(
   }
 
   const langConfig = config.language
-  const enableAIContentAware = !!config.translate.enableAIContentAware
+  const enableAIContentAware = !!config.translate.aiContentAware.enabled
 
   const translationPromises = fragments.map(fragment =>
     translateSingleSubtitle(fragment.text, langConfig, providerConfig, enableAIContentAware, videoContext),


### PR DESCRIPTION

## Type of Changes

<!--- Please select one type below -->

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->
This PR will allow users to select an LLM provider separately for AI intelligent contextualization features. For example, users can choose a small, inexpensive, and fast model to summarize text, while using a standard LLM for standard translation tasks.


## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #1148

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable AI Smart Context to use its own LLM provider, independent from translation. This lets users run summaries on a cheaper/faster model while keeping their preferred translation provider.

- **New Features**
  - Added provider selection for AI Smart Context in Options → General → Providers.
  - Replaced `translate.enableAIContentAware` with `translate.aiContentAware { enabled, providerId }`.
  - Summary generation now respects the toggle and uses the selected LLM in page, input, and subtitles flows.
  - Added i18n label for the feature.

- **Migration**
  - Schema bumped to 65 with `v064-to-v065` migration.
  - Provider pick strategy: use `translate.providerId` if it’s an enabled LLM; else the first enabled LLM; else the existing translate provider; else `"openai-default"`.
  - No user action required.

<sup>Written for commit a1af504f0a2f13e781980c8b0495ff148ecc4ff8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->
