### PR TITLE
✨ Quality: Add LaTeX-aware preprocessing/postprocessing to webpage translation pipeline

### DIFF
--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -28,16 +28,63 @@ export function shouldUseBatchQueue(providerConfig: ProviderConfig): boolean {
   return isLLMProviderConfig(providerConfig)
 }
 
+interface LatexProtectionResult {
+  text: string
+  segments: string[]
+}
+
+function shouldProtectLatex(text: string): boolean {
+  return /\\\(|\\\[|\\begin\{|\$\$|\$[^$\n]+\$/.test(text)
+}
+
+function protectLatex(text: string): LatexProtectionResult {
+  if (!shouldProtectLatex(text)) {
+    return { text, segments: [] }
+  }
+
+  const segments: string[] = []
+  const patterns = [
+    /\$\$[\s\S]*?\$\$/g,
+    /\\\[[\s\S]*?\\\]/g,
+    /\\\([\s\S]*?\\\)/g,
+    /\\begin\{([^\n{}]+)\}[\s\S]*?\\end\{\1\}/g,
+    /\$[^$\n]+?\$/g,
+  ]
+
+  let protectedText = text
+  for (const pattern of patterns) {
+    protectedText = protectedText.replace(pattern, (match) => {
+      const index = segments.push(match) - 1
+      return `__READ_FROG_LATEX_${index}__`
+    })
+  }
+
+  return { text: protectedText, segments }
+}
+
+function restoreLatex(text: string, segments: string[]): string {
+  if (segments.length === 0) {
+    return text
+  }
+
+  return text.replace(/__READ_FROG_LATEX_(\d+)__/g, (match, index) => {
+    const segment = segments[Number(index)]
+    return segment ?? match
+  })
+}
+
 export async function executeBatchTranslation(
   dataList: TranslateBatchData[],
   promptResolver: PromptResolver,
 ): Promise<string[]> {
   const { langConfig, providerConfig, content } = dataList[0]
-  const texts = dataList.map(d => d.text)
+  const protectedTexts = dataList.map(d => protectLatex(d.text))
 
-  const batchText = texts.join(`\n\n${BATCH_SEPARATOR}\n\n`)
+  const batchText = protectedTexts.map(d => d.text).join(`\n\n${BATCH_SEPARATOR}\n\n`)
   const result = await executeTranslate(batchText, langConfig, providerConfig, promptResolver, { isBatch: true, content })
-  return parseBatchResult(result)
+  const translatedTexts = parseBatchResult(result)
+
+  return protectedTexts.map((item, index) => restoreLatex(translatedTexts[index] ?? "", item.segments))
 }
 
 async function getOrGenerateSummary(
@@ -145,7 +192,9 @@ async function createTranslationQueues(config: TranslationQueueSetupConfig) {
       const { text, langConfig, providerConfig, hash, scheduleAt, content } = data
       const thunk = async () => {
         await putBatchRequestRecord({ originalRequestCount: 1, providerConfig })
-        return executeTranslate(text, langConfig, providerConfig, promptResolver, { content })
+        const protectedText = protectLatex(text)
+        const translated = await executeTranslate(protectedText.text, langConfig, providerConfig, promptResolver, { content })
+        return restoreLatex(translated, protectedText.segments)
       }
       return requestQueue.enqueue(thunk, scheduleAt, hash)
     },


### PR DESCRIPTION
## ✨ Code Quality

### Problem
The bug is in final translation formatting on arXiv HTML pages, which strongly suggests the current translation flow lets the model rewrite math syntax (or surrounding delimiters/line breaks). This file should be updated where webpage translation jobs are built/executed so LaTeX segments are protected before sending text to the LLM and restored after translation. This keeps formulas stable while still translating normal prose.

**Severity**: `high`
**File**: `src/entrypoints/background/translation-queues.ts`

### Solution
Introduce a LaTeX-format branch in the webpage queue flow (domain or content based detection):

### Changes
- `src/entrypoints/background/translation-queues.ts` (modified)

## Type of Changes



- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description



## Related Issue



Closes #1070

## How Has This Been Tested?



- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots



## Checklist



- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information



---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>
