### PR TITLE
✨ Quality: Apply conditional language-detection flow to avoid redundant LLM calls

### DIFF
--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -28,6 +28,10 @@ export function shouldUseBatchQueue(providerConfig: ProviderConfig): boolean {
   return isLLMProviderConfig(providerConfig)
 }
 
+function shouldDetectLanguage(providerConfig: ProviderConfig): boolean {
+  return !isLLMProviderConfig(providerConfig)
+}
+
 export async function executeBatchTranslation(
   dataList: TranslateBatchData[],
   promptResolver: PromptResolver,
@@ -36,7 +40,11 @@ export async function executeBatchTranslation(
   const texts = dataList.map(d => d.text)
 
   const batchText = texts.join(`\n\n${BATCH_SEPARATOR}\n\n`)
-  const result = await executeTranslate(batchText, langConfig, providerConfig, promptResolver, { isBatch: true, content })
+  const result = await executeTranslate(batchText, langConfig, providerConfig, promptResolver, {
+    isBatch: true,
+    content,
+    shouldDetectLanguage: shouldDetectLanguage(providerConfig),
+  })
   return parseBatchResult(result)
 }
 
@@ -145,7 +153,10 @@ async function createTranslationQueues(config: TranslationQueueSetupConfig) {
       const { text, langConfig, providerConfig, hash, scheduleAt, content } = data
       const thunk = async () => {
         await putBatchRequestRecord({ originalRequestCount: 1, providerConfig })
-        return executeTranslate(text, langConfig, providerConfig, promptResolver, { content })
+        return executeTranslate(text, langConfig, providerConfig, promptResolver, {
+          content,
+          shouldDetectLanguage: shouldDetectLanguage(providerConfig),
+        })
       }
       return requestQueue.enqueue(thunk, scheduleAt, hash)
     },


### PR DESCRIPTION
## ✨ Code Quality

### Problem
The translation queue orchestration should be updated so language detection is no longer always executed when “skip language” is enabled. Right now, the queue appears to detect first and then translate for every paragraph, which creates the slowdown reported in #1110. This file should implement the decision matrix from the issue and only invoke detection when needed by the translator path.

**Severity**: `critical`
**File**: `src/entrypoints/background/translation-queues.ts`

### Solution
Refactor the per-segment translation pipeline to branch by:

### Changes
- `src/entrypoints/background/translation-queues.ts` (modified)

## Type of Changes



- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description



## Related Issue



Closes #1110

## How Has This Been Tested?



- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots



## Checklist



- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information



---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>
