### PR TITLE
fix(selection-toolbar): avoid hidden focused trigger warnings

### DIFF
--- a/.changeset/lovely-hounds-relax.md
+++ b/.changeset/lovely-hounds-relax.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection-toolbar): avoid hiding focused triggers behind overlays

--- a/src/components/ui/selection-popover/__tests__/selection-popover.test.tsx
+++ b/src/components/ui/selection-popover/__tests__/selection-popover.test.tsx
@@ -201,6 +201,14 @@ function renderPopover({
   title = "Test Popover",
   onOpenChange = onOpenChangeSpy,
   triggerRect = buildTriggerRect(),
+  contentProps,
+}: {
+  customTrigger?: boolean
+  triggerLabel?: string
+  title?: string
+  onOpenChange?: typeof onOpenChangeSpy
+  triggerRect?: DOMRect
+  contentProps?: Partial<React.ComponentProps<typeof SelectionPopover.Content>>
 } = {}) {
   render(
     <SelectionPopover.Root onOpenChange={onOpenChange}>
@@ -209,7 +217,7 @@ function renderPopover({
       >
         {triggerLabel}
       </SelectionPopover.Trigger>
-      <SelectionPopover.Content>
+      <SelectionPopover.Content {...contentProps}>
         <SelectionPopover.Header className="border-b">
           <SelectionPopover.Title>{title}</SelectionPopover.Title>
           <div className="flex items-center gap-1">
@@ -553,6 +561,42 @@ describe("selectionPopover", () => {
     flushRaf()
 
     expect(screen.getByRole("button", { name: "Pin popover" })).toHaveAttribute("aria-pressed", "false")
+  })
+
+  it("restores focus to the trigger by default when closing", async () => {
+    const { trigger } = renderPopover()
+    const closeButton = screen.getByRole("button", { name: "Close" })
+
+    closeButton.focus()
+    expect(closeButton).toHaveFocus()
+
+    fireEvent.click(closeButton)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(trigger).toHaveFocus()
+  })
+
+  it("supports opting out of trigger focus restoration on close", async () => {
+    const { trigger } = renderPopover({
+      contentProps: {
+        finalFocus: false,
+      },
+    })
+    const closeButton = screen.getByRole("button", { name: "Close" })
+
+    closeButton.focus()
+    expect(closeButton).toHaveFocus()
+
+    fireEvent.click(closeButton)
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(document.activeElement).not.toBe(trigger)
   })
 
   it("closes a pinned popover when another popover opens", () => {

--- a/src/components/ui/selection-popover/index.tsx
+++ b/src/components/ui/selection-popover/index.tsx
@@ -316,10 +316,12 @@ function SelectionPopoverContent({
   className,
   children,
   container,
+  finalFocus,
   render,
   ...props
 }: useRender.ComponentProps<"div"> & React.ComponentProps<"div"> & {
   container?: SelectionPopoverPortalContainer
+  finalFocus?: DialogPrimitive.Popup.Props["finalFocus"]
 }) {
   const { open, setOpen, anchor, triggerElement } = useSelectionPopoverRootContext()
   const bodyElementRef = React.useRef<HTMLDivElement | null>(null)
@@ -388,6 +390,8 @@ function SelectionPopoverContent({
     return null
   }
 
+  const resolvedFinalFocus = finalFocus ?? (triggerElement ? { current: triggerElement } : false)
+
   return (
     <DialogPrimitive.Portal container={container}>
       <DialogPrimitive.Popup
@@ -395,7 +399,7 @@ function SelectionPopoverContent({
           "fixed inset-0 pointer-events-none focus:outline-none",
           SELECTION_CONTENT_OVERLAY_LAYERS.popover,
         )}
-        finalFocus={triggerElement ? { current: triggerElement } : false}
+        finalFocus={resolvedFinalFocus}
       >
         <SelectionPopoverShell
           rndRef={rndRef}

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
@@ -89,11 +89,21 @@ vi.mock("@/components/ui/selection-popover", async () => {
     )
   }
 
-  function Content({ children }: { children: React.ReactNode }) {
+  function Content({
+    children,
+    finalFocus,
+  }: {
+    children: React.ReactNode
+    finalFocus?: boolean
+  }) {
     const { open } = usePopoverContext()
     return open
       ? (
-          <div data-testid="selection-popover-content" data-rf-selection-overlay-root="">
+          <div
+            data-testid="selection-popover-content"
+            data-final-focus={finalFocus === false ? "false" : undefined}
+            data-rf-selection-overlay-root=""
+          >
             {children}
           </div>
         )
@@ -502,6 +512,22 @@ describe("selection toolbar requests", () => {
     fireEvent.blur(trigger)
     await waitFor(() => {
       expect(document.querySelector("[data-slot='tooltip-content']")).toBeNull()
+    })
+  })
+
+  it("opts out of focus restoration when closing the translation popover", async () => {
+    translateTextCoreMock.mockResolvedValue("translated once")
+    getOrFetchArticleDataMock.mockResolvedValue(null)
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    setSelectionState(store, { text: "Selected text" })
+    renderWithProviders(<TranslateButton />, store)
+
+    fireEvent.click(screen.getByRole("button", { name: "action.translation" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selection-popover-content")).toHaveAttribute("data-final-focus", "false")
     })
   })
 

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
@@ -514,6 +514,27 @@ describe("selectionToolbar - isInputOrTextarea logic", () => {
 
     spy.mockRestore()
   })
+
+  it("keeps aria-hidden off the toolbar in both hidden and visible states", async () => {
+    render(
+      <div>
+        <SelectionToolbar />
+        <div data-testid="test-element">{MOCK_SELECTED_TEXT}</div>
+      </div>,
+    )
+
+    const toolbar = document.querySelector(".absolute.z-2147483647") as HTMLElement | null
+    if (!toolbar) {
+      throw new Error("Selection toolbar is missing")
+    }
+
+    expect(toolbar).not.toHaveAttribute("aria-hidden")
+
+    await triggerMouseUpWithSelection(screen.getByTestId("test-element"))
+    await waitFor(expectToolbarVisible)
+
+    expect(toolbar).not.toHaveAttribute("aria-hidden")
+  })
 })
 
 describe("selectionToolbar - positioning logic", () => {

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/custom-action-trigger.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/custom-action-trigger.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { SelectionToolbarCustomActionTrigger } from "../custom-action-trigger"
+
+const openToolbarCustomActionMock = vi.fn()
+
+vi.mock("../../../components/selection-tooltip", () => ({
+  SelectionToolbarTooltip: ({ render }: { render: ReactElement }) => render,
+}))
+
+vi.mock("../provider", () => ({
+  useSelectionCustomActionPopover: () => ({
+    openToolbarCustomAction: openToolbarCustomActionMock,
+  }),
+}))
+
+describe("selectionToolbarCustomActionTrigger", () => {
+  beforeEach(() => {
+    openToolbarCustomActionMock.mockReset()
+  })
+
+  it("blurs the toolbar trigger before opening the custom action popover", () => {
+    render(
+      <SelectionToolbarCustomActionTrigger
+        action={{
+          id: "summarize",
+          name: "Summarize",
+          icon: "tabler:sparkles",
+          providerId: "openai-default",
+          systemPrompt: "system",
+          prompt: "prompt",
+          outputSchema: [
+            {
+              id: "summary",
+              name: "Summary",
+              type: "string",
+              description: "",
+              speaking: false,
+            },
+          ],
+        }}
+      />,
+    )
+
+    const trigger = screen.getByRole("button", { name: "Summarize" })
+    const blurSpy = vi.spyOn(trigger, "blur")
+
+    trigger.focus()
+    expect(trigger).toHaveFocus()
+
+    fireEvent.click(trigger)
+
+    expect(blurSpy).toHaveBeenCalledOnce()
+    expect(openToolbarCustomActionMock).toHaveBeenCalledOnce()
+    expect(openToolbarCustomActionMock).toHaveBeenCalledWith("summarize", trigger)
+    expect(blurSpy.mock.invocationCallOrder[0]).toBeLessThan(openToolbarCustomActionMock.mock.invocationCallOrder[0]!)
+    expect(document.activeElement).not.toBe(trigger)
+  })
+})

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/custom-action-trigger.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/custom-action-trigger.tsx
@@ -9,6 +9,7 @@ export function SelectionToolbarCustomActionTrigger({ action }: { action: Select
   const { openToolbarCustomAction } = useSelectionCustomActionPopover()
 
   const handleClick = useCallback((event: MouseEvent<HTMLButtonElement>) => {
+    event.currentTarget.blur()
     openToolbarCustomAction(action.id, event.currentTarget)
   }, [action.id, openToolbarCustomAction])
 

--- a/src/entrypoints/selection.content/selection-toolbar/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/index.tsx
@@ -442,7 +442,7 @@ export function SelectionToolbar() {
       {selectionToolbar.enabled && !isSiteDisabled && hasAnyEnabledFeature && (
         <div
           ref={tooltipRef}
-          aria-hidden={!isSelectionToolbarVisible}
+          inert={!isSelectionToolbarVisible}
           className={cn(
             `group absolute ${SELECTION_CONTENT_OVERLAY_LAYERS.selectionOverlay} bg-popover rounded-sm shadow-floating border border-border/50 overflow-visible flex items-center transition-opacity`,
             isSelectionToolbarVisible ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0",

--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/__tests__/index.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/__tests__/index.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import type { ComponentProps, ReactElement } from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { TranslateButton } from ".."
+
+const prepareToolbarOpenMock = vi.fn()
+
+vi.mock("#imports", () => ({
+  i18n: {
+    t: (key: string) => key,
+  },
+}))
+
+vi.mock("@/components/ui/selection-popover", () => ({
+  SelectionPopover: {
+    Trigger: ({ children, ...props }: ComponentProps<"button">) => (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    ),
+  },
+}))
+
+vi.mock("../../../components/selection-tooltip", () => ({
+  SelectionToolbarTooltip: ({ render }: { render: ReactElement }) => render,
+}))
+
+vi.mock("../provider", () => ({
+  useSelectionTranslationPopover: () => ({
+    prepareToolbarOpen: prepareToolbarOpenMock,
+  }),
+}))
+
+describe("translateButton", () => {
+  beforeEach(() => {
+    prepareToolbarOpenMock.mockReset()
+  })
+
+  it("blurs the toolbar trigger before opening the translation popover", () => {
+    render(<TranslateButton />)
+
+    const trigger = screen.getByRole("button", { name: "action.translation" })
+    const blurSpy = vi.spyOn(trigger, "blur")
+
+    trigger.focus()
+    expect(trigger).toHaveFocus()
+
+    fireEvent.click(trigger)
+
+    expect(blurSpy).toHaveBeenCalledOnce()
+    expect(prepareToolbarOpenMock).toHaveBeenCalledOnce()
+    expect(blurSpy.mock.invocationCallOrder[0]).toBeLessThan(prepareToolbarOpenMock.mock.invocationCallOrder[0]!)
+    expect(document.activeElement).not.toBe(trigger)
+  })
+})

--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/index.tsx
@@ -11,7 +11,15 @@ export function TranslateButton() {
   return (
     <SelectionToolbarTooltip
       content={triggerLabel}
-      render={<SelectionPopover.Trigger aria-label={triggerLabel} onClick={prepareToolbarOpen} />}
+      render={(
+        <SelectionPopover.Trigger
+          aria-label={triggerLabel}
+          onClick={(event) => {
+            event.currentTarget.blur()
+            prepareToolbarOpen()
+          }}
+        />
+      )}
     >
       <RiTranslate className="size-4.5" />
     </SelectionToolbarTooltip>

--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx
@@ -462,7 +462,11 @@ export function SelectionTranslationProvider({
         onAnchorChange={setAnchor}
       >
         {children}
-        <SelectionPopover.Content key={popoverSessionKey} container={shadowWrapper ?? document.body}>
+        <SelectionPopover.Content
+          key={popoverSessionKey}
+          container={shadowWrapper ?? document.body}
+          finalFocus={false}
+        >
           <SelectionPopover.Header className="border-b">
             <SelectionToolbarTitleContent
               title="Translation"


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Prevent the selection toolbar from leaving focused triggers inside hidden overlay UI when opening and closing toolbar-launched popovers.

- replace the hidden toolbar's `aria-hidden` state with `inert` so the hidden toolbar is no longer exposed as a focused-but-hidden subtree
- blur selection toolbar triggers before opening translation and custom-action popovers so focus leaves the toolbar before it is hidden
- add an explicit `finalFocus` override to the shared selection popover wrapper and disable trigger focus restoration for the translation popover
- add regression coverage for trigger blur behavior, toolbar accessibility state, and popover focus restoration defaults

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

- `SKIP_FREE_API=true pnpm vitest run src/components/ui/selection-popover/__tests__/selection-popover.test.tsx src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx src/entrypoints/selection.content/selection-toolbar/translate-button/__tests__/index.test.tsx src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/custom-action-trigger.test.tsx`
- `pnpm type-check`
- `git push origin fix/selection-toolbar-focus-handoff -u` (remote hook ran `lint`, `type-check`, and full `vitest run`)

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This keeps the fix scoped to the selection-toolbar overlay path instead of changing shared Base UI dialog focus behavior globally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes focus handoff in the selection toolbar to avoid keeping a focused trigger inside a hidden overlay. This removes console warnings and prevents focus jumps when opening or closing toolbar popovers.

- **Bug Fixes**
  - Use `inert` instead of `aria-hidden` on the hidden toolbar so it isn’t exposed as a focused subtree.
  - Blur toolbar triggers before opening translation and custom-action popovers to move focus out before hiding the toolbar.
  - Add `finalFocus` to `SelectionPopover.Content`; default restores focus to the trigger on close. Translation popover opts out (`finalFocus={false}`) to avoid re-focusing the hidden trigger.
  - Add tests for trigger blurring, toolbar accessibility state, and focus restoration behavior.

<sup>Written for commit 97212ff89920c11abdc9b4741f38746c94a52135. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

