### PR TITLE
fix(selection-toolbar): ignore retargeted interactive clicks

### DIFF
--- a/.changeset/selection-toolbar-retarget-clicks.md
+++ b/.changeset/selection-toolbar-retarget-clicks.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection-toolbar): ignore retargeted interactive clicks

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
@@ -303,6 +303,90 @@ describe("selectionToolbar - isInputOrTextarea logic", () => {
     expectToolbarHidden()
   })
 
+  it("should not show toolbar when selection does not contain the clicked button ancestor", async () => {
+    render(
+      <div>
+        <SelectionToolbar />
+        <div data-testid="selected-element">{MOCK_SELECTED_TEXT}</div>
+        <button data-testid="click-button" type="button">
+          <span data-testid="click-button-label">Click target</span>
+        </button>
+      </div>,
+    )
+
+    await clearToolbarState()
+
+    const clickButton = screen.getByTestId("click-button")
+    const clickTarget = screen.getByTestId("click-button-label")
+
+    window.getSelection = vi.fn(() => ({
+      toString: vi.fn(() => MOCK_SELECTED_TEXT),
+      getRangeAt: () => ({
+        startContainer: document.body,
+        startOffset: 0,
+        endContainer: document.body,
+        endOffset: 1,
+      }),
+      containsNode: vi.fn((node: Node) => node !== clickButton),
+    })) as unknown as typeof window.getSelection
+
+    await triggerMouseUpWithSelection(clickTarget)
+    expectToolbarHidden()
+  })
+
+  it("should not show toolbar when shadow DOM retargets button clicks to the host element", async () => {
+    render(
+      <div>
+        <SelectionToolbar />
+        <div data-testid="selected-element">{MOCK_SELECTED_TEXT}</div>
+      </div>,
+    )
+
+    await clearToolbarState()
+
+    const shadowHost = document.createElement("read-frog-selection")
+    const shadowButton = document.createElement("button")
+    shadowButton.type = "button"
+    let dispatchComplete = false
+
+    window.getSelection = vi.fn(() => ({
+      toString: vi.fn(() => MOCK_SELECTED_TEXT),
+      getRangeAt: () => ({
+        startContainer: document.body,
+        startOffset: 0,
+        endContainer: document.body,
+        endOffset: 1,
+      }),
+      containsNode: vi.fn((node: Node) => node !== shadowButton),
+    })) as unknown as typeof window.getSelection
+
+    const mouseUpEvent = new MouseEvent("mouseup", {
+      bubbles: true,
+      clientX: 100,
+      clientY: 100,
+      composed: true,
+    })
+
+    Object.defineProperty(mouseUpEvent, "target", {
+      value: shadowHost,
+      writable: false,
+    })
+
+    Object.defineProperty(mouseUpEvent, "composedPath", {
+      value: () => dispatchComplete ? [] : [shadowButton, shadowHost, document.body, document, window],
+    })
+
+    await act(async () => {
+      document.dispatchEvent(mouseUpEvent)
+      dispatchComplete = true
+      const callbacks = [...rafCallbacks]
+      rafCallbacks = []
+      callbacks.forEach(cb => cb(0))
+    })
+
+    expectToolbarHidden()
+  })
+
   it("should show toolbar when selection contains the click target", async () => {
     render(
       <div>
@@ -327,6 +411,36 @@ describe("selectionToolbar - isInputOrTextarea logic", () => {
     })) as unknown as typeof window.getSelection
 
     await triggerMouseUpWithSelection(element)
+    await waitFor(expectToolbarVisible)
+  })
+
+  it("should show toolbar when selection contains the clicked button ancestor", async () => {
+    render(
+      <div>
+        <SelectionToolbar />
+        <button data-testid="click-button" type="button">
+          <span data-testid="click-button-label">Selected button text</span>
+        </button>
+      </div>,
+    )
+
+    await clearToolbarState()
+
+    const clickButton = screen.getByTestId("click-button")
+    const clickTarget = screen.getByTestId("click-button-label")
+
+    window.getSelection = vi.fn(() => ({
+      toString: vi.fn(() => MOCK_SELECTED_TEXT),
+      getRangeAt: () => ({
+        startContainer: document.body,
+        startOffset: 0,
+        endContainer: document.body,
+        endOffset: 1,
+      }),
+      containsNode: vi.fn((node: Node) => node === clickButton || clickButton.contains(node)),
+    })) as unknown as typeof window.getSelection
+
+    await triggerMouseUpWithSelection(clickTarget)
     await waitFor(expectToolbarVisible)
   })
 

--- a/src/entrypoints/selection.content/selection-toolbar/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/index.tsx
@@ -24,6 +24,45 @@ enum SelectionDirection {
   BOTTOM_RIGHT = "BOTTOM_RIGHT",
 }
 
+const SELECTION_GUARD_INTERACTIVE_SELECTOR = [
+  "button",
+  "[role=\"button\"]",
+  "a[href]",
+  "input",
+  "textarea",
+  "select",
+  "summary",
+].join(", ")
+
+function getInteractiveGuardTarget(event: MouseEvent) {
+  const eventPath = event.composedPath()
+
+  for (const node of eventPath) {
+    if (!(node instanceof Element)) {
+      continue
+    }
+
+    if (node.matches(SELECTION_GUARD_INTERACTIVE_SELECTOR)) {
+      return node
+    }
+
+    const closestInteractive = node.closest(SELECTION_GUARD_INTERACTIVE_SELECTOR)
+    if (closestInteractive) {
+      return closestInteractive
+    }
+  }
+
+  if (!(event.target instanceof Element)) {
+    return null
+  }
+
+  if (event.target.matches(SELECTION_GUARD_INTERACTIVE_SELECTOR)) {
+    return event.target
+  }
+
+  return event.target.closest(SELECTION_GUARD_INTERACTIVE_SELECTOR)
+}
+
 function getSelectionDirection(
   startX: number,
   startY: number,
@@ -128,6 +167,8 @@ export function SelectionToolbar() {
         return
       }
 
+      const interactiveTarget = getInteractiveGuardTarget(e)
+
       // Use requestAnimationFrame to delay selection check
       // This ensures selectionchange event fires first if text selection was cleared
       requestAnimationFrame(() => {
@@ -143,7 +184,7 @@ export function SelectionToolbar() {
 
         // https://github.com/mengxi-ream/read-frog/issues/547
         // https://github.com/mengxi-ream/read-frog/pull/790
-        if (!isInputOrTextarea && !selection?.containsNode(e.target as Node, true) && e.target instanceof HTMLButtonElement) {
+        if (!isInputOrTextarea && interactiveTarget && !selection?.containsNode(interactiveTarget, true)) {
           return
         }
 


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fix selection toolbar reappearing when users click interactive controls that are outside the current selection but are retargeted through shadow DOM or nested under a host button.

- capture the interactive click target synchronously from `mouseup` before `requestAnimationFrame`
- guard against nested button/control clicks via `composedPath()` and closest interactive ancestors
- add regression tests for nested button descendants and shadow DOM retargeting

## Related Issue

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

`SKIP_FREE_API=true pnpm exec vitest run src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx`

Manual verification:
- rebuilt `edge-mv3`
- reproduced selection -> open translation popover -> click the expand/collapse button inside the popover
- confirmed the selection toolbar stayed hidden in a fresh Edge profile

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The fix is intentionally scoped to interactive controls and keeps the existing selection session behavior intact.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the selection toolbar so it doesn’t reappear when clicking buttons or other controls outside the selection. Handles shadow DOM retargeting and nested button descendants to keep the toolbar hidden.

- **Bug Fixes**
  - Capture the interactive click target synchronously on mouseup using `composedPath()`/`closest`, and only show the toolbar if the selection contains that interactive ancestor.
  - Add regression tests for nested button descendants and shadow DOM retargeting.

<sup>Written for commit 063e0840039d91a7e1fe3ca18537e07e768c98a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

