### PR TITLE
fix: close selection toolbar translate tooltip on open

### DIFF
--- a/.changeset/selection-toolbar-translate-tooltip-close.md
+++ b/.changeset/selection-toolbar-translate-tooltip-close.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection-toolbar): close the translate tooltip when opening the translation popover

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
@@ -9,6 +9,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { createStore, Provider } from "jotai"
 import { afterEach, describe, expect, it, vi } from "vitest"
+import { TooltipProvider } from "@/components/ui/base-ui/tooltip"
 import { isLLMProviderConfig, isTranslateProviderConfig } from "@/types/config/provider"
 import { configAtom } from "@/utils/atoms/config"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
@@ -376,6 +377,56 @@ describe("selection toolbar requests", () => {
     vi.resetAllMocks()
   })
 
+  it("closes the translate tooltip after opening the popover", async () => {
+    translateTextCoreMock.mockResolvedValue("translated once")
+    getOrFetchArticleDataMock.mockResolvedValue(null)
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    setSelectionState(store, { text: "Selected text" })
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    })
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Provider store={store}>
+          <TooltipProvider>
+            <SelectionTranslationProvider>
+              <SelectionCustomActionProvider>
+                <TranslateButton />
+              </SelectionCustomActionProvider>
+            </SelectionTranslationProvider>
+          </TooltipProvider>
+        </Provider>
+      </QueryClientProvider>,
+    )
+
+    const trigger = screen.getByRole("button", { name: "action.translation" })
+
+    fireEvent.mouseEnter(trigger)
+    fireEvent.focus(trigger)
+
+    await waitFor(() => {
+      expect(document.querySelector("[data-slot='tooltip-content']")).toHaveTextContent("action.translation")
+    })
+
+    fireEvent.click(trigger)
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selection-popover-content")).toBeInTheDocument()
+    })
+
+    await waitFor(() => {
+      expect(document.querySelector("[data-slot='tooltip-content']")).toBeNull()
+    })
+  })
+
   it("does not rerun translation on passive config refresh, but reruns when request values change", async () => {
     translateTextCoreMock.mockResolvedValue("translated once")
     getOrFetchArticleDataMock.mockResolvedValue(null)
@@ -383,7 +434,7 @@ describe("selection toolbar requests", () => {
     const store = createStore()
     store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
     setSelectionState(store, { text: "Selected text" })
-    const view = renderWithProviders(<TranslateButton />, store)
+    renderWithProviders(<TranslateButton />, store)
 
     fireEvent.click(screen.getByRole("button", { name: "action.translation" }))
 
@@ -395,17 +446,6 @@ describe("selection toolbar requests", () => {
     act(() => {
       store.set(configAtom, refreshedConfig)
     })
-    view.rerender(
-      <QueryClientProvider client={view.queryClient}>
-        <Provider store={store}>
-          <SelectionTranslationProvider>
-            <SelectionCustomActionProvider>
-              <TranslateButton />
-            </SelectionCustomActionProvider>
-          </SelectionTranslationProvider>
-        </Provider>
-      </QueryClientProvider>,
-    )
 
     await act(async () => {
       await Promise.resolve()

--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/index.tsx
@@ -1,5 +1,6 @@
 import { i18n } from "#imports"
 import { RiTranslate } from "@remixicon/react"
+import { useCallback, useState } from "react"
 import { SelectionPopover } from "@/components/ui/selection-popover"
 import { SelectionToolbarTooltip } from "../../components/selection-tooltip"
 import { useSelectionTranslationPopover } from "./provider"
@@ -7,11 +8,19 @@ import { useSelectionTranslationPopover } from "./provider"
 export function TranslateButton() {
   const { prepareToolbarOpen } = useSelectionTranslationPopover()
   const triggerLabel = i18n.t("action.translation")
+  const [tooltipOpen, setTooltipOpen] = useState(false)
+
+  const handleClick = useCallback(() => {
+    setTooltipOpen(false)
+    prepareToolbarOpen()
+  }, [prepareToolbarOpen])
 
   return (
     <SelectionToolbarTooltip
       content={triggerLabel}
-      render={<SelectionPopover.Trigger aria-label={triggerLabel} onClick={prepareToolbarOpen} />}
+      open={tooltipOpen}
+      onOpenChange={setTooltipOpen}
+      render={<SelectionPopover.Trigger aria-label={triggerLabel} onClick={handleClick} />}
     >
       <RiTranslate className="size-4.5" />
     </SelectionToolbarTooltip>


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [x] ✅ Test related (test)
- [ ] ✨ New feature (feat)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Close the selection toolbar translate tooltip when opening the translation popover.

This fixes the case where the tooltip text could remain visible after clicking the translate button, even though the selection toolbar itself had already been hidden.

Closes #1178.

## How Has This Been Tested?

- [x] Added unit/integration tests
- [ ] Verified through manual testing

Tested locally with:

- `pnpm exec vitest run src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx`
- `pnpm exec eslint src/entrypoints/selection.content/selection-toolbar/translate-button/index.tsx src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx`
- repo pre-push checks: `lint`, `type-check`, and full `vitest run`

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The patch switches the translate button tooltip to controlled open state and explicitly closes it before the translation popover opens. A regression test covers the click-to-open path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a UI bug where the translate tooltip in the selection toolbar stayed visible after opening the translation popover. Now the tooltip closes immediately on click to avoid lingering text. Closes #1178.

- **Bug Fixes**
  - Switched the translate tooltip to a controlled `open` state and close it before calling `prepareToolbarOpen()`.
  - Added a regression test for the hover/focus → click flow using `TooltipProvider`.

<sup>Written for commit d63c69bbc06d9738fdcb0a5058d5975094bf1301. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

