### PR TITLE
fix(url): support caddy localhost URLs in dev mode

### DIFF
--- a/.changeset/localhost-caddy-dev-url.md
+++ b/.changeset/localhost-caddy-dev-url.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(url): support caddy localhost URLs in dev mode

--- a/src/utils/constants/url.ts
+++ b/src/utils/constants/url.ts
@@ -1,10 +1,11 @@
-import { LOCALHOST_DOMAIN, READFROG_DOMAIN, WEBSITE_DEV_URL, WEBSITE_PROD_URL } from "@read-frog/definitions"
+import { LOCALHOST_DOMAIN, READFROG_DOMAIN, WEBSITE_CADDY_DEV_URL, WEBSITE_PROD_URL } from "@read-frog/definitions"
 
 export const OFFICIAL_SITE_URL_PATTERNS = [
   `https://*.${READFROG_DOMAIN}/*`,
   `http://${LOCALHOST_DOMAIN}/*`,
+  `https://${LOCALHOST_DOMAIN}/*`,
 ]
 
 export const WEBSITE_URL = (import.meta.env.DEV && import.meta.env.WXT_USE_LOCAL_PACKAGES === "true")
-  ? WEBSITE_DEV_URL
+  ? WEBSITE_CADDY_DEV_URL
   : WEBSITE_PROD_URL


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable dev support for Caddy-served HTTPS localhost. This lets the extension match and open the local site when using the Caddy reverse proxy.

- **Bug Fixes**
  - Added https://localhost/* to `OFFICIAL_SITE_URL_PATTERNS`.
  - Use `WEBSITE_CADDY_DEV_URL` for `WEBSITE_URL` in dev when `WXT_USE_LOCAL_PACKAGES === "true"`.

<sup>Written for commit 1a596225f3b69513f112ad9437f8831baf1ce473. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

