### PR TITLE
fix: normalize pasted URL patterns

### DIFF
--- a/src/entrypoints/options/pages/floating-button/floating-button-disabled-sites.tsx
+++ b/src/entrypoints/options/pages/floating-button/floating-button-disabled-sites.tsx
@@ -1,6 +1,7 @@
 import { i18n } from "#imports"
 import { useAtom } from "jotai"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { normalizeDomainPattern } from "@/utils/url"
 import { ConfigCard } from "../../components/config-card"
 import { PatternsTable } from "../../components/patterns-table"
 
@@ -9,13 +10,13 @@ export function FloatingButtonDisabledSites() {
   const { disabledFloatingButtonPatterns = [] } = floatingButtonConfig
 
   const addPattern = (pattern: string) => {
-    const cleanedPattern = pattern.trim()
-    if (!cleanedPattern || disabledFloatingButtonPatterns.includes(cleanedPattern))
+    const normalizedPattern = normalizeDomainPattern(pattern)
+    if (!normalizedPattern || disabledFloatingButtonPatterns.includes(normalizedPattern))
       return
 
     void setFloatingButtonConfig({
       ...floatingButtonConfig,
-      disabledFloatingButtonPatterns: [...disabledFloatingButtonPatterns, cleanedPattern],
+      disabledFloatingButtonPatterns: [...disabledFloatingButtonPatterns, normalizedPattern],
     })
   }
 

--- a/src/entrypoints/options/pages/general/site-control-mode.tsx
+++ b/src/entrypoints/options/pages/general/site-control-mode.tsx
@@ -3,6 +3,7 @@ import { useAtom } from "jotai"
 import { Label } from "@/components/ui/base-ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/base-ui/radio-group"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { normalizeDomainPattern } from "@/utils/url"
 import { ConfigCard } from "../../components/config-card"
 import { PatternsTable } from "../../components/patterns-table"
 
@@ -15,13 +16,13 @@ export default function SiteControlMode() {
   const patterns = siteControl[patternsKey] ?? []
 
   const addPattern = async (pattern: string) => {
-    const cleanedPattern = pattern.trim()
-    if (!cleanedPattern || patterns.includes(cleanedPattern))
+    const normalizedPattern = normalizeDomainPattern(pattern)
+    if (!normalizedPattern || patterns.includes(normalizedPattern))
       return
 
     await setSiteControl({
       ...siteControl,
-      [patternsKey]: [...patterns, cleanedPattern],
+      [patternsKey]: [...patterns, normalizedPattern],
     })
   }
 

--- a/src/entrypoints/options/pages/selection-toolbar/selection-toolbar-disabled-sites.tsx
+++ b/src/entrypoints/options/pages/selection-toolbar/selection-toolbar-disabled-sites.tsx
@@ -1,6 +1,7 @@
 import { i18n } from "#imports"
 import { useAtom } from "jotai"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { normalizeDomainPattern } from "@/utils/url"
 import { ConfigCard } from "../../components/config-card"
 import { PatternsTable } from "../../components/patterns-table"
 
@@ -9,13 +10,13 @@ export function SelectionToolbarDisabledSites() {
   const { disabledSelectionToolbarPatterns = [] } = selectionToolbarConfig
 
   const addPattern = (pattern: string) => {
-    const cleanedPattern = pattern.trim()
-    if (!cleanedPattern || disabledSelectionToolbarPatterns.includes(cleanedPattern))
+    const normalizedPattern = normalizeDomainPattern(pattern)
+    if (!normalizedPattern || disabledSelectionToolbarPatterns.includes(normalizedPattern))
       return
 
     void setSelectionToolbarConfig({
       ...selectionToolbarConfig,
-      disabledSelectionToolbarPatterns: [...disabledSelectionToolbarPatterns, cleanedPattern],
+      disabledSelectionToolbarPatterns: [...disabledSelectionToolbarPatterns, normalizedPattern],
     })
   }
 

--- a/src/entrypoints/options/pages/translation/auto-translate-website-patterns.tsx
+++ b/src/entrypoints/options/pages/translation/auto-translate-website-patterns.tsx
@@ -1,6 +1,7 @@
 import { i18n } from "#imports"
 import { useAtom } from "jotai"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { normalizeDomainPattern } from "@/utils/url"
 import { ConfigCard } from "../../components/config-card"
 import { PatternsTable } from "../../components/patterns-table"
 
@@ -9,14 +10,14 @@ export function AutoTranslateWebsitePatterns() {
   const { autoTranslatePatterns } = translateConfig.page
 
   const addPattern = (pattern: string) => {
-    const cleanedPattern = pattern.trim()
-    if (!cleanedPattern || autoTranslatePatterns.includes(cleanedPattern))
+    const normalizedPattern = normalizeDomainPattern(pattern)
+    if (!normalizedPattern || autoTranslatePatterns.includes(normalizedPattern))
       return
 
     void setTranslateConfig({
       page: {
         ...translateConfig.page,
-        autoTranslatePatterns: [...autoTranslatePatterns, cleanedPattern],
+        autoTranslatePatterns: [...autoTranslatePatterns, normalizedPattern],
       },
     })
   }

--- a/src/utils/__tests__/url.test.ts
+++ b/src/utils/__tests__/url.test.ts
@@ -1,5 +1,23 @@
 import { describe, expect, it } from "vitest"
-import { matchDomainPattern } from "../url"
+import { matchDomainPattern, normalizeDomainPattern } from "../url"
+
+describe("normalizeDomainPattern", () => {
+  it("extracts the hostname from a full URL", () => {
+    expect(normalizeDomainPattern("https://news.ycombinator.com/")).toBe("news.ycombinator.com")
+  })
+
+  it("extracts the hostname from a bare hostname with a path", () => {
+    expect(normalizeDomainPattern("news.ycombinator.com/item?id=1")).toBe("news.ycombinator.com")
+  })
+
+  it("preserves a plain domain pattern", () => {
+    expect(normalizeDomainPattern("  Example.com  ")).toBe("example.com")
+  })
+
+  it("returns invalid non-url input as a trimmed lowercase pattern", () => {
+    expect(normalizeDomainPattern("  not a valid url pattern  ")).toBe("not a valid url pattern")
+  })
+})
 
 describe("matchDomainPattern", () => {
   describe("exact domain match", () => {
@@ -35,6 +53,11 @@ describe("matchDomainPattern", () => {
 
     it("should handle pattern with extra whitespace", () => {
       const result = matchDomainPattern("https://x.com", "  x.com  ")
+      expect(result).toBe(true)
+    })
+
+    it("should match when the pattern is a full URL", () => {
+      const result = matchDomainPattern("https://news.ycombinator.com/item?id=1", "https://news.ycombinator.com/")
       expect(result).toBe(true)
     })
   })

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,5 +1,26 @@
 import { z } from "zod"
 
+export function normalizeDomainPattern(pattern: string): string {
+  const cleanedPattern = pattern.trim()
+  if (!cleanedPattern) {
+    return ""
+  }
+
+  const candidates = cleanedPattern.includes("://")
+    ? [cleanedPattern]
+    : [cleanedPattern, `https://${cleanedPattern}`]
+
+  for (const candidate of candidates) {
+    if (!z.url().safeParse(candidate).success) {
+      continue
+    }
+
+    return new URL(candidate).hostname.toLowerCase()
+  }
+
+  return cleanedPattern.toLowerCase()
+}
+
 export function matchDomainPattern(url: string, pattern: string): boolean {
   if (!z.url().safeParse(url).success) {
     return false
@@ -7,7 +28,7 @@ export function matchDomainPattern(url: string, pattern: string): boolean {
 
   const urlObj = new URL(url)
   const hostname = urlObj.hostname.toLowerCase()
-  const patternLower = pattern.toLowerCase().trim()
+  const patternLower = normalizeDomainPattern(pattern)
 
   if (hostname === patternLower) {
     return true


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [ ] ✨ New feature (feat)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Normalize pasted URL-like hostname patterns before saving them in the options UI, and also normalize stored patterns when matching.

This fixes the case where users paste `https://news.ycombinator.com/` into a hostname-based pattern list and silently get no match.

## Related Issue

Closes #1250

## How Has This Been Tested?

- [x] Ran `wxt prepare`
- [x] Ran `vitest run src/utils/__tests__/url.test.ts`
- [x] Ran ESLint on the touched files

## Additional Information

The fix covers the site control whitelist/blacklist UI and the other hostname-based pattern tables that use the same matching model, so pasted full URLs now get stored as hostnames instead of failing later at match time.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize pasted URL patterns in the options UI and matching logic so full URLs (e.g. https://news.ycombinator.com/) are stored as hostnames and match as expected. Fixes #1250.

- **Bug Fixes**
  - Added `normalizeDomainPattern` to extract hostnames and lowercase; falls back to trimmed lowercase for non-URLs.
  - Applied normalization when adding patterns in site control lists, floating button/selection toolbar disabled sites, and auto-translate patterns.
  - Updated `matchDomainPattern` to use normalization and added tests for full-URL inputs.

<sup>Written for commit 5850c27c39b39cc12a8889530ced6a8fe107eba0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

