### PR TITLE
ci(github): add contributor trust workflow

### DIFF
--- a/.github/scripts/contributor-trust/comment-template.js
+++ b/.github/scripts/contributor-trust/comment-template.js
@@ -1,0 +1,87 @@
+import { createHash } from "node:crypto"
+
+import { BUCKET_TITLES, COMMENT_MARKER_HTML, FINGERPRINT_MARKER_PREFIX, POLICY } from "./config.js"
+
+function formatMonths(createdAt) {
+  if (!createdAt)
+    return "unknown"
+
+  const timestamp = new Date(createdAt).getTime()
+  if (Number.isNaN(timestamp))
+    return "unknown"
+
+  const months = Math.max(0, Math.floor((Date.now() - timestamp) / 2.628e9))
+  return `${months} month${months === 1 ? "" : "s"}`
+}
+
+function formatList(values) {
+  if (values.length === 0)
+    return "none"
+  return values.join(", ")
+}
+
+function buildContent({ owner, repo, pullRequest, author, metrics, score, plan }) {
+  const bucketTitle = BUCKET_TITLES[score.bucket]
+  const topRepoStars = metrics.topRepoStars.map(stars => String(stars))
+  const topRepoStarsMax = metrics.topRepoStars.length > 0 ? Math.max(...metrics.topRepoStars) : 0
+  const topRepoStarsTotal = metrics.topRepoStars.reduce((sum, stars) => sum + stars, 0)
+  const trustLabel = plan.targetTrustLabel ?? "none"
+  const reviewStatus = plan.needsMaintainerReview ? "required" : "not required"
+
+  const intro = score.exemptReason === "maintainer"
+    ? "This author has repository write access or higher, so the maintainer exemption applies in trust policy v1."
+    : `This score estimates contributor familiarity with \`${owner}/${repo}\` using public GitHub signals. It is advisory only and does not block merges automatically.`
+
+  return [
+    "## Contributor trust score",
+    "",
+    `**${score.total}/100** — ${bucketTitle}`,
+    "",
+    intro,
+    "",
+    "**Outcome**",
+    `- PR: #${pullRequest.number} — ${pullRequest.title}`,
+    `- Author: @${author.login}`,
+    `- Trust label: \`${trustLabel}\``,
+    `- Maintainer review: ${reviewStatus}`,
+    `- Override label: add \`${POLICY.overrideLabel}\` to stop future trust automation updates`,
+    "",
+    "**Score breakdown**",
+    "",
+    "| Dimension | Score | Signals |",
+    "| --- | ---: | --- |",
+    `| Repo familiarity | ${score.repoFamiliarity}/35 | merged PRs, resolved PR history, reviews |`,
+    `| Community standing | ${score.communityStanding}/25 | account age, followers |`,
+    `| OSS influence | ${score.ossInfluence}/20 | stars on top repositories |`,
+    `| PR track record | ${score.prTrackRecord}/20 | merge rate across resolved PRs in this repo |`,
+    "",
+    "**Signals used**",
+    `- Repo PR history: merged ${metrics.mergedPrs}, open ${metrics.openPrs}, closed-unmerged ${metrics.closedPrs}`,
+    `- Repo reviews: ${metrics.reviews}`,
+    `- Followers: ${metrics.followers}`,
+    `- Public repos: ${metrics.publicRepos}`,
+    `- Account age: ${formatMonths(metrics.accountCreated)}`,
+    `- Top repo stars: max ${topRepoStarsMax}, total ${topRepoStarsTotal} (${formatList(topRepoStars)})`,
+    "",
+    "**Policy**",
+    `- Low-score review threshold: < ${POLICY.lowScoreThreshold}`,
+    `- Auto-close: disabled in v1`,
+    `- Policy version: \`${POLICY.version}\``,
+    "",
+    `_${pullRequest.state === "closed" ? "Manually re-evaluated on a closed PR." : "Updated automatically when the PR changes or when a maintainer reruns the workflow."}_`,
+  ].join("\n")
+}
+
+export function buildTrustComment({ owner, repo, pullRequest, author, metrics, score, plan }) {
+  const content = buildContent({ owner, repo, pullRequest, author, metrics, score, plan })
+  const fingerprint = createHash("sha256").update(content).digest("hex").slice(0, 12)
+
+  return {
+    fingerprint,
+    body: [
+      COMMENT_MARKER_HTML,
+      `<!-- ${FINGERPRINT_MARKER_PREFIX}${fingerprint} -->`,
+      content,
+    ].join("\n"),
+  }
+}

--- a/.github/scripts/contributor-trust/config.js
+++ b/.github/scripts/contributor-trust/config.js
@@ -1,0 +1,79 @@
+export const COMMENT_MARKER = "contributor-trust-score:v1"
+export const COMMENT_MARKER_HTML = `<!-- ${COMMENT_MARKER} -->`
+export const FINGERPRINT_MARKER_PREFIX = "contributor-trust-fingerprint:"
+export const TRUST_LABEL_PREFIX = "contrib-trust:"
+
+export const POLICY = Object.freeze({
+  version: "v1",
+  lowScoreThreshold: 30,
+  autoCloseBelowScore: null,
+  overrideLabel: "trust-check:skip",
+  needsMaintainerReviewLabel: "needs-maintainer-review",
+  maintainerLabel: `${TRUST_LABEL_PREFIX}maintainer`,
+  maintainerPermissions: ["write", "maintain", "admin"],
+})
+
+export const TRUST_BUCKETS = Object.freeze({
+  HIGHLY_TRUSTED: "highly-trusted",
+  TRUSTED: "trusted",
+  MODERATE: "moderate",
+  NEW: "new",
+})
+
+export const BUCKET_LABELS = Object.freeze({
+  [TRUST_BUCKETS.HIGHLY_TRUSTED]: `${TRUST_LABEL_PREFIX}highly-trusted`,
+  [TRUST_BUCKETS.TRUSTED]: `${TRUST_LABEL_PREFIX}trusted`,
+  [TRUST_BUCKETS.MODERATE]: `${TRUST_LABEL_PREFIX}moderate`,
+  [TRUST_BUCKETS.NEW]: `${TRUST_LABEL_PREFIX}new`,
+})
+
+export const BUCKET_TITLES = Object.freeze({
+  [TRUST_BUCKETS.HIGHLY_TRUSTED]: "Highly trusted",
+  [TRUST_BUCKETS.TRUSTED]: "Trusted",
+  [TRUST_BUCKETS.MODERATE]: "Moderate",
+  [TRUST_BUCKETS.NEW]: "New contributor",
+})
+
+export const LABEL_DEFINITIONS = Object.freeze({
+  [BUCKET_LABELS[TRUST_BUCKETS.HIGHLY_TRUSTED]]: {
+    color: "0e8a16",
+    description: "PR author trust score is 80-100.",
+  },
+  [BUCKET_LABELS[TRUST_BUCKETS.TRUSTED]]: {
+    color: "1d76db",
+    description: "PR author trust score is 60-79.",
+  },
+  [BUCKET_LABELS[TRUST_BUCKETS.MODERATE]]: {
+    color: "fbca04",
+    description: "PR author trust score is 30-59.",
+  },
+  [BUCKET_LABELS[TRUST_BUCKETS.NEW]]: {
+    color: "d4c5f9",
+    description: "PR author trust score is 0-29.",
+  },
+  [POLICY.maintainerLabel]: {
+    color: "5319e7",
+    description: "PR author has repository write access or higher.",
+  },
+  [POLICY.needsMaintainerReviewLabel]: {
+    color: "b60205",
+    description: "Contributor trust automation recommends maintainer review.",
+  },
+  [POLICY.overrideLabel]: {
+    color: "bfd4f2",
+    description: "Skip contributor trust automation on this PR.",
+  },
+})
+
+export const MANAGED_TRUST_LABELS = Object.freeze([
+  ...Object.values(BUCKET_LABELS),
+  POLICY.maintainerLabel,
+])
+
+export function bucketToLabel(bucket) {
+  return BUCKET_LABELS[bucket]
+}
+
+export function bucketToTitle(bucket) {
+  return BUCKET_TITLES[bucket]
+}

--- a/.github/scripts/contributor-trust/github-api.js
+++ b/.github/scripts/contributor-trust/github-api.js
@@ -1,0 +1,296 @@
+const API_BASE_URL = "https://api.github.com"
+
+class GitHubApiError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = "GitHubApiError"
+    this.details = details
+  }
+}
+
+function buildHeaders(token, extraHeaders = {}) {
+  return {
+    "Accept": "application/vnd.github+json",
+    "Authorization": `Bearer ${token}`,
+    "Content-Type": "application/json",
+    "User-Agent": "read-frog-contributor-trust",
+    ...extraHeaders,
+  }
+}
+
+async function parseResponse(response) {
+  const text = await response.text()
+  if (!text)
+    return null
+
+  try {
+    return JSON.parse(text)
+  }
+  catch {
+    return text
+  }
+}
+
+function buildErrorMessage(method, path, response, payload) {
+  const suffix = payload && typeof payload === "object" && "message" in payload
+    ? `: ${payload.message}`
+    : ""
+  return `${method} ${path} failed with ${response.status} ${response.statusText}${suffix}`
+}
+
+export async function apiRequest(token, path, { body, headers, method = "GET" } = {}) {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    method,
+    headers: buildHeaders(token, headers),
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  const payload = await parseResponse(response)
+
+  if (!response.ok) {
+    throw new GitHubApiError(buildErrorMessage(method, path, response, payload), {
+      path,
+      payload,
+      response,
+    })
+  }
+
+  return payload
+}
+
+export async function graphqlRequest(token, query, variables) {
+  const response = await fetch(`${API_BASE_URL}/graphql`, {
+    method: "POST",
+    headers: buildHeaders(token),
+    body: JSON.stringify({ query, variables }),
+  })
+  const payload = await parseResponse(response)
+
+  if (!response.ok) {
+    throw new GitHubApiError(buildErrorMessage("POST", "/graphql", response, payload), {
+      payload,
+      response,
+    })
+  }
+
+  if (payload.errors?.length) {
+    throw new GitHubApiError(payload.errors.map(error => error.message).join("; "), {
+      payload,
+      response,
+    })
+  }
+
+  return payload.data
+}
+
+export async function paginate(token, path) {
+  const items = []
+
+  for (let page = 1; page <= 10; page += 1) {
+    const url = new URL(`${API_BASE_URL}${path}`)
+    url.searchParams.set("per_page", "100")
+    url.searchParams.set("page", String(page))
+
+    const response = await fetch(url, {
+      headers: buildHeaders(token),
+    })
+    const payload = await parseResponse(response)
+
+    if (!response.ok) {
+      throw new GitHubApiError(buildErrorMessage("GET", `${path}?page=${page}`, response, payload), {
+        payload,
+        response,
+      })
+    }
+
+    if (!Array.isArray(payload)) {
+      throw new GitHubApiError(`Expected array payload from ${path}`, { payload })
+    }
+
+    items.push(...payload)
+    if (payload.length < 100)
+      break
+  }
+
+  return items
+}
+
+export async function getPullRequest(token, owner, repo, pullNumber) {
+  return apiRequest(token, `/repos/${owner}/${repo}/pulls/${pullNumber}`)
+}
+
+export async function listIssueLabels(token, owner, repo, issueNumber) {
+  const labels = await apiRequest(token, `/repos/${owner}/${repo}/issues/${issueNumber}/labels?per_page=100`)
+  return labels.map(label => label.name)
+}
+
+export async function listIssueComments(token, owner, repo, issueNumber) {
+  return paginate(token, `/repos/${owner}/${repo}/issues/${issueNumber}/comments`)
+}
+
+export async function createIssueComment(token, owner, repo, issueNumber, body) {
+  return apiRequest(token, `/repos/${owner}/${repo}/issues/${issueNumber}/comments`, {
+    body: { body },
+    method: "POST",
+  })
+}
+
+export async function updateIssueComment(token, owner, repo, commentId, body) {
+  return apiRequest(token, `/repos/${owner}/${repo}/issues/comments/${commentId}`, {
+    body: { body },
+    method: "PATCH",
+  })
+}
+
+export async function addLabelsToIssue(token, owner, repo, issueNumber, labels) {
+  if (labels.length === 0)
+    return []
+
+  return apiRequest(token, `/repos/${owner}/${repo}/issues/${issueNumber}/labels`, {
+    body: { labels },
+    method: "POST",
+  })
+}
+
+export async function removeLabelFromIssue(token, owner, repo, issueNumber, labelName) {
+  return apiRequest(token, `/repos/${owner}/${repo}/issues/${issueNumber}/labels/${encodeURIComponent(labelName)}`, {
+    method: "DELETE",
+  })
+}
+
+export async function closePullRequestIssue(token, owner, repo, issueNumber) {
+  return apiRequest(token, `/repos/${owner}/${repo}/issues/${issueNumber}`, {
+    body: { state: "closed" },
+    method: "PATCH",
+  })
+}
+
+export async function getCollaboratorPermission(token, owner, repo, username) {
+  try {
+    const response = await apiRequest(token, `/repos/${owner}/${repo}/collaborators/${encodeURIComponent(username)}/permission`)
+    return response.permission ?? null
+  }
+  catch (error) {
+    if (error instanceof GitHubApiError && error.details.response?.status === 404)
+      return null
+    throw error
+  }
+}
+
+export async function ensureRepositoryLabels(token, owner, repo, labelDefinitions) {
+  for (const [name, definition] of Object.entries(labelDefinitions)) {
+    try {
+      await apiRequest(token, `/repos/${owner}/${repo}/labels/${encodeURIComponent(name)}`)
+    }
+    catch (error) {
+      if (!(error instanceof GitHubApiError) || error.details.response?.status !== 404)
+        throw error
+
+      try {
+        await apiRequest(token, `/repos/${owner}/${repo}/labels`, {
+          body: {
+            color: definition.color,
+            description: definition.description,
+            name,
+          },
+          method: "POST",
+        })
+      }
+      catch (createError) {
+        if (!(createError instanceof GitHubApiError) || createError.details.response?.status !== 422)
+          throw createError
+      }
+    }
+  }
+}
+
+export async function getAuthorMetrics(token, owner, repo, authorLogin) {
+  const slug = `${owner}/${repo}`
+  const query = `
+    query ContributorTrust(
+      $login: String!
+      $openPrsQuery: String!
+      $mergedPrsQuery: String!
+      $closedPrsQuery: String!
+      $reviewsQuery: String!
+    ) {
+      rateLimit {
+        cost
+        remaining
+        resetAt
+      }
+      user(login: $login) {
+        login
+        name
+        url
+        avatarUrl
+        createdAt
+        followers {
+          totalCount
+        }
+        repositories {
+          totalCount
+        }
+        topRepositories(first: 6, orderBy: { field: STARGAZERS, direction: DESC }) {
+          nodes {
+            stargazerCount
+          }
+        }
+      }
+      openPrs: search(query: $openPrsQuery, type: ISSUE, first: 1) {
+        issueCount
+      }
+      mergedPrs: search(query: $mergedPrsQuery, type: ISSUE, first: 1) {
+        issueCount
+      }
+      closedPrs: search(query: $closedPrsQuery, type: ISSUE, first: 1) {
+        issueCount
+      }
+      reviews: search(query: $reviewsQuery, type: ISSUE, first: 1) {
+        issueCount
+      }
+    }
+  `
+
+  const variables = {
+    login: authorLogin,
+    openPrsQuery: `repo:${slug} author:${authorLogin} type:pr is:open`,
+    mergedPrsQuery: `repo:${slug} author:${authorLogin} type:pr is:merged`,
+    closedPrsQuery: `repo:${slug} author:${authorLogin} type:pr is:closed is:unmerged`,
+    reviewsQuery: `repo:${slug} reviewed-by:${authorLogin} type:pr`,
+  }
+
+  const data = await graphqlRequest(token, query, variables)
+  const user = data.user ?? await getUserFallback(token, authorLogin)
+
+  return {
+    author: {
+      avatarUrl: user?.avatarUrl ?? user?.avatar_url ?? null,
+      createdAt: user?.createdAt ?? user?.created_at ?? null,
+      followers: user?.followers?.totalCount ?? user?.followers ?? 0,
+      login: user?.login ?? authorLogin,
+      name: user?.name ?? null,
+      publicRepos: user?.repositories?.totalCount ?? user?.public_repos ?? 0,
+      url: user?.url ?? user?.html_url ?? `https://github.com/${authorLogin}`,
+    },
+    rateLimit: data.rateLimit ?? null,
+    repoHistory: {
+      closedPrs: data.closedPrs?.issueCount ?? 0,
+      mergedPrs: data.mergedPrs?.issueCount ?? 0,
+      openPrs: data.openPrs?.issueCount ?? 0,
+      reviews: data.reviews?.issueCount ?? 0,
+      topRepoStars: (data.user?.topRepositories?.nodes ?? [])
+        .map(node => node?.stargazerCount ?? 0),
+    },
+  }
+}
+
+async function getUserFallback(token, authorLogin) {
+  try {
+    return await apiRequest(token, `/users/${encodeURIComponent(authorLogin)}`)
+  }
+  catch (error) {
+    if (error instanceof GitHubApiError && error.details.response?.status === 404)
+      return null
+    throw error
+  }
+}

--- a/.github/scripts/contributor-trust/plan-actions.js
+++ b/.github/scripts/contributor-trust/plan-actions.js
@@ -1,0 +1,63 @@
+import { bucketToLabel, MANAGED_TRUST_LABELS, POLICY } from "./config.js"
+
+function uniqueSorted(values) {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right))
+}
+
+export function planTrustActions({ currentLabels = [], score }) {
+  const labelSet = new Set(currentLabels)
+
+  if (labelSet.has(POLICY.overrideLabel)) {
+    return {
+      skipAutomation: true,
+      skipReason: `Override label \`${POLICY.overrideLabel}\` is present.`,
+      targetTrustLabel: null,
+      labelsToAdd: [],
+      labelsToRemove: labelSet.has(POLICY.needsMaintainerReviewLabel)
+        ? [POLICY.needsMaintainerReviewLabel]
+        : [],
+      needsMaintainerReview: false,
+      shouldClosePr: false,
+      closeReason: null,
+    }
+  }
+
+  const targetTrustLabel = score.exemptReason === "maintainer"
+    ? POLICY.maintainerLabel
+    : bucketToLabel(score.bucket)
+  const needsMaintainerReview = !score.exemptReason && score.total < POLICY.lowScoreThreshold
+
+  const labelsToAdd = []
+  const labelsToRemove = []
+
+  if (!labelSet.has(targetTrustLabel))
+    labelsToAdd.push(targetTrustLabel)
+
+  for (const label of MANAGED_TRUST_LABELS) {
+    if (label !== targetTrustLabel && labelSet.has(label))
+      labelsToRemove.push(label)
+  }
+
+  if (needsMaintainerReview) {
+    if (!labelSet.has(POLICY.needsMaintainerReviewLabel))
+      labelsToAdd.push(POLICY.needsMaintainerReviewLabel)
+  }
+  else if (labelSet.has(POLICY.needsMaintainerReviewLabel)) {
+    labelsToRemove.push(POLICY.needsMaintainerReviewLabel)
+  }
+
+  const shouldClosePr = POLICY.autoCloseBelowScore !== null && score.total < POLICY.autoCloseBelowScore
+
+  return {
+    skipAutomation: false,
+    skipReason: null,
+    targetTrustLabel,
+    labelsToAdd: uniqueSorted(labelsToAdd),
+    labelsToRemove: uniqueSorted(labelsToRemove),
+    needsMaintainerReview,
+    shouldClosePr,
+    closeReason: shouldClosePr
+      ? `Score ${score.total} is below auto-close threshold ${POLICY.autoCloseBelowScore}.`
+      : null,
+  }
+}

--- a/.github/scripts/contributor-trust/plan-actions.test.js
+++ b/.github/scripts/contributor-trust/plan-actions.test.js
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+
+import { POLICY } from "./config.js"
+import { planTrustActions } from "./plan-actions.js"
+
+describe("planTrustActions", () => {
+  it("assigns the low-trust labels for new contributors", () => {
+    const plan = planTrustActions({
+      currentLabels: [],
+      score: {
+        bucket: "new",
+        exemptReason: null,
+        total: 18,
+      },
+    })
+
+    expect(plan).toMatchObject({
+      labelsToAdd: ["contrib-trust:new", POLICY.needsMaintainerReviewLabel].sort(),
+      labelsToRemove: [],
+      needsMaintainerReview: true,
+      shouldClosePr: false,
+      skipAutomation: false,
+      targetTrustLabel: "contrib-trust:new",
+    })
+  })
+
+  it("cleans up stale trust labels when the score improves", () => {
+    const plan = planTrustActions({
+      currentLabels: ["contrib-trust:new", POLICY.needsMaintainerReviewLabel],
+      score: {
+        bucket: "trusted",
+        exemptReason: null,
+        total: 74,
+      },
+    })
+
+    expect(plan).toMatchObject({
+      labelsToAdd: ["contrib-trust:trusted"],
+      labelsToRemove: [POLICY.needsMaintainerReviewLabel, "contrib-trust:new"].sort(),
+      needsMaintainerReview: false,
+      skipAutomation: false,
+      targetTrustLabel: "contrib-trust:trusted",
+    })
+  })
+
+  it("uses the maintainer label for exempt scores", () => {
+    const plan = planTrustActions({
+      currentLabels: ["contrib-trust:new"],
+      score: {
+        bucket: "highly-trusted",
+        exemptReason: "maintainer",
+        total: 100,
+      },
+    })
+
+    expect(plan).toMatchObject({
+      labelsToAdd: [POLICY.maintainerLabel],
+      labelsToRemove: ["contrib-trust:new"],
+      needsMaintainerReview: false,
+      skipAutomation: false,
+      targetTrustLabel: POLICY.maintainerLabel,
+    })
+  })
+
+  it("short-circuits when the override label is present", () => {
+    const plan = planTrustActions({
+      currentLabels: [POLICY.overrideLabel, POLICY.needsMaintainerReviewLabel, "contrib-trust:new"],
+      score: {
+        bucket: "new",
+        exemptReason: null,
+        total: 10,
+      },
+    })
+
+    expect(plan).toMatchObject({
+      labelsToAdd: [],
+      labelsToRemove: [POLICY.needsMaintainerReviewLabel],
+      needsMaintainerReview: false,
+      shouldClosePr: false,
+      skipAutomation: true,
+      targetTrustLabel: null,
+    })
+  })
+})

--- a/.github/scripts/contributor-trust/run.js
+++ b/.github/scripts/contributor-trust/run.js
@@ -1,0 +1,262 @@
+import { appendFile, readFile } from "node:fs/promises"
+import process from "node:process"
+
+import { buildTrustComment } from "./comment-template.js"
+import { COMMENT_MARKER_HTML, LABEL_DEFINITIONS, POLICY } from "./config.js"
+import {
+  addLabelsToIssue,
+  closePullRequestIssue,
+  createIssueComment,
+  ensureRepositoryLabels,
+  getAuthorMetrics,
+  getCollaboratorPermission,
+  getPullRequest,
+  listIssueComments,
+  listIssueLabels,
+  removeLabelFromIssue,
+  updateIssueComment,
+} from "./github-api.js"
+import { planTrustActions } from "./plan-actions.js"
+import { computeContributorScore } from "./score-author.js"
+
+function getRequiredEnv(name) {
+  const value = process.env[name]
+  if (!value)
+    throw new Error(`Missing required environment variable: ${name}`)
+  return value
+}
+
+function getRepository() {
+  const repository = getRequiredEnv("GITHUB_REPOSITORY")
+  const [owner, repo] = repository.split("/")
+  if (!owner || !repo)
+    throw new Error(`Invalid GITHUB_REPOSITORY value: ${repository}`)
+  return { owner, repo }
+}
+
+async function getEventPayload() {
+  const eventPath = getRequiredEnv("GITHUB_EVENT_PATH")
+  return JSON.parse(await readFile(eventPath, "utf8"))
+}
+
+function resolvePullNumber(eventName, payload) {
+  const manualInput = process.env.TRUST_PR_NUMBER?.trim()
+  if (manualInput)
+    return Number.parseInt(manualInput, 10)
+
+  if (eventName === "pull_request_target")
+    return payload.pull_request?.number
+
+  return null
+}
+
+function buildScoreInput({ isMaintainer, metrics }) {
+  const contributionCount = metrics.mergedPrs + metrics.reviews
+
+  return {
+    accountCreated: metrics.accountCreated,
+    commitsInRepo: metrics.mergedPrs,
+    contributionCount,
+    followers: metrics.followers,
+    isContributor: contributionCount > 0,
+    isMaintainer,
+    prsInRepo: [
+      ...Array.from({ length: metrics.mergedPrs }).fill({ state: "merged" }),
+      ...Array.from({ length: metrics.closedPrs }).fill({ state: "closed" }),
+      ...Array.from({ length: metrics.openPrs }).fill({ state: "open" }),
+    ],
+    publicRepos: metrics.publicRepos,
+    reviewsInRepo: metrics.reviews,
+    topRepoStars: metrics.topRepoStars,
+  }
+}
+
+async function writeJobSummary(lines) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY
+  if (!summaryPath)
+    return
+
+  await appendFile(summaryPath, `${lines.join("\n")}\n`)
+}
+
+async function syncLabels({ currentLabels, issueNumber, labelsToAdd, labelsToRemove, owner, repo, token }) {
+  for (const label of labelsToRemove) {
+    if (!currentLabels.includes(label))
+      continue
+    await removeLabelFromIssue(token, owner, repo, issueNumber, label)
+    console.log(`Removed label: ${label}`)
+  }
+
+  const missingLabels = labelsToAdd.filter(label => !currentLabels.includes(label))
+  if (missingLabels.length > 0) {
+    await addLabelsToIssue(token, owner, repo, issueNumber, missingLabels)
+    console.log(`Added labels: ${missingLabels.join(", ")}`)
+  }
+}
+
+async function upsertComment({ body, issueNumber, owner, repo, token }) {
+  const comments = await listIssueComments(token, owner, repo, issueNumber)
+  const existingComment = comments.find(comment => comment.body?.includes(COMMENT_MARKER_HTML))
+
+  if (existingComment?.body === body) {
+    console.log("Trust comment is already up to date.")
+    return { action: "unchanged", commentId: existingComment.id }
+  }
+
+  if (existingComment) {
+    await updateIssueComment(token, owner, repo, existingComment.id, body)
+    console.log(`Updated trust comment ${existingComment.id}.`)
+    return { action: "updated", commentId: existingComment.id }
+  }
+
+  const createdComment = await createIssueComment(token, owner, repo, issueNumber, body)
+  console.log(`Created trust comment ${createdComment.id}.`)
+  return { action: "created", commentId: createdComment.id }
+}
+
+async function main() {
+  const token = getRequiredEnv("GITHUB_TOKEN")
+  const eventName = getRequiredEnv("GITHUB_EVENT_NAME")
+  const payload = await getEventPayload()
+  const pullNumber = resolvePullNumber(eventName, payload)
+
+  if (!Number.isInteger(pullNumber) || pullNumber <= 0)
+    throw new Error(`Unable to resolve a valid pull request number for event ${eventName}.`)
+
+  const { owner, repo } = getRepository()
+  const pullRequest = await getPullRequest(token, owner, repo, pullNumber)
+
+  const summaryLines = [
+    "## Contributor trust automation",
+    "",
+    `- Event: \`${eventName}\``,
+    `- PR: #${pullRequest.number}`,
+    `- Title: ${pullRequest.title}`,
+    `- State: ${pullRequest.state}${pullRequest.draft ? " (draft)" : ""}`,
+    `- Author: @${pullRequest.user.login}`,
+  ]
+
+  if (eventName === "pull_request_target" && pullRequest.draft) {
+    summaryLines.push("- Result: skipped automatic trust checks for a draft PR")
+    await writeJobSummary(summaryLines)
+    return
+  }
+
+  await ensureRepositoryLabels(token, owner, repo, LABEL_DEFINITIONS)
+  const currentLabels = await listIssueLabels(token, owner, repo, pullRequest.number)
+
+  const overridePlan = planTrustActions({
+    currentLabels,
+    score: {
+      bucket: "new",
+      exemptReason: null,
+      total: 0,
+    },
+  })
+
+  if (overridePlan.skipAutomation) {
+    await syncLabels({
+      currentLabels,
+      issueNumber: pullRequest.number,
+      labelsToAdd: [],
+      labelsToRemove: overridePlan.labelsToRemove,
+      owner,
+      repo,
+      token,
+    })
+
+    summaryLines.push(`- Result: skipped due to \`${POLICY.overrideLabel}\``)
+    if (overridePlan.labelsToRemove.length > 0)
+      summaryLines.push(`- Cleanup: removed ${overridePlan.labelsToRemove.map(label => `\`${label}\``).join(", ")}`)
+    await writeJobSummary(summaryLines)
+    return
+  }
+
+  const permission = await getCollaboratorPermission(token, owner, repo, pullRequest.user.login)
+  const authorMetrics = await getAuthorMetrics(token, owner, repo, pullRequest.user.login)
+  const scoreInput = buildScoreInput({
+    isMaintainer: POLICY.maintainerPermissions.includes(permission ?? ""),
+    metrics: {
+      accountCreated: authorMetrics.author.createdAt,
+      closedPrs: authorMetrics.repoHistory.closedPrs,
+      followers: authorMetrics.author.followers,
+      mergedPrs: authorMetrics.repoHistory.mergedPrs,
+      openPrs: authorMetrics.repoHistory.openPrs,
+      publicRepos: authorMetrics.author.publicRepos,
+      reviews: authorMetrics.repoHistory.reviews,
+      topRepoStars: authorMetrics.repoHistory.topRepoStars,
+    },
+  })
+
+  const score = computeContributorScore(scoreInput)
+  const plan = planTrustActions({ currentLabels, score })
+  const comment = buildTrustComment({
+    author: {
+      login: authorMetrics.author.login,
+      name: authorMetrics.author.name,
+      type: pullRequest.user.type,
+      url: authorMetrics.author.url,
+    },
+    metrics: {
+      accountCreated: authorMetrics.author.createdAt,
+      closedPrs: authorMetrics.repoHistory.closedPrs,
+      followers: authorMetrics.author.followers,
+      mergedPrs: authorMetrics.repoHistory.mergedPrs,
+      openPrs: authorMetrics.repoHistory.openPrs,
+      publicRepos: authorMetrics.author.publicRepos,
+      reviews: authorMetrics.repoHistory.reviews,
+      topRepoStars: authorMetrics.repoHistory.topRepoStars,
+    },
+    owner,
+    plan,
+    pullRequest,
+    repo,
+    score,
+  })
+
+  await syncLabels({
+    currentLabels,
+    issueNumber: pullRequest.number,
+    labelsToAdd: plan.labelsToAdd,
+    labelsToRemove: plan.labelsToRemove,
+    owner,
+    repo,
+    token,
+  })
+  const commentResult = await upsertComment({
+    body: comment.body,
+    issueNumber: pullRequest.number,
+    owner,
+    repo,
+    token,
+  })
+
+  if (plan.shouldClosePr) {
+    await closePullRequestIssue(token, owner, repo, pullRequest.number)
+    console.log(`Closed PR #${pullRequest.number}: ${plan.closeReason}`)
+  }
+
+  summaryLines.push(`- Trust score: **${score.total}/100**`)
+  summaryLines.push(`- Bucket: \`${score.bucket}\``)
+  summaryLines.push(`- Target label: \`${plan.targetTrustLabel}\``)
+  summaryLines.push(`- Maintainer review: ${plan.needsMaintainerReview ? "required" : "not required"}`)
+  summaryLines.push(`- Comment: ${commentResult.action}`)
+  summaryLines.push(`- Fingerprint: \`${comment.fingerprint}\``)
+
+  if (authorMetrics.rateLimit) {
+    summaryLines.push(`- GraphQL rate limit: remaining ${authorMetrics.rateLimit.remaining}, cost ${authorMetrics.rateLimit.cost}, resets ${authorMetrics.rateLimit.resetAt}`)
+  }
+
+  await writeJobSummary(summaryLines)
+}
+
+main().catch(async (error) => {
+  console.error(error)
+  await writeJobSummary([
+    "## Contributor trust automation",
+    "",
+    `- Result: failed`,
+    `- Error: ${error instanceof Error ? error.message : String(error)}`,
+  ])
+  process.exitCode = 1
+})

--- a/.github/scripts/contributor-trust/score-author.js
+++ b/.github/scripts/contributor-trust/score-author.js
@@ -1,0 +1,114 @@
+import { POLICY, TRUST_BUCKETS } from "./config.js"
+
+function toNumber(value) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+}
+
+function accountAgeMonths(createdAt) {
+  if (!createdAt)
+    return 0
+
+  const timestamp = new Date(createdAt).getTime()
+  if (Number.isNaN(timestamp))
+    return 0
+
+  return (Date.now() - timestamp) / 2.628e9
+}
+
+function scoreRepoFamiliarity(input) {
+  let score = 0
+
+  const commitsInRepo = toNumber(input.commitsInRepo)
+  score += commitsInRepo === 0 ? 0 : commitsInRepo <= 5 ? 3 : commitsInRepo <= 20 ? 7 : 10
+
+  const mergedPrs = input.prsInRepo.filter(pr => pr.state === "merged").length
+  score += mergedPrs === 0 ? 0 : mergedPrs === 1 ? 3 : mergedPrs <= 5 ? 6 : mergedPrs <= 15 ? 9 : 12
+
+  const reviewsInRepo = toNumber(input.reviewsInRepo)
+  score += reviewsInRepo === 0 ? 0 : reviewsInRepo <= 3 ? 3 : reviewsInRepo <= 10 ? 5 : 8
+
+  if (input.isContributor)
+    score += 5
+
+  return Math.min(score, 35)
+}
+
+function scoreCommunityStanding(input) {
+  let score = 0
+
+  const accountMonths = accountAgeMonths(input.accountCreated)
+  score += accountMonths < 3 ? 0 : accountMonths < 12 ? 2 : accountMonths < 36 ? 3 : accountMonths < 84 ? 4 : 5
+
+  const followers = toNumber(input.followers)
+  score += followers < 10 ? 1 : followers < 50 ? 3 : followers < 200 ? 5 : followers < 1000 ? 7 : 10
+
+  return Math.min(score, 25)
+}
+
+function scoreOSSInfluence(input) {
+  const topRepoStars = input.topRepoStars.map(toNumber)
+  const maxStars = topRepoStars.length > 0 ? Math.max(...topRepoStars) : 0
+  const totalStars = topRepoStars.reduce((sum, stars) => sum + stars, 0)
+
+  let score = 0
+  score += maxStars === 0 ? 0 : maxStars <= 50 ? 3 : maxStars <= 500 ? 6 : maxStars <= 5000 ? 12 : 15
+  score += totalStars < 50 ? 0 : totalStars < 500 ? 2 : 5
+
+  return Math.min(score, 20)
+}
+
+function scorePRTrackRecord(input) {
+  if (input.prsInRepo.length === 0)
+    return 5
+
+  const mergedPrs = input.prsInRepo.filter(pr => pr.state === "merged").length
+  const resolvedPrs = input.prsInRepo.filter(pr => pr.state === "merged" || pr.state === "closed").length
+  if (resolvedPrs === 0)
+    return 5
+
+  const mergeRate = (mergedPrs / resolvedPrs) * 100
+  return mergeRate === 0 ? 0 : mergeRate < 50 ? 5 : mergeRate < 75 ? 10 : mergeRate < 90 ? 15 : 20
+}
+
+export function getTrustBucket(total) {
+  if (total >= 80)
+    return TRUST_BUCKETS.HIGHLY_TRUSTED
+  if (total >= 60)
+    return TRUST_BUCKETS.TRUSTED
+  if (total >= 30)
+    return TRUST_BUCKETS.MODERATE
+  return TRUST_BUCKETS.NEW
+}
+
+export function computeContributorScore(input) {
+  if (input.isMaintainer) {
+    return {
+      total: 100,
+      repoFamiliarity: 35,
+      communityStanding: 25,
+      ossInfluence: 20,
+      prTrackRecord: 20,
+      bucket: TRUST_BUCKETS.HIGHLY_TRUSTED,
+      exemptReason: "maintainer",
+      lowScoreThreshold: POLICY.lowScoreThreshold,
+    }
+  }
+
+  const repoFamiliarity = scoreRepoFamiliarity(input)
+  const communityStanding = scoreCommunityStanding(input)
+  const ossInfluence = scoreOSSInfluence(input)
+  const prTrackRecord = scorePRTrackRecord(input)
+  const total = repoFamiliarity + communityStanding + ossInfluence + prTrackRecord
+
+  return {
+    total,
+    repoFamiliarity,
+    communityStanding,
+    ossInfluence,
+    prTrackRecord,
+    bucket: getTrustBucket(total),
+    exemptReason: null,
+    lowScoreThreshold: POLICY.lowScoreThreshold,
+  }
+}

--- a/.github/scripts/contributor-trust/score-author.test.js
+++ b/.github/scripts/contributor-trust/score-author.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+
+import { TRUST_BUCKETS } from "./config.js"
+import { computeContributorScore, getTrustBucket } from "./score-author.js"
+
+function createBaseInput() {
+  return {
+    accountCreated: "2020-01-01T00:00:00Z",
+    commitsInRepo: 0,
+    contributionCount: 0,
+    followers: 0,
+    isContributor: false,
+    isMaintainer: false,
+    prsInRepo: [],
+    publicRepos: 0,
+    reviewsInRepo: 0,
+    topRepoStars: [],
+  }
+}
+
+describe("getTrustBucket", () => {
+  it("maps score boundaries to the expected bucket", () => {
+    expect(getTrustBucket(80)).toBe(TRUST_BUCKETS.HIGHLY_TRUSTED)
+    expect(getTrustBucket(79)).toBe(TRUST_BUCKETS.TRUSTED)
+    expect(getTrustBucket(60)).toBe(TRUST_BUCKETS.TRUSTED)
+    expect(getTrustBucket(59)).toBe(TRUST_BUCKETS.MODERATE)
+    expect(getTrustBucket(30)).toBe(TRUST_BUCKETS.MODERATE)
+    expect(getTrustBucket(29)).toBe(TRUST_BUCKETS.NEW)
+  })
+})
+
+describe("computeContributorScore", () => {
+  it("gives maintainers a full trust exemption", () => {
+    const score = computeContributorScore({
+      ...createBaseInput(),
+      isMaintainer: true,
+    })
+
+    expect(score).toMatchObject({
+      bucket: TRUST_BUCKETS.HIGHLY_TRUSTED,
+      communityStanding: 25,
+      exemptReason: "maintainer",
+      ossInfluence: 20,
+      prTrackRecord: 20,
+      repoFamiliarity: 35,
+      total: 100,
+    })
+  })
+
+  it("keeps first-time contributors in the new bucket with the neutral PR history score", () => {
+    const score = computeContributorScore(createBaseInput())
+
+    expect(score.total).toBe(10)
+    expect(score.prTrackRecord).toBe(5)
+    expect(score.bucket).toBe(TRUST_BUCKETS.NEW)
+  })
+
+  it("accumulates the better-hub style dimensions for experienced contributors", () => {
+    const score = computeContributorScore({
+      ...createBaseInput(),
+      commitsInRepo: 24,
+      contributionCount: 18,
+      followers: 230,
+      isContributor: true,
+      prsInRepo: [
+        ...Array.from({ length: 9 }).fill({ state: "merged" }),
+        { state: "closed" },
+      ],
+      reviewsInRepo: 12,
+      topRepoStars: [520, 40, 12],
+    })
+
+    expect(score).toMatchObject({
+      bucket: TRUST_BUCKETS.HIGHLY_TRUSTED,
+      communityStanding: 11,
+      ossInfluence: 17,
+      prTrackRecord: 20,
+      repoFamiliarity: 32,
+      total: 80,
+    })
+  })
+})

--- a/.github/workflows/pr-contributor-trust.yml
+++ b/.github/workflows/pr-contributor-trust.yml
@@ -1,0 +1,46 @@
+name: PR - Contributor Trust
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to re-score
+        required: true
+        type: number
+
+concurrency:
+  group: contributor-trust-${{ github.event.pull_request.number || inputs.pr_number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  trust-score:
+    name: Score contributor trust
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Checkout trusted workflow code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.sha || github.event.repository.default_branch }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Score contributor and sync trust state
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRUST_PR_NUMBER: ${{ inputs.pr_number || '' }}
+        run: node .github/scripts/contributor-trust/run.js


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [x] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Add a contributor trust workflow for pull requests.

- score PR authors with a Better Hub-style trust model using GitHub REST + GraphQL
- upsert one advisory PR comment with score details and repo-specific signals
- apply trust labels and `needs-maintainer-review` for low-score non-maintainers
- support manual reruns from the Actions page with a `pr_number` input
- keep the workflow safe for forked PRs by running only trusted base/default-branch code

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Manual/local validation:
- `pnpm eslint .github/scripts/contributor-trust`
- `SKIP_FREE_API=true pnpm vitest run .github/scripts/contributor-trust/score-author.test.js .github/scripts/contributor-trust/plan-actions.test.js`
- `git push -u origin ci/contributor-trust-pr-automation` (pre-push hooks ran lint, type-check, and the full test suite)

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- Maintainers can skip future trust automation on a PR by adding the `trust-check:skip` label.
- The workflow currently keeps auto-close disabled, but the policy/actions layer is structured so it can be enabled later without redesigning the workflow.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a contributor trust workflow that scores PR authors and applies labels to guide triage. Posts one advisory comment with a clear score breakdown and recommended review actions.

- **New Features**
  - Adds `PR - Contributor Trust` workflow (`pull_request_target` + `workflow_dispatch`) that runs trusted base/default-branch code.
  - Scores authors via GitHub REST/GraphQL and buckets them; maintainers are exempt.
  - Upserts a single comment with score, signals, and policy details (fingerprinted to prevent churn).
  - Manages labels: `contrib-trust:*`, `trust-check:skip`, `needs-maintainer-review`; cleans up stale labels.
  - Flags low scores (<30) with `needs-maintainer-review`; auto-close is disabled.
  - Supports manual reruns with `pr_number`; override by adding `trust-check:skip`.
  - Includes unit tests for scoring and action planning; ensures labels are created if missing.

<sup>Written for commit 9b7a5f16294c9fca118c28754fbf9b6ffe05545e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

