### PR TITLE
fix(changeset): add missing frontmatter fence

### DIFF
--- a/.changeset/five-apricots-compare.md
+++ b/.changeset/five-apricots-compare.md
@@ -1,3 +1,4 @@
+---
 "@read-frog/extension": patch
 ---
 


### PR DESCRIPTION
## Summary
- add the missing opening frontmatter fence to `.changeset/five-apricots-compare.md`
- keep the existing package bump + summary unchanged

## Why
Changeset files should start with `---`. Without the opening fence, the file is malformed and release tooling may skip or misread the bump metadata.

## Testing
- verified the file now matches the same frontmatter structure used by other changeset files in `.changeset/`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the missing opening frontmatter fence (`---`) to `.changeset/five-apricots-compare.md`. Ensures the patch bump for `@read-frog/extension` is parsed correctly by release tooling.

<sup>Written for commit 4ebb1b0729af9c546c9e1d1d7d3095fc11baf655. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

