### PR TITLE
fix(translation): force block translation for Reddit post text body

### DIFF
--- a/.changeset/reddit-force-block-post-text-body.md
+++ b/.changeset/reddit-force-block-post-text-body.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): force block translation for Reddit post text body

--- a/src/utils/constants/dom-rules.ts
+++ b/src/utils/constants/dom-rules.ts
@@ -161,6 +161,9 @@ export const CUSTOM_FORCE_BLOCK_TRANSLATION_SELECTOR_MAP: Record<string, string[
   "engoo.com": [
     "#windowexercise-2 > div > div > div.css-ep7xq6 > div > div > div.css-19m2fbm *",
   ],
+  "www.reddit.com": [
+    "shreddit-post-text-body",
+  ],
   "www.youtube.com": [
     "yt-attributed-string > span",
   ],

--- a/src/utils/host/dom/__tests__/custom-force-block.test.ts
+++ b/src/utils/host/dom/__tests__/custom-force-block.test.ts
@@ -33,6 +33,15 @@ describe("isCustomForceBlockTranslation", () => {
     expect(isCustomForceBlockTranslation(taskLists)).toBe(false)
   })
 
+  it("matches shreddit-post-text-body element on www.reddit.com", () => {
+    setHost("www.reddit.com")
+
+    const postTextBody = document.createElement("shreddit-post-text-body")
+    document.body.appendChild(postTextBody)
+
+    expect(isCustomForceBlockTranslation(postTextBody)).toBe(true)
+  })
+
   it("does not match element outside configured parent on configured host", () => {
     setHost("github.com")
 


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

- Add a Reddit-specific custom force-block translation rule for `shreddit-post-text-body`
- Keep Reddit post body translations rendering as block paragraphs instead of being squeezed into a single inline translation area
- Add a unit test covering the Reddit selector match

## Related Issue

Closes #1177

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Additional local verification:
- `pnpm vitest run src/utils/host/dom/__tests__/custom-force-block.test.ts`
- pre-push checks passed: `lint`, `type-check`, `vitest run`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- Includes a patch changeset for `@read-frog/extension`
