### PR TITLE
perf(subtitles): add concurrent chunk processing for AI segmentation

### DIFF
--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -88,8 +88,13 @@ export class SegmentationPipeline {
 
         // Process chunks concurrently, then merge results synchronously
         const results = await Promise.all(chunks.map(chunk => this.processChunk(chunk)))
-        if (this.stopped)
+        if (this.stopped) {
+          // Roll back claimed fragments so they can be reprocessed on restart
+          for (const chunk of chunks) {
+            chunk.forEach(f => this.segmentedRawStarts.delete(f.start))
+          }
           break
+        }
         for (const result of results) {
           this.mergeFragments(result.fragments, result.chunk)
         }

--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -1,8 +1,13 @@
 import type { SubtitlesFragment } from "@/utils/subtitles/types"
 import { getLocalConfig } from "@/utils/config/storage"
-import { PROCESS_LOOK_AHEAD_MS } from "@/utils/constants/subtitles"
+import { MAX_CONCURRENT_SEGMENTS, PROCESS_LOOK_AHEAD_MS } from "@/utils/constants/subtitles"
 import { aiSegmentBlock } from "@/utils/subtitles/processor/ai-segmentation"
-import { optimizeSubtitles } from "@/utils/subtitles/processor/optimizer"
+import { optimizeSubtitles, rebalanceToTargetRange } from "@/utils/subtitles/processor/optimizer"
+
+interface ChunkResult {
+  fragments: SubtitlesFragment[]
+  chunk: SubtitlesFragment[]
+}
 
 export class SegmentationPipeline {
   // Segmented results, read by translation pipeline
@@ -16,15 +21,18 @@ export class SegmentationPipeline {
 
   private getVideoElement: () => HTMLVideoElement | null
   private getSourceLanguage: () => string
+  private onChunkProcessed: (() => void) | null
 
   constructor(options: {
     rawFragments: SubtitlesFragment[]
     getVideoElement: () => HTMLVideoElement | null
     getSourceLanguage: () => string
+    onChunkProcessed?: () => void
   }) {
     this.rawFragments = options.rawFragments
     this.getVideoElement = options.getVideoElement
     this.getSourceLanguage = options.getSourceLanguage
+    this.onChunkProcessed = options.onChunkProcessed ?? null
   }
 
   get isRunning(): boolean {
@@ -68,9 +76,24 @@ export class SegmentationPipeline {
 
     try {
       while (!this.stopped && this.hasUnprocessedChunks()) {
-        const didWork = await this.processNextChunk(video.currentTime * 1000)
-        if (!didWork)
+        const currentTimeMs = video.currentTime * 1000
+        const chunks = this.findNextChunks(currentTimeMs, MAX_CONCURRENT_SEGMENTS)
+        if (chunks.length === 0)
           break
+
+        // Mark all fragments as in-progress
+        for (const chunk of chunks) {
+          chunk.forEach(f => this.segmentedRawStarts.add(f.start))
+        }
+
+        // Process chunks concurrently, then merge results synchronously
+        const results = await Promise.all(chunks.map(chunk => this.processChunk(chunk)))
+        for (const result of results) {
+          if (result) {
+            this.mergeFragments(result.fragments, result.chunk)
+          }
+        }
+        this.onChunkProcessed?.()
       }
     }
     finally {
@@ -78,41 +101,56 @@ export class SegmentationPipeline {
     }
   }
 
-  private async processNextChunk(currentTimeMs: number): Promise<boolean> {
-    const chunk = this.findNextChunk(currentTimeMs)
-    if (chunk.length === 0)
-      return false
-
-    chunk.forEach(f => this.segmentedRawStarts.add(f.start))
-
+  private async processChunk(chunk: SubtitlesFragment[]): Promise<ChunkResult | null> {
     try {
       const config = await getLocalConfig()
       if (config) {
         const segmented = await aiSegmentBlock(chunk, config)
-        const optimized = optimizeSubtitles(segmented, this.getSourceLanguage())
-        const chunkStart = chunk[0].start
-        const chunkEnd = chunk.at(-1)!.end
-        this.processedFragments = this.processedFragments.filter(
-          f => f.start < chunkStart || f.start > chunkEnd,
-        )
-        this.processedFragments.push(...optimized)
-        this.processedFragments.sort((a, b) => a.start - b.start)
+        const rebalanced = rebalanceToTargetRange(segmented, this.getSourceLanguage())
+        return { fragments: rebalanced, chunk }
       }
     }
     catch {
       chunk.forEach(f => this.aiSegmentFailedRawStarts.add(f.start))
       const optimized = optimizeSubtitles(chunk, this.getSourceLanguage())
-      this.processedFragments.push(...optimized)
-      this.processedFragments.sort((a, b) => a.start - b.start)
+      return { fragments: optimized, chunk }
     }
 
-    return true
+    return null
   }
 
-  private findNextChunk(currentTimeMs: number): SubtitlesFragment[] {
+  private mergeFragments(newFragments: SubtitlesFragment[], chunk: SubtitlesFragment[]): void {
+    const rawStarts = new Set(chunk.map(f => f.start))
+    this.processedFragments = this.processedFragments.filter(
+      f => !rawStarts.has(f.start),
+    )
+    this.processedFragments.push(...newFragments)
+    this.processedFragments.sort((a, b) => a.start - b.start)
+  }
+
+  /**
+   * Find up to `maxChunks` non-overlapping chunks, prioritizing fragments
+   * closest to the current playback position.
+   */
+  private findNextChunks(currentTimeMs: number, maxChunks: number): SubtitlesFragment[][] {
+    const chunks: SubtitlesFragment[][] = []
+    const claimed = new Set<number>()
+
+    for (let i = 0; i < maxChunks; i++) {
+      const chunk = this.findNextChunk(currentTimeMs, claimed)
+      if (chunk.length === 0)
+        break
+      chunks.push(chunk)
+      chunk.forEach(f => claimed.add(f.start))
+    }
+
+    return chunks
+  }
+
+  private findNextChunk(currentTimeMs: number, claimed: Set<number>): SubtitlesFragment[] {
     const searchStart = Math.max(0, currentTimeMs - 10_000)
     const firstUnprocessed = this.rawFragments.find(
-      f => f.start >= searchStart && !this.segmentedRawStarts.has(f.start),
+      f => f.start >= searchStart && !this.segmentedRawStarts.has(f.start) && !claimed.has(f.start),
     )
     if (!firstUnprocessed)
       return []
@@ -120,7 +158,7 @@ export class SegmentationPipeline {
     const windowEnd = firstUnprocessed.start + PROCESS_LOOK_AHEAD_MS
     return this.rawFragments.filter(
       f => f.start >= firstUnprocessed.start && f.start < windowEnd
-        && !this.segmentedRawStarts.has(f.start),
+        && !this.segmentedRawStarts.has(f.start) && !claimed.has(f.start),
     )
   }
 }

--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -91,9 +91,7 @@ export class SegmentationPipeline {
         if (this.stopped)
           break
         for (const result of results) {
-          if (result) {
-            this.mergeFragments(result.fragments, result.chunk)
-          }
+          this.mergeFragments(result.fragments, result.chunk)
         }
         this.onChunkProcessed?.()
       }
@@ -103,7 +101,7 @@ export class SegmentationPipeline {
     }
   }
 
-  private async processChunk(chunk: SubtitlesFragment[]): Promise<ChunkResult | null> {
+  private async processChunk(chunk: SubtitlesFragment[]): Promise<ChunkResult> {
     try {
       const config = await getLocalConfig()
       if (config) {

--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -88,6 +88,8 @@ export class SegmentationPipeline {
 
         // Process chunks concurrently, then merge results synchronously
         const results = await Promise.all(chunks.map(chunk => this.processChunk(chunk)))
+        if (this.stopped)
+          break
         for (const result of results) {
           if (result) {
             this.mergeFragments(result.fragments, result.chunk)
@@ -116,7 +118,9 @@ export class SegmentationPipeline {
       return { fragments: optimized, chunk }
     }
 
-    return null
+    // Config unavailable — fall back to non-AI processing to avoid dropping chunks
+    const optimized = optimizeSubtitles(chunk, this.getSourceLanguage())
+    return { fragments: optimized, chunk }
   }
 
   private mergeFragments(newFragments: SubtitlesFragment[], chunk: SubtitlesFragment[]): void {

--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -120,7 +120,8 @@ export class SegmentationPipeline {
         return { fragments: rebalanced, chunk }
       }
     }
-    catch {
+    catch (error) {
+      console.warn("[SegmentationPipeline] AI segmentation failed, falling back:", error)
       chunk.forEach(f => this.aiSegmentFailedRawStarts.add(f.start))
       const optimized = optimizeSubtitles(chunk, this.getSourceLanguage())
       return { fragments: optimized, chunk }

--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -98,7 +98,12 @@ export class SegmentationPipeline {
         for (const result of results) {
           this.mergeFragments(result.fragments, result.chunk)
         }
-        this.onChunkProcessed?.()
+        try {
+          this.onChunkProcessed?.()
+        }
+        catch {
+          // callback errors must not kill the segmentation loop
+        }
       }
     }
     finally {

--- a/src/entrypoints/subtitles.content/translation-coordinator.ts
+++ b/src/entrypoints/subtitles.content/translation-coordinator.ts
@@ -19,6 +19,7 @@ export class TranslationCoordinator {
   private translatedStarts = new Set<number>()
   private failedStarts = new Set<number>()
   private isTranslating = false
+  private stopped = false
   private lastEmittedState: SubtitlesState = "idle"
   private videoContext: SubtitlesVideoContext = { videoTitle: "", subtitlesTextContent: "" }
 
@@ -43,6 +44,8 @@ export class TranslationCoordinator {
       this.videoContext = videoContext
     }
 
+    this.stopped = false
+
     const video = this.getVideoElement()
     if (!video)
       return
@@ -59,6 +62,7 @@ export class TranslationCoordinator {
   }
 
   stop() {
+    this.stopped = true
     const video = this.getVideoElement()
     if (!video)
       return
@@ -82,6 +86,8 @@ export class TranslationCoordinator {
   }
 
   triggerTranslationTick() {
+    if (this.stopped)
+      return
     this.handleTranslationTick()
   }
 

--- a/src/entrypoints/subtitles.content/translation-coordinator.ts
+++ b/src/entrypoints/subtitles.content/translation-coordinator.ts
@@ -81,6 +81,10 @@ export class TranslationCoordinator {
     this.failedStarts.clear()
   }
 
+  triggerTranslationTick() {
+    this.handleTranslationTick()
+  }
+
   private handleTranslationTick = () => {
     const video = this.getVideoElement()
     if (!video)

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -332,6 +332,7 @@ export class UniversalVideoAdapter {
         rawFragments: this.originalSubtitles,
         getVideoElement: () => this.subtitlesScheduler?.getVideoElement() ?? null,
         getSourceLanguage: () => this.subtitlesFetcher.getSourceLanguage(),
+        onChunkProcessed: () => this.translationCoordinator?.triggerTranslationTick(),
       })
     }
     else {

--- a/src/utils/constants/subtitles.ts
+++ b/src/utils/constants/subtitles.ts
@@ -10,6 +10,9 @@ export const MAX_WORDS = 15
 export const MAX_CHARS_CJK = 30
 export const SENTENCE_END_PATTERN = /[,.。?？！!；;…؟۔\n]$/
 
+// AI segmentation concurrency
+export const MAX_CONCURRENT_SEGMENTS = 3
+
 // On-demand translation constants
 export const TRANSLATION_BATCH_SIZE = 5
 export const TRANSLATE_LOOK_AHEAD_MS = 30_000

--- a/src/utils/subtitles/processor/optimizer.ts
+++ b/src/utils/subtitles/processor/optimizer.ts
@@ -165,7 +165,7 @@ function shouldKeepBoundary(left: SubtitlesFragment, right: SubtitlesFragment): 
   return isTimeout || startsWithSign
 }
 
-function rebalanceToTargetRange(
+export function rebalanceToTargetRange(
   fragments: SubtitlesFragment[],
   language: string,
 ): SubtitlesFragment[] {


### PR DESCRIPTION
## Summary

- Process up to 3 subtitle chunks in parallel (`MAX_CONCURRENT_SEGMENTS`), reducing AI segmentation latency for long videos
- Fix race condition from original #1264: use **collect-then-merge** pattern — `processChunk` returns results, `Promise.all` collects them, then `mergeFragments` runs synchronously
- Fix cross-chunk data loss: `mergeFragments` uses **exact raw-start Set filtering** instead of time-range `[chunkStart, chunkEnd]` filtering, preventing fragments from being incorrectly removed when `rebalanceToTargetRange` adjusts boundary timestamps
- AI success path uses `rebalanceToTargetRange` instead of full `optimizeSubtitles` — AI already performs semantic sentence segmentation, only length rebalancing is needed
- Add `triggerTranslationTick()` to `TranslationCoordinator`, triggered via `onChunkProcessed` callback after all chunks in a batch are merged

Supersedes #1264 (closed due to fork deletion). This is a clean reimplementation on latest `main` with both race condition fixes applied.

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes  
- [x] `pnpm test` — 106 files, 964 tests all pass
- [ ] Manual test: seek around in a long video, verify segments near chunk boundaries display correctly
- [ ] Manual test: verify translation kicks in promptly after segmentation completes


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Process up to 3 subtitle chunks in parallel to speed up segmentation for long videos. Fixes races, prevents cross‑chunk data loss, handles mid‑batch stops safely, and logs errors before falling back when needed.

- **New Features**
  - Concurrent chunk processing (up to 3) using `Promise.all`.
  - Lighter success path with `rebalanceToTargetRange` instead of `optimizeSubtitles`.
  - `onChunkProcessed` now calls `triggerTranslationTick()` to start translation promptly.

- **Bug Fixes**
  - Collect‑then‑merge pattern removes the race on `processedFragments`.
  - Exact raw‑start filtering prevents cross‑chunk data loss.
  - Stop‑safe: roll back claimed starts, skip merge/callbacks, guard callback errors, block translation after `stop()`, and fall back when config is missing (with warnings).

<sup>Written for commit 5953da676394434acbaf61f336b6558d98de8f61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



