### PR TITLE
fix(selection-toolbar): keep selection host above page modals

### DIFF
--- a/src/entrypoints/selection.content/__tests__/index.test.ts
+++ b/src/entrypoints/selection.content/__tests__/index.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { SELECTION_CONTENT_HOST_Z_INDEX } from "../overlay-layers"
+
+const getLocalConfigMock = vi.fn()
+vi.mock("@/utils/config/storage", () => ({
+  getLocalConfig: getLocalConfigMock,
+}))
+
+const getLocalThemeModeMock = vi.fn()
+vi.mock("@/utils/theme", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/theme")>()
+  return {
+    ...actual,
+    getLocalThemeMode: getLocalThemeModeMock,
+  }
+})
+
+const isSiteEnabledMock = vi.fn()
+const getEffectiveSiteControlUrlMock = vi.fn()
+const clearEffectiveSiteControlUrlMock = vi.fn()
+vi.mock("@/utils/site-control", () => ({
+  clearEffectiveSiteControlUrl: clearEffectiveSiteControlUrlMock,
+  getEffectiveSiteControlUrl: getEffectiveSiteControlUrlMock,
+  isSiteEnabled: isSiteEnabledMock,
+}))
+
+const ensureIconifyBackgroundFetchMock = vi.fn()
+vi.mock("@/utils/iconify/setup-background-fetch", () => ({
+  ensureIconifyBackgroundFetch: ensureIconifyBackgroundFetchMock,
+}))
+
+vi.mock("../app", () => ({
+  default: () => null,
+}))
+
+describe("selection.content entrypoint", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    document.body.innerHTML = ""
+    window.__READ_FROG_SELECTION_INJECTED__ = false
+    getLocalConfigMock.mockResolvedValue({})
+    getLocalThemeModeMock.mockResolvedValue("system")
+    getEffectiveSiteControlUrlMock.mockReturnValue(window.location.href)
+    isSiteEnabledMock.mockReturnValue(true)
+  })
+
+  it("mounts the WXT shadow host above page content with a max z-index", async () => {
+    const entrypoint = (await import("../index")).default
+
+    await entrypoint.main({
+      onInvalidated: vi.fn(),
+    } as any)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    const shadowHost = document.body.querySelector("read-frog-selection")
+
+    expect(shadowHost).toBeTruthy()
+    expect(shadowHost).toHaveStyle({ zIndex: String(SELECTION_CONTENT_HOST_Z_INDEX) })
+  })
+})

--- a/src/entrypoints/selection.content/index.tsx
+++ b/src/entrypoints/selection.content/index.tsx
@@ -20,6 +20,7 @@ import { addStyleToShadow } from "@/utils/styles"
 import { queryClient } from "@/utils/tanstack-query"
 import { getLocalThemeMode } from "@/utils/theme"
 import App from "./app"
+import { SELECTION_CONTENT_HOST_Z_INDEX } from "./overlay-layers"
 import "@/assets/styles/theme.css"
 
 function HydrateAtoms({
@@ -56,6 +57,7 @@ async function mountSelectionUI(ctx: ContentScriptContext) {
   const ui = await createShadowRootUi(ctx, {
     name: `${kebabCase(APP_NAME)}-selection`,
     position: "overlay",
+    zIndex: SELECTION_CONTENT_HOST_Z_INDEX,
     anchor: "body",
     css: selectionContentCss,
     onMount: (container, shadow, shadowHost) => {

--- a/src/entrypoints/selection.content/overlay-layers.ts
+++ b/src/entrypoints/selection.content/overlay-layers.ts
@@ -1,3 +1,5 @@
+export const SELECTION_CONTENT_HOST_Z_INDEX = 2147483647
+
 export const SELECTION_CONTENT_OVERLAY_LAYERS = {
   selectionOverlay: "z-2147483647",
   popover: "z-2147483646",


### PR DESCRIPTION
## Summary
- pass a max z-index into the WXT selection-content shadow host so the whole injected overlay stays above site modals
- keep the existing toolbar/popover child layer classes unchanged and localize the fix to the selection-content mount path
- add a focused regression test that mounts the real selection-content entrypoint and asserts the host element receives the max z-index

## Testing
- SKIP_FREE_API=true pnpm exec vitest run src/entrypoints/selection.content

Closes #1218

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the selection toolbar above site modals by setting the shadow host to the max z-index. Fixes #1218 where the toolbar could be hidden behind page dialogs.

- **Bug Fixes**
  - Define `SELECTION_CONTENT_HOST_Z_INDEX = 2147483647` and pass it to `createShadowRootUi` in `selection.content` to elevate the host.
  - Leave existing overlay layer classes unchanged; only the mount host is elevated.
  - Add a regression test that mounts the real entrypoint and asserts the host receives the max z-index.

<sup>Written for commit bccb7227770c7e8b0528bdf973ea73654e601b4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

