### PR TITLE
fix(extension): preserve shared popup close-state behavior in builds

### DIFF
--- a/.changeset/plain-yaks-warn.md
+++ b/.changeset/plain-yaks-warn.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(extension): preserve shared popup close-state behavior in builds

--- a/src/components/ui/base-ui/__tests__/popup-animation-classes.test.ts
+++ b/src/components/ui/base-ui/__tests__/popup-animation-classes.test.ts
@@ -1,0 +1,31 @@
+import { readFile } from "node:fs/promises"
+import { describe, expect, it } from "vitest"
+import { SHARED_POPUP_CLOSED_STATE_CLASS } from "../popup-animation-classes"
+
+async function readSource(relativePath: string) {
+  return await readFile(new URL(relativePath, import.meta.url), "utf8")
+}
+
+describe("shared popup animation classes", () => {
+  it("exports the shared closed-state contract", () => {
+    expect(SHARED_POPUP_CLOSED_STATE_CLASS).toBe("data-closed:pointer-events-none data-closed:[animation-fill-mode:forwards]")
+  })
+
+  it("is applied to popup-like base-ui primitives", async () => {
+    const files = await Promise.all([
+      readSource("../select.tsx"),
+      readSource("../combobox.tsx"),
+      readSource("../popover.tsx"),
+      readSource("../dropdown-menu.tsx"),
+      readSource("../tooltip.tsx"),
+      readSource("../dialog.tsx"),
+      readSource("../alert-dialog.tsx"),
+      readSource("../hover-card.tsx"),
+      readSource("../sheet.tsx"),
+    ])
+
+    for (const source of files) {
+      expect(source).toContain("SHARED_POPUP_CLOSED_STATE_CLASS")
+    }
+  })
+})

--- a/src/components/ui/base-ui/alert-dialog.tsx
+++ b/src/components/ui/base-ui/alert-dialog.tsx
@@ -4,6 +4,7 @@ import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog
 import * as React from "react"
 
 import { Button } from "@/components/ui/base-ui/button"
+import { SHARED_POPUP_CLOSED_STATE_CLASS } from "@/components/ui/base-ui/popup-animation-classes"
 import { cn } from "@/utils/styles/utils"
 
 function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
@@ -31,6 +32,7 @@ function AlertDialogOverlay({
       data-slot="alert-dialog-overlay"
       className={cn(
         "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50",
+        SHARED_POPUP_CLOSED_STATE_CLASS,
         className,
       )}
       {...props}
@@ -56,6 +58,7 @@ function AlertDialogContent({
         data-size={size}
         className={cn(
           "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 gap-4 rounded-xl p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          SHARED_POPUP_CLOSED_STATE_CLASS,
           className,
         )}
         {...props}

--- a/src/components/ui/base-ui/combobox.tsx
+++ b/src/components/ui/base-ui/combobox.tsx
@@ -9,6 +9,7 @@ import {
   InputGroupButton,
   InputGroupInput,
 } from "@/components/ui/base-ui/input-group"
+import { SHARED_POPUP_CLOSED_STATE_CLASS } from "@/components/ui/base-ui/popup-animation-classes"
 import { cn } from "@/utils/styles/utils"
 
 const Combobox = ComboboxPrimitive.Root
@@ -116,7 +117,7 @@ function ComboboxContent({
         <ComboboxPrimitive.Popup
           data-slot="combobox-content"
           data-chips={!!anchor}
-          className={cn("bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 ring-foreground/10 *:data-[slot=input-group]:bg-input/30 *:data-[slot=input-group]:border-input/30 overflow-hidden rounded-lg shadow-md ring-1 duration-100 *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-8 *:data-[slot=input-group]:shadow-none group/combobox-content relative max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) data-[chips=true]:min-w-(--anchor-width)", className)}
+          className={cn("bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 ring-foreground/10 *:data-[slot=input-group]:bg-input/30 *:data-[slot=input-group]:border-input/30 overflow-hidden rounded-lg shadow-md ring-1 duration-100 *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-8 *:data-[slot=input-group]:shadow-none group/combobox-content relative max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) data-[chips=true]:min-w-(--anchor-width)", SHARED_POPUP_CLOSED_STATE_CLASS, className)}
           {...props}
         />
       </ComboboxPrimitive.Positioner>

--- a/src/components/ui/base-ui/dialog.tsx
+++ b/src/components/ui/base-ui/dialog.tsx
@@ -5,6 +5,7 @@ import { IconX } from "@tabler/icons-react"
 
 import * as React from "react"
 import { Button } from "@/components/ui/base-ui/button"
+import { SHARED_POPUP_CLOSED_STATE_CLASS } from "@/components/ui/base-ui/popup-animation-classes"
 import { cn } from "@/utils/styles/utils"
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
@@ -30,7 +31,7 @@ function DialogOverlay({
   return (
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
-      className={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50", className)}
+      className={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50", SHARED_POPUP_CLOSED_STATE_CLASS, className)}
       {...props}
     />
   )
@@ -54,6 +55,7 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          SHARED_POPUP_CLOSED_STATE_CLASS,
           className,
         )}
         {...props}

--- a/src/components/ui/base-ui/dropdown-menu.tsx
+++ b/src/components/ui/base-ui/dropdown-menu.tsx
@@ -4,6 +4,7 @@ import { Menu as MenuPrimitive } from "@base-ui/react/menu"
 import { IconCheck, IconChevronRight } from "@tabler/icons-react"
 
 import * as React from "react"
+import { SHARED_POPUP_CLOSED_STATE_CLASS } from "@/components/ui/base-ui/popup-animation-classes"
 import { cn } from "@/utils/styles/utils"
 
 function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
@@ -44,7 +45,7 @@ function DropdownMenuContent({
       >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
-          className={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden", className)}
+          className={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden", SHARED_POPUP_CLOSED_STATE_CLASS, className)}
           {...props}
         />
       </MenuPrimitive.Positioner>

--- a/src/components/ui/base-ui/hover-card.tsx
+++ b/src/components/ui/base-ui/hover-card.tsx
@@ -1,5 +1,6 @@
 import { PreviewCard as PreviewCardPrimitive } from "@base-ui/react/preview-card"
 
+import { SHARED_POPUP_CLOSED_STATE_CLASS } from "@/components/ui/base-ui/popup-animation-classes"
 import { cn } from "@/utils/styles/utils"
 
 function HoverCard({ ...props }: PreviewCardPrimitive.Root.Props) {
@@ -39,6 +40,7 @@ function HoverCardContent({
           data-slot="hover-card-content"
           className={cn(
             "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground w-64 rounded-lg p-4 text-sm shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 origin-(--transform-origin) outline-hidden",
+            SHARED_POPUP_CLOSED_STATE_CLASS,
             className,
           )}
           {...props}

--- a/src/components/ui/base-ui/popover.tsx
+++ b/src/components/ui/base-ui/popover.tsx
@@ -3,6 +3,7 @@
 import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
 import * as React from "react"
 
+import { SHARED_POPUP_CLOSED_STATE_CLASS } from "@/components/ui/base-ui/popup-animation-classes"
 import { cn } from "@/utils/styles/utils"
 
 function Popover({ ...props }: PopoverPrimitive.Root.Props) {
@@ -44,6 +45,7 @@ function PopoverContent({
           data-slot="popover-content"
           className={cn(
             "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 flex flex-col gap-2.5 rounded-lg p-2.5 text-sm shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 w-72 origin-(--transform-origin) outline-hidden",
+            SHARED_POPUP_CLOSED_STATE_CLASS,
             className,
           )}
           {...props}

--- a/src/components/ui/base-ui/popup-animation-classes.ts
+++ b/src/components/ui/base-ui/popup-animation-classes.ts
@@ -1,0 +1,1 @@
+export const SHARED_POPUP_CLOSED_STATE_CLASS = "data-closed:pointer-events-none data-closed:[animation-fill-mode:forwards]"

--- a/src/components/ui/base-ui/select.tsx
+++ b/src/components/ui/base-ui/select.tsx
@@ -2,6 +2,7 @@ import { Select as SelectPrimitive } from "@base-ui/react/select"
 import { IconCheck, IconChevronDown, IconChevronUp } from "@tabler/icons-react"
 
 import * as React from "react"
+import { SHARED_POPUP_CLOSED_STATE_CLASS } from "@/components/ui/base-ui/popup-animation-classes"
 import { cn } from "@/utils/styles/utils"
 
 const Select = SelectPrimitive.Root
@@ -87,7 +88,7 @@ function SelectContent({
         <SelectPrimitive.Popup
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
-          className={cn("bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-lg shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto data-[align-trigger=true]:animate-none", className)}
+          className={cn("bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-lg shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto data-[align-trigger=true]:animate-none", SHARED_POPUP_CLOSED_STATE_CLASS, className)}
           {...props}
         >
           <SelectScrollUpButton />

--- a/src/components/ui/base-ui/sheet.tsx
+++ b/src/components/ui/base-ui/sheet.tsx
@@ -5,6 +5,7 @@ import { IconX } from "@tabler/icons-react"
 
 import * as React from "react"
 import { Button } from "@/components/ui/base-ui/button"
+import { SHARED_POPUP_CLOSED_STATE_CLASS } from "@/components/ui/base-ui/popup-animation-classes"
 import { cn } from "@/utils/styles/utils"
 
 function Sheet({ ...props }: SheetPrimitive.Root.Props) {
@@ -27,7 +28,7 @@ function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
   return (
     <SheetPrimitive.Backdrop
       data-slot="sheet-overlay"
-      className={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50", className)}
+      className={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50", SHARED_POPUP_CLOSED_STATE_CLASS, className)}
       {...props}
     />
   )
@@ -52,7 +53,7 @@ function SheetContent({
       <SheetPrimitive.Popup
         data-slot="sheet-content"
         data-side={side}
-        className={cn("bg-background data-open:animate-in data-closed:animate-out data-[side=right]:data-closed:slide-out-to-right-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=top]:data-closed:slide-out-to-top-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:fade-out-0 data-open:fade-in-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=bottom]:data-open:slide-in-from-bottom-10 fixed z-50 flex flex-col gap-4 bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm", className)}
+        className={cn("bg-background data-open:animate-in data-closed:animate-out data-[side=right]:data-closed:slide-out-to-right-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=top]:data-closed:slide-out-to-top-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:fade-out-0 data-open:fade-in-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=bottom]:data-open:slide-in-from-bottom-10 fixed z-50 flex flex-col gap-4 bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm", SHARED_POPUP_CLOSED_STATE_CLASS, className)}
         {...props}
       >
         {children}

--- a/src/components/ui/base-ui/tooltip.tsx
+++ b/src/components/ui/base-ui/tooltip.tsx
@@ -1,5 +1,6 @@
 import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
 
+import { SHARED_POPUP_CLOSED_STATE_CLASS } from "@/components/ui/base-ui/popup-animation-classes"
 import { cn } from "@/utils/styles/utils"
 
 function TooltipProvider({
@@ -55,6 +56,7 @@ function TooltipContent({
           data-slot="tooltip-content"
           className={cn(
             "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 rounded-md px-3 py-1.5 text-xs data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 bg-foreground text-background z-50 w-fit max-w-xs origin-(--transform-origin)",
+            SHARED_POPUP_CLOSED_STATE_CLASS,
             className,
           )}
           {...props}

--- a/src/entrypoints/selection.content/components/selection-toolbar-footer-content.tsx
+++ b/src/entrypoints/selection.content/components/selection-toolbar-footer-content.tsx
@@ -17,7 +17,10 @@ import {
 } from "@/components/ui/base-ui/popover"
 import { SelectionPopover, useSelectionPopoverOverlayProps } from "@/components/ui/selection-popover"
 import { cn } from "@/utils/styles/utils"
-import { SelectionPopoverTooltip, useSelectionTooltipState } from "./selection-tooltip"
+import {
+  SelectionPopoverTooltip,
+  useSelectionTooltipState,
+} from "./selection-tooltip"
 
 function PreviewField({
   field,

--- a/src/entrypoints/selection.content/components/selection-tooltip.tsx
+++ b/src/entrypoints/selection.content/components/selection-tooltip.tsx
@@ -72,15 +72,10 @@ function SelectionTooltip({
         // 2) even after Base UI set the tooltip to the closed state, the node
         //    could remain visually visible until unmount.
         //
-        // The CSS here intentionally addresses both layers:
-        // - `pointer-events-none`: make the tooltip body mouse-transparent so
-        //   it cannot become the hover target after leaving the trigger.
-        // - `data-closed:hidden data-closed:opacity-0`: Base UI guarantees the
-        //   `data-closed` attribute, but not an immediate visual hide. In the
-        //   selection-content shadow DOM we saw `data-closed` nodes remain
-        //   `display:block`/`opacity:1`, so we force the closed state to render
-        //   as invisible before unmount finishes.
-        className={cn("data-closed:hidden data-closed:opacity-0 pointer-events-none whitespace-nowrap", className)}
+        // This path keeps the popup mouse-transparent while open so
+        // hover-leave cannot land on the tooltip itself and contaminate the
+        // hover chain.
+        className={cn("pointer-events-none whitespace-nowrap", className)}
         container={container}
         // The positioner is a separate overlay box around the popup. Making the
         // popup itself transparent is not enough if the pointer can still land


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] 🐛 Bug fix (fix)
- [ ] ✨ New feature (feat)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

This PR moves the popup closed-state contract into a shared Base UI helper so popup primitives preserve the correct closed-state behavior in production builds.

- add a shared closed-state class with `data-closed:pointer-events-none` and `data-closed:[animation-fill-mode:forwards]`
- apply that shared contract across popup-like Base UI primitives, including dialogs, sheets, popovers, tooltips, selects, comboboxes, dropdown menus, hover cards, and alert dialogs
- remove the selection-tooltip-specific forced hide workaround so the selection tooltip relies on the shared popup contract instead of bespoke closed-state classes
- add unit coverage for the shared helper and for the affected selection tooltip interactions

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [x] Added unit tests
- [ ] Verified through manual testing

Commands run:

- `SKIP_FREE_API=true pnpm exec vitest run src/components/ui/base-ui/__tests__/popup-animation-classes.test.ts src/entrypoints/selection.content/components/__tests__/action-tooltips.test.tsx src/entrypoints/selection.content/components/__tests__/selection-toolbar-footer-content.test.tsx`
- `pnpm exec eslint src/components/ui/base-ui/alert-dialog.tsx src/components/ui/base-ui/combobox.tsx src/components/ui/base-ui/dialog.tsx src/components/ui/base-ui/dropdown-menu.tsx src/components/ui/base-ui/hover-card.tsx src/components/ui/base-ui/popover.tsx src/components/ui/base-ui/select.tsx src/components/ui/base-ui/sheet.tsx src/components/ui/base-ui/tooltip.tsx src/components/ui/base-ui/popup-animation-classes.ts src/components/ui/base-ui/__tests__/popup-animation-classes.test.ts src/entrypoints/selection.content/components/selection-toolbar-footer-content.tsx src/entrypoints/selection.content/components/selection-tooltip.tsx`
- `pnpm type-check`
- `pnpm build`

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

Not applicable.

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

`tmp/selection-repro.html` was kept local and is not part of the PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes popup close-state regressions in production builds by centralizing the closed-state styles and applying them to all Base UI popups. Closed popups are now non-interactive and their exit animations complete reliably.

- **Bug Fixes**
  - Introduced a shared closed-state class with pointer-events disabled and animation fill preserved.
  - Applied across Dialog, Sheet, Popover, Tooltip, Select, Combobox, Dropdown Menu, Hover Card, and Alert Dialog.
  - Removed the selection tooltip’s bespoke forced-hide CSS; it now relies on the shared contract.
  - Added unit tests for the shared helper and key selection tooltip interactions.

<sup>Written for commit 22a7f31338e0e0691bd484302667ee048c7ed329. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

