### PR TITLE
fix(translation): keep reduced-motion spinners visible

### DIFF
--- a/.changeset/calm-geckos-wave.md
+++ b/.changeset/calm-geckos-wave.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): keep reduced-motion spinners visibly active without animation

--- a/src/entrypoints/selection.content/input-translation/use-input-translation.ts
+++ b/src/entrypoints/selection.content/input-translation/use-input-translation.ts
@@ -76,8 +76,9 @@ function showSpinner(element: HTMLElement): () => void {
     )
   }
   else {
-    // For reduced motion, show static spinner with muted color
-    spinner.style.borderTopColor = "#a3a3a3"
+    // For reduced motion, keep the spinner static but preserve the primary
+    // segment so the loading state remains visible without animation.
+    spinner.style.borderTopColor = "#4ade80"
   }
 
   // Calculate position - vertically centered relative to the element

--- a/src/utils/host/translate/ui/__tests__/spinner.test.ts
+++ b/src/utils/host/translate/ui/__tests__/spinner.test.ts
@@ -15,6 +15,7 @@ describe("spinner", () => {
     document.head.innerHTML = ""
     document.body.innerHTML = ""
     ensurePresetStylesMock.mockReset()
+    vi.restoreAllMocks()
   })
 
   it("ensures preset styles on the document before appending the spinner", async () => {
@@ -61,5 +62,35 @@ describe("spinner", () => {
     expect(shadow.querySelector("#read-frog-preset-styles")).not.toBeNull()
     expect(wrapper.lastElementChild).toBe(spinner)
     expect(spinner.className).toBe("read-frog-spinner")
+  })
+
+  it("keeps the primary segment visible when reduced motion is enabled", async () => {
+    Object.defineProperty(window, "matchMedia", {
+      value: vi.fn().mockReturnValue({
+        matches: true,
+        media: "(prefers-reduced-motion: reduce)",
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      }),
+      configurable: true,
+      writable: true,
+    })
+
+    const animateMock = vi.fn()
+    Object.defineProperty(HTMLElement.prototype, "animate", {
+      value: animateMock,
+      configurable: true,
+      writable: true,
+    })
+
+    const { createLightweightSpinner } = await import("../spinner")
+    const spinner = createLightweightSpinner(document)
+
+    expect(animateMock).not.toHaveBeenCalled()
+    expect(spinner.style.borderTopColor).toBe("var(--read-frog-primary)")
   })
 })

--- a/src/utils/host/translate/ui/spinner.ts
+++ b/src/utils/host/translate/ui/spinner.ts
@@ -60,8 +60,10 @@ export function createLightweightSpinner(ownerDoc: Document): HTMLElement {
     )
   }
   else {
-    // For reduced motion or when Web Animations API isn't available, show static spinner with muted color
-    spinner.style.borderTopColor = "var(--read-frog-muted)"
+    // For reduced motion or when Web Animations API isn't available,
+    // keep a static spinner while preserving the primary segment so the
+    // loading state stays visible without requiring animation.
+    spinner.style.borderTopColor = "var(--read-frog-primary)"
   }
 
   return spinner


### PR DESCRIPTION
Closes #887

## Summary

- keep the primary spinner segment visible when reduced motion is enabled
- apply the same reduced-motion visibility behavior to input translation spinner
- add a regression test covering the reduced-motion branch

## Testing

- `../../node_modules/.bin/eslint src/utils/host/translate/ui/spinner.ts src/entrypoints/selection.content/input-translation/use-input-translation.ts src/utils/host/translate/ui/__tests__/spinner.test.ts`
- `../../node_modules/.bin/vitest run src/utils/host/translate/ui/__tests__/spinner.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep translation spinners visible for users with reduced motion by preserving the primary-colored segment while disabling animation. Applies to both the lightweight spinner and the input translation spinner, with a regression test added.

- **Bug Fixes**
  - Preserve the primary segment color when reduced motion is enabled or Web Animations API is unavailable.
  - Apply the same reduced-motion behavior to the input translation spinner.
  - Add a test to ensure no animation runs and the primary color is used in reduced-motion mode.

<sup>Written for commit bf21577cc4cc1c0c3c136c4b268a50dab7c2e927. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

