### PR TITLE
style: fix toast direction

### DIFF
--- a/.changeset/tiny-frogs-smile.md
+++ b/.changeset/tiny-frogs-smile.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+style: preset FrogToast default position to bottom-left to avoid covering top-page controls

--- a/src/components/frog-toast/index.tsx
+++ b/src/components/frog-toast/index.tsx
@@ -21,10 +21,11 @@ const frogIconElement = (
   />
 )
 
-function FrogToast(props: React.ComponentProps<typeof Toaster>) {
+function FrogToast({ position = "bottom-left", toastOptions, ...props }: React.ComponentProps<typeof Toaster>) {
   return (
     <Toaster
       {...props}
+      position={position}
       richColors
       icons={{
         warning: frogIconElement,
@@ -34,7 +35,8 @@ function FrogToast(props: React.ComponentProps<typeof Toaster>) {
         loading: frogIconElement,
       }}
       toastOptions={{
-        className: `${kebabCase(APP_NAME)}-toaster`,
+        ...toastOptions,
+        className: [`${kebabCase(APP_NAME)}-toaster`, toastOptions?.className].filter(Boolean).join(" "),
       }}
       className="z-[2147483647] notranslate"
     />


### PR DESCRIPTION
Codex generated this pull request, but encountered an unexpected error after generation. This is a placeholder PR message.
closes #1131 
------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b8e8e366fc8320b08090646591e801)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default FrogToast position to bottom-left so toasts don’t cover top-page controls. Also merge user `toastOptions` while preserving the base toaster class; position remains overridable.

- **New Features**
  - Default `position="bottom-left"`; can still be overridden via prop.
  - Merge `toastOptions` and append `className` to the base class instead of replacing it (patch release for `@read-frog/extension`).

<sup>Written for commit 4f12f827f432cbdb9a88f4a1cc80e1154fe4b2fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

