### PR TITLE
fix: route selection context menu to selection translation

### DIFF
--- a/src/entrypoints/background/__tests__/context-menu.test.ts
+++ b/src/entrypoints/background/__tests__/context-menu.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
+import { getTranslationStateKey } from "@/utils/constants/storage-keys"
+
+const mockState = vi.hoisted(() => ({
+  contextMenusCreate: vi.fn(),
+  contextMenusRemoveAll: vi.fn(),
+  contextMenusUpdate: vi.fn(),
+  contextMenusOnClickedAddListener: vi.fn(),
+  createFeatureUsageContext: vi.fn((feature: string, surface: string) => ({
+    feature,
+    surface,
+    startedAt: 123,
+  })),
+  ensureInitializedConfig: vi.fn(),
+  i18nT: vi.fn((key: string) => {
+    const translations: Record<string, string> = {
+      "contextMenu.translate": "Translate",
+      "contextMenu.translateSelection": "Translate \"%s\"",
+      "contextMenu.showOriginal": "Show Original",
+    }
+
+    return translations[key] ?? key
+  }),
+  sendMessage: vi.fn(),
+  storageGetItem: vi.fn(),
+  storageSetItem: vi.fn(),
+  storageWatch: vi.fn(),
+  tabsOnActivatedAddListener: vi.fn(),
+  tabsOnUpdatedAddListener: vi.fn(),
+  tabsQuery: vi.fn(),
+  storageSessionOnChangedAddListener: vi.fn(),
+}))
+
+vi.mock("#imports", () => ({
+  browser: {
+    contextMenus: {
+      create: mockState.contextMenusCreate,
+      onClicked: {
+        addListener: mockState.contextMenusOnClickedAddListener,
+      },
+      removeAll: mockState.contextMenusRemoveAll,
+      update: mockState.contextMenusUpdate,
+    },
+    storage: {
+      session: {
+        onChanged: {
+          addListener: mockState.storageSessionOnChangedAddListener,
+        },
+      },
+    },
+    tabs: {
+      onActivated: {
+        addListener: mockState.tabsOnActivatedAddListener,
+      },
+      onUpdated: {
+        addListener: mockState.tabsOnUpdatedAddListener,
+      },
+      query: mockState.tabsQuery,
+    },
+  },
+  i18n: {
+    t: mockState.i18nT,
+  },
+  storage: {
+    getItem: mockState.storageGetItem,
+    setItem: mockState.storageSetItem,
+    watch: mockState.storageWatch,
+  },
+}))
+
+vi.mock("wxt/browser", () => ({
+  browser: {
+    contextMenus: {
+      create: mockState.contextMenusCreate,
+      onClicked: {
+        addListener: mockState.contextMenusOnClickedAddListener,
+      },
+      removeAll: mockState.contextMenusRemoveAll,
+      update: mockState.contextMenusUpdate,
+    },
+    storage: {
+      session: {
+        onChanged: {
+          addListener: mockState.storageSessionOnChangedAddListener,
+        },
+      },
+    },
+    tabs: {
+      onActivated: {
+        addListener: mockState.tabsOnActivatedAddListener,
+      },
+      onUpdated: {
+        addListener: mockState.tabsOnUpdatedAddListener,
+      },
+      query: mockState.tabsQuery,
+    },
+  },
+}))
+
+vi.mock("wxt/utils/storage", () => ({
+  storage: {
+    getItem: mockState.storageGetItem,
+    setItem: mockState.storageSetItem,
+    watch: mockState.storageWatch,
+  },
+}))
+
+vi.mock("#i18n", () => ({
+  i18n: {
+    t: mockState.i18nT,
+  },
+}))
+
+vi.mock("../config", () => ({
+  ensureInitializedConfig: mockState.ensureInitializedConfig,
+}))
+
+vi.mock("@/utils/analytics", () => ({
+  createFeatureUsageContext: mockState.createFeatureUsageContext,
+}))
+
+vi.mock("@/utils/message", () => ({
+  sendMessage: mockState.sendMessage,
+}))
+
+function getRegisteredContextMenuClickHandler() {
+  const handler = mockState.contextMenusOnClickedAddListener.mock.calls.at(-1)?.[0]
+  if (!handler) {
+    throw new Error("Expected context menu click listener to be registered")
+  }
+
+  return handler as (info: { menuItemId: string, selectionText?: string }, tab?: { id?: number }) => Promise<void>
+}
+
+describe("background context menu", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+
+    mockState.contextMenusRemoveAll.mockResolvedValue(undefined)
+    mockState.contextMenusUpdate.mockResolvedValue(undefined)
+    mockState.sendMessage.mockResolvedValue(undefined)
+    mockState.storageGetItem.mockResolvedValue(undefined)
+    mockState.storageSetItem.mockResolvedValue(undefined)
+    mockState.tabsQuery.mockResolvedValue([{ id: 7 }])
+    mockState.ensureInitializedConfig.mockResolvedValue({
+      contextMenu: {
+        enabled: true,
+      },
+    })
+  })
+
+  it("creates separate page and selection context-menu entries and keeps page title updates on the page item", async () => {
+    mockState.storageGetItem.mockResolvedValue({
+      enabled: true,
+    })
+
+    const { initializeContextMenu } = await import("../context-menu")
+    await initializeContextMenu()
+
+    expect(mockState.contextMenusRemoveAll).toHaveBeenCalledOnce()
+    expect(mockState.contextMenusCreate).toHaveBeenNthCalledWith(1, {
+      contexts: ["page"],
+      id: "read-frog-translate",
+      title: "Translate",
+    })
+    expect(mockState.contextMenusCreate).toHaveBeenNthCalledWith(2, {
+      contexts: ["selection"],
+      id: "read-frog-translate-selection",
+      title: "Translate \"%s\"",
+    })
+    expect(mockState.contextMenusUpdate).toHaveBeenCalledWith("read-frog-translate", {
+      title: "Show Original",
+    })
+  })
+
+  it("keeps page-translation toggling on the page menu item", async () => {
+    const { registerContextMenuListeners } = await import("../context-menu")
+    registerContextMenuListeners()
+
+    mockState.storageGetItem.mockResolvedValue({
+      enabled: false,
+    })
+
+    await getRegisteredContextMenuClickHandler()({
+      menuItemId: "read-frog-translate",
+    }, {
+      id: 42,
+    })
+
+    expect(mockState.storageSetItem).toHaveBeenCalledWith(getTranslationStateKey(42), {
+      enabled: true,
+    })
+    expect(mockState.sendMessage).toHaveBeenCalledWith("askManagerToTogglePageTranslation", {
+      enabled: true,
+      analyticsContext: {
+        feature: ANALYTICS_FEATURE.PAGE_TRANSLATION,
+        surface: ANALYTICS_SURFACE.CONTEXT_MENU,
+        startedAt: 123,
+      },
+    }, 42)
+    expect(mockState.contextMenusUpdate).toHaveBeenCalledWith("read-frog-translate", {
+      title: "Translate",
+    })
+  })
+
+  it("routes the selection menu item into selection translation instead of page translation", async () => {
+    const { registerContextMenuListeners } = await import("../context-menu")
+    registerContextMenuListeners()
+
+    await getRegisteredContextMenuClickHandler()({
+      menuItemId: "read-frog-translate-selection",
+      selectionText: "Selected text",
+    }, {
+      id: 42,
+    })
+
+    expect(mockState.storageSetItem).not.toHaveBeenCalled()
+    expect(mockState.sendMessage).toHaveBeenCalledWith("openSelectionToolbarTranslate", {
+      selectedText: "Selected text",
+      analyticsContext: {
+        feature: ANALYTICS_FEATURE.SELECTION_TRANSLATION,
+        surface: ANALYTICS_SURFACE.CONTEXT_MENU,
+        startedAt: 123,
+      },
+    }, 42)
+  })
+})

--- a/src/entrypoints/background/context-menu.ts
+++ b/src/entrypoints/background/context-menu.ts
@@ -8,7 +8,8 @@ import { getTranslationStateKey, TRANSLATION_STATE_KEY_PREFIX } from "@/utils/co
 import { sendMessage } from "@/utils/message"
 import { ensureInitializedConfig } from "./config"
 
-const MENU_ID_TRANSLATE = "read-frog-translate"
+const MENU_ID_TRANSLATE_PAGE = "read-frog-translate"
+const MENU_ID_TRANSLATE_SELECTION = "read-frog-translate-selection"
 
 /**
  * Register all context menu event listeners synchronously
@@ -88,9 +89,15 @@ async function updateContextMenuItems(config: Config) {
 
   if (translateEnabled) {
     browser.contextMenus.create({
-      id: MENU_ID_TRANSLATE,
+      id: MENU_ID_TRANSLATE_PAGE,
       title: i18n.t("contextMenu.translate"),
       contexts: ["page"],
+    })
+
+    browser.contextMenus.create({
+      id: MENU_ID_TRANSLATE_SELECTION,
+      title: i18n.t("contextMenu.translateSelection"),
+      contexts: ["selection"],
     })
   }
 
@@ -124,7 +131,7 @@ async function updateTranslateMenuTitle(tabId: number, enabled?: boolean) {
       isTranslated = state?.enabled ?? false
     }
 
-    await browser.contextMenus.update(MENU_ID_TRANSLATE, {
+    await browser.contextMenus.update(MENU_ID_TRANSLATE_PAGE, {
       title: isTranslated
         ? i18n.t("contextMenu.showOriginal")
         : i18n.t("contextMenu.translate"),
@@ -146,8 +153,12 @@ async function handleContextMenuClick(
     return
   }
 
-  if (info.menuItemId === MENU_ID_TRANSLATE) {
+  if (info.menuItemId === MENU_ID_TRANSLATE_PAGE) {
     await handleTranslateClick(tab.id)
+  }
+
+  if (info.menuItemId === MENU_ID_TRANSLATE_SELECTION) {
+    await handleSelectionTranslateClick(tab.id, info.selectionText)
   }
 }
 
@@ -174,4 +185,18 @@ async function handleTranslateClick(tabId: number) {
 
   // Update menu title immediately
   await updateTranslateMenuTitle(tabId)
+}
+
+async function handleSelectionTranslateClick(tabId: number, selectionText?: string) {
+  if (!selectionText?.trim()) {
+    return
+  }
+
+  void sendMessage("openSelectionToolbarTranslate", {
+    selectedText: selectionText,
+    analyticsContext: createFeatureUsageContext(
+      ANALYTICS_FEATURE.SELECTION_TRANSLATION,
+      ANALYTICS_SURFACE.CONTEXT_MENU,
+    ),
+  }, tabId)
 }

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/context-menu-translate.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/context-menu-translate.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from "@testing-library/react"
+import { atom } from "jotai"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
+import { SelectionToolbar } from "../index"
+
+const mockState = vi.hoisted(() => ({
+  contextMenuConfig: {
+    enabled: true,
+  },
+  openSelectionHandler: undefined as undefined | ((message: {
+    data: {
+      selectedText: string
+      analyticsContext?: {
+        feature: string
+        surface: string
+        startedAt: number
+      }
+    }
+  }) => void),
+  selectionToolbarConfig: {
+    enabled: true,
+    disabledSelectionToolbarPatterns: [],
+    opacity: 100,
+    features: {
+      translate: { enabled: true, providerId: "microsoft-translate-default" },
+      speak: { enabled: false },
+      vocabularyInsight: { enabled: false, providerId: "openai-default" },
+    },
+    customActions: [],
+  },
+  translateButtonMock: vi.fn(),
+}))
+
+vi.mock("@/utils/atoms/config", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/atoms/config")>()
+  return {
+    ...actual,
+    configFieldsAtomMap: {
+      ...actual.configFieldsAtomMap,
+      contextMenu: atom(() => mockState.contextMenuConfig),
+      selectionToolbar: atom(() => mockState.selectionToolbarConfig),
+    },
+  }
+})
+
+vi.mock("@/utils/message", () => ({
+  onMessage: (type: string, handler: typeof mockState.openSelectionHandler) => {
+    if (type === "openSelectionToolbarTranslate") {
+      mockState.openSelectionHandler = handler
+    }
+    return vi.fn()
+  },
+}))
+
+vi.mock("../translate-button", () => ({
+  TranslateButton: (props: {
+    renderTrigger?: boolean
+    openRequest?: {
+      nonce: number
+      analyticsContext?: {
+        surface?: string
+      }
+    }
+  }) => {
+    mockState.translateButtonMock(props)
+
+    return (
+      <div
+        data-open-request={String(props.openRequest?.nonce ?? 0)}
+        data-surface={props.openRequest?.analyticsContext?.surface ?? ""}
+        data-testid={props.renderTrigger === false ? "translate-button-bridge" : "translate-button-trigger"}
+      />
+    )
+  },
+}))
+
+vi.mock("../ai-button", () => ({
+  AiButton: () => null,
+}))
+
+vi.mock("../speak-button", () => ({
+  SpeakButton: () => null,
+}))
+
+vi.mock("../custom-action-button", () => ({
+  SelectionToolbarCustomActionButtons: () => null,
+}))
+
+vi.mock("../close-button", () => ({
+  CloseButton: () => null,
+  DropEvent: "read-frog:selection-toolbar-dropdown-open",
+}))
+
+function mockCurrentSelection(text: string | null) {
+  if (!text) {
+    window.getSelection = vi.fn(() => ({
+      anchorNode: null,
+      focusNode: null,
+      rangeCount: 0,
+      containsNode: vi.fn(() => false),
+      getRangeAt: () => {
+        throw new Error("No range available")
+      },
+      toString: () => "",
+    })) as unknown as typeof window.getSelection
+    return
+  }
+
+  const selectionHost = document.createElement("p")
+  selectionHost.textContent = text
+  document.body.appendChild(selectionHost)
+  const textNode = selectionHost.firstChild
+
+  if (!textNode) {
+    throw new Error("Expected selection text node")
+  }
+
+  window.getSelection = vi.fn(() => ({
+    anchorNode: textNode,
+    focusNode: textNode,
+    rangeCount: 1,
+    containsNode: vi.fn(() => true),
+    getRangeAt: () => ({
+      startContainer: textNode,
+      startOffset: 0,
+      endContainer: textNode,
+      endOffset: text.length,
+    }),
+    toString: () => text,
+  })) as unknown as typeof window.getSelection
+}
+
+describe("selection toolbar context-menu translate bridge", () => {
+  beforeEach(() => {
+    mockState.contextMenuConfig = {
+      enabled: true,
+    }
+    mockState.openSelectionHandler = undefined
+    mockState.selectionToolbarConfig = {
+      enabled: true,
+      disabledSelectionToolbarPatterns: [],
+      opacity: 100,
+      features: {
+        translate: { enabled: true, providerId: "microsoft-translate-default" },
+        speak: { enabled: false },
+        vocabularyInsight: { enabled: false, providerId: "openai-default" },
+      },
+      customActions: [],
+    }
+    mockState.translateButtonMock.mockClear()
+  })
+
+  afterEach(() => {
+    cleanup()
+    document.body.innerHTML = ""
+    vi.clearAllMocks()
+  })
+
+  it("forwards a context-menu translate request to the visible translate button", async () => {
+    mockCurrentSelection("Selected text")
+    render(<SelectionToolbar />)
+
+    await act(async () => {
+      mockState.openSelectionHandler?.({
+        data: {
+          selectedText: "Selected text",
+          analyticsContext: {
+            feature: ANALYTICS_FEATURE.SELECTION_TRANSLATION,
+            surface: ANALYTICS_SURFACE.CONTEXT_MENU,
+            startedAt: 123,
+          },
+        },
+      })
+    })
+
+    expect(screen.getByTestId("translate-button-trigger")).toHaveAttribute("data-open-request", "1")
+    expect(screen.getByTestId("translate-button-trigger")).toHaveAttribute("data-surface", ANALYTICS_SURFACE.CONTEXT_MENU)
+    expect(screen.queryByTestId("translate-button-bridge")).toBeNull()
+  })
+
+  it("reuses the cached context-menu selection when the live selection is cleared before the handler runs", async () => {
+    mockCurrentSelection("Selected text")
+    render(<SelectionToolbar />)
+
+    await act(async () => {
+      document.dispatchEvent(new Event("contextmenu"))
+    })
+
+    mockCurrentSelection(null)
+
+    await act(async () => {
+      mockState.openSelectionHandler?.({
+        data: {
+          selectedText: "Selected text",
+          analyticsContext: {
+            feature: ANALYTICS_FEATURE.SELECTION_TRANSLATION,
+            surface: ANALYTICS_SURFACE.CONTEXT_MENU,
+            startedAt: 456,
+          },
+        },
+      })
+    })
+
+    expect(screen.getByTestId("translate-button-trigger")).toHaveAttribute("data-open-request", "1")
+    expect(screen.getByTestId("translate-button-trigger")).toHaveAttribute("data-surface", ANALYTICS_SURFACE.CONTEXT_MENU)
+  })
+})

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
@@ -467,6 +467,40 @@ describe("selection toolbar requests", () => {
     expect(screen.getByTestId("translation-status").textContent).toBe("false")
   })
 
+  it("can open and run translation programmatically without rendering the toolbar trigger", async () => {
+    translateTextCoreMock.mockResolvedValue("translated from context menu")
+    getOrFetchArticleDataMock.mockResolvedValue(null)
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    setSelectionState(store, { text: "Selected text" })
+    renderWithProviders(
+      <TranslateButton
+        renderTrigger={false}
+        openRequest={{
+          nonce: 1,
+          analyticsContext: {
+            feature: "selection_translation",
+            surface: "context_menu",
+            startedAt: 123,
+          },
+        }}
+      />,
+      store,
+    )
+
+    expect(screen.queryByRole("button", { name: "action.translation" })).toBeNull()
+
+    await waitFor(() => {
+      expect(translateTextCoreMock).toHaveBeenCalledTimes(1)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("translation-result").textContent).toBe("translated from context menu")
+    })
+    expect(screen.getByTestId("translation-selection").textContent).toBe("Selected text")
+  })
+
   it("aborts llm translations when the popover closes without surfacing an error", async () => {
     const streamCalls: Array<{ signal?: AbortSignal, onChunk?: (data: BackgroundTextStreamSnapshot) => void }> = []
     translateTextCoreMock.mockResolvedValue("")

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
@@ -23,6 +23,10 @@ vi.mock("../custom-action-button", () => ({
   SelectionToolbarCustomActionButtons: () => null,
 }))
 
+vi.mock("@/utils/message", () => ({
+  onMessage: () => vi.fn(),
+}))
+
 // Mock atoms
 vi.mock("@/utils/atoms/config", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/utils/atoms/config")>()
@@ -30,6 +34,9 @@ vi.mock("@/utils/atoms/config", async (importOriginal) => {
     ...actual,
     configFieldsAtomMap: {
       ...actual.configFieldsAtomMap,
+      contextMenu: atom({
+        enabled: true,
+      }),
       selectionToolbar: atom({
         enabled: true,
         disabledSelectionToolbarPatterns: [],

--- a/src/entrypoints/selection.content/selection-toolbar/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/index.tsx
@@ -1,12 +1,15 @@
+import type { ContextSnapshot, SelectionSnapshot } from "../utils"
+import type { FeatureUsageContext } from "@/types/analytics"
 import { useAtom, useAtomValue, useSetAtom } from "jotai"
-import { useCallback, useEffect, useLayoutEffect, useRef } from "react"
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react"
 import { SELECTION_CONTENT_OVERLAY_LAYERS } from "@/entrypoints/selection.content/overlay-layers"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { NOTRANSLATE_CLASS } from "@/utils/constants/dom-labels"
 import { MARGIN } from "@/utils/constants/selection"
+import { onMessage } from "@/utils/message"
 import { cn } from "@/utils/styles/utils"
 import { matchDomainPattern } from "@/utils/url"
-import { buildContextSnapshot, readSelectionSnapshot } from "../utils"
+import { buildContextSnapshot, normalizeSelectedText, readSelectionSnapshot } from "../utils"
 import { AiButton } from "./ai-button"
 import {
   clearSelectionStateAtom,
@@ -74,11 +77,17 @@ export function SelectionToolbar() {
   const selectionPositionRef = useRef<{ x: number, y: number } | null>(null) // store selection position (base position without direction offset)
   const selectionStartRef = useRef<{ x: number, y: number } | null>(null) // store selection start position
   const selectionDirectionRef = useRef<SelectionDirection>(SelectionDirection.BOTTOM_RIGHT) // store selection direction
+  const contextMenuSelectionRef = useRef<{ selection: SelectionSnapshot, context: ContextSnapshot | null } | null>(null)
   const isDraggingFromTooltipRef = useRef(false) // track if dragging started from tooltip
+  const [translateOpenRequest, setTranslateOpenRequest] = useState<{
+    nonce: number
+    analyticsContext?: FeatureUsageContext
+  }>({ nonce: 0 })
   const [isSelectionToolbarVisible, setIsSelectionToolbarVisible] = useAtom(isSelectionToolbarVisibleAtom)
   const setSelectionState = useSetAtom(setSelectionStateAtom)
   const clearSelectionState = useSetAtom(clearSelectionStateAtom)
   const selectionToolbar = useAtomValue(configFieldsAtomMap.selectionToolbar)
+  const contextMenu = useAtomValue(configFieldsAtomMap.contextMenu)
   const dropdownOpenRef = useRef(false)
 
   const updatePosition = useCallback(() => {
@@ -197,9 +206,23 @@ export function SelectionToolbar() {
 
       // Record selection start position
       selectionStartRef.current = { x: e.clientX, y: e.clientY }
+      contextMenuSelectionRef.current = null
 
       clearSelectionState()
       setIsSelectionToolbarVisible(false)
+    }
+
+    const handleContextMenu = () => {
+      const selectionSnapshot = readSelectionSnapshot(window.getSelection())
+      if (!selectionSnapshot) {
+        contextMenuSelectionRef.current = null
+        return
+      }
+
+      contextMenuSelectionRef.current = {
+        selection: selectionSnapshot,
+        context: buildContextSnapshot(selectionSnapshot),
+      }
     }
 
     const handleSelectionChange = () => {
@@ -226,12 +249,14 @@ export function SelectionToolbar() {
 
     document.addEventListener("mouseup", handleMouseUp)
     document.addEventListener("mousedown", handleMouseDown)
+    document.addEventListener("contextmenu", handleContextMenu)
     document.addEventListener("selectionchange", handleSelectionChange)
     window.addEventListener("scroll", handleScroll, { passive: true })
 
     return () => {
       document.removeEventListener("mouseup", handleMouseUp)
       document.removeEventListener("mousedown", handleMouseDown)
+      document.removeEventListener("contextmenu", handleContextMenu)
       document.removeEventListener("selectionchange", handleSelectionChange)
       window.removeEventListener("scroll", handleScroll)
       if (animationFrameId) {
@@ -239,6 +264,38 @@ export function SelectionToolbar() {
       }
     }
   }, [clearSelectionState, isSelectionToolbarVisible, setIsSelectionToolbarVisible, setSelectionState, updatePosition])
+
+  useEffect(() => {
+    return onMessage("openSelectionToolbarTranslate", (message) => {
+      const selectedText = normalizeSelectedText(message.data.selectedText)
+      if (selectedText === "") {
+        return
+      }
+
+      const liveSelection = readSelectionSnapshot(window.getSelection())
+      const fallbackSelection = contextMenuSelectionRef.current?.selection.text === selectedText
+        ? contextMenuSelectionRef.current
+        : null
+      const selection = liveSelection ?? fallbackSelection?.selection
+
+      if (!selection) {
+        return
+      }
+
+      setSelectionState({
+        selection,
+        context: liveSelection
+          ? buildContextSnapshot(liveSelection)
+          : fallbackSelection?.context ?? buildContextSnapshot(selection),
+      })
+      setIsSelectionToolbarVisible(false)
+      setTranslateOpenRequest(prev => ({
+        nonce: prev.nonce + 1,
+        analyticsContext: message.data.analyticsContext,
+      }))
+      contextMenuSelectionRef.current = null
+    })
+  }, [setIsSelectionToolbarVisible, setSelectionState])
 
   useEffect(() => {
     const handler = (e: Event) => {
@@ -259,10 +316,12 @@ export function SelectionToolbar() {
       || (!isFirefox && features.speak.enabled)
       || features.vocabularyInsight.enabled
       || selectionToolbar.customActions.some(a => a.enabled !== false)
+  const isToolbarVisible = selectionToolbar.enabled && !isSiteDisabled && hasAnyEnabledFeature
+  const shouldRenderContextMenuTranslateBridge = contextMenu.enabled && !(isToolbarVisible && features.translate.enabled)
 
   return (
     <div ref={tooltipContainerRef} className={NOTRANSLATE_CLASS}>
-      {selectionToolbar.enabled && !isSiteDisabled && hasAnyEnabledFeature && (
+      {isToolbarVisible && (
         <div
           ref={tooltipRef}
           aria-hidden={!isSelectionToolbarVisible}
@@ -272,13 +331,19 @@ export function SelectionToolbar() {
           )}
         >
           <div className="flex items-center overflow-x-auto overflow-y-hidden rounded-sm max-w-105 no-scrollbar">
-            {features.translate.enabled && <TranslateButton />}
+            {features.translate.enabled && <TranslateButton openRequest={translateOpenRequest} />}
             {!isFirefox && features.speak.enabled && <SpeakButton />}
             {features.vocabularyInsight.enabled && <AiButton />}
             <SelectionToolbarCustomActionButtons />
           </div>
           <CloseButton />
         </div>
+      )}
+      {shouldRenderContextMenuTranslateBridge && (
+        <TranslateButton
+          renderTrigger={false}
+          openRequest={translateOpenRequest}
+        />
       )}
     </div>
   )

--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/index.tsx
@@ -1,12 +1,13 @@
 import type { SelectionToolbarTranslateRequestSlice } from "../atoms"
 import type { SelectionToolbarInlineError } from "../inline-error"
+import type { FeatureUsageContext } from "@/types/analytics"
 import type { BackgroundTextStreamSnapshot, ThinkingSnapshot } from "@/types/background-stream"
 import type { LLMProviderConfig, ProviderConfig } from "@/types/config/provider"
 import { i18n } from "#imports"
 import { LANG_CODE_TO_EN_NAME } from "@read-frog/definitions"
 import { RiTranslate } from "@remixicon/react"
 import { useAtomValue, useSetAtom } from "jotai"
-import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useEffectEvent, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { SelectionPopover } from "@/components/ui/selection-popover"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { isLLMProviderConfig, isTranslateProviderConfig } from "@/types/config/provider"
@@ -109,13 +110,27 @@ async function translateWithStandardProvider({
   return translatedText
 }
 
-export function TranslateButton() {
+interface TranslateButtonOpenRequest {
+  nonce: number
+  analyticsContext?: FeatureUsageContext
+}
+
+interface TranslateButtonProps {
+  renderTrigger?: boolean
+  openRequest?: TranslateButtonOpenRequest
+}
+
+export function TranslateButton({
+  renderTrigger = true,
+  openRequest,
+}: TranslateButtonProps) {
   const [open, setOpen] = useState(false)
   const [isTranslating, setIsTranslating] = useState(false)
   const [rerunNonce, setRerunNonce] = useState(0)
   const [translatedText, setTranslatedText] = useState<string | undefined>(undefined)
   const [thinking, setThinking] = useState<ThinkingSnapshot | null>(null)
   const [error, setError] = useState<SelectionToolbarInlineError | null>(null)
+  const [sessionAnalyticsContext, setSessionAnalyticsContext] = useState<FeatureUsageContext | null>(null)
   const translateRequest = useAtomValue(selectionToolbarTranslateRequestAtom)
   const providersConfig = useAtomValue(configFieldsAtomMap.providersConfig)
   const setIsSelectionToolbarVisible = useSetAtom(isSelectionToolbarVisibleAtom)
@@ -165,10 +180,11 @@ export function TranslateButton() {
       return
     }
 
-    const analyticsContext = createFeatureUsageContext(
-      ANALYTICS_FEATURE.SELECTION_TRANSLATION,
-      ANALYTICS_SURFACE.SELECTION_TOOLBAR,
-    )
+    const analyticsContext = sessionAnalyticsContext
+      ?? createFeatureUsageContext(
+        ANALYTICS_FEATURE.SELECTION_TRANSLATION,
+        ANALYTICS_SURFACE.SELECTION_TOOLBAR,
+      )
 
     setIsTranslating(true)
     setTranslatedText(undefined)
@@ -266,7 +282,7 @@ export function TranslateButton() {
         setIsTranslating(false)
       }
     }
-  }, [resetSessionState, selectionText, translateRequest])
+  }, [resetSessionState, selectionText, sessionAnalyticsContext, translateRequest])
 
   const startTranslation = useEffectEvent((runId: number) => {
     void runTranslation(runId)
@@ -308,20 +324,38 @@ export function TranslateButton() {
     }
 
     setOpen(nextOpen)
+    if (!nextOpen) {
+      setSessionAnalyticsContext(null)
+    }
 
     if (nextOpen) {
       setIsSelectionToolbarVisible(false)
     }
   }, [cancelCurrentTranslation, captureSelectionSnapshot, clearSelectionSnapshot, resetSessionState, setIsSelectionToolbarVisible])
 
+  useLayoutEffect(() => {
+    if (!openRequest || openRequest.nonce === 0) {
+      return
+    }
+
+    cancelCurrentTranslation()
+    resetSessionState()
+    setSessionAnalyticsContext(openRequest.analyticsContext ?? null)
+    captureSelectionSnapshot()
+    setOpen(true)
+    setIsSelectionToolbarVisible(false)
+  }, [cancelCurrentTranslation, captureSelectionSnapshot, openRequest, resetSessionState, setIsSelectionToolbarVisible])
+
   return (
     <SelectionPopover.Root open={open} onOpenChange={handleOpenChange}>
-      <SelectionToolbarTooltip
-        content={triggerLabel}
-        render={<SelectionPopover.Trigger aria-label={triggerLabel} />}
-      >
-        <RiTranslate className="size-4.5" />
-      </SelectionToolbarTooltip>
+      {renderTrigger && (
+        <SelectionToolbarTooltip
+          content={triggerLabel}
+          render={<SelectionPopover.Trigger aria-label={triggerLabel} />}
+        >
+          <RiTranslate className="size-4.5" />
+        </SelectionToolbarTooltip>
+      )}
 
       <SelectionPopover.Content key={popoverSessionKey} container={shadowWrapper ?? document.body}>
         <SelectionPopover.Header className="border-b">

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -7,6 +7,7 @@ dataTypes:
   number: Number
 contextMenu:
   translate: Translate
+  translateSelection: 'Translate "%s"'
   showOriginal: Show Original
 popup:
   theme: Theme

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -7,6 +7,7 @@ dataTypes:
   number: 数値
 contextMenu:
   translate: 翻訳
+  translateSelection: "「%s」を翻訳"
   showOriginal: 原文を表示
 popup:
   theme: テーマ

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -7,6 +7,7 @@ dataTypes:
   number: 숫자
 contextMenu:
   translate: 번역
+  translateSelection: '"%s" 번역'
   showOriginal: 원문 보기
 popup:
   theme: 테마

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -7,6 +7,7 @@ dataTypes:
   number: Число
 contextMenu:
   translate: Перевести
+  translateSelection: "Перевести «%s»"
   showOriginal: Показать оригинал
 popup:
   theme: Тема

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -7,6 +7,7 @@ dataTypes:
   number: Sayı
 contextMenu:
   translate: Çevir
+  translateSelection: '"%s" metnini çevir'
   showOriginal: Orijinali Göster
 popup:
   theme: Tema

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -7,6 +7,7 @@ dataTypes:
   number: Số
 contextMenu:
   translate: Dịch
+  translateSelection: 'Dịch "%s"'
   showOriginal: Hiển thị bản gốc
 popup:
   theme: Chủ đề

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -7,6 +7,7 @@ dataTypes:
   number: 数字
 contextMenu:
   translate: 翻译
+  translateSelection: 翻译“%s”
   showOriginal: 显示原文
 popup:
   theme: 主题

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -7,6 +7,7 @@ dataTypes:
   number: 數字
 contextMenu:
   translate: 翻譯
+  translateSelection: 翻譯「%s」
   showOriginal: 顯示原文
 popup:
   theme: 主題

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -35,6 +35,7 @@ interface ProtocolMap {
   tryToSetEnablePageTranslationOnContentScript: (data: { enabled: boolean, analyticsContext?: FeatureUsageContext }) => void
   setAndNotifyPageTranslationStateChangedByManager: (data: { enabled: boolean }) => void
   notifyTranslationStateChanged: (data: { enabled: boolean }) => void
+  openSelectionToolbarTranslate: (data: { selectedText: string, analyticsContext?: FeatureUsageContext }) => void
   // for auto start page translation
   checkAndAskAutoPageTranslation: (data: { url: string, detectedCodeOrUnd: LangCodeISO6393 | "und" }) => void
   // ask host to start page translation


### PR DESCRIPTION
## Summary
- split the browser context menu into page and selection entries so right-clicking selected text no longer offers full-page translation
- route the selection entry into the existing selection-translation popover flow, including fallback handling when the live selection is cleared after opening the context menu
- add coverage for menu registration/click routing and the selection-toolbar bridge, and add localized selection menu labels

Fixes #1033

## Testing
- SKIP_FREE_API=true pnpm vitest run src/entrypoints/background/__tests__/context-menu.test.ts src/entrypoints/selection.content/selection-toolbar/__tests__/context-menu-translate.test.tsx src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
- SKIP_FREE_API=true pnpm type-check
- pre-push hook: nx lint, nx type-check, nx test (82 files / 824 tests passed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the browser context menu into separate page and selection items so right‑clicking selected text opens the selection translation popover instead of toggling full‑page translation. Fixes #1033.

- **Bug Fixes**
  - Added two items: page “Translate” and selection ‘Translate “%s”’.
  - Routed the selection item to `openSelectionToolbarTranslate` with CONTEXT_MENU analytics and a cached-selection fallback if the live selection is cleared.
  - Kept page translation toggle and title updates on the page item only.
  - Added tests for menu registration/click routing and the selection-toolbar bridge, plus new `contextMenu.translateSelection` locales.

<sup>Written for commit 1b194667cd501317b185fb0eb345bbf32043f5ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

