### PR TITLE
fix(extension): preserve bilingual layout around floated content

### DIFF
--- a/.changeset/fuzzy-cats-hunt.md
+++ b/.changeset/fuzzy-cats-hunt.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(extension): preserve float-wrapping for bilingual block translations on Wikipedia

--- a/src/assets/styles/translation-node-preset.css
+++ b/src/assets/styles/translation-node-preset.css
@@ -6,9 +6,14 @@
   text-decoration-skip-ink: auto;
 }
 
+.read-frog-translated-content-wrapper--block {
+  display: block;
+  margin-top: 4px;
+}
+
 .read-frog-translated-block-content {
-  display: inline-block;
-  margin: 8px 0 !important;
+  display: block;
+  margin: 0 !important;
   color: inherit;
   font-family: inherit;
 }

--- a/src/utils/constants/dom-labels.ts
+++ b/src/utils/constants/dom-labels.ts
@@ -1,4 +1,5 @@
 export const CONTENT_WRAPPER_CLASS = "read-frog-translated-content-wrapper"
+export const BLOCK_WRAPPER_CLASS = "read-frog-translated-content-wrapper--block"
 export const INLINE_CONTENT_CLASS = "read-frog-translated-inline-content"
 export const BLOCK_CONTENT_CLASS = "read-frog-translated-block-content"
 

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -7,6 +7,7 @@ import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import {
   BLOCK_ATTRIBUTE,
   BLOCK_CONTENT_CLASS,
+  BLOCK_WRAPPER_CLASS,
   CONTENT_WRAPPER_CLASS,
   INLINE_ATTRIBUTE,
   INLINE_CONTENT_CLASS,
@@ -113,6 +114,8 @@ describe("translate", () => {
         expectNodeLabels(node, [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
         const wrapper = expectTranslationWrapper(node, "bilingual")
         expect(wrapper).toBe(node.childNodes[1])
+        expect(wrapper).toHaveClass(BLOCK_WRAPPER_CLASS)
+        expect(wrapper?.querySelector("br")).toBeNull()
         expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
 
         await removeOrShowPageTranslation("bilingual", true)
@@ -773,10 +776,16 @@ describe("translate", () => {
 
         expectNodeLabels(node, [BLOCK_ATTRIBUTE])
         const wrapper1 = node.children[0]
+        expect(wrapper1).toHaveClass(BLOCK_WRAPPER_CLASS)
+        expect(wrapper1.querySelector("br")).toBeNull()
         expectTranslatedContent(wrapper1 as Element, BLOCK_CONTENT_CLASS)
         const wrapper2 = node.children[2]
+        expect(wrapper2).toHaveClass(BLOCK_WRAPPER_CLASS)
+        expect(wrapper2.querySelector("br")).toBeNull()
         expectTranslatedContent(wrapper2 as Element, BLOCK_CONTENT_CLASS)
         const wrapper3 = node.children[4]
+        expect(wrapper3).toHaveClass(BLOCK_WRAPPER_CLASS)
+        expect(wrapper3.querySelector("br")).toBeNull()
         expectTranslatedContent(wrapper3 as Element, BLOCK_CONTENT_CLASS)
 
         await removeOrShowPageTranslation("bilingual", true)

--- a/src/utils/host/translate/dom/translation-insertion.ts
+++ b/src/utils/host/translate/dom/translation-insertion.ts
@@ -1,6 +1,6 @@
 import type { TranslationNodeStyleConfig } from "@/types/config/translate"
 import type { TransNode } from "@/types/dom"
-import { BLOCK_CONTENT_CLASS, INLINE_CONTENT_CLASS, NOTRANSLATE_CLASS } from "../../../constants/dom-labels"
+import { BLOCK_CONTENT_CLASS, BLOCK_WRAPPER_CLASS, INLINE_CONTENT_CLASS, NOTRANSLATE_CLASS } from "../../../constants/dom-labels"
 import { isBlockTransNode, isCustomForceBlockTranslation, isHTMLElement, isInlineTransNode } from "../../dom/filter"
 import { getOwnerDocument } from "../../dom/node"
 import { decorateTranslationNode } from "../ui/decorate-translation"
@@ -13,9 +13,8 @@ export function addInlineTranslation(ownerDoc: Document, translatedWrapperNode: 
   translatedNode.className = `${NOTRANSLATE_CLASS} ${INLINE_CONTENT_CLASS}`
 }
 
-export function addBlockTranslation(ownerDoc: Document, translatedWrapperNode: HTMLElement, translatedNode: HTMLElement): void {
-  const brNode = ownerDoc.createElement("br")
-  translatedWrapperNode.appendChild(brNode)
+export function addBlockTranslation(_ownerDoc: Document, translatedWrapperNode: HTMLElement, translatedNode: HTMLElement): void {
+  translatedWrapperNode.classList.add(BLOCK_WRAPPER_CLASS)
   translatedNode.className = `${NOTRANSLATE_CLASS} ${BLOCK_CONTENT_CLASS}`
 }
 


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

This PR fixes bilingual block translation layout regressions on Wikipedia pages with floated content.

It removes the injected `<br>` before translated block content, adds a dedicated block wrapper class, and updates translation preset CSS so bilingual translations render as their own block wrapper without forcing the translated content into an `inline-block` that drops below floated sidebars or images.

It also adds integration coverage to verify block translation wrappers use the new class and no longer inject `<br>` nodes.

## Related Issue

Closes #1155
Closes #847

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Local verification:
- `pnpm exec vitest run src/utils/host/__tests__/translate.integration.test.tsx`
- `pnpm exec eslint src/assets/styles/translation-node-preset.css src/utils/constants/dom-labels.ts src/utils/host/translate/dom/translation-insertion.ts src/utils/host/__tests__/translate.integration.test.tsx`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes bilingual block translation layout on Wikipedia pages with floated sidebars/images. Uses a dedicated block wrapper to preserve float wrapping and removes the injected <br> that pushed translations below floats. Closes #1155, #847.

- **Bug Fixes**
  - Added `read-frog-translated-content-wrapper--block` to block wrappers and applied it in insertion.
  - Removed the injected `<br>` before translated blocks.
  - Updated CSS: wrappers are `display: block` with small top margin; `.read-frog-translated-block-content` is `display: block` with no extra margin.
  - Added integration tests to assert wrapper class usage and absence of `<br>`; introduced `BLOCK_WRAPPER_CLASS` constant.

<sup>Written for commit 08247867252a5891849009de5f78f171de6789ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

