### PR TITLE
fix(providers): set domestic base URLs for minimax and alibaba

### DIFF
--- a/.changeset/friendly-cougars-argue.md
+++ b/.changeset/friendly-cougars-argue.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(providers): set domestic base URLs for minimax and alibaba

--- a/src/utils/constants/providers.ts
+++ b/src/utils/constants/providers.ts
@@ -532,6 +532,7 @@ export const DEFAULT_PROVIDER_CONFIG = {
     description: i18n.t("options.apiProviders.providers.description.minimax"),
     enabled: true,
     provider: "minimax",
+    baseURL: "https://api.minimaxi.com/anthropic/v1",
     model: DEFAULT_LLM_PROVIDER_MODELS.minimax,
   },
   "alibaba": {
@@ -540,6 +541,7 @@ export const DEFAULT_PROVIDER_CONFIG = {
     description: i18n.t("options.apiProviders.providers.description.alibaba"),
     enabled: true,
     provider: "alibaba",
+    baseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1",
     model: DEFAULT_LLM_PROVIDER_MODELS.alibaba,
   },
   "moonshotai": {


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [ ] ✨ New feature (feat)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Set provider template `baseURL` defaults for MiniMax and Alibaba so newly added providers use the domestic-compatible endpoints required by current vendor docs.

- MiniMax now defaults to `https://api.minimaxi.com/anthropic/v1`
- Alibaba now defaults to `https://dashscope.aliyuncs.com/compatible-mode/v1`
- Existing saved provider configs are unchanged because this PR only updates defaults

## Related Issue

Closes #1252, Closes #1192, Closes #1227

## How Has This Been Tested?

- [ ] Added unit tests
- [ ] Verified through manual testing
- [x] Verified through local type checking (`pnpm type-check`)

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set default base URLs for `minimax` and `alibaba` providers to domestic-compatible endpoints so new setups work out of the box. Existing saved provider configs are unchanged.

- **Bug Fixes**
  - `minimax` default baseURL: https://api.minimaxi.com/anthropic/v1
  - `alibaba` default baseURL: https://dashscope.aliyuncs.com/compatible-mode/v1

<sup>Written for commit 129462c14bc627aef54fa4823af8b9696ee6f1a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

