### PR TITLE
feat: add firefox android build target

### DIFF
--- a/.changeset/firefox-android-support.md
+++ b/.changeset/firefox-android-support.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(extension): add a Firefox Android build target with an Android-compatible manifest and hide unsupported context menu and Google Drive sync features.

--- a/README.md
+++ b/README.md
@@ -256,6 +256,12 @@ Ask AI to understand the project: [Dosu](https://app.dosu.dev/29569286-71ba-47dd
 
 Check out the [Contribution Guide](https://readfrog.app/en/tutorial/code-contribution/contribution-guide) for more details.
 
+#### Firefox Android local debug
+
+- Run `pnpm dev:firefox-android` for a local Firefox Android development build.
+- Run `pnpm build:firefox-android` to generate a locally installable Android-targeted package.
+- This target enables `browser_specific_settings.gecko_android` and removes `identity` and `contextMenus`, so Google Drive Sync and Context Menu are intentionally unavailable.
+
 ReadFrog is dual-licensed under GPLv3 and a commercial license.
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for contributor licensing terms.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -254,6 +254,12 @@ Read Frog 的愿景是为各个级别的语言学习者提供易于使用、智�
 
 查看[贡献指南](https://readfrog.app/zh/tutorial/code-contribution/contribution-guide)了解更多详情。
 
+#### Firefox Android 本地调试
+
+- 使用 `pnpm dev:firefox-android` 启动 Firefox Android 本地开发构建。
+- 使用 `pnpm build:firefox-android` 生成可本地安装调试的 Android 定向产物。
+- 该目标会启用 `browser_specific_settings.gecko_android`，并移除 `identity` 与 `contextMenus`，因此 Google Drive Sync 和 Context Menu 会按预期不可用。
+
 ReadFrog 采用 GPLv3 和商业许可双重授权。
 
 贡献者许可条款请参阅 [CONTRIBUTING.md](./CONTRIBUTING.md)。

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "build": "DOTENV_CONFIG_QUIET=false wxt build",
     "build:edge": "DOTENV_CONFIG_QUIET=false wxt build -b edge",
     "build:firefox": "DOTENV_CONFIG_QUIET=false wxt build -b firefox --mv3",
+    "build:firefox-android": "DOTENV_CONFIG_QUIET=false WXT_FIREFOX_ANDROID=true wxt build -b firefox --mv3",
     "build:analyze": "wxt build --analyze",
     "dev:local": "WXT_USE_LOCAL_PACKAGES=true wxt",
     "dev": "DOTENV_CONFIG_QUIET=false wxt",
     "dev:edge": "DOTENV_CONFIG_QUIET=false wxt -b edge",
     "dev:firefox": "DOTENV_CONFIG_QUIET=false wxt -b firefox --mv3",
+    "dev:firefox-android": "DOTENV_CONFIG_QUIET=false WXT_FIREFOX_ANDROID=true wxt -b firefox --mv3",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "postinstall": "wxt prepare",
@@ -25,6 +27,7 @@
     "zip": "DOTENV_CONFIG_QUIET=false WXT_ZIP_MODE=true wxt zip",
     "zip:edge": "DOTENV_CONFIG_QUIET=false WXT_ZIP_MODE=true wxt zip -b edge",
     "zip:firefox": "DOTENV_CONFIG_QUIET=false WXT_ZIP_MODE=true wxt zip -b firefox --mv3",
+    "zip:firefox-android": "DOTENV_CONFIG_QUIET=false WXT_ZIP_MODE=true WXT_FIREFOX_ANDROID=true wxt zip -b firefox --mv3",
     "zip:all": "DOTENV_CONFIG_QUIET=false pnpm zip && pnpm zip:edge && pnpm zip:firefox",
     "release": "changeset tag && git push origin --tags",
     "prepare": "husky"
@@ -174,6 +177,12 @@
         "executor": "nx:run-commands",
         "options": {
           "command": "wxt build -b firefox"
+        }
+      },
+      "build:firefox-android": {
+        "executor": "nx:run-commands",
+        "options": {
+          "command": "WXT_FIREFOX_ANDROID=true wxt build -b firefox --mv3"
         }
       },
       "test": {

--- a/src/entrypoints/background/context-menu.ts
+++ b/src/entrypoints/background/context-menu.ts
@@ -6,6 +6,7 @@ import { createFeatureUsageContext } from "@/utils/analytics"
 import { CONFIG_STORAGE_KEY } from "@/utils/constants/config"
 import { getTranslationStateKey, TRANSLATION_STATE_KEY_PREFIX } from "@/utils/constants/storage-keys"
 import { sendMessage } from "@/utils/message"
+import { supportsContextMenu } from "@/utils/platform"
 import { ensureInitializedConfig } from "./config"
 
 const MENU_ID_TRANSLATE = "read-frog-translate"
@@ -16,6 +17,10 @@ const MENU_ID_TRANSLATE = "read-frog-translate"
  * before Chrome completes initialization
  */
 export function registerContextMenuListeners() {
+  if (!supportsContextMenu) {
+    return
+  }
+
   // Listen for config changes to update context menu
   storage.watch<Config>(`local:${CONFIG_STORAGE_KEY}`, async (newConfig) => {
     if (newConfig) {
@@ -68,6 +73,10 @@ export function registerContextMenuListeners() {
  * This can be called asynchronously after listeners are registered
  */
 export async function initializeContextMenu() {
+  if (!supportsContextMenu) {
+    return
+  }
+
   // Ensure config is initialized before setting up context menu
   const config = await ensureInitializedConfig()
   if (!config) {
@@ -81,6 +90,10 @@ export async function initializeContextMenu() {
  * Update context menu items based on config
  */
 async function updateContextMenuItems(config: Config) {
+  if (!supportsContextMenu) {
+    return
+  }
+
   // Remove all existing menu items first
   await browser.contextMenus.removeAll()
 
@@ -107,6 +120,10 @@ async function updateContextMenuItems(config: Config) {
  * @param enabled - Optional: if provided, use this value instead of reading from storage
  */
 async function updateTranslateMenuTitle(tabId: number, enabled?: boolean) {
+  if (!supportsContextMenu) {
+    return
+  }
+
   const config = await ensureInitializedConfig()
   if (!config?.contextMenu.enabled) {
     return
@@ -155,6 +172,10 @@ async function handleContextMenuClick(
  * Handle translate menu click - toggle page translation
  */
 async function handleTranslateClick(tabId: number) {
+  if (!supportsContextMenu) {
+    return
+  }
+
   const state = await storage.getItem<{ enabled: boolean }>(
     getTranslationStateKey(tabId),
   )

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -3,6 +3,7 @@ import { browser, defineBackground } from "#imports"
 import { WEBSITE_URL } from "@/utils/constants/url"
 import { logger } from "@/utils/logger"
 import { onMessage } from "@/utils/message"
+import { supportsContextMenu } from "@/utils/platform"
 import { SessionCacheGroupRegistry } from "@/utils/session-cache/session-cache-group-registry"
 import { runAiSegmentSubtitles } from "./ai-segmentation"
 import { setupAnalyticsMessageHandlers } from "./analytics"
@@ -21,6 +22,25 @@ import { setUpSubtitlesTranslationQueue, setUpWebPageTranslationQueue } from "./
 import { translationMessage } from "./translation-signal"
 import { setupTTSPlaybackMessageHandlers } from "./tts-playback"
 import { setupUninstallSurvey } from "./uninstall-survey"
+
+interface OptionalContextMenuDependencies {
+  initializeContextMenu: () => Promise<void>
+  registerContextMenuListeners: () => void
+  supportsContextMenu: boolean
+}
+
+export function setupOptionalContextMenu({
+  initializeContextMenu,
+  registerContextMenuListeners,
+  supportsContextMenu,
+}: OptionalContextMenuDependencies) {
+  if (!supportsContextMenu) {
+    return
+  }
+
+  registerContextMenuListeners()
+  void initializeContextMenu()
+}
 
 export default defineBackground({
   type: "module",
@@ -82,12 +102,12 @@ export default defineBackground({
     setupAnalyticsMessageHandlers()
     translationMessage()
 
-    // Register context menu listeners synchronously
-    // This ensures listeners are registered before Chrome completes initialization
-    registerContextMenuListeners()
-
-    // Initialize context menu items asynchronously
-    void initializeContextMenu()
+    // Register optional browser features only when the target supports them.
+    setupOptionalContextMenu({
+      initializeContextMenu,
+      registerContextMenuListeners,
+      supportsContextMenu,
+    })
 
     void setUpWebPageTranslationQueue()
     void setUpSubtitlesTranslationQueue()

--- a/src/entrypoints/host.content/index.tsx
+++ b/src/entrypoints/host.content/index.tsx
@@ -65,14 +65,14 @@ export default defineContentScript({
       logger.error("Failed to check translation state:", error)
     }
     if (translationEnabled) {
-      void manager.start()
+      void manager.setEnabled(true)
     }
 
     const handleUrlChange = async (from: string, to: string) => {
       if (from !== to) {
         logger.info("URL changed from", from, "to", to)
         if (manager.isActive) {
-          manager.stop()
+          void manager.setEnabled(false)
         }
         // Only the top frame should detect and set language to avoid race conditions from iframes
         if (window === window.top) {
@@ -94,9 +94,7 @@ export default defineContentScript({
     // Listen for translation state changes from background
     const cleanupTranslationStateListener = onMessage("askManagerToTogglePageTranslation", (msg) => {
       const { enabled, analyticsContext } = msg.data
-      if (enabled === manager.isActive)
-        return
-      enabled ? void manager.start(window === window.top ? analyticsContext : undefined) : manager.stop()
+      return manager.setEnabled(enabled, window === window.top ? analyticsContext : undefined)
     })
 
     ctx.onInvalidated(() => {

--- a/src/entrypoints/host.content/translation-control/__tests__/handle-config-change.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/handle-config-change.test.ts
@@ -10,8 +10,7 @@ function createMockConfig(mode: "bilingual" | "translationOnly"): Config {
 function createMockManager(isActive: boolean): PageTranslationManager {
   return {
     isActive,
-    start: vi.fn().mockResolvedValue(undefined),
-    stop: vi.fn(),
+    setEnabled: vi.fn().mockResolvedValue(undefined),
   } as unknown as PageTranslationManager
 }
 
@@ -25,8 +24,8 @@ describe("handleTranslationModeChange", () => {
       manager,
     )
 
-    expect(manager.stop).toHaveBeenCalled()
-    expect(manager.start).toHaveBeenCalled()
+    expect(manager.setEnabled).toHaveBeenNthCalledWith(1, false)
+    expect(manager.setEnabled).toHaveBeenNthCalledWith(2, true)
   })
 
   it("should not trigger when mode stays the same", () => {
@@ -38,7 +37,7 @@ describe("handleTranslationModeChange", () => {
       manager,
     )
 
-    expect(manager.stop).not.toHaveBeenCalled()
+    expect(manager.setEnabled).not.toHaveBeenCalled()
   })
 
   it("should not trigger when manager is not active", () => {
@@ -50,6 +49,6 @@ describe("handleTranslationModeChange", () => {
       manager,
     )
 
-    expect(manager.stop).not.toHaveBeenCalled()
+    expect(manager.setEnabled).not.toHaveBeenCalled()
   })
 })

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts
@@ -80,11 +80,14 @@ vi.mock("@/utils/message", () => ({
 }))
 
 class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = []
   observe = vi.fn()
   unobserve = vi.fn()
   disconnect = vi.fn()
 
-  constructor(_callback: IntersectionObserverCallback, _options?: IntersectionObserverInit) {}
+  constructor(_callback: IntersectionObserverCallback, _options?: IntersectionObserverInit) {
+    MockIntersectionObserver.instances.push(this)
+  }
 }
 
 function createDeferred<T>() {
@@ -111,6 +114,7 @@ describe("pageTranslationManager title handling", () => {
     document.title = "Original Title"
 
     vi.stubGlobal("IntersectionObserver", MockIntersectionObserver)
+    MockIntersectionObserver.instances = []
 
     mockGetDetectedCodeFromStorage.mockResolvedValue("eng")
     mockGetLocalConfig.mockResolvedValue(DEFAULT_CONFIG)
@@ -190,5 +194,70 @@ describe("pageTranslationManager title handling", () => {
 
     manager.stop()
     expect(document.title).toBe("Updated Source Title")
+  })
+
+  it("coalesces concurrent enable requests into a single startup flow", async () => {
+    const configDeferred = createDeferred<typeof DEFAULT_CONFIG | null>()
+    mockGetLocalConfig
+      .mockImplementationOnce(() => configDeferred.promise)
+      .mockResolvedValue(DEFAULT_CONFIG)
+
+    const manager = new PageTranslationManager()
+    const firstEnable = manager.setEnabled(true)
+    const secondEnable = manager.setEnabled(true)
+
+    expect(manager.isActive).toBe(true)
+
+    configDeferred.resolve(DEFAULT_CONFIG)
+    await Promise.all([firstEnable, secondEnable])
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1)
+    expect(mockWalkAndLabelElement).toHaveBeenCalledTimes(1)
+    expect(
+      mockSendMessage.mock.calls.filter(
+        ([type, payload]) => type === "setAndNotifyPageTranslationStateChangedByManager" && payload?.enabled === true,
+      ),
+    ).toHaveLength(1)
+  })
+
+  it("applies a disable request immediately after an in-flight enable finishes", async () => {
+    const configDeferred = createDeferred<typeof DEFAULT_CONFIG | null>()
+    mockGetLocalConfig
+      .mockImplementationOnce(() => configDeferred.promise)
+      .mockResolvedValue(DEFAULT_CONFIG)
+
+    const manager = new PageTranslationManager()
+    const enablePromise = manager.setEnabled(true)
+    const disablePromise = manager.setEnabled(false)
+
+    configDeferred.resolve(DEFAULT_CONFIG)
+    await Promise.all([enablePromise, disablePromise])
+
+    expect(manager.isActive).toBe(false)
+    expect(mockRemoveAllTranslatedWrapperNodes).toHaveBeenCalledTimes(1)
+    expect(
+      mockSendMessage.mock.calls.filter(
+        ([type]) => type === "setAndNotifyPageTranslationStateChangedByManager",
+      ),
+    ).toEqual([
+      ["setAndNotifyPageTranslationStateChangedByManager", { enabled: true }],
+      ["setAndNotifyPageTranslationStateChangedByManager", { enabled: false }],
+    ])
+  })
+
+  it("ignores repeated enable requests once translation is already active", async () => {
+    const manager = new PageTranslationManager()
+
+    await manager.setEnabled(true)
+    expect(MockIntersectionObserver.instances).toHaveLength(1)
+
+    await manager.setEnabled(true)
+
+    expect(MockIntersectionObserver.instances).toHaveLength(1)
+    expect(
+      mockSendMessage.mock.calls.filter(
+        ([type, payload]) => type === "setAndNotifyPageTranslationStateChangedByManager" && payload?.enabled === true,
+      ),
+    ).toHaveLength(1)
   })
 })

--- a/src/entrypoints/host.content/translation-control/bind-translation-shortcut.ts
+++ b/src/entrypoints/host.content/translation-control/bind-translation-shortcut.ts
@@ -19,14 +19,10 @@ export async function bindTranslationShortcutKey(pageTranslationManager: PageTra
   const shortcut = config.translate.page.shortcut.join("+")
 
   hotkeys(shortcut, () => {
-    if (pageTranslationManager.isActive) {
-      pageTranslationManager.stop()
-    }
-    else {
-      void pageTranslationManager.start(
-        createFeatureUsageContext(ANALYTICS_FEATURE.PAGE_TRANSLATION, ANALYTICS_SURFACE.SHORTCUT),
-      )
-    }
+    void pageTranslationManager.setEnabled(
+      !pageTranslationManager.isActive,
+      createFeatureUsageContext(ANALYTICS_FEATURE.PAGE_TRANSLATION, ANALYTICS_SURFACE.SHORTCUT),
+    )
     return false
   })
 }

--- a/src/entrypoints/host.content/translation-control/handle-config-change.ts
+++ b/src/entrypoints/host.content/translation-control/handle-config-change.ts
@@ -13,7 +13,7 @@ export function handleTranslationModeChange(
   const modeChanged = newConfig && oldConfig && newConfig.translate.mode !== oldConfig.translate.mode
 
   if (modeChanged && manager.isActive) {
-    manager.stop()
-    void manager.start()
+    void manager.setEnabled(false)
+    void manager.setEnabled(true)
   }
 }

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -26,6 +26,13 @@ interface IPageTranslationManager {
   readonly isActive: boolean
 
   /**
+   * Serializes page translation state transitions.
+   * Repeated requests with the same target state are coalesced and the latest
+   * requested state wins after the current transition finishes.
+   */
+  setEnabled: (enabled: boolean, analyticsContext?: FeatureUsageContext) => Promise<void>
+
+  /**
    * Starts the automatic page translation functionality
    * Registers observers, touch triggers and set storage
    */
@@ -62,6 +69,9 @@ export class PageTranslationManager implements IPageTranslationManager {
   private lastSourceTitle: string | null = null
   private lastAppliedTranslatedTitle: string | null = null
   private titleRequestVersion = 0
+  private desiredEnabled = false
+  private transitionPromise: Promise<void> | null = null
+  private pendingEnableAnalyticsContext: FeatureUsageContext | undefined
 
   constructor(intersectionOptions: SimpleIntersectionOptions = {}) {
     if (intersectionOptions.threshold !== undefined) {
@@ -80,48 +90,79 @@ export class PageTranslationManager implements IPageTranslationManager {
     return this.isPageTranslating
   }
 
+  async setEnabled(enabled: boolean, analyticsContext?: FeatureUsageContext): Promise<void> {
+    this.desiredEnabled = enabled
+
+    if (enabled) {
+      this.pendingEnableAnalyticsContext = window === window.top
+        ? analyticsContext
+        : undefined
+    }
+
+    if (this.transitionPromise) {
+      return this.transitionPromise
+    }
+
+    this.transitionPromise = this.runTransitionLoop()
+
+    try {
+      await this.transitionPromise
+    }
+    finally {
+      this.transitionPromise = null
+    }
+  }
+
   async start(analyticsContext?: FeatureUsageContext): Promise<void> {
     if (this.isPageTranslating) {
       console.warn("PageTranslationManager is already active")
       return
     }
 
+    this.desiredEnabled = true
     const trackedContext = window === window.top ? analyticsContext : undefined
+    let didNotifyEnabled = false
 
-    const config = await getLocalConfig()
-    if (!config) {
-      console.warn("Config is not initialized")
-      if (trackedContext) {
-        void trackFeatureUsed({
-          ...trackedContext,
-          outcome: "failure",
-        })
-      }
-      return
-    }
-
-    const detectedCode = await getDetectedCodeFromStorage()
-
-    if (!validateTranslationConfigAndToast({
-      providersConfig: config.providersConfig,
-      translate: config.translate,
-      language: config.language,
-    }, detectedCode)) {
-      if (trackedContext) {
-        void trackFeatureUsed({
-          ...trackedContext,
-          outcome: "failure",
-        })
-      }
-      return
-    }
+    // Occupy the active slot before the first async boundary so concurrent
+    // enable requests cannot enter a second startup flow.
+    this.isPageTranslating = true
 
     try {
+      const config = await getLocalConfig()
+      if (!config) {
+        this.handleStartFailure()
+        console.warn("Config is not initialized")
+        if (trackedContext) {
+          void trackFeatureUsed({
+            ...trackedContext,
+            outcome: "failure",
+          })
+        }
+        return
+      }
+
+      const detectedCode = await getDetectedCodeFromStorage()
+
+      if (!validateTranslationConfigAndToast({
+        providersConfig: config.providersConfig,
+        translate: config.translate,
+        language: config.language,
+      }, detectedCode)) {
+        this.handleStartFailure()
+        if (trackedContext) {
+          void trackFeatureUsed({
+            ...trackedContext,
+            outcome: "failure",
+          })
+        }
+        return
+      }
+
       await sendMessage("setAndNotifyPageTranslationStateChangedByManager", {
         enabled: true,
       })
+      didNotifyEnabled = true
 
-      this.isPageTranslating = true
       await this.primeDocumentTitleContext(config.translate.enableAIContentAware)
       this.startDocumentTitleTracking()
 
@@ -161,6 +202,12 @@ export class PageTranslationManager implements IPageTranslationManager {
       }
     }
     catch (error) {
+      this.handleStartFailure()
+      if (didNotifyEnabled) {
+        await sendMessage("setAndNotifyPageTranslationStateChangedByManager", {
+          enabled: false,
+        })
+      }
       if (trackedContext) {
         void trackFeatureUsed({
           ...trackedContext,
@@ -172,6 +219,8 @@ export class PageTranslationManager implements IPageTranslationManager {
   }
 
   stop(): void {
+    this.desiredEnabled = false
+
     if (!this.isPageTranslating) {
       console.warn("AutoTranslationManager is already inactive")
       return
@@ -233,12 +282,13 @@ export class PageTranslationManager implements IPageTranslationManager {
       if (!startTouches)
         return
       if (performance.now() - startTime < PageTranslationManager.MAX_DURATION) {
-        this.isPageTranslating
-          ? this.stop()
-          : void this.start(createFeatureUsageContext(
+        void this.setEnabled(
+          !this.isPageTranslating,
+          createFeatureUsageContext(
             ANALYTICS_FEATURE.PAGE_TRANSLATION,
             ANALYTICS_SURFACE.TOUCH_GESTURE,
-          ))
+          ),
+        )
       }
       reset()
     }
@@ -259,6 +309,36 @@ export class PageTranslationManager implements IPageTranslationManager {
 
   private shouldManageDocumentTitle(): boolean {
     return window === window.top
+  }
+
+  private async runTransitionLoop(): Promise<void> {
+    while (this.isPageTranslating !== this.desiredEnabled) {
+      if (this.desiredEnabled) {
+        const analyticsContext = this.pendingEnableAnalyticsContext
+        this.pendingEnableAnalyticsContext = undefined
+        await this.start(analyticsContext)
+        continue
+      }
+
+      this.stop()
+      await Promise.resolve()
+    }
+  }
+
+  private handleStartFailure(): void {
+    this.desiredEnabled = false
+    this.isPageTranslating = false
+    this.walkId = null
+    this.dontWalkIntoElementsCache = new WeakSet()
+    this.stopDocumentTitleTracking()
+
+    if (this.intersectionObserver) {
+      this.intersectionObserver.disconnect()
+      this.intersectionObserver = null
+    }
+
+    this.mutationObservers.forEach(observer => observer.disconnect())
+    this.mutationObservers = []
   }
 
   private async primeDocumentTitleContext(enableAIContentAware: boolean): Promise<void> {

--- a/src/entrypoints/options/app-sidebar/nav-items.ts
+++ b/src/entrypoints/options/app-sidebar/nav-items.ts
@@ -1,3 +1,4 @@
+import { supportsContextMenu } from "@/utils/platform"
 import { ApiProvidersPage } from "../pages/api-providers"
 import { ConfigPage } from "../pages/config"
 import { ContextMenuPage } from "../pages/context-menu"
@@ -19,7 +20,7 @@ export const ROUTE_CONFIG = [
   { path: "/video-subtitles", component: VideoSubtitlesPage },
   { path: "/floating-button", component: FloatingButtonPage },
   { path: "/selection-toolbar", component: SelectionToolbarPage },
-  { path: "/context-menu", component: ContextMenuPage },
+  ...(supportsContextMenu ? [{ path: "/context-menu", component: ContextMenuPage }] : []),
   { path: "/input-translation", component: InputTranslationPage },
   ...(import.meta.env.BROWSER === "firefox" ? [] : [{ path: "/tts", component: TextToSpeechPage }]),
   { path: "/statistics", component: StatisticsPage },

--- a/src/entrypoints/options/app-sidebar/settings-nav.tsx
+++ b/src/entrypoints/options/app-sidebar/settings-nav.tsx
@@ -17,8 +17,11 @@ import {
   SidebarMenuSubButton,
   SidebarMenuSubItem,
 } from "@/components/ui/base-ui/sidebar"
+import { supportsContextMenu } from "@/utils/platform"
 
-const OVERLAY_TOOLS_PATHS = ["/floating-button", "/selection-toolbar", "/context-menu"] as const
+const OVERLAY_TOOLS_PATHS = supportsContextMenu
+  ? ["/floating-button", "/selection-toolbar", "/context-menu"]
+  : ["/floating-button", "/selection-toolbar"]
 
 export function SettingsNav() {
   const { pathname } = useLocation()
@@ -94,11 +97,13 @@ export function SettingsNav() {
                       <span>{i18n.t("options.overlayTools.selectionToolbar.title")}</span>
                     </SidebarMenuSubButton>
                   </SidebarMenuSubItem>
-                  <SidebarMenuSubItem>
-                    <SidebarMenuSubButton render={<Link to="/context-menu" />} isActive={pathname === "/context-menu"}>
-                      <span>{i18n.t("options.overlayTools.contextMenu.title")}</span>
-                    </SidebarMenuSubButton>
-                  </SidebarMenuSubItem>
+                  {supportsContextMenu && (
+                    <SidebarMenuSubItem>
+                      <SidebarMenuSubButton render={<Link to="/context-menu" />} isActive={pathname === "/context-menu"}>
+                        <span>{i18n.t("options.overlayTools.contextMenu.title")}</span>
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                  )}
                 </SidebarMenuSub>
               </CollapsibleContent>
             </SidebarMenuItem>

--- a/src/entrypoints/options/app.tsx
+++ b/src/entrypoints/options/app.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router"
+import { Navigate, Route, Routes } from "react-router"
 import { ROUTE_CONFIG } from "./app-sidebar/nav-items"
 
 export default function App() {
@@ -7,6 +7,7 @@ export default function App() {
       {ROUTE_CONFIG.map(({ path, component: Component }) => (
         <Route key={path} path={path} element={<Component />} />
       ))}
+      <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   )
 }

--- a/src/entrypoints/options/command-palette/search-items.ts
+++ b/src/entrypoints/options/command-palette/search-items.ts
@@ -1,4 +1,5 @@
 import type { GeneratedI18nStructure } from "#i18n"
+import { supportsContextMenu, supportsGoogleDriveSync } from "@/utils/platform"
 
 type I18nKey = keyof GeneratedI18nStructure
 
@@ -28,6 +29,26 @@ const TTS_SEARCH_ITEMS: SearchItemDefinition[] = !IS_FIREFOX
     }]
   : []
 
+const GOOGLE_DRIVE_SEARCH_ITEMS: SearchItemDefinition[] = supportsGoogleDriveSync
+  ? [{
+      sectionId: "google-drive-sync",
+      route: "/config",
+      titleKey: "options.config.sync.googleDrive.title",
+      descriptionKey: "options.config.sync.googleDrive.description",
+      pageKey: "options.config.title",
+    }]
+  : []
+
+const CONTEXT_MENU_SEARCH_ITEMS: SearchItemDefinition[] = supportsContextMenu
+  ? [{
+      sectionId: "context-menu-translate",
+      route: "/context-menu",
+      titleKey: "options.floatingButtonAndToolbar.contextMenu.translate.title",
+      descriptionKey: "options.floatingButtonAndToolbar.contextMenu.translate.description",
+      pageKey: "options.overlayTools.contextMenu.title",
+    }]
+  : []
+
 const CONFIG_SEARCH_ITEMS = [
   {
     sectionId: "beta-experience",
@@ -36,13 +57,7 @@ const CONFIG_SEARCH_ITEMS = [
     descriptionKey: "options.betaExperience.description",
     pageKey: "options.config.title",
   },
-  {
-    sectionId: "google-drive-sync",
-    route: "/config",
-    titleKey: "options.config.sync.googleDrive.title",
-    descriptionKey: "options.config.sync.googleDrive.description",
-    pageKey: "options.config.title",
-  },
+  ...GOOGLE_DRIVE_SEARCH_ITEMS,
   {
     sectionId: "manual-config-sync",
     route: "/config",
@@ -261,13 +276,7 @@ export const SEARCH_ITEMS: SearchItem[] = [
   },
 
   // Context Menu page
-  {
-    sectionId: "context-menu-translate",
-    route: "/context-menu",
-    titleKey: "options.floatingButtonAndToolbar.contextMenu.translate.title",
-    descriptionKey: "options.floatingButtonAndToolbar.contextMenu.translate.description",
-    pageKey: "options.overlayTools.contextMenu.title",
-  },
+  ...CONTEXT_MENU_SEARCH_ITEMS,
 
   // Input Translation page
   {

--- a/src/entrypoints/options/pages/config/google-drive-sync/index.tsx
+++ b/src/entrypoints/options/pages/config/google-drive-sync/index.tsx
@@ -10,6 +10,7 @@ import { lastSyncTimeAtom } from "@/utils/atoms/last-sync-time"
 import { clearAccessToken } from "@/utils/google-drive/auth"
 import { syncConfig } from "@/utils/google-drive/sync"
 import { logger } from "@/utils/logger"
+import { supportsGoogleDriveSync } from "@/utils/platform"
 import { ConfigCard } from "../../../components/config-card"
 import { UnresolvedDialog } from "./components/unresolved-dialog"
 
@@ -20,6 +21,10 @@ export function GoogleDriveSyncCard() {
   const setUnresolvedData = useSetAtom(unresolvedConfigsAtom)
   const setResolutions = useSetAtom(resolutionsAtom)
   const lastSyncTime = useAtomValue(lastSyncTimeAtom)
+
+  if (!supportsGoogleDriveSync) {
+    return null
+  }
 
   const handleSync = async () => {
     setIsSyncing(true)

--- a/src/entrypoints/options/pages/config/index.tsx
+++ b/src/entrypoints/options/pages/config/index.tsx
@@ -1,4 +1,5 @@
 import { i18n } from "#imports"
+import { supportsGoogleDriveSync } from "@/utils/platform"
 import { PageLayout } from "../../components/page-layout"
 import { AboutCard } from "./about-card"
 import { BetaExperienceConfig } from "./beta-experience"
@@ -11,7 +12,7 @@ export function ConfigPage() {
   return (
     <PageLayout title={i18n.t("options.config.title")} innerClassName="*:border-b [&>*:last-child]:border-b-0">
       <BetaExperienceConfig />
-      <GoogleDriveSyncCard />
+      {supportsGoogleDriveSync && <GoogleDriveSyncCard />}
       <ManualConfigSync />
       <ConfigBackup />
       <AboutCard />

--- a/src/entrypoints/side.content/components/floating-button/__tests__/floating-button.test.tsx
+++ b/src/entrypoints/side.content/components/floating-button/__tests__/floating-button.test.tsx
@@ -1,0 +1,366 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { createStore, Provider } from "jotai"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { enablePageTranslationAtom, isDraggingButtonAtom, isSideOpenAtom } from "../../../atoms"
+import FloatingButton from "../index"
+
+const {
+  atomRefs,
+  createFeatureUsageContextMock,
+  sendMessageMock,
+} = vi.hoisted(() => ({
+  atomRefs: {
+    floatingButtonBaseAtom: undefined as any,
+    sideContentBaseAtom: undefined as any,
+  },
+  createFeatureUsageContextMock: vi.fn(() => ({
+    feature: "page_translation",
+    surface: "floating_button",
+    startedAt: 123,
+  })),
+  sendMessageMock: vi.fn(),
+}))
+
+vi.mock("#imports", () => ({
+  browser: {
+    runtime: {
+      getManifest: () => ({ version: "1.0.0" }),
+      getURL: (path: string) => `chrome-extension://read-frog${path}`,
+    },
+  },
+  i18n: {
+    t: (key: string) => key,
+  },
+}))
+
+vi.mock("@/utils/analytics", () => ({
+  createFeatureUsageContext: createFeatureUsageContextMock,
+}))
+
+vi.mock("@/utils/message", () => ({
+  sendMessage: sendMessageMock,
+}))
+
+vi.mock("../../../atoms", async () => {
+  const { atom } = await import("jotai")
+
+  const mockedEnablePageTranslationAtom = atom({ enabled: false })
+  const mockedIsDraggingButtonAtom = atom(false)
+  const mockedIsSideOpenAtom = atom(false)
+
+  return {
+    enablePageTranslationAtom: mockedEnablePageTranslationAtom,
+    isDraggingButtonAtom: mockedIsDraggingButtonAtom,
+    isSideOpenAtom: mockedIsSideOpenAtom,
+  }
+})
+
+vi.mock("@/utils/atoms/config", async () => {
+  const { atom } = await import("jotai")
+
+  atomRefs.floatingButtonBaseAtom = atom({
+    enabled: true,
+    position: 0.5,
+    disabledFloatingButtonPatterns: [],
+    clickAction: "translate",
+  })
+
+  const floatingButtonAtom = atom(
+    get => get(atomRefs.floatingButtonBaseAtom),
+    (get, set, patch: Record<string, unknown>) => {
+      const currentValue = get(atomRefs.floatingButtonBaseAtom) as Record<string, unknown>
+
+      set(atomRefs.floatingButtonBaseAtom, {
+        ...currentValue,
+        ...patch,
+      })
+    },
+  )
+
+  atomRefs.sideContentBaseAtom = atom({ width: 320 })
+  const sideContentAtom = atom(get => get(atomRefs.sideContentBaseAtom))
+
+  return {
+    configFieldsAtomMap: {
+      floatingButton: floatingButtonAtom,
+      sideContent: sideContentAtom,
+    },
+  }
+})
+
+vi.mock("../../../index", () => ({
+  shadowWrapper: document.body,
+}))
+
+vi.mock("@/components/ui/base-ui/dropdown-menu", async () => {
+  const React = await import("react")
+
+  const MenuContext = React.createContext<{
+    open: boolean
+    onOpenChange?: (open: boolean) => void
+  }>({
+    open: false,
+  })
+
+  return {
+    DropdownMenu: ({
+      open = false,
+      onOpenChange,
+      children,
+    }: any) => (
+      <MenuContext value={{ open, onOpenChange }}>
+        {children}
+      </MenuContext>
+    ),
+    DropdownMenuTrigger: ({
+      render,
+      children,
+    }: any) => {
+      const { open, onOpenChange } = React.use(MenuContext)
+
+      return React.cloneElement(render, {
+        onClick: (event: any) => {
+          render.props.onClick?.(event)
+          onOpenChange?.(!open)
+        },
+        onPointerDown: (event: any) => {
+          render.props.onPointerDown?.(event)
+        },
+      }, children)
+    },
+    DropdownMenuContent: ({
+      children,
+    }: any) => {
+      const { open } = React.use(MenuContext)
+      return open ? <div>{children}</div> : null
+    },
+    DropdownMenuItem: ({
+      children,
+      onClick,
+      onPointerDown,
+    }: any) => (
+      <button type="button" onClick={onClick} onPointerDown={onPointerDown}>
+        {children}
+      </button>
+    ),
+  }
+})
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve
+  })
+
+  return { promise, resolve }
+}
+
+function createMatchMedia(matches: boolean) {
+  return vi.fn().mockImplementation((query: string) => ({
+    matches: query === "(pointer: coarse)" ? matches : false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+}
+
+function renderFloatingButton(options?: {
+  clickAction?: "panel" | "translate"
+  translationEnabled?: boolean
+}) {
+  const store = createStore()
+
+  store.set(atomRefs.floatingButtonBaseAtom, {
+    enabled: true,
+    position: 0.5,
+    disabledFloatingButtonPatterns: [],
+    clickAction: options?.clickAction ?? "translate",
+  })
+  store.set(atomRefs.sideContentBaseAtom, { width: 320 })
+  store.set(enablePageTranslationAtom, { enabled: options?.translationEnabled ?? false })
+  store.set(isDraggingButtonAtom, false)
+  store.set(isSideOpenAtom, false)
+
+  render(
+    <Provider store={store}>
+      <FloatingButton />
+    </Provider>,
+  )
+
+  const mainBall = screen.getByAltText("Read Frog").parentElement
+  if (!mainBall) {
+    throw new Error("Floating button main ball not found")
+  }
+
+  return { store, mainBall }
+}
+
+describe("floating button interactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useRealTimers()
+
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: createMatchMedia(false),
+    })
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      writable: true,
+      value: 1000,
+    })
+    Object.defineProperty(HTMLElement.prototype, "setPointerCapture", {
+      configurable: true,
+      value: vi.fn(),
+    })
+    Object.defineProperty(HTMLElement.prototype, "releasePointerCapture", {
+      configurable: true,
+      value: vi.fn(),
+    })
+
+    sendMessageMock.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("updates the stored position on pointer drag without triggering the primary click action", async () => {
+    const { store, mainBall } = renderFloatingButton({
+      clickAction: "translate",
+      translationEnabled: false,
+    })
+
+    await act(async () => {
+      fireEvent.pointerDown(mainBall, {
+        button: 0,
+        clientX: 20,
+        clientY: 200,
+        pointerId: 1,
+        pointerType: "touch",
+      })
+      fireEvent.pointerMove(mainBall, {
+        clientX: 20,
+        clientY: 280,
+        pointerId: 1,
+        pointerType: "touch",
+      })
+      fireEvent.pointerUp(mainBall, {
+        clientX: 20,
+        clientY: 280,
+        pointerId: 1,
+        pointerType: "touch",
+      })
+    })
+
+    expect(sendMessageMock).not.toHaveBeenCalled()
+    await waitFor(() => {
+      const floatingButtonState = store.get(atomRefs.floatingButtonBaseAtom) as { position: number }
+      expect(floatingButtonState.position).not.toBe(0.5)
+    })
+  })
+
+  it("opens the menu on touch long press without triggering translation or panel actions", async () => {
+    vi.useFakeTimers()
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: createMatchMedia(true),
+    })
+
+    const { store, mainBall } = renderFloatingButton({
+      clickAction: "panel",
+      translationEnabled: false,
+    })
+
+    await act(async () => {
+      fireEvent.pointerDown(mainBall, {
+        button: 0,
+        clientX: 24,
+        clientY: 220,
+        pointerId: 2,
+        pointerType: "touch",
+      })
+      vi.advanceTimersByTime(450)
+    })
+
+    expect(
+      screen.getByText("options.floatingButtonAndToolbar.floatingButton.closeMenu.disableForSite"),
+    ).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.pointerUp(mainBall, {
+        clientX: 24,
+        clientY: 220,
+        pointerId: 2,
+        pointerType: "touch",
+      })
+    })
+
+    expect(sendMessageMock).not.toHaveBeenCalled()
+    expect(store.get(isSideOpenAtom)).toBe(false)
+  })
+
+  it("sends only one translate toggle request while a previous toggle is still pending", async () => {
+    const toggleDeferred = createDeferred<void>()
+    sendMessageMock.mockImplementation(() => toggleDeferred.promise)
+
+    const { mainBall } = renderFloatingButton({
+      clickAction: "translate",
+      translationEnabled: false,
+    })
+
+    await act(async () => {
+      fireEvent.pointerDown(mainBall, {
+        button: 0,
+        clientX: 30,
+        clientY: 240,
+        pointerId: 3,
+        pointerType: "mouse",
+      })
+      fireEvent.pointerUp(mainBall, {
+        clientX: 30,
+        clientY: 240,
+        pointerId: 3,
+        pointerType: "mouse",
+      })
+      fireEvent.pointerDown(mainBall, {
+        button: 0,
+        clientX: 30,
+        clientY: 240,
+        pointerId: 4,
+        pointerType: "mouse",
+      })
+      fireEvent.pointerUp(mainBall, {
+        clientX: 30,
+        clientY: 240,
+        pointerId: 4,
+        pointerType: "mouse",
+      })
+    })
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      "tryToSetEnablePageTranslationOnContentScript",
+      {
+        enabled: true,
+        analyticsContext: {
+          feature: "page_translation",
+          surface: "floating_button",
+          startedAt: 123,
+        },
+      },
+    )
+
+    toggleDeferred.resolve()
+    await act(async () => {
+      await toggleDeferred.promise
+    })
+  })
+})

--- a/src/entrypoints/side.content/components/floating-button/__tests__/floating-button.test.tsx
+++ b/src/entrypoints/side.content/components/floating-button/__tests__/floating-button.test.tsx
@@ -200,6 +200,32 @@ function renderFloatingButton(options?: {
   return { store, mainBall }
 }
 
+async function tapMainBall(
+  mainBall: Element,
+  options?: {
+    pointerId?: number
+    pointerType?: "mouse" | "touch"
+    clientX?: number
+    clientY?: number
+  },
+) {
+  await act(async () => {
+    fireEvent.pointerDown(mainBall, {
+      button: 0,
+      clientX: options?.clientX ?? 30,
+      clientY: options?.clientY ?? 240,
+      pointerId: options?.pointerId ?? 1,
+      pointerType: options?.pointerType ?? "touch",
+    })
+    fireEvent.pointerUp(mainBall, {
+      clientX: options?.clientX ?? 30,
+      clientY: options?.clientY ?? 240,
+      pointerId: options?.pointerId ?? 1,
+      pointerType: options?.pointerType ?? "touch",
+    })
+  })
+}
+
 describe("floating button interactions", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -236,6 +262,8 @@ describe("floating button interactions", () => {
       clickAction: "translate",
       translationEnabled: false,
     })
+    const translateButton = screen.getByTitle("Toggle page translation")
+    const closeTrigger = screen.getByTitle("Close floating button")
 
     await act(async () => {
       fireEvent.pointerDown(mainBall, {
@@ -260,14 +288,15 @@ describe("floating button interactions", () => {
     })
 
     expect(sendMessageMock).not.toHaveBeenCalled()
+    expect(translateButton).not.toHaveClass("translate-x-0")
+    expect(closeTrigger).not.toHaveClass("block")
     await waitFor(() => {
       const floatingButtonState = store.get(atomRefs.floatingButtonBaseAtom) as { position: number }
       expect(floatingButtonState.position).not.toBe(0.5)
     })
   })
 
-  it("opens the menu on touch long press without triggering translation or panel actions", async () => {
-    vi.useFakeTimers()
+  it("executes the panel action and reveals the side actions on touch tap", async () => {
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
       writable: true,
@@ -278,16 +307,77 @@ describe("floating button interactions", () => {
       clickAction: "panel",
       translationEnabled: false,
     })
+    const translateButton = screen.getByTitle("Toggle page translation")
+    const settingsButton = screen.getByTitle("Open extension settings")
+    const closeTrigger = screen.getByTitle("Close floating button")
+
+    await tapMainBall(mainBall, { pointerId: 2, pointerType: "touch", clientX: 24, clientY: 220 })
+
+    expect(store.get(isSideOpenAtom)).toBe(true)
+    expect(sendMessageMock).not.toHaveBeenCalled()
+    expect(translateButton).toHaveClass("translate-x-0")
+    expect(settingsButton).toHaveClass("translate-x-0")
+    expect(closeTrigger).toHaveClass("block")
+  })
+
+  it("keeps the side actions visible after a touch tap and auto-hides them after 3000ms", async () => {
+    vi.useFakeTimers()
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: createMatchMedia(true),
+    })
+
+    const { mainBall } = renderFloatingButton({
+      clickAction: "translate",
+      translationEnabled: false,
+    })
+    const translateButton = screen.getByTitle("Toggle page translation")
+    const settingsButton = screen.getByTitle("Open extension settings")
+    const closeTrigger = screen.getByTitle("Close floating button")
+
+    await tapMainBall(mainBall, { pointerId: 3, pointerType: "touch" })
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+    expect(translateButton).toHaveClass("translate-x-0")
+    expect(settingsButton).toHaveClass("translate-x-0")
+    expect(closeTrigger).toHaveClass("block")
 
     await act(async () => {
-      fireEvent.pointerDown(mainBall, {
-        button: 0,
-        clientX: 24,
-        clientY: 220,
-        pointerId: 2,
-        pointerType: "touch",
-      })
-      vi.advanceTimersByTime(450)
+      vi.advanceTimersByTime(2999)
+    })
+
+    expect(translateButton).toHaveClass("translate-x-0")
+    expect(settingsButton).toHaveClass("translate-x-0")
+    expect(closeTrigger).toHaveClass("block")
+
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+    })
+
+    expect(translateButton).not.toHaveClass("translate-x-0")
+    expect(settingsButton).not.toHaveClass("translate-x-0")
+    expect(closeTrigger).not.toHaveClass("block")
+  })
+
+  it("pauses auto-hide while the close menu is open and restarts it after closing", async () => {
+    vi.useFakeTimers()
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: createMatchMedia(true),
+    })
+
+    const { mainBall } = renderFloatingButton({
+      clickAction: "translate",
+      translationEnabled: false,
+    })
+    const closeTrigger = screen.getByTitle("Close floating button")
+
+    await tapMainBall(mainBall, { pointerId: 4, pointerType: "touch" })
+
+    await act(async () => {
+      fireEvent.click(closeTrigger)
     })
 
     expect(
@@ -295,55 +385,75 @@ describe("floating button interactions", () => {
     ).toBeInTheDocument()
 
     await act(async () => {
-      fireEvent.pointerUp(mainBall, {
-        clientX: 24,
-        clientY: 220,
-        pointerId: 2,
-        pointerType: "touch",
-      })
+      vi.advanceTimersByTime(5000)
     })
 
-    expect(sendMessageMock).not.toHaveBeenCalled()
-    expect(store.get(isSideOpenAtom)).toBe(false)
+    expect(closeTrigger).toHaveClass("block")
+    expect(
+      screen.getByText("options.floatingButtonAndToolbar.floatingButton.closeMenu.disableForSite"),
+    ).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(closeTrigger)
+    })
+
+    expect(
+      screen.queryByText("options.floatingButtonAndToolbar.floatingButton.closeMenu.disableForSite"),
+    ).not.toBeInTheDocument()
+
+    await act(async () => {
+      vi.advanceTimersByTime(2999)
+    })
+
+    expect(closeTrigger).toHaveClass("block")
+
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+    })
+
+    expect(closeTrigger).not.toHaveClass("block")
   })
 
-  it("sends only one translate toggle request while a previous toggle is still pending", async () => {
-    const toggleDeferred = createDeferred<void>()
-    sendMessageMock.mockImplementation(() => toggleDeferred.promise)
-
+  it("does not enter the mobile expanded state on mouse click", async () => {
     const { mainBall } = renderFloatingButton({
       clickAction: "translate",
       translationEnabled: false,
     })
+    const translateButton = screen.getByTitle("Toggle page translation")
+    const settingsButton = screen.getByTitle("Open extension settings")
+    const closeTrigger = screen.getByTitle("Close floating button")
+
+    await tapMainBall(mainBall, { pointerId: 5, pointerType: "mouse" })
+
+    expect(sendMessageMock).toHaveBeenCalledTimes(1)
+    expect(translateButton).not.toHaveClass("translate-x-0")
+    expect(settingsButton).not.toHaveClass("translate-x-0")
+    expect(closeTrigger).not.toHaveClass("block")
+  })
+
+  it("sends only one translate toggle request while pending and renews the mobile auto-hide timer", async () => {
+    vi.useFakeTimers()
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: createMatchMedia(true),
+    })
+
+    const toggleDeferred = createDeferred<void>()
+    sendMessageMock.mockImplementation(() => toggleDeferred.promise)
+    const { mainBall } = renderFloatingButton({
+      clickAction: "translate",
+      translationEnabled: false,
+    })
+    const translateButton = screen.getByTitle("Toggle page translation")
+
+    await tapMainBall(mainBall, { pointerId: 6, pointerType: "touch" })
 
     await act(async () => {
-      fireEvent.pointerDown(mainBall, {
-        button: 0,
-        clientX: 30,
-        clientY: 240,
-        pointerId: 3,
-        pointerType: "mouse",
-      })
-      fireEvent.pointerUp(mainBall, {
-        clientX: 30,
-        clientY: 240,
-        pointerId: 3,
-        pointerType: "mouse",
-      })
-      fireEvent.pointerDown(mainBall, {
-        button: 0,
-        clientX: 30,
-        clientY: 240,
-        pointerId: 4,
-        pointerType: "mouse",
-      })
-      fireEvent.pointerUp(mainBall, {
-        clientX: 30,
-        clientY: 240,
-        pointerId: 4,
-        pointerType: "mouse",
-      })
+      vi.advanceTimersByTime(2000)
     })
+
+    await tapMainBall(mainBall, { pointerId: 7, pointerType: "touch" })
 
     expect(sendMessageMock).toHaveBeenCalledTimes(1)
     expect(sendMessageMock).toHaveBeenCalledWith(
@@ -357,6 +467,19 @@ describe("floating button interactions", () => {
         },
       },
     )
+    expect(translateButton).toHaveClass("translate-x-0")
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+    })
+
+    expect(translateButton).toHaveClass("translate-x-0")
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+    })
+
+    expect(translateButton).not.toHaveClass("translate-x-0")
 
     toggleDeferred.resolve()
     await act(async () => {

--- a/src/entrypoints/side.content/components/floating-button/components/hidden-button.tsx
+++ b/src/entrypoints/side.content/components/floating-button/components/hidden-button.tsx
@@ -5,15 +5,19 @@ export default function HiddenButton({
   onClick,
   children,
   className,
+  title,
 }: {
   icon: React.ReactNode
   onClick: () => void
   children?: React.ReactNode
   className?: string
+  title?: string
 }) {
   return (
     <button
       type="button"
+      title={title}
+      aria-label={title}
       className={cn(
         "border-border mr-2 translate-x-12 cursor-pointer rounded-full border bg-white p-1.5 text-neutral-600 dark:text-neutral-400 transition-transform duration-300 group-hover:translate-x-0 hover:bg-neutral-100 dark:bg-neutral-900 dark:hover:bg-neutral-800",
         className,

--- a/src/entrypoints/side.content/components/floating-button/index.tsx
+++ b/src/entrypoints/side.content/components/floating-button/index.tsx
@@ -240,7 +240,7 @@ export default function FloatingButton() {
         top: `${(dragPosition ?? floatingButton.position) * 100}vh`,
       }}
     >
-      <TranslateButton className={attachSideClassName} onClick={revealMobileActions} />
+      <TranslateButton className={attachSideClassName} onClick={() => revealMobileActions()} />
       <div
         className={cn(
           "border-border flex h-10 w-15 items-center rounded-l-full border border-r-0 bg-white opacity-60 shadow-lg group-hover:opacity-100 dark:bg-neutral-900",
@@ -267,7 +267,7 @@ export default function FloatingButton() {
                   shouldRevealSideActions && "block",
                   isDropdownOpen && "block",
                 )}
-                onClick={revealMobileActions}
+                onClick={() => revealMobileActions()}
                 onPointerDown={e => e.stopPropagation()}
               />
             )}

--- a/src/entrypoints/side.content/components/floating-button/index.tsx
+++ b/src/entrypoints/side.content/components/floating-button/index.tsx
@@ -19,9 +19,22 @@ import { matchDomainPattern } from "@/utils/url"
 import { enablePageTranslationAtom, isDraggingButtonAtom, isSideOpenAtom } from "../../atoms"
 import { shadowWrapper } from "../../index"
 import HiddenButton from "./components/hidden-button"
+import { requestPageTranslationToggle } from "./request-page-translation-toggle"
 import TranslateButton from "./translate-button"
 
 const readFrogLogoUrl = new URL(readFrogLogo, browser.runtime.getURL("/")).href
+const DRAG_THRESHOLD = 6
+const DRAG_THRESHOLD_SQUARED = DRAG_THRESHOLD * DRAG_THRESHOLD
+const LONG_PRESS_DURATION = 450
+
+interface PointerInteraction {
+  pointerId: number
+  startX: number
+  startY: number
+  startPosition: number
+  isDragging: boolean
+  longPressTriggered: boolean
+}
 
 export default function FloatingButton() {
   const [floatingButton, setFloatingButton] = useAtom(
@@ -33,42 +46,15 @@ export default function FloatingButton() {
   const [isDraggingButton, setIsDraggingButton] = useAtom(isDraggingButtonAtom)
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const [dragPosition, setDragPosition] = useState<number | null>(null)
-  const initialClientYRef = useRef<number | null>(null)
+  const pointerInteractionRef = useRef<PointerInteraction | null>(null)
+  const longPressTimerRef = useRef<number | null>(null)
 
-  // 按钮拖动处理
   useEffect(() => {
-    const initialClientY = initialClientYRef.current
-    if (!isDraggingButton || !initialClientY || !floatingButton)
-      return
-
-    const handleMouseMove = (e: MouseEvent) => {
-      const initialY = floatingButton.position * window.innerHeight
-      const newY = Math.max(
-        30,
-        Math.min(
-          window.innerHeight - 200,
-          initialY + e.clientY - initialClientY,
-        ),
-      )
-      const newPosition = newY / window.innerHeight
-      setDragPosition(newPosition)
-    }
-
-    const handleMouseUp = () => {
-      setIsDraggingButton(false)
-    }
-
-    document.addEventListener("mousemove", handleMouseMove)
-    document.addEventListener("mouseup", handleMouseUp)
-
-    document.body.style.userSelect = "none"
+    document.body.style.userSelect = isDraggingButton ? "none" : ""
 
     return () => {
-      document.removeEventListener("mousemove", handleMouseMove)
-      document.removeEventListener("mouseup", handleMouseUp)
       document.body.style.userSelect = ""
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDraggingButton])
 
   // 拖拽结束时写入 storage
@@ -80,47 +66,138 @@ export default function FloatingButton() {
     }
   }, [isDraggingButton, dragPosition, setFloatingButton])
 
-  const handleButtonDragStart = (e: React.MouseEvent) => {
-    // 记录初始位置，用于后续判断是点击还是拖动
-    initialClientYRef.current = e.clientY
-    let hasMoved = false // 标记是否发生了移动
+  useEffect(() => {
+    return () => {
+      if (longPressTimerRef.current !== null) {
+        window.clearTimeout(longPressTimerRef.current)
+      }
+    }
+  }, [])
+
+  const clearLongPressTimer = () => {
+    if (longPressTimerRef.current !== null) {
+      window.clearTimeout(longPressTimerRef.current)
+      longPressTimerRef.current = null
+    }
+  }
+
+  const shouldOpenMenuByLongPress = (pointerType: string) => {
+    if (pointerType === "touch") {
+      return true
+    }
+
+    return typeof window.matchMedia === "function"
+      && window.matchMedia("(pointer: coarse)").matches
+  }
+
+  const handlePrimaryAction = () => {
+    if (floatingButton.clickAction === "translate") {
+      const nextEnabled = !translationState.enabled
+      void requestPageTranslationToggle(
+        nextEnabled,
+        nextEnabled
+          ? createFeatureUsageContext(ANALYTICS_FEATURE.PAGE_TRANSLATION, ANALYTICS_SURFACE.FLOATING_BUTTON)
+          : undefined,
+      )
+      return
+    }
+
+    setIsSideOpen(open => !open)
+  }
+
+  const finishPointerInteraction = (
+    e: React.PointerEvent<HTMLDivElement>,
+    shouldTriggerClick: boolean,
+  ) => {
+    const interaction = pointerInteractionRef.current
+    if (!interaction || interaction.pointerId !== e.pointerId) {
+      return
+    }
+
+    clearLongPressTimer()
+    pointerInteractionRef.current = null
+    e.currentTarget.releasePointerCapture?.(e.pointerId)
+
+    if (interaction.isDragging) {
+      setIsDraggingButton(false)
+      return
+    }
+
+    setIsDraggingButton(false)
+
+    if (!shouldTriggerClick || interaction.longPressTriggered) {
+      return
+    }
+
+    handlePrimaryAction()
+  }
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.pointerType === "mouse" && e.button !== 0) {
+      return
+    }
 
     e.preventDefault()
-    setIsDraggingButton(true)
+    pointerInteractionRef.current = {
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      startPosition: dragPosition ?? floatingButton.position,
+      isDragging: false,
+      longPressTriggered: false,
+    }
 
-    // 创建一个监听器检测移动
-    const handleMouseMove = (moveEvent: MouseEvent) => {
-      const moveDistance = Math.abs(moveEvent.clientY - e.clientY)
-      // 如果移动距离大于阈值，标记为已移动
-      if (moveDistance > 5) {
-        hasMoved = true
+    e.currentTarget.setPointerCapture?.(e.pointerId)
+    clearLongPressTimer()
+
+    if (!shouldOpenMenuByLongPress(e.pointerType)) {
+      return
+    }
+
+    longPressTimerRef.current = window.setTimeout(() => {
+      const interaction = pointerInteractionRef.current
+      if (!interaction || interaction.pointerId !== e.pointerId || interaction.isDragging) {
+        return
+      }
+
+      interaction.longPressTriggered = true
+      setIsDropdownOpen(true)
+    }, LONG_PRESS_DURATION)
+  }
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const interaction = pointerInteractionRef.current
+    if (!interaction || interaction.pointerId !== e.pointerId) {
+      return
+    }
+
+    const dx = e.clientX - interaction.startX
+    const dy = e.clientY - interaction.startY
+
+    if (!interaction.isDragging && dx * dx + dy * dy > DRAG_THRESHOLD_SQUARED) {
+      interaction.isDragging = true
+      clearLongPressTimer()
+      setIsDraggingButton(true)
+
+      if (interaction.longPressTriggered) {
+        setIsDropdownOpen(false)
       }
     }
 
-    // 在鼠标释放时，只有未移动才触发点击事件
-    const handleMouseUp = () => {
-      document.removeEventListener("mousemove", handleMouseMove)
-      document.removeEventListener("mouseup", handleMouseUp)
-
-      // 只有未移动过才触发点击
-      if (!hasMoved) {
-        if (floatingButton.clickAction === "translate") {
-          const nextEnabled = !translationState.enabled
-          void sendMessage("tryToSetEnablePageTranslationOnContentScript", {
-            enabled: nextEnabled,
-            analyticsContext: nextEnabled
-              ? createFeatureUsageContext(ANALYTICS_FEATURE.PAGE_TRANSLATION, ANALYTICS_SURFACE.FLOATING_BUTTON)
-              : undefined,
-          })
-        }
-        else {
-          setIsSideOpen(o => !o)
-        }
-      }
+    if (!interaction.isDragging) {
+      return
     }
 
-    document.addEventListener("mouseup", handleMouseUp)
-    document.addEventListener("mousemove", handleMouseMove)
+    const initialY = interaction.startPosition * window.innerHeight
+    const newY = Math.max(
+      30,
+      Math.min(
+        window.innerHeight - 200,
+        initialY + dy,
+      ),
+    )
+
+    setDragPosition(newY / window.innerHeight)
   }
 
   const attachSideClassName = isDraggingButton || isSideOpen || isDropdownOpen ? "translate-x-0" : ""
@@ -145,10 +222,14 @@ export default function FloatingButton() {
           "border-border flex h-10 w-15 items-center rounded-l-full border border-r-0 bg-white opacity-60 shadow-lg group-hover:opacity-100 dark:bg-neutral-900",
           "translate-x-5 transition-transform duration-300 group-hover:translate-x-0",
           (isSideOpen || isDropdownOpen) && "opacity-100",
+          "touch-none",
           isDraggingButton ? "cursor-move" : "cursor-pointer",
           attachSideClassName,
         )}
-        onMouseDown={handleButtonDragStart}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={e => finishPointerInteraction(e, true)}
+        onPointerCancel={e => finishPointerInteraction(e, false)}
       >
         <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
           <DropdownMenuTrigger
@@ -161,7 +242,7 @@ export default function FloatingButton() {
                   "group-hover:block",
                   isDropdownOpen && "block",
                 )}
-                onMouseDown={e => e.stopPropagation()} // 父级不会收到 mousedown
+                onPointerDown={e => e.stopPropagation()}
               />
             )}
           >
@@ -169,7 +250,7 @@ export default function FloatingButton() {
           </DropdownMenuTrigger>
           <DropdownMenuContent container={shadowWrapper} align="start" side="left" className="z-2147483647 w-fit! whitespace-nowrap">
             <DropdownMenuItem
-              onMouseDown={e => e.stopPropagation()}
+              onPointerDown={e => e.stopPropagation()}
               onClick={() => {
                 const currentDomain = window.location.hostname
                 const currentPatterns = floatingButton.disabledFloatingButtonPatterns || []
@@ -182,7 +263,7 @@ export default function FloatingButton() {
               {i18n.t("options.floatingButtonAndToolbar.floatingButton.closeMenu.disableForSite")}
             </DropdownMenuItem>
             <DropdownMenuItem
-              onMouseDown={e => e.stopPropagation()}
+              onPointerDown={e => e.stopPropagation()}
               onClick={() => {
                 void setFloatingButton({ ...floatingButton, enabled: false })
               }}

--- a/src/entrypoints/side.content/components/floating-button/index.tsx
+++ b/src/entrypoints/side.content/components/floating-button/index.tsx
@@ -25,7 +25,7 @@ import TranslateButton from "./translate-button"
 const readFrogLogoUrl = new URL(readFrogLogo, browser.runtime.getURL("/")).href
 const DRAG_THRESHOLD = 6
 const DRAG_THRESHOLD_SQUARED = DRAG_THRESHOLD * DRAG_THRESHOLD
-const LONG_PRESS_DURATION = 450
+const MOBILE_ACTIONS_AUTO_HIDE_DELAY = 3000
 
 interface PointerInteraction {
   pointerId: number
@@ -33,7 +33,7 @@ interface PointerInteraction {
   startY: number
   startPosition: number
   isDragging: boolean
-  longPressTriggered: boolean
+  isMobilePointer: boolean
 }
 
 export default function FloatingButton() {
@@ -45,9 +45,10 @@ export default function FloatingButton() {
   const [isSideOpen, setIsSideOpen] = useAtom(isSideOpenAtom)
   const [isDraggingButton, setIsDraggingButton] = useAtom(isDraggingButtonAtom)
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const [isMobileActionsOpen, setIsMobileActionsOpen] = useState(false)
   const [dragPosition, setDragPosition] = useState<number | null>(null)
   const pointerInteractionRef = useRef<PointerInteraction | null>(null)
-  const longPressTimerRef = useRef<number | null>(null)
+  const mobileActionsTimerRef = useRef<number | null>(null)
 
   useEffect(() => {
     document.body.style.userSelect = isDraggingButton ? "none" : ""
@@ -68,26 +69,63 @@ export default function FloatingButton() {
 
   useEffect(() => {
     return () => {
-      if (longPressTimerRef.current !== null) {
-        window.clearTimeout(longPressTimerRef.current)
+      if (mobileActionsTimerRef.current !== null) {
+        window.clearTimeout(mobileActionsTimerRef.current)
       }
     }
   }, [])
 
-  const clearLongPressTimer = () => {
-    if (longPressTimerRef.current !== null) {
-      window.clearTimeout(longPressTimerRef.current)
-      longPressTimerRef.current = null
+  const isCoarsePointer = () => {
+    return typeof window.matchMedia === "function"
+      && window.matchMedia("(pointer: coarse)").matches
+  }
+
+  const clearMobileActionsTimer = () => {
+    if (mobileActionsTimerRef.current !== null) {
+      window.clearTimeout(mobileActionsTimerRef.current)
+      mobileActionsTimerRef.current = null
     }
   }
 
-  const shouldOpenMenuByLongPress = (pointerType: string) => {
-    if (pointerType === "touch") {
-      return true
+  const startMobileActionsTimer = () => {
+    clearMobileActionsTimer()
+    mobileActionsTimerRef.current = window.setTimeout(() => {
+      setIsMobileActionsOpen(false)
+      mobileActionsTimerRef.current = null
+    }, MOBILE_ACTIONS_AUTO_HIDE_DELAY)
+  }
+
+  const closeMobileActions = () => {
+    clearMobileActionsTimer()
+    setIsMobileActionsOpen(false)
+  }
+
+  const revealMobileActions = (forceOpen = false) => {
+    if (!forceOpen && !isCoarsePointer()) {
+      return
     }
 
-    return typeof window.matchMedia === "function"
-      && window.matchMedia("(pointer: coarse)").matches
+    setIsMobileActionsOpen(true)
+
+    if (isDropdownOpen) {
+      clearMobileActionsTimer()
+      return
+    }
+
+    startMobileActionsTimer()
+  }
+
+  const handleDropdownOpenChange = (open: boolean) => {
+    setIsDropdownOpen(open)
+
+    if (open) {
+      clearMobileActionsTimer()
+      return
+    }
+
+    if (isMobileActionsOpen) {
+      startMobileActionsTimer()
+    }
   }
 
   const handlePrimaryAction = () => {
@@ -114,7 +152,6 @@ export default function FloatingButton() {
       return
     }
 
-    clearLongPressTimer()
     pointerInteractionRef.current = null
     e.currentTarget.releasePointerCapture?.(e.pointerId)
 
@@ -125,11 +162,15 @@ export default function FloatingButton() {
 
     setIsDraggingButton(false)
 
-    if (!shouldTriggerClick || interaction.longPressTriggered) {
+    if (!shouldTriggerClick) {
       return
     }
 
     handlePrimaryAction()
+
+    if (interaction.isMobilePointer) {
+      revealMobileActions(true)
+    }
   }
 
   const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -144,25 +185,10 @@ export default function FloatingButton() {
       startY: e.clientY,
       startPosition: dragPosition ?? floatingButton.position,
       isDragging: false,
-      longPressTriggered: false,
+      isMobilePointer: e.pointerType === "touch" || isCoarsePointer(),
     }
 
     e.currentTarget.setPointerCapture?.(e.pointerId)
-    clearLongPressTimer()
-
-    if (!shouldOpenMenuByLongPress(e.pointerType)) {
-      return
-    }
-
-    longPressTimerRef.current = window.setTimeout(() => {
-      const interaction = pointerInteractionRef.current
-      if (!interaction || interaction.pointerId !== e.pointerId || interaction.isDragging) {
-        return
-      }
-
-      interaction.longPressTriggered = true
-      setIsDropdownOpen(true)
-    }, LONG_PRESS_DURATION)
   }
 
   const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -176,12 +202,9 @@ export default function FloatingButton() {
 
     if (!interaction.isDragging && dx * dx + dy * dy > DRAG_THRESHOLD_SQUARED) {
       interaction.isDragging = true
-      clearLongPressTimer()
+      closeMobileActions()
+      setIsDropdownOpen(false)
       setIsDraggingButton(true)
-
-      if (interaction.longPressTriggered) {
-        setIsDropdownOpen(false)
-      }
     }
 
     if (!interaction.isDragging) {
@@ -200,7 +223,8 @@ export default function FloatingButton() {
     setDragPosition(newY / window.innerHeight)
   }
 
-  const attachSideClassName = isDraggingButton || isSideOpen || isDropdownOpen ? "translate-x-0" : ""
+  const shouldRevealSideActions = isMobileActionsOpen || isSideOpen || isDropdownOpen
+  const attachSideClassName = shouldRevealSideActions ? "translate-x-0" : ""
 
   if (!floatingButton.enabled || floatingButton.disabledFloatingButtonPatterns.some(pattern => matchDomainPattern(window.location.href, pattern))) {
     return null
@@ -216,12 +240,12 @@ export default function FloatingButton() {
         top: `${(dragPosition ?? floatingButton.position) * 100}vh`,
       }}
     >
-      <TranslateButton className={attachSideClassName} />
+      <TranslateButton className={attachSideClassName} onClick={revealMobileActions} />
       <div
         className={cn(
           "border-border flex h-10 w-15 items-center rounded-l-full border border-r-0 bg-white opacity-60 shadow-lg group-hover:opacity-100 dark:bg-neutral-900",
           "translate-x-5 transition-transform duration-300 group-hover:translate-x-0",
-          (isSideOpen || isDropdownOpen) && "opacity-100",
+          shouldRevealSideActions && "opacity-100",
           "touch-none",
           isDraggingButton ? "cursor-move" : "cursor-pointer",
           attachSideClassName,
@@ -231,7 +255,7 @@ export default function FloatingButton() {
         onPointerUp={e => finishPointerInteraction(e, true)}
         onPointerCancel={e => finishPointerInteraction(e, false)}
       >
-        <DropdownMenu open={isDropdownOpen} onOpenChange={setIsDropdownOpen}>
+        <DropdownMenu open={isDropdownOpen} onOpenChange={handleDropdownOpenChange}>
           <DropdownMenuTrigger
             render={(
               <button
@@ -240,8 +264,10 @@ export default function FloatingButton() {
                 className={cn(
                   "border-border absolute -top-1 -left-1 hidden cursor-pointer rounded-full border bg-neutral-100 dark:bg-neutral-900",
                   "group-hover:block",
+                  shouldRevealSideActions && "block",
                   isDropdownOpen && "block",
                 )}
+                onClick={revealMobileActions}
                 onPointerDown={e => e.stopPropagation()}
               />
             )}
@@ -281,7 +307,9 @@ export default function FloatingButton() {
       <HiddenButton
         className={attachSideClassName}
         icon={<IconSettings className="h-5 w-5" />}
+        title="Open extension settings"
         onClick={() => {
+          revealMobileActions()
           void sendMessage("openOptionsPage", undefined)
         }}
       />

--- a/src/entrypoints/side.content/components/floating-button/request-page-translation-toggle.ts
+++ b/src/entrypoints/side.content/components/floating-button/request-page-translation-toggle.ts
@@ -1,0 +1,23 @@
+import type { FeatureUsageContext } from "@/types/analytics"
+import { sendMessage } from "@/utils/message"
+
+let pendingTogglePromise: Promise<void> | null = null
+
+export async function requestPageTranslationToggle(
+  enabled: boolean,
+  analyticsContext?: FeatureUsageContext,
+): Promise<boolean> {
+  if (pendingTogglePromise) {
+    return false
+  }
+
+  pendingTogglePromise = sendMessage("tryToSetEnablePageTranslationOnContentScript", {
+    enabled,
+    analyticsContext,
+  }).finally(() => {
+    pendingTogglePromise = null
+  })
+
+  await pendingTogglePromise
+  return true
+}

--- a/src/entrypoints/side.content/components/floating-button/translate-button.tsx
+++ b/src/entrypoints/side.content/components/floating-button/translate-button.tsx
@@ -6,7 +6,13 @@ import { enablePageTranslationAtom } from "../../atoms"
 import HiddenButton from "./components/hidden-button"
 import { requestPageTranslationToggle } from "./request-page-translation-toggle"
 
-export default function TranslateButton({ className }: { className: string }) {
+export default function TranslateButton({
+  className,
+  onClick,
+}: {
+  className: string
+  onClick?: () => void
+}) {
   const translationState = useAtomValue(enablePageTranslationAtom)
   const isEnabled = translationState.enabled
 
@@ -14,8 +20,10 @@ export default function TranslateButton({ className }: { className: string }) {
     <HiddenButton
       icon={<RiTranslate className="h-5 w-5" />}
       className={className}
+      title="Toggle page translation"
       onClick={() => {
         void requestPageTranslationToggle(!isEnabled)
+        onClick?.()
       }}
     >
       <IconCheck

--- a/src/entrypoints/side.content/components/floating-button/translate-button.tsx
+++ b/src/entrypoints/side.content/components/floating-button/translate-button.tsx
@@ -1,10 +1,10 @@
 import { RiTranslate } from "@remixicon/react"
 import { IconCheck } from "@tabler/icons-react"
 import { useAtomValue } from "jotai"
-import { sendMessage } from "@/utils/message"
 import { cn } from "@/utils/styles/utils"
 import { enablePageTranslationAtom } from "../../atoms"
 import HiddenButton from "./components/hidden-button"
+import { requestPageTranslationToggle } from "./request-page-translation-toggle"
 
 export default function TranslateButton({ className }: { className: string }) {
   const translationState = useAtomValue(enablePageTranslationAtom)
@@ -15,7 +15,7 @@ export default function TranslateButton({ className }: { className: string }) {
       icon={<RiTranslate className="h-5 w-5" />}
       className={className}
       onClick={() => {
-        void sendMessage("tryToSetEnablePageTranslationOnContentScript", { enabled: !isEnabled })
+        void requestPageTranslationToggle(!isEnabled)
       }}
     >
       <IconCheck

--- a/src/hooks/use-google-drive-auth.ts
+++ b/src/hooks/use-google-drive-auth.ts
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useCallback, useEffect } from "react"
 import { GOOGLE_DRIVE_TOKEN_STORAGE_KEY } from "@/utils/constants/config"
 import { getGoogleUserInfo, getIsAuthenticated, getValidAccessToken } from "@/utils/google-drive/auth"
+import { supportsGoogleDriveSync } from "@/utils/platform"
 
 interface GoogleDriveAuthData {
   isAuthenticated: boolean
@@ -17,6 +18,7 @@ export function useGoogleDriveAuth() {
 
   const query = useQuery({
     queryKey: QUERY_KEY,
+    enabled: supportsGoogleDriveSync,
     queryFn: async (): Promise<GoogleDriveAuthData> => {
       const authenticated = await getIsAuthenticated()
       if (!authenticated) {

--- a/src/tests/background-optional-context-menu.test.ts
+++ b/src/tests/background-optional-context-menu.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest"
+import { setupOptionalContextMenu } from "@/entrypoints/background"
+
+describe("setupOptionalContextMenu", () => {
+  it("skips context menu setup when the target does not support it", () => {
+    const registerContextMenuListeners = vi.fn()
+    const initializeContextMenu = vi.fn()
+
+    setupOptionalContextMenu({
+      initializeContextMenu,
+      registerContextMenuListeners,
+      supportsContextMenu: false,
+    })
+
+    expect(registerContextMenuListeners).not.toHaveBeenCalled()
+    expect(initializeContextMenu).not.toHaveBeenCalled()
+  })
+
+  it("registers and initializes context menus when supported", () => {
+    const registerContextMenuListeners = vi.fn()
+    const initializeContextMenu = vi.fn()
+
+    setupOptionalContextMenu({
+      initializeContextMenu,
+      registerContextMenuListeners,
+      supportsContextMenu: true,
+    })
+
+    expect(registerContextMenuListeners).toHaveBeenCalledOnce()
+    expect(initializeContextMenu).toHaveBeenCalledOnce()
+  })
+})

--- a/src/tests/options-search-items.test.ts
+++ b/src/tests/options-search-items.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+async function loadSearchItems(
+  browser: string,
+  wxtFirefoxAndroid?: string,
+) {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+  vi.stubEnv("BROWSER", browser)
+
+  if (wxtFirefoxAndroid !== undefined) {
+    vi.stubEnv("WXT_FIREFOX_ANDROID", wxtFirefoxAndroid)
+  }
+
+  return import("@/entrypoints/options/command-palette/search-items")
+}
+
+describe("search item visibility", () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+  })
+
+  it("hides Android-unsupported entries in the Firefox Android build", async () => {
+    const { SEARCH_ITEMS } = await loadSearchItems("firefox", "true")
+    const sectionIds = SEARCH_ITEMS.map(item => item.sectionId)
+
+    expect(sectionIds).not.toContain("google-drive-sync")
+    expect(sectionIds).not.toContain("context-menu-translate")
+  })
+
+  it("keeps desktop Firefox entries available", async () => {
+    const { SEARCH_ITEMS } = await loadSearchItems("firefox")
+    const sectionIds = SEARCH_ITEMS.map(item => item.sectionId)
+
+    expect(sectionIds).toContain("google-drive-sync")
+    expect(sectionIds).toContain("context-menu-translate")
+  })
+})

--- a/src/utils/__tests__/platform.test.ts
+++ b/src/utils/__tests__/platform.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+async function loadPlatformModule(
+  browser: string,
+  wxtFirefoxAndroid?: string,
+) {
+  vi.resetModules()
+  vi.unstubAllEnvs()
+  vi.stubEnv("BROWSER", browser)
+
+  if (wxtFirefoxAndroid !== undefined) {
+    vi.stubEnv("WXT_FIREFOX_ANDROID", wxtFirefoxAndroid)
+  }
+
+  return import("../platform")
+}
+
+describe("platform capabilities", () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+  })
+
+  it("detects Firefox Android builds", async () => {
+    const platform = await loadPlatformModule("firefox", "true")
+
+    expect(platform.isFirefoxAndroidBuild).toBe(true)
+    expect(platform.supportsContextMenu).toBe(false)
+    expect(platform.supportsGoogleDriveSync).toBe(false)
+  })
+
+  it("keeps desktop Firefox capabilities enabled", async () => {
+    const platform = await loadPlatformModule("firefox")
+
+    expect(platform.isFirefoxAndroidBuild).toBe(false)
+    expect(platform.supportsContextMenu).toBe(true)
+    expect(platform.supportsGoogleDriveSync).toBe(true)
+  })
+})

--- a/src/utils/google-drive/__tests__/auth.test.ts
+++ b/src/utils/google-drive/__tests__/auth.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+describe("google drive auth", () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+    vi.doUnmock("#imports")
+  })
+
+  it("does not read identity redirect URLs during module evaluation", async () => {
+    const getRedirectURL = vi.fn(() => "https://example.com")
+
+    vi.doMock("#imports", () => ({
+      browser: {
+        identity: {
+          getRedirectURL,
+          launchWebAuthFlow: vi.fn(),
+        },
+      },
+      storage: {
+        getItem: vi.fn(),
+        removeItem: vi.fn(),
+        setItem: vi.fn(),
+      },
+    }))
+
+    await import("../auth")
+
+    expect(getRedirectURL).not.toHaveBeenCalled()
+  })
+
+  it("returns a recognizable unsupported-platform error on Firefox Android", async () => {
+    vi.stubEnv("BROWSER", "firefox")
+    vi.stubEnv("WXT_FIREFOX_ANDROID", "true")
+
+    const auth = await import("../auth")
+
+    for (const action of [
+      () => auth.authenticateGoogleDriveAndSaveTokenToStorage(),
+      () => auth.getValidAccessToken(),
+      () => auth.getIsAuthenticated(),
+    ]) {
+      try {
+        await action()
+        throw new Error("Expected Google Drive auth action to fail")
+      }
+      catch (error) {
+        expect(auth.isGoogleDrivePlatformUnsupportedError(error)).toBe(true)
+        expect(error).toMatchObject({
+          code: auth.GOOGLE_DRIVE_PLATFORM_UNSUPPORTED_ERROR_CODE,
+        })
+      }
+    }
+  })
+})

--- a/src/utils/google-drive/auth.ts
+++ b/src/utils/google-drive/auth.ts
@@ -1,15 +1,16 @@
 import { browser, storage } from "#imports"
 import { z } from "zod"
+import { supportsGoogleDriveSync } from "@/utils/platform"
 import { GOOGLE_DRIVE_TOKEN_STORAGE_KEY } from "../constants/config"
 import { logger } from "../logger"
 
 const GOOGLE_CLIENT_ID = import.meta.env.WXT_GOOGLE_CLIENT_ID || "YOUR_CLIENT_ID"
-const GOOGLE_REDIRECT_URI = browser.identity.getRedirectURL()
 const GOOGLE_SCOPES = [
   "https://www.googleapis.com/auth/drive.appdata",
   "https://www.googleapis.com/auth/userinfo.email",
 ]
 const TOKEN_EXPIRY_BUFFER_MS = 60000
+export const GOOGLE_DRIVE_PLATFORM_UNSUPPORTED_ERROR_CODE = "PLATFORM_NOT_SUPPORTED"
 
 const googleAuthTokenSchema = z.object({
   access_token: z.string(),
@@ -26,6 +27,44 @@ const googleUserInfoSchema = z.object({
 
 export type GoogleAuthToken = z.infer<typeof googleAuthTokenSchema>
 export type GoogleUserInfo = z.infer<typeof googleUserInfoSchema>
+
+export class GoogleDrivePlatformUnsupportedError extends Error {
+  code = GOOGLE_DRIVE_PLATFORM_UNSUPPORTED_ERROR_CODE
+
+  constructor(message = "Google Drive sync is not supported on this platform.") {
+    super(message)
+    this.name = "GoogleDrivePlatformUnsupportedError"
+  }
+}
+
+export function isGoogleDrivePlatformUnsupportedError(
+  error: unknown,
+): error is GoogleDrivePlatformUnsupportedError {
+  return error instanceof GoogleDrivePlatformUnsupportedError
+    || (
+      typeof error === "object"
+      && error !== null
+      && "code" in error
+      && error.code === GOOGLE_DRIVE_PLATFORM_UNSUPPORTED_ERROR_CODE
+    )
+}
+
+function createPlatformUnsupportedError(): GoogleDrivePlatformUnsupportedError {
+  return new GoogleDrivePlatformUnsupportedError()
+}
+
+function getIdentityApi() {
+  if (!supportsGoogleDriveSync) {
+    throw createPlatformUnsupportedError()
+  }
+
+  const identity = browser.identity
+  if (!identity?.getRedirectURL || !identity.launchWebAuthFlow) {
+    throw createPlatformUnsupportedError()
+  }
+
+  return identity
+}
 
 /**
  * Get token from storage with validation
@@ -56,14 +95,15 @@ async function getTokenFromStorage(): Promise<GoogleAuthToken | null> {
  */
 export async function authenticateGoogleDriveAndSaveTokenToStorage(): Promise<string> {
   try {
+    const identity = getIdentityApi()
     const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth")
     authUrl.searchParams.set("client_id", GOOGLE_CLIENT_ID)
     authUrl.searchParams.set("response_type", "token")
-    authUrl.searchParams.set("redirect_uri", GOOGLE_REDIRECT_URI)
+    authUrl.searchParams.set("redirect_uri", identity.getRedirectURL())
     authUrl.searchParams.set("scope", GOOGLE_SCOPES.join(" "))
     authUrl.searchParams.set("prompt", "select_account")
 
-    const responseUrl = await browser.identity.launchWebAuthFlow({
+    const responseUrl = await identity.launchWebAuthFlow({
       url: authUrl.toString(),
       interactive: true,
     })
@@ -106,6 +146,10 @@ export async function authenticateGoogleDriveAndSaveTokenToStorage(): Promise<st
  */
 export async function getValidAccessToken(): Promise<string> {
   try {
+    if (!supportsGoogleDriveSync) {
+      throw createPlatformUnsupportedError()
+    }
+
     const tokenData = await getTokenFromStorage()
 
     // Re-authenticate if token not found or expiring soon (within 1 minute)
@@ -137,6 +181,10 @@ export async function clearAccessToken(): Promise<void> {
  */
 export async function getIsAuthenticated(): Promise<boolean> {
   try {
+    if (!supportsGoogleDriveSync) {
+      throw createPlatformUnsupportedError()
+    }
+
     const tokenData = await getTokenFromStorage()
 
     if (!tokenData) {
@@ -147,6 +195,10 @@ export async function getIsAuthenticated(): Promise<boolean> {
   }
   catch (error) {
     logger.error("Failed to check authentication status", error)
+    if (isGoogleDrivePlatformUnsupportedError(error)) {
+      throw error
+    }
+
     return false
   }
 }
@@ -155,6 +207,10 @@ export async function getIsAuthenticated(): Promise<boolean> {
  * Fetch Google user info using access token
  */
 export async function getGoogleUserInfo(accessToken: string): Promise<GoogleUserInfo> {
+  if (!supportsGoogleDriveSync) {
+    throw createPlatformUnsupportedError()
+  }
+
   const res = await fetch("https://www.googleapis.com/oauth2/v2/userinfo", {
     headers: { Authorization: `Bearer ${accessToken}` },
   })

--- a/src/utils/platform.ts
+++ b/src/utils/platform.ts
@@ -1,0 +1,6 @@
+export const isFirefoxAndroidBuild
+  = import.meta.env.BROWSER === "firefox"
+    && import.meta.env.WXT_FIREFOX_ANDROID === "true"
+
+export const supportsContextMenu = !isFirefoxAndroidBuild
+export const supportsGoogleDriveSync = !isFirefoxAndroidBuild

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -1,6 +1,11 @@
 import path from "node:path"
 import process from "node:process"
 import { defineConfig } from "wxt"
+import {
+  createExtensionManifest,
+  getZipRequiredEnvVars,
+  isFirefoxAndroidBuildTargetEnabled,
+} from "./wxt.manifest"
 
 const WXT_API_KEY_PATTERN = /^WXT_.*API_KEY/
 const ALLOWED_BUNDLED_API_KEYS = new Set([
@@ -20,54 +25,10 @@ export default defineConfig({
         "@read-frog/api-contract": path.resolve(__dirname, "../read-frog-monorepo/packages/api-contract/src"),
       }
     : {},
-  manifest: ({ mode, browser }) => ({
-    name: "__MSG_extName__",
-    description: "__MSG_extDescription__",
-    default_locale: "en",
-    // Fixed extension ID for development
-    ...(mode === "development" && (browser === "chrome" || browser === "edge") && {
-      key: "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAw2KhiXO2vySZtPu5pNSbyKhYavh8Be7gXmCZt8aJf6tQ/L3JK0qzL+3JSc/o20td3Jw+B2Dcw+EI93NAZr24xKnTNXQiJpuIuHb8xLXD0Ra/HrTVi4TJIhPdESogoG4uL6CD/F3TxfZJ2trX4Bt9cdAw1RGGeU+xU0g+YFfEka4ZUCpFAmTEw9H3/DU+nCp8yGaJWyiVgCTcFe38GZKEPt0iMJkTw956wz/iiafLx0pNG/RaztG9cAPoQOD2+SMFaeQ+b/G4OG17TYhzb09AhNBl6zSJ3jTKHSwuedCFwCce8Q/EchJfQZv71mjAE97bzwvkDYPCLj31Z5FE8HntMwIDAQAB",
-    }),
-    permissions: [
-      "storage",
-      "tabs",
-      "alarms",
-      "cookies",
-      "contextMenus",
-      "identity",
-      "scripting",
-      "webNavigation",
-      ...(browser !== "firefox" ? ["offscreen"] : []),
-    ],
-    host_permissions: [
-      "*://*/*", // Required for scripting.executeScript in any frame
-    ],
-    // Allow images/SVGs referenced by content-script UI <img> tags to be loaded from
-    // moz-extension:// URLs on regular pages. Firefox enforces this more strictly.
-    web_accessible_resources: [
-      {
-        resources: ["assets/*.png", "assets/*.svg", "assets/*.webp"],
-        matches: ["*://*/*", "file:///*"],
-      },
-    ],
-    // Firefox-specific settings for MV3
-    ...(browser === "firefox" && {
-      // Override default CSP to exclude `upgrade-insecure-requests` (Firefox MV3 default),
-      // which would upgrade custom provider HTTP URLs (e.g. LAN) to HTTPS.
-      content_security_policy: {
-        extension_pages: "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';",
-      },
-      browser_specific_settings: {
-        gecko: {
-          id: "{bd311a81-4530-4fcc-9178-74006155461b}",
-          strict_min_version: "112.0",
-          data_collection_permissions: {
-            required: ["none"],
-            optional: ["technicalAndInteraction"],
-          },
-        },
-      },
-    }),
+  manifest: ({ mode, browser }) => createExtensionManifest({
+    mode,
+    browser,
+    isFirefoxAndroidBuild: browser === "firefox" && isFirefoxAndroidBuildTargetEnabled(),
   }),
   zip: {
     includeSources: [".env.production"],
@@ -98,11 +59,7 @@ export default defineConfig({
 
               // Check required env vars only for zip builds
               if (process.env.WXT_ZIP_MODE) {
-                const requiredEnvVars = [
-                  "WXT_GOOGLE_CLIENT_ID",
-                  "WXT_POSTHOG_API_KEY",
-                  "WXT_POSTHOG_HOST",
-                ]
+                const requiredEnvVars = getZipRequiredEnvVars()
                 const missing = requiredEnvVars.filter(key => !process.env[key])
 
                 if (missing.length > 0) {

--- a/wxt.manifest.test.ts
+++ b/wxt.manifest.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+import { createExtensionManifest } from "./wxt.manifest"
+
+describe("createExtensionManifest", () => {
+  it("keeps desktop Firefox permissions unchanged", () => {
+    const manifest = createExtensionManifest({
+      browser: "firefox",
+      mode: "production",
+      isFirefoxAndroidBuild: false,
+    })
+
+    expect(manifest.permissions).toContain("contextMenus")
+    expect(manifest.permissions).toContain("identity")
+    expect(manifest.permissions).not.toContain("offscreen")
+    expect(manifest.browser_specific_settings).toMatchObject({
+      gecko: {
+        id: "{bd311a81-4530-4fcc-9178-74006155461b}",
+      },
+    })
+    expect(manifest.browser_specific_settings).not.toHaveProperty("gecko_android")
+  })
+
+  it("builds a Firefox Android manifest without unsupported permissions", () => {
+    const manifest = createExtensionManifest({
+      browser: "firefox",
+      mode: "production",
+      isFirefoxAndroidBuild: true,
+    })
+
+    expect(manifest.permissions).not.toContain("contextMenus")
+    expect(manifest.permissions).not.toContain("identity")
+    expect(manifest.permissions).toEqual(expect.arrayContaining([
+      "storage",
+      "tabs",
+      "alarms",
+      "cookies",
+      "scripting",
+      "webNavigation",
+    ]))
+    expect(manifest.permissions).not.toContain("offscreen")
+    expect(manifest.browser_specific_settings).toMatchObject({
+      gecko: {
+        id: "{bd311a81-4530-4fcc-9178-74006155461b}",
+      },
+      gecko_android: {},
+    })
+  })
+})

--- a/wxt.manifest.ts
+++ b/wxt.manifest.ts
@@ -1,0 +1,84 @@
+import process from "node:process"
+
+const DEVELOPMENT_CHROME_EDGE_KEY = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAw2KhiXO2vySZtPu5pNSbyKhYavh8Be7gXmCZt8aJf6tQ/L3JK0qzL+3JSc/o20td3Jw+B2Dcw+EI93NAZr24xKnTNXQiJpuIuHb8xLXD0Ra/HrTVi4TJIhPdESogoG4uL6CD/F3TxfZJ2trX4Bt9cdAw1RGGeU+xU0g+YFfEka4ZUCpFAmTEw9H3/DU+nCp8yGaJWyiVgCTcFe38GZKEPt0iMJkTw956wz/iiafLx0pNG/RaztG9cAPoQOD2+SMFaeQ+b/G4OG17TYhzb09AhNBl6zSJ3jTKHSwuedCFwCce8Q/EchJfQZv71mjAE97bzwvkDYPCLj31Z5FE8HntMwIDAQAB"
+
+interface CreateExtensionManifestOptions {
+  browser: string
+  mode: string
+  isFirefoxAndroidBuild?: boolean
+}
+
+export function isFirefoxAndroidBuildTargetEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env.WXT_FIREFOX_ANDROID === "true"
+}
+
+export function getZipRequiredEnvVars(isFirefoxAndroidBuild = isFirefoxAndroidBuildTargetEnabled()): string[] {
+  return [
+    ...(!isFirefoxAndroidBuild ? ["WXT_GOOGLE_CLIENT_ID"] : []),
+    "WXT_POSTHOG_API_KEY",
+    "WXT_POSTHOG_HOST",
+  ]
+}
+
+function getManifestPermissions(
+  browser: string,
+  isFirefoxAndroidBuild: boolean,
+): string[] {
+  return [
+    "storage",
+    "tabs",
+    "alarms",
+    "cookies",
+    ...(!isFirefoxAndroidBuild ? ["contextMenus", "identity"] : []),
+    "scripting",
+    "webNavigation",
+    ...(browser !== "firefox" ? ["offscreen"] : []),
+  ]
+}
+
+export function createExtensionManifest({
+  browser,
+  mode,
+  isFirefoxAndroidBuild = browser === "firefox" && isFirefoxAndroidBuildTargetEnabled(),
+}: CreateExtensionManifestOptions) {
+  return {
+    name: "__MSG_extName__",
+    description: "__MSG_extDescription__",
+    default_locale: "en",
+    ...(mode === "development" && (browser === "chrome" || browser === "edge") && {
+      key: DEVELOPMENT_CHROME_EDGE_KEY,
+    }),
+    permissions: getManifestPermissions(browser, isFirefoxAndroidBuild),
+    host_permissions: [
+      "*://*/*", // Required for scripting.executeScript in any frame
+    ],
+    // Allow images/SVGs referenced by content-script UI <img> tags to be loaded from
+    // moz-extension:// URLs on regular pages. Firefox enforces this more strictly.
+    web_accessible_resources: [
+      {
+        resources: ["assets/*.png", "assets/*.svg", "assets/*.webp"],
+        matches: ["*://*/*", "file:///*"],
+      },
+    ],
+    ...(browser === "firefox" && {
+      // Override default CSP to exclude `upgrade-insecure-requests` (Firefox MV3 default),
+      // which would upgrade custom provider HTTP URLs (e.g. LAN) to HTTPS.
+      content_security_policy: {
+        extension_pages: "script-src 'self' 'wasm-unsafe-eval'; object-src 'self';",
+      },
+      browser_specific_settings: {
+        gecko: {
+          id: "{bd311a81-4530-4fcc-9178-74006155461b}",
+          strict_min_version: "112.0",
+          data_collection_permissions: {
+            required: ["none"],
+            optional: ["technicalAndInteraction"],
+          },
+        },
+        ...(isFirefoxAndroidBuild ? { gecko_android: {} } : {}),
+      },
+    }),
+  }
+}


### PR DESCRIPTION
resolve #1169 

## Type of Changes

<!--- Please select one type below -->

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [x] Added unit tests
- [x] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Firefox Android Usage / Verification Steps

This branch was validated on a real Android phone over USB with Firefox for Android `148.0.2` and `adb`.

### Prerequisites

1. Install Firefox for Android on the phone.
2. On Android, enable Developer Options by tapping `Build number` 7 times in `Settings > About phone`.
3. On Android, enable `USB debugging` in `Settings > Developer options`.
4. Connect the phone to the computer with a USB cable and accept the computer's debugging authorization prompt on the phone if Android asks.
5. In Firefox for Android, enable `Remote debugging via USB`.
   If `Developer tools` is not visible in Firefox settings, open `Settings > About Firefox` and tap the Firefox logo 5 times to enable the hidden debug menu, then go back to settings and enable `Remote debugging via USB` there.
6. Confirm the device is visible from the computer:

```bash
adb devices -l
```

### Build and run the extension on Android Firefox

1. Build the Android Firefox extension bundle:

```bash
pnpm build:firefox-android
```

2. Temporarily install the built extension into Firefox on the connected Android device:

```bash
npx --yes web-ext run \
  --target=firefox-android \
  --android-device=<adb-device-id> \
  --firefox-apk=org.mozilla.firefox \
  --source-dir=.output/firefox-mv3
```

3. Replace `<adb-device-id>` with the device ID from `adb devices -l`.
   Example used during validation:

```bash
npx --yes web-ext run \
  --target=firefox-android \
  --android-device=17da6c75 \
  --firefox-apk=org.mozilla.firefox \
  --source-dir=.output/firefox-mv3
```

4. Keep the `web-ext` process running. It installs the extension as a temporary add-on and reloads it if files change.
5. Open Firefox on the phone and browse to any normal web page to verify the content scripts load.

### Manual verification for the floating button behavior

1. Open a normal web page in Firefox on Android.
2. Confirm the Read Frog floating button is visible on the right edge of the page.
3. Tap the main floating ball once.
4. Verify the configured primary action still fires.
   For `clickAction=translate`, page translation should toggle.
   For `clickAction=panel`, the side panel should toggle.
5. Verify the side action strip also expands immediately after the same tap.
6. Verify the side action strip stays interactive after finger release.
7. Wait `3000ms` without interacting and verify the side action strip auto-collapses.
8. Tap the main ball again before `3000ms` elapses and verify the visible state is renewed.
9. Tap the `X` entry while the side action strip is visible and verify the close menu opens.
10. Keep the close menu open for more than `3000ms` and verify the strip does not auto-hide while the menu is open.
11. Close the menu and verify the `3000ms` auto-hide timer starts again.
12. Drag the main ball instead of tapping it and verify it moves position without firing the primary action and without expanding the side action strip.
13. Click the main ball with a mouse on desktop Firefox and verify desktop hover behavior is unchanged and no persistent mobile expanded state is entered.

## Additional Information

<!--- Any other information that reviewers should know -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Firefox Android build target and improves touch UX by stabilizing page translation toggles and the floating button. Ships an Android-safe manifest and guards to disable unsupported features, plus scripts, tests, and docs.

- **Bug Fixes**
  - Coalesced page translation toggles via a new `manager.setEnabled()`; content script now uses it on init, URL changes, and shortcuts; adds tests for concurrent enable/disable and title handling.
  - Deduplicated floating-button translate requests with `request-page-translation-toggle`; distinguishes drag vs tap, reveals side actions on touch, auto-hides after 3s, and pauses the timer while the close menu is open; fixes click handlers; adds comprehensive UI tests.
  - Wrapped context menu setup and handlers behind `supportsContextMenu` with `setupOptionalContextMenu`; hides Context Menu and Google Drive entries in options and command palette when unsupported; adds a catch-all route redirect; tests cover platform detection and search items.
  - Deferred `browser.identity` access in Google Drive auth and return a clear `PLATFORM_NOT_SUPPORTED` error on Android; gated hook/query by `supportsGoogleDriveSync`; adds tests for import safety and errors.

- **Migration**
  - Use `pnpm dev:firefox-android`, `pnpm build:firefox-android`, or `pnpm zip:firefox-android` for the Android build (sets `WXT_FIREFOX_ANDROID=true`).
  - On Firefox Android, Context Menu and Google Drive Sync are disabled by design; `WXT_GOOGLE_CLIENT_ID` isn’t required for Android zip builds.

<sup>Written for commit 1b9a5d33dcbad58b8ab407d7347f5aa9a0375d2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

