### PR TITLE
fix(github): refine trust role and ownership scoring

### DIFF
--- a/.github/scripts/contributor-trust/comment-template.js
+++ b/.github/scripts/contributor-trust/comment-template.js
@@ -38,11 +38,7 @@ function buildContent({ owner, repo, pullRequest, author, metrics, score, plan }
   const trustLabel = plan.targetTrustLabel ?? "none"
   const reviewStatus = plan.needsMaintainerReview ? "required" : "not required"
   const includedRepositories = summarizeTopRepositories(metrics.topRepositories)
-  const excludedForkRepositories = formatRepositoryList(metrics.excludedForkRepositories)
-
-  const intro = score.exemptReason === "admin"
-    ? "This author has repository admin access, so the admin exemption applies in trust policy v1."
-    : `This score estimates contributor familiarity with \`${owner}/${repo}\` using public GitHub signals. It is advisory only and does not block merges automatically.`
+  const intro = `This score estimates contributor familiarity with \`${owner}/${repo}\` using public GitHub signals. It is advisory only and does not block merges automatically.`
 
   return [
     "## Contributor trust score",
@@ -63,18 +59,17 @@ function buildContent({ owner, repo, pullRequest, author, metrics, score, plan }
     "| Dimension | Score | Signals |",
     "| --- | ---: | --- |",
     `| Repo familiarity | ${score.repoFamiliarity}/35 | merged PRs, resolved PR history, reviews |`,
-    `| Community standing | ${score.communityStanding}/25 | account age, followers, public repos |`,
-    `| OSS influence | ${score.ossInfluence}/20 | stars on top non-fork repositories |`,
+    `| Community standing | ${score.communityStanding}/25 | account age, followers, repo role |`,
+    `| OSS influence | ${score.ossInfluence}/20 | stars on owned non-fork repositories |`,
     `| PR track record | ${score.prTrackRecord}/20 | merge rate across resolved PRs in this repo |`,
     "",
     "**Signals used**",
     `- Repo PR history: merged ${metrics.mergedPrs}, open ${metrics.openPrs}, closed-unmerged ${metrics.closedPrs}`,
     `- Repo reviews: ${metrics.reviews}`,
+    `- Repo permission: ${metrics.repoPermission ?? "none"}`,
     `- Followers: ${metrics.followers}`,
-    `- Public repos: ${metrics.publicRepos}`,
     `- Account age: ${formatMonths(metrics.accountCreated)}`,
-    `- Top non-fork repos considered: max ${includedRepositories.max}, total ${includedRepositories.total} (${includedRepositories.list})`,
-    `- Fork repos excluded from OSS influence: ${excludedForkRepositories}`,
+    `- Owned non-fork repos considered: max ${includedRepositories.max}, total ${includedRepositories.total} (${includedRepositories.list})`,
     "",
     "**Policy**",
     `- Low-score review threshold: < ${POLICY.lowScoreThreshold}`,

--- a/.github/scripts/contributor-trust/comment-template.test.js
+++ b/.github/scripts/contributor-trust/comment-template.test.js
@@ -14,18 +14,10 @@ describe("buildTrustComment", () => {
       metrics: {
         accountCreated: "2019-01-01T00:00:00Z",
         closedPrs: 0,
-        excludedForkRepositories: [
-          {
-            isFork: true,
-            nameWithOwner: "kilidoc/read-frog",
-            parentNameWithOwner: "mengxi-ream/read-frog",
-            stargazerCount: 5040,
-          },
-        ],
         followers: 3,
         mergedPrs: 1,
         openPrs: 0,
-        publicRepos: 31,
+        repoPermission: "write",
         reviews: 1,
         topRepositories: [
           {
@@ -58,8 +50,10 @@ describe("buildTrustComment", () => {
       },
     })
 
-    expect(comment.body).toContain("stars on top non-fork repositories")
-    expect(comment.body).toContain("Top non-fork repos considered: max 42, total 42 (kilidoc/browser-tools (42))")
-    expect(comment.body).toContain("Fork repos excluded from OSS influence: kilidoc/read-frog (5040)")
+    expect(comment.body).toContain("stars on owned non-fork repositories")
+    expect(comment.body).toContain("Repo permission: write")
+    expect(comment.body).toContain("Owned non-fork repos considered: max 42, total 42 (kilidoc/browser-tools (42))")
+    expect(comment.body).not.toContain("Fork repos excluded from OSS influence")
+    expect(comment.body).not.toContain("Public repos:")
   })
 })

--- a/.github/scripts/contributor-trust/config.js
+++ b/.github/scripts/contributor-trust/config.js
@@ -11,7 +11,7 @@ export const POLICY = Object.freeze({
   overrideLabel: "trust-check:skip",
   needsMaintainerReviewLabel: "needs-maintainer-review",
   adminLabel: `${TRUST_LABEL_PREFIX}admin`,
-  adminPermissions: ["admin"],
+  repoFamiliarityBonusPermissions: ["admin", "maintain", "write"],
 })
 
 export const TRUST_BUCKETS = Object.freeze({
@@ -54,7 +54,7 @@ export const LABEL_DEFINITIONS = Object.freeze({
   },
   [POLICY.adminLabel]: {
     color: "5319e7",
-    description: "PR author has repository admin access.",
+    description: "Legacy trust label kept for cleanup of old automation runs.",
   },
   [POLICY.needsMaintainerReviewLabel]: {
     color: "b60205",

--- a/.github/scripts/contributor-trust/github-api.js
+++ b/.github/scripts/contributor-trust/github-api.js
@@ -203,39 +203,35 @@ export async function ensureRepositoryLabels(token, owner, repo, labelDefinition
   }
 }
 
-function normalizeTopRepository(node) {
-  if (!node?.nameWithOwner)
+function normalizeOwnedRepository(node, ownerLogin) {
+  if (!node?.nameWithOwner || !ownerLogin)
+    return null
+
+  const repositoryOwner = node.owner?.login?.toLowerCase()
+  if (repositoryOwner !== ownerLogin.toLowerCase())
+    return null
+
+  if (node.isFork === true)
     return null
 
   return {
-    isFork: node.isFork === true,
     nameWithOwner: node.nameWithOwner,
-    parentNameWithOwner: node.parent?.nameWithOwner ?? null,
     stargazerCount: Number(node.stargazerCount) || 0,
   }
 }
 
-export function splitTopRepositories(nodes) {
+export function selectOwnedNonForkRepositories(nodes, ownerLogin) {
   const topRepositories = []
-  const excludedForkRepositories = []
 
   for (const node of nodes ?? []) {
-    const repository = normalizeTopRepository(node)
+    const repository = normalizeOwnedRepository(node, ownerLogin)
     if (!repository)
       continue
-
-    if (repository.isFork) {
-      excludedForkRepositories.push(repository)
-      continue
-    }
 
     topRepositories.push(repository)
   }
 
-  return {
-    excludedForkRepositories,
-    topRepositories,
-  }
+  return topRepositories
 }
 
 export async function getAuthorMetrics(token, owner, repo, authorLogin) {
@@ -265,12 +261,17 @@ export async function getAuthorMetrics(token, owner, repo, authorLogin) {
         repositories {
           totalCount
         }
-        topRepositories(first: 20, orderBy: { field: STARGAZERS, direction: DESC }) {
+        ownedNonForkRepositories: repositories(
+          first: 20
+          ownerAffiliations: [OWNER]
+          isFork: false
+          orderBy: { field: STARGAZERS, direction: DESC }
+        ) {
           nodes {
             isFork
             nameWithOwner
-            parent {
-              nameWithOwner
+            owner {
+              login
             }
             stargazerCount
           }
@@ -301,7 +302,7 @@ export async function getAuthorMetrics(token, owner, repo, authorLogin) {
 
   const data = await graphqlRequest(token, query, variables)
   const user = data.user ?? await getUserFallback(token, authorLogin)
-  const topRepositoryBuckets = splitTopRepositories(data.user?.topRepositories?.nodes ?? [])
+  const topRepositories = selectOwnedNonForkRepositories(data.user?.ownedNonForkRepositories?.nodes ?? [], authorLogin)
 
   return {
     author: {
@@ -316,11 +317,10 @@ export async function getAuthorMetrics(token, owner, repo, authorLogin) {
     rateLimit: data.rateLimit ?? null,
     repoHistory: {
       closedPrs: data.closedPrs?.issueCount ?? 0,
-      excludedForkRepositories: topRepositoryBuckets.excludedForkRepositories,
       mergedPrs: data.mergedPrs?.issueCount ?? 0,
       openPrs: data.openPrs?.issueCount ?? 0,
       reviews: data.reviews?.issueCount ?? 0,
-      topRepositories: topRepositoryBuckets.topRepositories,
+      topRepositories,
     },
   }
 }

--- a/.github/scripts/contributor-trust/github-api.test.js
+++ b/.github/scripts/contributor-trust/github-api.test.js
@@ -1,53 +1,51 @@
 import { describe, expect, it } from "vitest"
 
-import { splitTopRepositories } from "./github-api.js"
+import { selectOwnedNonForkRepositories } from "./github-api.js"
 
-describe("splitTopRepositories", () => {
-  it("keeps non-fork repos for OSS influence and excludes forks", () => {
-    const result = splitTopRepositories([
+describe("selectOwnedNonForkRepositories", () => {
+  it("keeps only repos that the PR author owns and that are not forks", () => {
+    const result = selectOwnedNonForkRepositories([
       {
         isFork: true,
         nameWithOwner: "kilidoc/read-frog",
-        parent: { nameWithOwner: "mengxi-ream/read-frog" },
+        owner: { login: "kilidoc" },
         stargazerCount: 5040,
       },
       {
         isFork: false,
         nameWithOwner: "kilidoc/anki-langkit",
-        parent: null,
+        owner: { login: "kilidoc" },
         stargazerCount: 42,
       },
       {
         isFork: false,
         nameWithOwner: "kilidoc/browser-tools",
-        parent: null,
+        owner: { login: "kilidoc" },
+        stargazerCount: 5,
+      },
+      {
+        isFork: false,
+        nameWithOwner: "mengxi-ream/read-frog",
+        owner: { login: "mengxi-ream" },
+        stargazerCount: 5041,
+      },
+      {
+        isFork: false,
+        nameWithOwner: "better-auth/better-auth",
+        owner: { login: "better-auth" },
+        stargazerCount: 27534,
+      },
+    ], "kilidoc")
+
+    expect(result).toEqual([
+      {
+        nameWithOwner: "kilidoc/anki-langkit",
+        stargazerCount: 42,
+      },
+      {
+        nameWithOwner: "kilidoc/browser-tools",
         stargazerCount: 5,
       },
     ])
-
-    expect(result).toEqual({
-      excludedForkRepositories: [
-        {
-          isFork: true,
-          nameWithOwner: "kilidoc/read-frog",
-          parentNameWithOwner: "mengxi-ream/read-frog",
-          stargazerCount: 5040,
-        },
-      ],
-      topRepositories: [
-        {
-          isFork: false,
-          nameWithOwner: "kilidoc/anki-langkit",
-          parentNameWithOwner: null,
-          stargazerCount: 42,
-        },
-        {
-          isFork: false,
-          nameWithOwner: "kilidoc/browser-tools",
-          parentNameWithOwner: null,
-          stargazerCount: 5,
-        },
-      ],
-    })
   })
 })

--- a/.github/scripts/contributor-trust/plan-actions.js
+++ b/.github/scripts/contributor-trust/plan-actions.js
@@ -22,10 +22,8 @@ export function planTrustActions({ currentLabels = [], score }) {
     }
   }
 
-  const targetTrustLabel = score.exemptReason === "admin"
-    ? POLICY.adminLabel
-    : bucketToLabel(score.bucket)
-  const needsMaintainerReview = !score.exemptReason && score.total < POLICY.lowScoreThreshold
+  const targetTrustLabel = bucketToLabel(score.bucket)
+  const needsMaintainerReview = score.total < POLICY.lowScoreThreshold
 
   const labelsToAdd = []
   const labelsToRemove = []

--- a/.github/scripts/contributor-trust/plan-actions.test.js
+++ b/.github/scripts/contributor-trust/plan-actions.test.js
@@ -43,22 +43,22 @@ describe("planTrustActions", () => {
     })
   })
 
-  it("uses the admin label for exempt scores", () => {
+  it("cleans up the legacy admin trust label when recomputing a score", () => {
     const plan = planTrustActions({
-      currentLabels: ["contrib-trust:new"],
+      currentLabels: ["contrib-trust:new", POLICY.adminLabel],
       score: {
         bucket: "highly-trusted",
-        exemptReason: "admin",
-        total: 100,
+        exemptReason: null,
+        total: 82,
       },
     })
 
     expect(plan).toMatchObject({
-      labelsToAdd: [POLICY.adminLabel],
-      labelsToRemove: ["contrib-trust:new"],
+      labelsToAdd: ["contrib-trust:highly-trusted"],
+      labelsToRemove: [POLICY.adminLabel, "contrib-trust:new"].sort(),
       needsMaintainerReview: false,
       skipAutomation: false,
-      targetTrustLabel: POLICY.adminLabel,
+      targetTrustLabel: "contrib-trust:highly-trusted",
     })
   })
 

--- a/.github/scripts/contributor-trust/run.js
+++ b/.github/scripts/contributor-trust/run.js
@@ -51,7 +51,7 @@ function resolvePullNumber(eventName, payload) {
   return null
 }
 
-function buildScoreInput({ isAdmin, metrics }) {
+function buildScoreInput({ metrics, repoPermission }) {
   const contributionCount = metrics.mergedPrs + metrics.reviews
 
   return {
@@ -60,13 +60,12 @@ function buildScoreInput({ isAdmin, metrics }) {
     contributionCount,
     followers: metrics.followers,
     isContributor: contributionCount > 0,
-    isAdmin,
     prsInRepo: [
       ...Array.from({ length: metrics.mergedPrs }).fill({ state: "merged" }),
       ...Array.from({ length: metrics.closedPrs }).fill({ state: "closed" }),
       ...Array.from({ length: metrics.openPrs }).fill({ state: "open" }),
     ],
-    publicRepos: metrics.publicRepos,
+    repoPermission,
     reviewsInRepo: metrics.reviews,
     topRepoStars: metrics.topRepositories.map(repository => repository.stargazerCount),
   }
@@ -176,18 +175,16 @@ async function main() {
   const permission = await getCollaboratorPermission(token, owner, repo, pullRequest.user.login)
   const authorMetrics = await getAuthorMetrics(token, owner, repo, pullRequest.user.login)
   const scoreInput = buildScoreInput({
-    isAdmin: POLICY.adminPermissions.includes(permission ?? ""),
     metrics: {
       accountCreated: authorMetrics.author.createdAt,
       closedPrs: authorMetrics.repoHistory.closedPrs,
-      excludedForkRepositories: authorMetrics.repoHistory.excludedForkRepositories,
       followers: authorMetrics.author.followers,
       mergedPrs: authorMetrics.repoHistory.mergedPrs,
       openPrs: authorMetrics.repoHistory.openPrs,
-      publicRepos: authorMetrics.author.publicRepos,
       reviews: authorMetrics.repoHistory.reviews,
       topRepositories: authorMetrics.repoHistory.topRepositories,
     },
+    repoPermission: permission ?? null,
   })
 
   const score = computeContributorScore(scoreInput)
@@ -202,11 +199,10 @@ async function main() {
     metrics: {
       accountCreated: authorMetrics.author.createdAt,
       closedPrs: authorMetrics.repoHistory.closedPrs,
-      excludedForkRepositories: authorMetrics.repoHistory.excludedForkRepositories,
       followers: authorMetrics.author.followers,
       mergedPrs: authorMetrics.repoHistory.mergedPrs,
       openPrs: authorMetrics.repoHistory.openPrs,
-      publicRepos: authorMetrics.author.publicRepos,
+      repoPermission: permission ?? "none",
       reviews: authorMetrics.repoHistory.reviews,
       topRepositories: authorMetrics.repoHistory.topRepositories,
     },

--- a/.github/scripts/contributor-trust/score-author.js
+++ b/.github/scripts/contributor-trust/score-author.js
@@ -43,8 +43,8 @@ function scoreCommunityStanding(input) {
   const followers = toNumber(input.followers)
   score += followers < 10 ? 1 : followers < 50 ? 3 : followers < 200 ? 5 : followers < 1000 ? 7 : 10
 
-  const publicRepos = toNumber(input.publicRepos)
-  score += publicRepos === 0 ? 0 : publicRepos <= 5 ? 2 : publicRepos <= 20 ? 4 : publicRepos <= 50 ? 7 : 10
+  if (POLICY.repoFamiliarityBonusPermissions.includes(input.repoPermission ?? ""))
+    score += 10
 
   return Math.min(score, 25)
 }
@@ -87,19 +87,6 @@ export function getTrustBucket(total) {
 }
 
 export function computeContributorScore(input) {
-  if (input.isAdmin) {
-    return {
-      total: 100,
-      repoFamiliarity: 35,
-      communityStanding: 25,
-      ossInfluence: 20,
-      prTrackRecord: 20,
-      bucket: TRUST_BUCKETS.HIGHLY_TRUSTED,
-      exemptReason: "admin",
-      lowScoreThreshold: POLICY.lowScoreThreshold,
-    }
-  }
-
   const repoFamiliarity = scoreRepoFamiliarity(input)
   const communityStanding = scoreCommunityStanding(input)
   const ossInfluence = scoreOSSInfluence(input)
@@ -113,7 +100,6 @@ export function computeContributorScore(input) {
     ossInfluence,
     prTrackRecord,
     bucket: getTrustBucket(total),
-    exemptReason: null,
     lowScoreThreshold: POLICY.lowScoreThreshold,
   }
 }

--- a/.github/scripts/contributor-trust/score-author.test.js
+++ b/.github/scripts/contributor-trust/score-author.test.js
@@ -9,10 +9,9 @@ function createBaseInput() {
     commitsInRepo: 0,
     contributionCount: 0,
     followers: 0,
-    isAdmin: false,
     isContributor: false,
     prsInRepo: [],
-    publicRepos: 0,
+    repoPermission: null,
     reviewsInRepo: 0,
     topRepoStars: [],
   }
@@ -30,20 +29,18 @@ describe("getTrustBucket", () => {
 })
 
 describe("computeContributorScore", () => {
-  it("gives repo admins a full trust exemption", () => {
+  it("does not grant any direct trust exemption to repo admins", () => {
     const score = computeContributorScore({
       ...createBaseInput(),
-      isAdmin: true,
+      repoPermission: "admin",
     })
 
     expect(score).toMatchObject({
-      bucket: TRUST_BUCKETS.HIGHLY_TRUSTED,
-      communityStanding: 25,
-      exemptReason: "admin",
-      ossInfluence: 20,
-      prTrackRecord: 20,
-      repoFamiliarity: 35,
-      total: 100,
+      bucket: TRUST_BUCKETS.NEW,
+      communityStanding: 15,
+      prTrackRecord: 5,
+      repoFamiliarity: 0,
+      total: 20,
     })
   })
 
@@ -79,18 +76,17 @@ describe("computeContributorScore", () => {
         ...Array.from({ length: 9 }).fill({ state: "merged" }),
         { state: "closed" },
       ],
-      publicRepos: 34,
       reviewsInRepo: 12,
       topRepoStars: [520, 40, 12],
     })
 
     expect(score).toMatchObject({
-      bucket: TRUST_BUCKETS.HIGHLY_TRUSTED,
-      communityStanding: 18,
+      bucket: TRUST_BUCKETS.TRUSTED,
+      communityStanding: 11,
       ossInfluence: 17,
       prTrackRecord: 17,
       repoFamiliarity: 32,
-      total: 84,
+      total: 77,
     })
   })
 
@@ -102,9 +98,19 @@ describe("computeContributorScore", () => {
       followers: 12,
       isContributor: true,
       prsInRepo: Array.from({ length: 10 }).fill({ state: "merged" }),
-      publicRepos: 6,
     })
 
     expect(score.prTrackRecord).toBe(18)
+  })
+
+  it("adds the full community standing bonus for admin, maintain, and write access", () => {
+    for (const repoPermission of ["admin", "maintain", "write"]) {
+      const score = computeContributorScore({
+        ...createBaseInput(),
+        repoPermission,
+      })
+
+      expect(score.communityStanding).toBe(15)
+    }
   })
 })


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [x] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fix the contributor trust workflow so OSS influence only reflects repositories the PR author actually owns, and align role scoring with the updated policy.

- replace the OSS repo source with author-owned non-fork repositories only, preventing other organizations' popular repos from inflating trust scores
- remove direct role-based exemptions; `admin`, `maintain`, and `write` now contribute a +10 role bonus inside community standing instead
- keep legacy admin-label cleanup so older trust runs can still be normalized on rerun
- update the trust comment wording to show owned non-fork repos and repo permission explicitly
- refresh focused tests for owned-repo filtering, comment rendering, role scoring, and trust action planning

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Manual/local validation:
- `pnpm eslint .github/scripts/contributor-trust`
- `SKIP_FREE_API=true pnpm vitest run .github/scripts/contributor-trust/score-author.test.js .github/scripts/contributor-trust/plan-actions.test.js .github/scripts/contributor-trust/github-api.test.js .github/scripts/contributor-trust/comment-template.test.js .github/scripts/contributor-trust/managed-comment.test.js`
- `git push -u origin fix/trust-owned-nonfork-oss` (pre-push hooks ran lint, type-check, and the full test suite)

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- This follow-up should fix misleading trust comments like the one on `#1168`, where non-owned repositories were previously counted toward OSS influence.
- After merging, rerun the contributor trust workflow on affected PRs to refresh their comments and labels.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix contributor trust scoring to only use author‑owned non‑fork repositories for OSS influence. Remove the admin exemption and replace it with a role bonus, and update comments/labels to match the policy.

- **Bug Fixes**
  - OSS influence now counts stars only from owned, non‑fork repos; updated GraphQL query and filtering.
  - `admin`/`maintain`/`write` add a +10 bonus under community standing; no direct admin exemption.
  - Keep legacy `contrib-trust:admin` label only for cleanup; planning no longer targets it.
  - Trust comment shows repo permission and “owned non‑fork repos”; removes “public repos” and fork exclusions.
  - Tests refreshed for repo filtering, role scoring, comment rendering, and action planning.

- **Migration**
  - Re-run the contributor trust workflow on existing PRs to refresh comments and remove old admin labels.

<sup>Written for commit 5b388115c156aceec1ed80e0ac7d06aae13b31e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

