### PR TITLE
fix(extension): resync detected language on tab visibility

### DIFF
--- a/src/entrypoints/host.content/runtime.ts
+++ b/src/entrypoints/host.content/runtime.ts
@@ -2,7 +2,7 @@ import type { ContentScriptContext } from "#imports"
 import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { Config } from "@/types/config/config"
 import { storage } from "#imports"
-import { DEFAULT_CONFIG, DETECTED_CODE_STORAGE_KEY } from "@/utils/constants/config"
+import { DEFAULT_CONFIG, DEFAULT_DETECTED_CODE, DETECTED_CODE_STORAGE_KEY } from "@/utils/constants/config"
 import { getDocumentInfo } from "@/utils/content/analyze"
 import { ensurePresetStyles } from "@/utils/host/translate/ui/style-injector"
 import { logger } from "@/utils/logger"
@@ -34,6 +34,27 @@ export async function bootstrapHostContent(ctx: ContentScriptContext, initialCon
 
   const cleanupTranslationShortcut = await bindTranslationShortcutKey(manager)
 
+  let latestDetectedCode: LangCodeISO6393 = DEFAULT_DETECTED_CODE
+
+  const syncDetectedCodeToStorage = async (detectedCode: LangCodeISO6393) => {
+    latestDetectedCode = detectedCode
+
+    if (document.visibilityState !== "visible") {
+      return
+    }
+
+    await storage.setItem<LangCodeISO6393>(`local:${DETECTED_CODE_STORAGE_KEY}`, detectedCode)
+  }
+
+  const handleDocumentVisibilityChange = () => {
+    if (window !== window.top || document.visibilityState !== "visible") {
+      return
+    }
+
+    void storage.setItem<LangCodeISO6393>(`local:${DETECTED_CODE_STORAGE_KEY}`, latestDetectedCode)
+  }
+  document.addEventListener("visibilitychange", handleDocumentVisibilityChange)
+
   // For late-loading iframes: check if translation is already enabled for this tab
   let translationEnabled = false
   try {
@@ -57,7 +78,7 @@ export async function bootstrapHostContent(ctx: ContentScriptContext, initialCon
       if (window === window.top) {
         const { detectedCodeOrUnd } = await getDocumentInfo()
         const detectedCode: LangCodeISO6393 = detectedCodeOrUnd === "und" ? "eng" : detectedCodeOrUnd
-        await storage.setItem<LangCodeISO6393>(`local:${DETECTED_CODE_STORAGE_KEY}`, detectedCode)
+        await syncDetectedCodeToStorage(detectedCode)
         // Notify background script that URL has changed, let it decide whether to automatically enable translation
         void sendMessage("checkAndAskAutoPageTranslation", { url: to, detectedCodeOrUnd })
       }
@@ -85,6 +106,7 @@ export async function bootstrapHostContent(ctx: ContentScriptContext, initialCon
     cleanupPageTranslationTriggers()
     cleanupTranslationShortcut()
     cleanupTranslationStateListener()
+    document.removeEventListener("visibilitychange", handleDocumentVisibilityChange)
     window.removeEventListener("extension:URLChange", handleExtensionUrlChange)
     window.__READ_FROG_HOST_INJECTED__ = false
     clearEffectiveSiteControlUrl()
@@ -94,7 +116,7 @@ export async function bootstrapHostContent(ctx: ContentScriptContext, initialCon
   if (window === window.top) {
     const { detectedCodeOrUnd } = await getDocumentInfo()
     const initialDetectedCode: LangCodeISO6393 = detectedCodeOrUnd === "und" ? "eng" : detectedCodeOrUnd
-    await storage.setItem<LangCodeISO6393>(`local:${DETECTED_CODE_STORAGE_KEY}`, initialDetectedCode)
+    await syncDetectedCodeToStorage(initialDetectedCode)
 
     // Check if auto-translation should be enabled for initial page load
     void sendMessage("checkAndAskAutoPageTranslation", { url: window.location.href, detectedCodeOrUnd })


### PR DESCRIPTION
## Summary
- keep each tab's last detected source language in memory inside the content script
- only sync `detectedCode` into shared storage when the tab becomes visible again
- prevent background tabs from overwriting the active tab's detected language state

Fixes #1281.

## Testing
- `pnpm exec wxt prepare`
- `pnpm exec eslint src/entrypoints/host.content/runtime.ts`
- `pnpm exec tsc --noEmit` *(currently fails in this checkout because of pre-existing unrelated type errors around Notebase / API contract types)*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resync detected language only when a tab is visible and keep a per-tab last value in memory. Prevents background tabs from overwriting the active tab’s detected language, fixing #1281.

- **Bug Fixes**
  - Defer writes to `local:${DETECTED_CODE_STORAGE_KEY}` unless `document.visibilityState === "visible"`.
  - Resync stored value on `visibilitychange` when the tab becomes visible; initialize with `DEFAULT_DETECTED_CODE`.
  - Replace direct writes on initial load and URL changes with a `syncDetectedCodeToStorage` helper and clean up the visibility listener on teardown.

<sup>Written for commit 7cdd2eb7af3f48ba0ed868c76fb8974af0a1bc5d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

