### PR TITLE
fix: skip GitHub PR review diff tables from translation

### DIFF
--- a/.changeset/github-pr-comment-diff-table.md
+++ b/.changeset/github-pr-comment-diff-table.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): skip GitHub PR review diff tables during page translation

--- a/src/utils/constants/dom-rules.ts
+++ b/src/utils/constants/dom-rules.ts
@@ -151,6 +151,7 @@ export const CUSTOM_DONT_WALK_INTO_ELEMENT_SELECTOR_MAP: Record<string, string[]
     "header *",
     "#repository-container-header *",
     "[class*=\"OverviewContent-module__Box_1--\"] *",
+    "table.diff-table", // https://github.com/mengxi-ream/read-frog/issues/1174
   ],
 }
 

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -43,6 +43,14 @@ const TRANSLATION_ONLY_CONFIG: Config = {
   },
 }
 
+function setHost(host: string) {
+  Object.defineProperty(window, "location", {
+    value: new URL(`https://${host}/some/path`),
+    writable: true,
+    configurable: true,
+  })
+}
+
 describe("translate", () => {
   // Setup and teardown for getComputedStyle mock
   const originalGetComputedStyle = window.getComputedStyle
@@ -1317,6 +1325,41 @@ describe("translate", () => {
 
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
         expect(node.textContent).toBe(codeContent)
+      })
+    })
+
+    describe("github diff table - should not translate review code snippets", () => {
+      it("bilingual mode: should skip github diff-table content entirely", async () => {
+        const originalLocation = window.location
+        setHost("github.com")
+        vi.mocked(translateTextForPage).mockClear()
+
+        try {
+          render(
+            <div data-testid="test-node">
+              <table className="diff-table">
+                <tbody>
+                  <tr>
+                    <td>const foo = 1</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>,
+          )
+          const node = screen.getByTestId("test-node")
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+          expect(node.textContent).toBe("const foo = 1")
+          expect(translateTextForPage).not.toHaveBeenCalled()
+        }
+        finally {
+          Object.defineProperty(window, "location", {
+            value: originalLocation,
+            writable: true,
+            configurable: true,
+          })
+        }
       })
     })
 

--- a/src/utils/host/dom/__tests__/custom-dont-walk.test.ts
+++ b/src/utils/host/dom/__tests__/custom-dont-walk.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
-import { isCustomDontWalkIntoElement, isDontWalkIntoAndDontTranslateAsChildElement } from "../filter"
+import { hasNoWalkAncestor, isCustomDontWalkIntoElement, isDontWalkIntoAndDontTranslateAsChildElement } from "../filter"
 
 function setHost(host: string) {
   // jsdom exposes location as read-only; override via defineProperty
@@ -103,5 +103,26 @@ describe("isCustomDontWalkIntoElement", () => {
 
     expect(isCustomDontWalkIntoElement(postFlair)).toBe(true)
     expect(isDontWalkIntoAndDontTranslateAsChildElement(postFlair, DEFAULT_CONFIG)).toBe(true)
+  })
+
+  it("matches github review diff table and blocks its descendants", () => {
+    setHost("github.com")
+
+    const diffTable = document.createElement("table")
+    diffTable.classList.add("diff-table")
+
+    const tbody = document.createElement("tbody")
+    const tr = document.createElement("tr")
+    const td = document.createElement("td")
+    td.textContent = "const foo = 1"
+
+    tr.appendChild(td)
+    tbody.appendChild(tr)
+    diffTable.appendChild(tbody)
+    document.body.appendChild(diffTable)
+
+    expect(isCustomDontWalkIntoElement(diffTable)).toBe(true)
+    expect(isDontWalkIntoAndDontTranslateAsChildElement(diffTable, DEFAULT_CONFIG)).toBe(true)
+    expect(hasNoWalkAncestor(td, DEFAULT_CONFIG)).toBe(true)
   })
 })


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [x] ✅ Test related (test)
- [ ] ✨ New feature (feat)
- [ ] 💄 UI/style change (style)
- [ ] 📝 Documentation change (docs)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Skip GitHub PR review code snippets rendered as `table.diff-table` during page translation.

This fixes the case where review/comment code blocks on GitHub PR pages were being extracted as normal page text and translated.

Closes #1174.

## How Has This Been Tested?

- [x] Added unit/integration tests
- [ ] Verified through manual testing

Tested locally with:

- `pnpm exec vitest run src/utils/host/dom/__tests__/custom-dont-walk.test.ts src/utils/host/__tests__/translate.integration.test.tsx`
- `pnpm exec eslint src/utils/constants/dom-rules.ts src/utils/host/dom/__tests__/custom-dont-walk.test.ts src/utils/host/__tests__/translate.integration.test.tsx`

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The changeset file is included in the branch as:

- `.changeset/github-pr-comment-diff-table.md`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip translating GitHub PR review diff tables so code snippets in review comments stay intact. Fixes #1174.

- **Bug Fixes**
  - Added a no-walk rule for `table.diff-table` on GitHub PR pages, blocking descendants.
  - Added unit and integration tests to ensure no wrapper injection and no translation calls in bilingual mode.

<sup>Written for commit 4452c8d5ab9a4108477b40316792f1f008a2e294. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

