### PR TITLE
fix(extension): keep heading anchor translations outside links

### DIFF
--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -253,6 +253,58 @@ describe("translate", () => {
         expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
       })
     })
+    describe("heading with single anchor child", () => {
+      it("bilingual mode: should keep the translated wrapper outside the heading anchor", async () => {
+        render(
+          <h1 data-testid="test-node" data-docs-heading="">
+            <a style={{ display: "inline-flex" }}>
+              {MOCK_ORIGINAL_TEXT}
+              <span aria-hidden="true"></span>
+            </a>
+          </h1>,
+        )
+        const node = screen.getByTestId("test-node")
+        const anchor = node.querySelector("a") as HTMLAnchorElement
+        await removeOrShowPageTranslation("bilingual", true)
+
+        expectNodeLabels(node, [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
+        expectNodeLabels(anchor, [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
+        const wrapper = expectTranslationWrapper(node, "bilingual")
+        expect(wrapper).toBe(node.lastChild)
+        expect(wrapper?.parentElement).toBe(node)
+        expect(anchor.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+        expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+
+        await removeOrShowPageTranslation("bilingual", true)
+        expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+        expect(node.querySelector("a")).toBeTruthy()
+        expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
+      })
+
+      it("translation only mode: should replace the heading anchor instead of injecting inside it", async () => {
+        render(
+          <h1 data-testid="test-node" data-docs-heading="">
+            <a style={{ display: "inline-flex" }}>
+              {MOCK_ORIGINAL_TEXT}
+              <span aria-hidden="true"></span>
+            </a>
+          </h1>,
+        )
+        const node = screen.getByTestId("test-node")
+        await removeOrShowPageTranslation("translationOnly", true)
+
+        expectNodeLabels(node, [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
+        const wrapper = expectTranslationWrapper(node, "translationOnly")
+        expect(wrapper).toBe(node.firstChild)
+        expect(wrapper?.closest("a")).toBeFalsy()
+        expect(node.querySelector("a")).toBeFalsy()
+
+        await removeOrShowPageTranslation("translationOnly", true)
+        expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+        expect(node.querySelector("a")).toBeTruthy()
+        expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
+      })
+    })
     describe("block node -> block node -> inline node", () => {
       it("bilingual mode: should insert translation wrapper after deepest inline node", async () => {
         render(

--- a/src/utils/host/dom/find.ts
+++ b/src/utils/host/dom/find.ts
@@ -1,3 +1,4 @@
+import type { Config } from "@/types/config/config"
 import type { Point } from "@/types/dom"
 
 import { getLocalConfig } from "@/utils/config/storage"
@@ -5,6 +6,8 @@ import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { CONTENT_WRAPPER_CLASS } from "@/utils/constants/dom-labels"
 import { isDontWalkIntoAndDontTranslateAsChildElement, isHTMLElement, isShallowInlineHTMLElement, isTranslatedContentNode, isTranslatedWrapperNode } from "./filter"
 import { smashTruncationStyle } from "./style"
+
+const HEADING_TAG_RE = /^H[1-6]$/
 
 /**
  * Find the deepest element at the given point, including inside shadow roots
@@ -117,29 +120,37 @@ export function deepQueryTopLevelSelector(element: HTMLElement | ShadowRoot | Do
   return result
 }
 
+export function findOnlyEffectiveHTMLElementChild(element: HTMLElement, config: Config): HTMLElement | null {
+  const shouldKeepNode = (child: ChildNode) => {
+    if (!child.textContent?.trim())
+      return false
+    if (child.nodeType === Node.TEXT_NODE)
+      return true
+    return isHTMLElement(child) && !isDontWalkIntoAndDontTranslateAsChildElement(child, config)
+  }
+
+  const effectiveChildNodes = [...element.childNodes].filter(shouldKeepNode)
+  const effectiveChildren = effectiveChildNodes.filter(child => child.nodeType === Node.ELEMENT_NODE)
+
+  if (!(effectiveChildren.length === 1 && effectiveChildNodes.length === 1))
+    return null
+
+  const onlyChildElement = effectiveChildren[0]
+  return isHTMLElement(onlyChildElement) ? onlyChildElement : null
+}
+
 export async function unwrapDeepestOnlyHTMLChild(element: HTMLElement) {
   const config = await getLocalConfig() ?? DEFAULT_CONFIG
   let currentElement = element
   while (currentElement) {
     smashTruncationStyle(currentElement)
 
-    const shouldKeepNode = (child: ChildNode) => {
-      if (!child.textContent?.trim())
-        return false
-      if (child.nodeType === Node.TEXT_NODE)
-        return true
-      return isHTMLElement(child) && !isDontWalkIntoAndDontTranslateAsChildElement(child, config)
-    }
-
-    const effectiveChildNodes = [...currentElement.childNodes].filter(shouldKeepNode)
-    const effectiveChildren = effectiveChildNodes.filter(child => child.nodeType === Node.ELEMENT_NODE)
-
-    // Only have one HTML child and no Text Child
-    if (!(effectiveChildren.length === 1 && effectiveChildNodes.length === 1))
+    const onlyChildElement = findOnlyEffectiveHTMLElementChild(currentElement, config)
+    if (!onlyChildElement)
       break
 
-    const onlyChildElement = effectiveChildren[0]
-    if (!isHTMLElement(onlyChildElement))
+    // Keep translated wrappers outside heading anchors so link-specific span styles do not hide them.
+    if (HEADING_TAG_RE.test(currentElement.tagName) && onlyChildElement.tagName === "A")
       break
 
     currentElement = onlyChildElement

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../constants/dom-labels"
 import { batchDOMOperation } from "../../dom/batch-dom"
 import { isBlockTransNode, isHTMLElement, isTextNode, isTransNode } from "../../dom/filter"
-import { unwrapDeepestOnlyHTMLChild } from "../../dom/find"
+import { findOnlyEffectiveHTMLElementChild, unwrapDeepestOnlyHTMLChild } from "../../dom/find"
 import { getOwnerDocument } from "../../dom/node"
 import { extractTextContent } from "../../dom/traversal"
 import { removeTranslatedWrapperWithRestore } from "../dom/translation-cleanup"
@@ -130,9 +130,16 @@ export async function translateNodesBilingualMode(
       return
     }
 
+    const onlyEffectiveChild = isHTMLElement(targetNode)
+      ? findOnlyEffectiveHTMLElementChild(targetNode, config)
+      : null
+    const translationStyleTarget = onlyEffectiveChild?.tagName === "A"
+      ? onlyEffectiveChild
+      : targetNode
+
     await insertTranslatedNodeIntoWrapper(
       translatedWrapperNode,
-      targetNode,
+      translationStyleTarget,
       translatedText,
       config.translate.translationNodeStyle,
       forceBlockTranslation,


### PR DESCRIPTION
## Summary
- keep translated wrappers outside heading anchors so heading link CSS does not hide injected translations
- preserve inline / inline-flex bilingual styling by still using the inner anchor as the translation style target
- add regression coverage for heading + anchor cases in both bilingual and translation-only modes

## Testing
- `SKIP_FREE_API=true node_modules/.bin/vitest run src/utils/host/__tests__/translate.integration.test.tsx src/utils/host/dom/__tests__/find.test.ts`

Closes #1050.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix heading translations by keeping translated wrappers outside heading anchor links, so link CSS no longer hides injected text. In bilingual mode we still style the inner anchor to preserve inline/inline-flex; translation-only replaces the anchor. Fixes #1050.

- Bug Fixes
  - Stop unwrapping into an anchor when the parent is an H1–H6.
  - In bilingual mode, use the inner anchor as the translation style target; in translation-only, replace the anchor.
  - Add regression tests for heading + anchor in both bilingual and translation-only modes.

<sup>Written for commit 0758b50ea783ba63440838aaec7cec8fa57f48c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

