### PR TITLE
Fix #1110: [BUG] improve the speed when skip language

### DIFF
--- a/src/utils/host/__tests__/translate-text.test.tsx
+++ b/src/utils/host/__tests__/translate-text.test.tsx
@@ -27,11 +27,16 @@ vi.mock("@/utils/host/translate/article-context", () => ({
   getOrFetchArticleData: vi.fn(),
 }))
 
+vi.mock("@/utils/content/language", () => ({
+  detectLanguage: vi.fn(),
+}))
+
 let mockSendMessage: any
 let mockMicrosoftTranslate: any
 let mockGetConfigFromStorage: any
 let mockGetTranslatePrompt: any
 let mockGetOrFetchArticleData: any
+let mockDetectLanguage: any
 
 describe("translate-text", () => {
   beforeEach(async () => {
@@ -43,6 +48,7 @@ describe("translate-text", () => {
     mockGetConfigFromStorage = vi.mocked((await import("@/utils/config/storage")).getLocalConfig)
     mockGetTranslatePrompt = vi.mocked((await import("@/utils/prompts/translate")).getTranslatePrompt)
     mockGetOrFetchArticleData = vi.mocked((await import("@/utils/host/translate/article-context")).getOrFetchArticleData)
+    mockDetectLanguage = vi.mocked((await import("@/utils/content/language")).detectLanguage)
 
     // Mock getOrFetchArticleData to return document.title
     mockGetOrFetchArticleData.mockImplementation(() => Promise.resolve({ title: document.title }))
@@ -129,6 +135,50 @@ describe("translate-text", () => {
         text: "Body text",
         articleTitle: "Translated Browser Title",
       }))
+    })
+  })
+
+  describe("skip language detection with LLM translation provider", () => {
+    // Text is 14 chars: >= MIN_LENGTH_FOR_SKIP_LLM_DETECTION(10), < MIN_LENGTH_FOR_TARGET_LANG_DETECTION(50)
+    // so only shouldSkipByLanguage triggers detectLanguage, not isTextAlreadyInTargetLanguage
+    const japaneseText = "これは日本語のテキスト。"
+
+    it("should not use LLM detection when translation provider is LLM-based", async () => {
+      const llmConfig = {
+        ...DEFAULT_CONFIG,
+        translate: {
+          ...DEFAULT_CONFIG.translate,
+          providerId: "openai-default",
+          page: { ...DEFAULT_CONFIG.translate.page, skipLanguages: ["jpn"] as any },
+        },
+        languageDetection: { mode: "llm" as const },
+      }
+      mockGetConfigFromStorage.mockResolvedValue(llmConfig)
+      mockDetectLanguage.mockResolvedValue("jpn")
+      mockSendMessage.mockResolvedValue("")
+
+      await translateTextForPage(japaneseText)
+
+      expect(mockDetectLanguage).toHaveBeenCalledWith(japaneseText, expect.objectContaining({ enableLLM: false }))
+    })
+
+    it("should use LLM detection when translation provider is non-LLM and mode is llm", async () => {
+      const nonLlmConfig = {
+        ...DEFAULT_CONFIG,
+        translate: {
+          ...DEFAULT_CONFIG.translate,
+          providerId: "microsoft-translate-default",
+          page: { ...DEFAULT_CONFIG.translate.page, skipLanguages: ["jpn"] as any },
+        },
+        languageDetection: { mode: "llm" as const },
+      }
+      mockGetConfigFromStorage.mockResolvedValue(nonLlmConfig)
+      mockDetectLanguage.mockResolvedValue("jpn")
+      mockSendMessage.mockResolvedValue("")
+
+      await translateTextForPage(japaneseText)
+
+      expect(mockDetectLanguage).toHaveBeenCalledWith(japaneseText, expect.objectContaining({ enableLLM: true }))
     })
   })
 

--- a/src/utils/host/translate/translate-variants.ts
+++ b/src/utils/host/translate/translate-variants.ts
@@ -2,6 +2,7 @@ import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { Config, InputTranslationLang } from "@/types/config/config"
 import { getDetectedCodeFromStorage, getFinalSourceCode } from "@/utils/config/languages"
 import { resolveProviderConfig } from "@/utils/constants/feature-providers"
+import { isLLMProviderConfig } from "@/types/config/provider"
 import { detectLanguage } from "@/utils/content/language"
 import { logger } from "@/utils/logger"
 import { getLocalConfig } from "../../config/storage"
@@ -52,7 +53,7 @@ async function translateTextUsingPageConfig(
     const shouldSkip = await shouldSkipByLanguage(
       preparedText,
       skipLanguages,
-      config.languageDetection.mode === "llm",
+      config.languageDetection.mode === "llm" && !isLLMProviderConfig(providerConfig),
     )
     if (shouldSkip) {
       logger.info(`translateTextForPage: skipping translation because text is in skip language list. text: ${preparedText}`)


### PR DESCRIPTION
Closes #1110

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

When the "skip language" feature was enabled with LLM language detection and an LLM translation provider, `shouldSkipByLanguage` was making a separate LLM API call to detect the language of every paragraph before translation. This was redundant because the LLM translation prompt already handles language detection internally, resulting in two LLM API calls per paragraph.

The fix is in `src/utils/host/translate/translate-variants.ts` inside `translateTextUsingPageConfig`. The `enableLLM` flag passed to `shouldSkipByLanguage` (and ultimately to `detectLanguage`) is now conditioned on whether the active translation provider is non-LLM:

```ts
// Before
config.languageDetection.mode === "llm"

// After
config.languageDetection.mode === "llm" && !isLLMProviderConfig(providerConfig)
```

This implements the exact behavior described in the issue:
- **LLM detection + LLM translation**: skip language check uses `franc` only (`enableLLM: false`) — no redundant API call
- **LLM detection + non-LLM translation** (e.g. `microsoft-translate-default`): LLM detection is still used (`enableLLM: true`)
- **franc detection**: unchanged, always uses `franc`
- **Skip languages off**: unchanged, detection is not called at all

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Two new unit tests added in `src/utils/host/__tests__/translate-text.test.tsx` under `"skip language detection with LLM translation provider"`:

1. **LLM provider (`openai-default`) + LLM detection mode + `skipLanguages: ["jpn"]`**: asserts `detectLanguage` is called with `{ enableLLM: false }`.
2. **Non-LLM provider (`microsoft-translate-default`) + LLM detection mode + `skipLanguages: ["jpn"]`**: asserts `detectLanguage` is called with `{ enableLLM: true }`.

Both tests use a 14-character Japanese string that falls in the range `>= MIN_LENGTH_FOR_SKIP_LLM_DETECTION (10)` and `< MIN_LENGTH_FOR_TARGET_LANG_DETECTION (50)`, ensuring only `shouldSkipByLanguage` triggers `detectLanguage`, not `isTextAlreadyInTargetLanguage`.

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

`isLLMProviderConfig` (imported from `@/types/config/provider`) is used to determine whether the resolved `providerConfig` is LLM-based, keeping the logic consistent with how provider types are already distinguished elsewhere in the codebase.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up page translation when “skip languages” is enabled by avoiding redundant LLM language detection with LLM translation providers. Fixes #1110 and removes one LLM API call per paragraph.

- **Bug Fixes**
  - LLM detection + LLM translation (e.g., `openai-default`): skip-language check uses `franc` only (no extra LLM call).
  - LLM detection + non-LLM translation (e.g., `microsoft-translate-default`): still uses LLM detection.
  - `franc`-only detection and “skip languages” off remain unchanged.
  - Added unit tests for both provider types to verify `enableLLM` behavior.

<sup>Written for commit e430f9b645cf134fcbdc0fb1c555f2deb8f0a358. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

