### PR TITLE
fix(models): broaden Qwen and Kimi model matching

### DIFF
--- a/.changeset/cuddly-falcons-battle.md
+++ b/.changeset/cuddly-falcons-battle.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(models): broaden Qwen and Kimi model matching

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx
@@ -145,6 +145,27 @@ describe("providerOptionsField", () => {
     )
   })
 
+  it("matches recommendations by model name even when the provider differs", () => {
+    render(
+      <ProviderOptionsFieldHarness
+        initialConfig={{
+          ...baseProviderConfig,
+          provider: "groq",
+          model: {
+            model: "qwen/qwen3-32b",
+            isCustomModel: false,
+            customModel: null,
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByLabelText("provider-options-editor")).toHaveAttribute(
+      "placeholder",
+      JSON.stringify({ enableThinking: false }, null, 2),
+    )
+  })
+
   it("syncs the editor when an external update arrives, even if the saved value is unchanged", async () => {
     const externalProviderOptions = { enableThinking: false }
 

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx
@@ -116,4 +116,18 @@ describe("providerOptionsRecommendationTrigger", () => {
 
     expect(onApply).toHaveBeenCalledWith({ reasoningEffort: "none" })
   })
+
+  it("renders Kimi recommendations based on model name alone", () => {
+    render(
+      <ProviderOptionsRecommendationTrigger
+        providerId="provider-1"
+        modelId="moonshotai/Kimi-K2-Instruct"
+        onApply={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole("button", {
+      name: "options.apiProviders.form.providerOptionsRecommendationTrigger",
+    })).toBeInTheDocument()
+  })
 })

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -133,18 +133,44 @@ describe("getProviderOptions", () => {
       expect(alibabaOptions.alibaba?.enableThinking).toBe(false)
     })
 
-    it("should apply Moonshot defaults to kimi-k2-turbo", () => {
-      const options = getProviderOptions("kimi-k2-turbo", "moonshotai")
-      expect(options.moonshotai?.thinking).toEqual({ type: "disabled" })
-      expect(options.moonshotai?.reasoningHistory).toBe("disabled")
+    it("should apply broader Kimi defaults for Moonshot and Fireworks variants", () => {
+      const moonshotTurboOptions = getProviderOptions("kimi-k2-turbo", "moonshotai")
+      expect(moonshotTurboOptions.moonshotai?.thinking).toEqual({ type: "disabled" })
+      expect(moonshotTurboOptions.moonshotai?.reasoningHistory).toBe("disabled")
+
+      const moonshotInstructOptions = getProviderOptions("kimi-k2-instruct-0905", "moonshotai")
+      expect(moonshotInstructOptions.moonshotai?.thinking).toEqual({ type: "disabled" })
+      expect(moonshotInstructOptions.moonshotai?.reasoningHistory).toBe("disabled")
+
+      const fireworksThinkingOptions = getProviderOptions("accounts/fireworks/models/kimi-k2-thinking", "fireworks")
+      expect(fireworksThinkingOptions.fireworks?.thinking).toEqual({ type: "disabled" })
+      expect(fireworksThinkingOptions.fireworks?.reasoningHistory).toBe("disabled")
+
+      const fireworksInstructOptions = getProviderOptions("accounts/fireworks/models/kimi-k2-instruct", "fireworks")
+      expect(fireworksInstructOptions.fireworks?.thinking).toEqual({ type: "disabled" })
+      expect(fireworksInstructOptions.fireworks?.reasoningHistory).toBe("disabled")
     })
 
-    it("should apply Alibaba defaults to qwen3.5 flash and plus models", () => {
+    it("should apply broader Alibaba defaults to Qwen variants", () => {
       const flashOptions = getProviderOptions("qwen3.5-flash", "alibaba")
       expect(flashOptions.alibaba?.enableThinking).toBe(false)
 
       const plusOptions = getProviderOptions("qwen3.5-plus", "alibaba")
       expect(plusOptions.alibaba?.enableThinking).toBe(false)
+
+      const maxOptions = getProviderOptions("qwen-max-latest", "alibaba")
+      expect(maxOptions.alibaba?.enableThinking).toBe(false)
+
+      const vlOptions = getProviderOptions("qwen2.5-vl-72b-instruct", "alibaba")
+      expect(vlOptions.alibaba?.enableThinking).toBe(false)
+
+      const nextOptions = getProviderOptions("Qwen/Qwen3-Next-80B-A3B-Instruct", "alibaba")
+      expect(nextOptions.alibaba?.enableThinking).toBe(false)
+    })
+
+    it("should keep explicit Alibaba thinking-only Qwen variants untouched", () => {
+      const options = getProviderOptions("qwen3-thinking-2507", "alibaba")
+      expect(options).toEqual({})
     })
 
     it("should return low/default-compatible reasoning settings for gpt-oss models", () => {
@@ -155,12 +181,18 @@ describe("getProviderOptions", () => {
       expect(cerebrasOptions.cerebras?.reasoningEffort).toBe("none")
     })
 
-    it("should not apply Alibaba-only enableThinking defaults to non-Alibaba Qwen model names", () => {
+    it("should apply broadened Qwen defaults to provider-prefixed model ids", () => {
       const groqOptions = getProviderOptions("qwen/qwen3-32b", "groq")
-      expect(groqOptions).toEqual({})
+      expect(groqOptions.groq?.enableThinking).toBe(false)
 
       const deepinfraOptions = getProviderOptions("Qwen/Qwen2.5-72B-Instruct", "deepinfra")
-      expect(deepinfraOptions).toEqual({})
+      expect(deepinfraOptions.deepinfra?.enableThinking).toBe(false)
+    })
+
+    it("should apply broadened Kimi defaults to provider-prefixed model ids", () => {
+      const huggingfaceOptions = getProviderOptions("moonshotai/Kimi-K2-Instruct", "huggingface")
+      expect(huggingfaceOptions.huggingface?.thinking).toEqual({ type: "disabled" })
+      expect(huggingfaceOptions.huggingface?.reasoningHistory).toBe("disabled")
     })
 
     it("should return empty object for non-matching models", () => {

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -182,20 +182,22 @@ export const LLM_MODEL_OPTIONS: Array<{
 
   // Fireworks reasoning-focused models - disable thinking/history by default
   {
-    pattern: /^accounts\/fireworks\/models\/(?:kimi-k2p5|minimax-m2)$/,
+    pattern: /^accounts\/fireworks\/models\/(?:kimi-k2(?:[a-z0-9.-].*)?|minimax-m2(?:[.-].*)?)$/i,
     options: { thinking: { type: "disabled" }, reasoningHistory: "disabled" } satisfies FireworksProviderOptions as Record<string, JSONValue>,
   },
 
-  // MoonshotAI Kimi K2 models - disable thinking/history by default
+  // Kimi K2 models - disable thinking/history by default.
+  // Keep this broad because recommendation matching is model-name based rather than provider-scoped.
   {
-    pattern: /^kimi-k2(?:\.5|-0905|-turbo|-thinking(?:-turbo)?)?$/,
+    pattern: /(?:^|\/)kimi-k2(?:[a-z0-9.-].*)?$/i,
     options: { thinking: { type: "disabled" }, reasoningHistory: "disabled" } satisfies MoonshotAIProviderOptions as Record<string, JSONValue>,
   },
 
-  // Alibaba hybrid-thinking Qwen models - disable thinking by default.
-  // Keep explicit thinking-only models (for example `qwq-*` and `*-thinking`) untouched.
+  // Qwen models - disable thinking by default.
+  // Keep this broad because recommendation matching is model-name based rather than provider-scoped.
+  // Keep explicit thinking-only variants (for example `qwq-*` and `*-thinking`) untouched.
   {
-    pattern: /^(?:qwen3(?:\.5-(?:plus|flash)|-(?:max(?:-preview)?|235b-a22b|32b|30b-a3b|14b|coder-plus|coder-flash))|qwen-(?:plus(?:-latest)?|flash|turbo(?:-latest)?|coder))$/,
+    pattern: /(?:^|\/)qwen(?!.*[/.-](?:thinking|qwq)(?:[/.-]|$)).*$/i,
     options: { enableThinking: false } satisfies AlibabaProviderOptions as Record<string, JSONValue>,
   },
 


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [x] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Broaden model-name matching for Qwen and Kimi recommendation defaults so provider-prefixed and case-variant model ids are recognized.

- Expand the Kimi pattern to match broader `kimi-k2*` variants, including provider-prefixed ids
- Expand the Qwen pattern to match broader `qwen*` variants, including `Qwen/...` ids
- Keep explicit thinking-oriented Qwen variants such as `*-thinking` and `qwq` excluded
- Add regression tests for the broader matching behavior in recommendation and provider option flows

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

`pnpm exec vitest run src/utils/constants/__tests__/model.test.ts src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx`

`pnpm exec tsc --noEmit --pretty false`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Recommendation matching remains model-name based rather than provider-scoped so shared upstream model ids continue to receive the same default options.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Broadened Qwen and Kimi model-name matching so provider-prefixed and case-insensitive IDs get the correct default options and recommendations. Fixes missed matches across Moonshot, Fireworks, and third‑party providers while keeping explicit thinking-only Qwen variants excluded.

- **Bug Fixes**
  - Qwen: broadened, case-insensitive pattern that excludes `*-thinking` and `qwq` variants; applies `enableThinking: false` to IDs like `qwen/qwen3-32b` and `Qwen/Qwen2.5-72B-Instruct`.
  - Kimi: expanded K2 matching across Moonshot and Fireworks, including provider-prefixed IDs (e.g., `moonshotai/Kimi-K2-Instruct`, `accounts/fireworks/models/kimi-k2-*`); disables thinking and reasoning history by default.
  - Matching remains model-name based (not provider-scoped). Added unit/UI tests to cover provider-prefixed IDs and ensure recommendations appear as expected.

<sup>Written for commit 658f4a6cab6800bb0002ac11a94033c71999a35e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

