### PR TITLE
fix(github): skip contributor trust for bot prs

### DIFF
--- a/.github/scripts/contributor-trust/bot-author.js
+++ b/.github/scripts/contributor-trust/bot-author.js
@@ -1,0 +1,14 @@
+export function isBotAuthor(user = null) {
+  const login = typeof user?.login === "string" ? user.login.trim() : ""
+  const type = typeof user?.type === "string" ? user.type : ""
+
+  return type === "Bot" || login.toLowerCase().endsWith("[bot]")
+}
+
+export function getBotAuthorSkipReason(user = null) {
+  if (!isBotAuthor(user))
+    return null
+
+  const login = typeof user?.login === "string" ? user.login.trim() : ""
+  return login ? `bot-authored PR by @${login}` : "bot-authored PR"
+}

--- a/.github/scripts/contributor-trust/bot-author.test.js
+++ b/.github/scripts/contributor-trust/bot-author.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+
+import { getBotAuthorSkipReason, isBotAuthor } from "./bot-author.js"
+
+describe("isBotAuthor", () => {
+  it("treats GitHub Bot accounts as bots", () => {
+    expect(isBotAuthor({
+      login: "dependabot[bot]",
+      type: "Bot",
+    })).toBe(true)
+  })
+
+  it("falls back to the login suffix when the type is not marked as Bot", () => {
+    expect(isBotAuthor({
+      login: "renovate[bot]",
+      type: "User",
+    })).toBe(true)
+  })
+
+  it("does not flag human authors", () => {
+    expect(isBotAuthor({
+      login: "mengxi-ream",
+      type: "User",
+    })).toBe(false)
+  })
+})
+
+describe("getBotAuthorSkipReason", () => {
+  it("returns a skip reason for bot-authored pull requests", () => {
+    expect(getBotAuthorSkipReason({
+      login: "dependabot[bot]",
+      type: "Bot",
+    })).toBe("bot-authored PR by @dependabot[bot]")
+  })
+
+  it("returns null for human-authored pull requests", () => {
+    expect(getBotAuthorSkipReason({
+      login: "mengxi-ream",
+      type: "User",
+    })).toBeNull()
+  })
+})

--- a/.github/scripts/contributor-trust/run.js
+++ b/.github/scripts/contributor-trust/run.js
@@ -1,6 +1,9 @@
 import { appendFile, readFile } from "node:fs/promises"
+import { resolve } from "node:path"
 import process from "node:process"
+import { fileURLToPath } from "node:url"
 
+import { getBotAuthorSkipReason } from "./bot-author.js"
 import { buildTrustComment } from "./comment-template.js"
 import { LABEL_DEFINITIONS, POLICY } from "./config.js"
 import {
@@ -130,7 +133,7 @@ async function upsertComment({ body, issueNumber, owner, repo, token }) {
   return { action: "created", commentId: createdComment.id }
 }
 
-async function main() {
+export async function main() {
   const token = getRequiredEnv("GITHUB_TOKEN")
   const eventName = getRequiredEnv("GITHUB_EVENT_NAME")
   const payload = await getEventPayload()
@@ -151,6 +154,13 @@ async function main() {
     `- State: ${pullRequest.state}${pullRequest.draft ? " (draft)" : ""}`,
     `- Author: @${pullRequest.user.login}`,
   ]
+
+  const botSkipReason = getBotAuthorSkipReason(pullRequest.user)
+  if (botSkipReason) {
+    summaryLines.push(`- Result: skipped ${botSkipReason}`)
+    await writeJobSummary(summaryLines)
+    return
+  }
 
   if (eventName === "pull_request_target" && pullRequest.draft) {
     summaryLines.push("- Result: skipped automatic trust checks for a draft PR")
@@ -262,13 +272,18 @@ async function main() {
   await writeJobSummary(summaryLines)
 }
 
-main().catch(async (error) => {
-  console.error(error)
-  await writeJobSummary([
-    "## Contributor trust automation",
-    "",
-    `- Result: failed`,
-    `- Error: ${error instanceof Error ? error.message : String(error)}`,
-  ])
-  process.exitCode = 1
-})
+const isDirectExecution = process.argv[1]
+  && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+
+if (isDirectExecution) {
+  main().catch(async (error) => {
+    console.error(error)
+    await writeJobSummary([
+      "## Contributor trust automation",
+      "",
+      `- Result: failed`,
+      `- Error: ${error instanceof Error ? error.message : String(error)}`,
+    ])
+    process.exitCode = 1
+  })
+}

--- a/.github/scripts/contributor-trust/run.test.js
+++ b/.github/scripts/contributor-trust/run.test.js
@@ -1,0 +1,208 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import process from "node:process"
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  buildTrustComment: vi.fn(),
+  computeContributorScore: vi.fn(),
+  createContributorMetrics: vi.fn(),
+  createIssueComment: vi.fn(),
+  addLabelsToIssue: vi.fn(),
+  closePullRequestIssue: vi.fn(),
+  ensureRepositoryLabels: vi.fn(),
+  getAuthorMetrics: vi.fn(),
+  getCollaboratorPermission: vi.fn(),
+  getPullRequest: vi.fn(),
+  listIssueComments: vi.fn(),
+  listIssueLabels: vi.fn(),
+  removeLabelFromIssue: vi.fn(),
+  updateIssueComment: vi.fn(),
+  findManagedTrustComment: vi.fn(),
+}))
+
+vi.mock("./comment-template.js", () => ({
+  buildTrustComment: mocks.buildTrustComment,
+}))
+
+vi.mock("./github-api.js", () => ({
+  addLabelsToIssue: mocks.addLabelsToIssue,
+  closePullRequestIssue: mocks.closePullRequestIssue,
+  createContributorMetrics: mocks.createContributorMetrics,
+  createIssueComment: mocks.createIssueComment,
+  ensureRepositoryLabels: mocks.ensureRepositoryLabels,
+  getAuthorMetrics: mocks.getAuthorMetrics,
+  getCollaboratorPermission: mocks.getCollaboratorPermission,
+  getPullRequest: mocks.getPullRequest,
+  listIssueComments: mocks.listIssueComments,
+  listIssueLabels: mocks.listIssueLabels,
+  removeLabelFromIssue: mocks.removeLabelFromIssue,
+  updateIssueComment: mocks.updateIssueComment,
+}))
+
+vi.mock("./managed-comment.js", () => ({
+  findManagedTrustComment: mocks.findManagedTrustComment,
+}))
+
+vi.mock("./score-author.js", () => ({
+  computeContributorScore: mocks.computeContributorScore,
+}))
+
+const ENV_KEYS = [
+  "GITHUB_EVENT_NAME",
+  "GITHUB_EVENT_PATH",
+  "GITHUB_REPOSITORY",
+  "GITHUB_STEP_SUMMARY",
+  "GITHUB_TOKEN",
+  "TRUST_PR_NUMBER",
+]
+
+const originalEnv = { ...process.env }
+
+async function loadMain() {
+  vi.resetModules()
+  return (await import("./run.js")).main
+}
+
+describe("main", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+
+    const tempDir = await mkdtemp(join(tmpdir(), "contributor-trust-run-"))
+    const eventPath = join(tempDir, "event.json")
+    const summaryPath = join(tempDir, "summary.md")
+
+    await writeFile(eventPath, JSON.stringify({}), "utf8")
+    await writeFile(summaryPath, "", "utf8")
+
+    process.env.GITHUB_EVENT_NAME = "workflow_dispatch"
+    process.env.GITHUB_EVENT_PATH = eventPath
+    process.env.GITHUB_REPOSITORY = "read-frog/read-frog"
+    process.env.GITHUB_STEP_SUMMARY = summaryPath
+    process.env.GITHUB_TOKEN = "test-token"
+    process.env.TRUST_PR_NUMBER = "42"
+  })
+
+  afterEach(() => {
+    for (const key of ENV_KEYS)
+      delete process.env[key]
+
+    Object.assign(process.env, originalEnv)
+  })
+
+  it("skips bot-authored pull requests without mutating trust state", async () => {
+    mocks.getPullRequest.mockResolvedValue({
+      draft: false,
+      number: 42,
+      state: "open",
+      title: "chore(deps): bump dependencies",
+      user: {
+        login: "dependabot[bot]",
+        type: "Bot",
+      },
+    })
+
+    const main = await loadMain()
+    await main()
+
+    expect(mocks.ensureRepositoryLabels).not.toHaveBeenCalled()
+    expect(mocks.listIssueLabels).not.toHaveBeenCalled()
+    expect(mocks.getCollaboratorPermission).not.toHaveBeenCalled()
+    expect(mocks.getAuthorMetrics).not.toHaveBeenCalled()
+
+    const summary = await readFile(process.env.GITHUB_STEP_SUMMARY, "utf8")
+    expect(summary).toContain("- Result: skipped bot-authored PR by @dependabot[bot]")
+  })
+
+  it("continues to process human-authored pull requests", async () => {
+    mocks.getPullRequest.mockResolvedValue({
+      additions: 20,
+      deletions: 5,
+      draft: false,
+      number: 42,
+      state: "open",
+      title: "fix: keep contributor trust scoring for humans",
+      user: {
+        login: "mengxi-ream",
+        type: "User",
+      },
+    })
+    mocks.ensureRepositoryLabels.mockResolvedValue(undefined)
+    mocks.listIssueLabels.mockResolvedValue([])
+    mocks.getCollaboratorPermission.mockResolvedValue("write")
+    mocks.getAuthorMetrics.mockResolvedValue({
+      author: {
+        createdAt: "2020-01-01T00:00:00Z",
+        followers: 12,
+        login: "mengxi-ream",
+        name: "Mengxi Ream",
+        url: "https://github.com/mengxi-ream",
+      },
+      repoHistory: {
+        closedPrs: 1,
+        commitsInRepo: 14,
+        mergedPrs: 2,
+        openPrs: 0,
+        reviews: 3,
+        topRepositories: [],
+      },
+    })
+    mocks.createContributorMetrics.mockReturnValue({ source: "metrics" })
+    mocks.computeContributorScore.mockReturnValue({
+      breakdown: {
+        communityStanding: {
+          accountAge: { months: 24, points: 5 },
+          followers: { count: 12, points: 10 },
+          repoPermission: { permission: "write", points: 10 },
+        },
+        ossInfluence: {
+          maxOwnedRepoStars: { count: 0, points: 0 },
+          totalOwnedRepoStars: { count: 0, points: 0 },
+        },
+        prTrackRecord: {
+          confidence: "medium",
+          mergedPrs: 2,
+          resolvedPrs: 3,
+          smoothedRate: 0.75,
+        },
+        repoFamiliarity: {
+          commitsInRepo: { count: 14, points: 10 },
+          contributorBonus: { eligible: true, points: 5 },
+          mergedPrs: { count: 2, points: 12 },
+          reviewsInRepo: { count: 3, points: 8 },
+        },
+      },
+      bucket: "trusted",
+      communityStanding: 25,
+      ossInfluence: 0,
+      prTrackRecord: 18,
+      repoFamiliarity: 35,
+      total: 78,
+    })
+    mocks.buildTrustComment.mockReturnValue({
+      body: "managed trust comment",
+      fingerprint: "fingerprint-123",
+    })
+    mocks.listIssueComments.mockResolvedValue([])
+    mocks.createIssueComment.mockResolvedValue({ id: 99 })
+    mocks.addLabelsToIssue.mockResolvedValue([])
+
+    const main = await loadMain()
+    await main()
+
+    expect(mocks.ensureRepositoryLabels).toHaveBeenCalledTimes(1)
+    expect(mocks.getCollaboratorPermission).toHaveBeenCalledWith(
+      "test-token",
+      "read-frog",
+      "read-frog",
+      "mengxi-ream",
+    )
+    expect(mocks.getAuthorMetrics).toHaveBeenCalledTimes(1)
+    expect(mocks.createIssueComment).toHaveBeenCalledTimes(1)
+
+    const summary = await readFile(process.env.GITHUB_STEP_SUMMARY, "utf8")
+    expect(summary).toContain("- Trust score: **78/100**")
+  })
+})

--- a/.github/workflows/pr-contributor-trust.yml
+++ b/.github/workflows/pr-contributor-trust.yml
@@ -19,8 +19,63 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  preflight:
+    name: Preflight
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      author_login: ${{ steps.inspect.outputs.author_login }}
+      pr_number: ${{ steps.inspect.outputs.pr_number }}
+      should_skip: ${{ steps.inspect.outputs.should_skip }}
+      skip_reason: ${{ steps.inspect.outputs.skip_reason }}
+    steps:
+      - name: Resolve PR metadata
+        id: inspect
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const prNumber = context.eventName === "pull_request_target"
+              ? context.payload.pull_request?.number
+              : Number(core.getInput("pr_number", { required: true }));
+
+            if (!Number.isInteger(prNumber) || prNumber <= 0)
+              throw new Error(`Unable to resolve a valid pull request number for event ${context.eventName}.`);
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            const authorLogin = pullRequest.user?.login ?? "";
+            const authorType = pullRequest.user?.type ?? "";
+            const shouldSkip = authorType === "Bot" || authorLogin.toLowerCase().endsWith("[bot]");
+
+            core.setOutput("author_login", authorLogin);
+            core.setOutput("pr_number", String(prNumber));
+            core.setOutput("should_skip", shouldSkip ? "true" : "false");
+            core.setOutput(
+              "skip_reason",
+              shouldSkip ? `bot-authored PR by @${authorLogin}` : "",
+            );
+
+      - name: Write skip summary
+        if: steps.inspect.outputs.should_skip == 'true'
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          ## Contributor trust automation
+
+          - Event: `${{ github.event_name }}`
+          - PR: #${{ steps.inspect.outputs.pr_number }}
+          - Author: @${{ steps.inspect.outputs.author_login }}
+          - Result: skipped ${{ steps.inspect.outputs.skip_reason }}
+          EOF
+
   trust-score:
     name: Score contributor trust
+    needs: preflight
+    if: needs.preflight.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -42,5 +97,5 @@ jobs:
       - name: Score contributor and sync trust state
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TRUST_PR_NUMBER: ${{ inputs.pr_number || '' }}
+          TRUST_PR_NUMBER: ${{ needs.preflight.outputs.pr_number }}
         run: node .github/scripts/contributor-trust/run.js


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] 🐛 Bug fix (fix)
- [ ] ✨ New feature (feat)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [x] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

- add a contributor-trust preflight step that resolves the target PR for both `pull_request_target` and `workflow_dispatch`
- skip contributor-trust automation entirely when the PR author is a bot, so bot PRs do not run scoring, labels, comments, or auto-close logic
- make manual reruns on bot-authored PRs end successfully with a clear Actions summary instead of entering the trust workflow
- add focused tests for bot-author detection and the runtime early-return path to prevent regressions

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [x] Added unit tests
- [ ] Verified through manual testing

Commands run:

```bash
pnpm eslint .github/scripts/contributor-trust
pnpm vitest run .github/scripts/contributor-trust/bot-author.test.js .github/scripts/contributor-trust/run.test.js .github/scripts/contributor-trust/plan-actions.test.js .github/scripts/contributor-trust/managed-comment.test.js .github/scripts/contributor-trust/comment-template.test.js .github/scripts/contributor-trust/score-author.test.js .github/scripts/contributor-trust/github-api.test.js
# pre-push hook also ran cached repo lint/type-check/test successfully
```

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

N/A

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- no changeset was added because this only changes GitHub contributor-trust automation and test coverage; it does not change the shipped extension package


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip contributor-trust for bot-authored PRs and add a preflight step to resolve PR metadata across events. This prevents noisy labels/comments on automated bot updates and writes a clear Actions summary.

- **Bug Fixes**
  - Skip trust flow when the author is a bot (`type: Bot` or login ends with `[bot]`); no scoring, labels, comments, or auto-close. Manual reruns end with a clear summary.
  - Add a workflow preflight to resolve the target PR for `pull_request_target` and `workflow_dispatch`, and write a skip summary for bots.
  - Add focused unit tests for bot detection and the early-return path; exported `main()` and guarded direct execution to enable testing.

<sup>Written for commit 7fb709fa267c1fa4fadaf93f7aef175cd4296179. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

