### PR TITLE
fix: stabilize AI-aware page translation cache title

### DIFF
--- a/.changeset/tall-poems-sparkle.md
+++ b/.changeset/tall-poems-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: keep AI-aware page translation cache title stable on same-page toggles

--- a/src/utils/host/translate/__tests__/article-context.test.ts
+++ b/src/utils/host/translate/__tests__/article-context.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockParse = vi.fn()
+const mockRemoveDummyNodes = vi.fn()
+const mockWarn = vi.fn()
+
+vi.mock("@mozilla/readability", () => ({
+  Readability: vi.fn().mockImplementation(() => ({
+    parse: mockParse,
+  })),
+}))
+
+vi.mock("@/utils/content/utils", () => ({
+  removeDummyNodes: mockRemoveDummyNodes,
+}))
+
+vi.mock("@/utils/logger", () => ({
+  logger: {
+    warn: mockWarn,
+  },
+}))
+
+async function loadModule() {
+  vi.resetModules()
+  return await import("../article-context")
+}
+
+describe("getOrFetchArticleData", () => {
+  beforeEach(() => {
+    mockParse.mockReset()
+    mockRemoveDummyNodes.mockReset()
+    mockWarn.mockReset()
+
+    mockParse.mockReturnValue({ textContent: "Readable article body" })
+    mockRemoveDummyNodes.mockResolvedValue(undefined)
+
+    document.title = "Original Title"
+    document.body.innerHTML = "<main>Article body</main>"
+    window.history.replaceState({}, "", "/article")
+  })
+
+  it("keeps the original title stable for AI-aware context on the same URL", async () => {
+    const { getOrFetchArticleData } = await loadModule()
+
+    const first = await getOrFetchArticleData(true)
+
+    document.title = "Translated Browser Title"
+    const second = await getOrFetchArticleData(true)
+
+    expect(first?.title).toBe("Original Title")
+    expect(first?.textContent).toBeTruthy()
+    expect(second).toEqual({
+      title: "Original Title",
+      textContent: first?.textContent,
+    })
+  })
+
+  it("still returns the live title when AI content aware is disabled", async () => {
+    const { getOrFetchArticleData } = await loadModule()
+
+    const first = await getOrFetchArticleData(false)
+    document.title = "Updated Live Title"
+    const second = await getOrFetchArticleData(false)
+
+    expect(first).toEqual({ title: "Original Title" })
+    expect(second).toEqual({ title: "Updated Live Title" })
+    expect(mockParse).not.toHaveBeenCalled()
+    expect(mockRemoveDummyNodes).not.toHaveBeenCalled()
+  })
+
+  it("refreshes the cached title and text content after the URL changes", async () => {
+    const { getOrFetchArticleData } = await loadModule()
+
+    const first = await getOrFetchArticleData(true)
+
+    document.title = "Next Article Title"
+    document.body.innerHTML = "<main>Next article body</main>"
+    mockParse.mockReturnValueOnce({ textContent: "Next readable article body" })
+    window.history.replaceState({}, "", "/article-2")
+
+    const second = await getOrFetchArticleData(true)
+
+    expect(first?.title).toBe("Original Title")
+    expect(first?.textContent).toBeTruthy()
+    expect(second?.title).toBe("Next Article Title")
+    expect(second?.textContent).toBeTruthy()
+    expect(second?.textContent).not.toBe(first?.textContent)
+  })
+})

--- a/src/utils/host/translate/article-context.ts
+++ b/src/utils/host/translate/article-context.ts
@@ -2,7 +2,7 @@ import { Readability } from "@mozilla/readability"
 import { removeDummyNodes } from "@/utils/content/utils"
 import { logger } from "@/utils/logger"
 
-let cachedTextContent: { url: string, textContent: string } | null = null
+let cachedArticleData: { url: string, title: string, textContent: string } | null = null
 
 async function fetchPageTextContent(): Promise<string> {
   try {
@@ -29,12 +29,18 @@ export async function getOrFetchArticleData(
     return { title }
 
   const currentUrl = window.location.href
-  if (cachedTextContent?.url === currentUrl) {
-    return { title, textContent: cachedTextContent.textContent }
+  if (cachedArticleData?.url === currentUrl) {
+    // Keep article context stable for the lifetime of a page URL. During page translation,
+    // document.title can be mutated to the translated title, and re-reading that live value
+    // would drift the prompt/context and the AI-aware cache key for the same page.
+    return {
+      title: cachedArticleData.title,
+      textContent: cachedArticleData.textContent,
+    }
   }
 
   const textContent = await fetchPageTextContent()
-  cachedTextContent = { url: currentUrl, textContent }
+  cachedArticleData = { url: currentUrl, title, textContent }
 
   return { title, textContent }
 }


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [x] ✅ Tests

## Description

This fixes the unstable same-page cache misses reported in #1254 when **AI Content Aware** is enabled.

### Root cause

`getOrFetchArticleData()` cached article `textContent` by URL, but it kept re-reading the live `document.title` on every request.
During page translation, the tab title itself can be translated, so the same page could produce two different article-title contexts:

1. first translation pass → original source title
2. second pass after toggling back on → translated browser title

That drift changed the AI-aware cache key for otherwise identical body text, causing needless cache misses and repeated API calls.

### Fix

- Cache the article title together with the article text content for a given URL
- Reuse that stable source title while the URL stays the same
- Add regression tests covering:
  - stable title reuse on the same URL
  - unchanged live-title behavior when AI Content Aware is off
  - cache refresh when the URL changes

Fixes #1254.

## Testing

- `vitest run src/utils/host/translate/__tests__/article-context.test.ts src/utils/host/__tests__/translate-text.test.tsx src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts`
- `eslint src/utils/host/translate/article-context.ts src/utils/host/translate/__tests__/article-context.test.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes page translation caching by storing the source title with article text per URL, preventing cache key drift when the browser title changes during translation. Fixes #1254 and reduces duplicate API calls.

- **Bug Fixes**
  - Cache `{ url, title, textContent }` in `getOrFetchArticleData()` and reuse the cached title while the URL stays the same.
  - Keep live `document.title` behavior when Content Aware is off.
  - Refresh cached data when the URL changes.
  - Added tests for stable title reuse, live-title behavior, and URL-change refresh.

<sup>Written for commit 63235c2d069dd6228780cd2a01939c567fb72520. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

