### PR TITLE
fix(github): read contributor trust dispatch input from event

### DIFF
--- a/.github/workflows/pr-contributor-trust.yml
+++ b/.github/workflows/pr-contributor-trust.yml
@@ -35,9 +35,10 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            // workflow_dispatch inputs live on the event payload, not as github-script action inputs.
             const prNumber = context.eventName === "pull_request_target"
               ? context.payload.pull_request?.number
-              : Number(core.getInput("pr_number", { required: true }));
+              : Number(context.payload.inputs?.pr_number ?? "");
 
             if (!Number.isInteger(prNumber) || prNumber <= 0)
               throw new Error(`Unable to resolve a valid pull request number for event ${context.eventName}.`);


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [x] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fix the manually triggered `PR - Contributor Trust` workflow so it reads `pr_number` from the workflow dispatch event payload.

Previously the preflight step called `core.getInput("pr_number")` inside `actions/github-script`, which only reads action step inputs and caused the run to fail with `Input required and not supplied: pr_number` even when a PR number was entered in the GitHub UI.

This change keeps the `pull_request_target` path unchanged and switches the manual dispatch path to `context.payload.inputs.pr_number`.

## Related Issue

Closes #

## How Has This Been Tested?

- [ ] Added unit tests
- [ ] Verified through manual testing

Reviewed the workflow logic locally and confirmed the manual dispatch path now reads from the event payload used by `workflow_dispatch`.

## Screenshots

N/A

## Checklist

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This is limited to the GitHub Actions workflow and does not affect extension runtime behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes manual runs of the `PR - Contributor Trust` workflow by reading the PR number from the `workflow_dispatch` event payload. This prevents “Input required and not supplied: pr_number” errors and keeps the `pull_request_target` path unchanged.

<sup>Written for commit b615f505f9eac0f527100b6384308f528a9c51f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

