### PR TITLE
refactor(subtitles): reuse prefetched source subtitles

### DIFF
--- a/.changeset/neat-brooms-burn.md
+++ b/.changeset/neat-brooms-burn.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+refactor(subtitles): reuse prefetched source subtitles across download and translation

--- a/src/entrypoints/subtitles.content/__tests__/segmentation-pipeline.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/segmentation-pipeline.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { SegmentationPipeline } from "../segmentation-pipeline"
+
+vi.mock("@/utils/config/storage", () => ({
+  getLocalConfig: vi.fn().mockResolvedValue({
+    videoSubtitles: {
+      aiSegmentation: true,
+    },
+  }),
+}))
+
+vi.mock("@/utils/subtitles/processor/ai-segmentation", () => ({
+  aiSegmentBlock: vi.fn().mockRejectedValue(new Error("ai failed")),
+}))
+
+describe("segmentation pipeline", () => {
+  it("replaces overlapping baseline fragments when AI fallback is used", async () => {
+    const rawFragments = [
+      { text: "hello", start: 0, end: 500 },
+      { text: "world", start: 500, end: 1000 },
+    ]
+
+    const pipeline = new SegmentationPipeline({
+      baselineFragments: [
+        { text: "hello world", start: 0, end: 1000 },
+      ],
+      rawFragments,
+      getVideoElement: () => ({ currentTime: 0 } as HTMLVideoElement),
+      getSourceLanguage: () => "en",
+    })
+
+    await (pipeline as any).processNextChunk(0)
+
+    expect(pipeline.processedFragments).toEqual([
+      { text: "hello world", start: 0, end: 1000 },
+    ])
+  })
+})

--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -92,23 +92,27 @@ export class SegmentationPipeline {
       if (config) {
         const segmented = await aiSegmentBlock(chunk, config)
         const optimized = optimizeSubtitles(segmented, this.getSourceLanguage())
-        const chunkStart = chunk[0].start
-        const chunkEnd = chunk.at(-1)!.end
-        this.processedFragments = this.processedFragments.filter(
-          f => f.start < chunkStart || f.start > chunkEnd,
-        )
-        this.processedFragments.push(...optimized)
-        this.processedFragments.sort((a, b) => a.start - b.start)
+        this.replaceProcessedChunk(chunk, optimized)
       }
     }
     catch {
       chunk.forEach(f => this.aiSegmentFailedRawStarts.add(f.start))
       const optimized = optimizeSubtitles(chunk, this.getSourceLanguage())
-      this.processedFragments.push(...optimized)
-      this.processedFragments.sort((a, b) => a.start - b.start)
+      this.replaceProcessedChunk(chunk, optimized)
     }
 
     return true
+  }
+
+  private replaceProcessedChunk(chunk: SubtitlesFragment[], nextFragments: SubtitlesFragment[]) {
+    const chunkStart = chunk[0].start
+    const chunkEnd = chunk.at(-1)!.end
+
+    this.processedFragments = this.processedFragments.filter(
+      fragment => fragment.start < chunkStart || fragment.start > chunkEnd,
+    )
+    this.processedFragments.push(...nextFragments)
+    this.processedFragments.sort((a, b) => a.start - b.start)
   }
 
   private findNextChunk(currentTimeMs: number): SubtitlesFragment[] {

--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -18,11 +18,13 @@ export class SegmentationPipeline {
   private getSourceLanguage: () => string
 
   constructor(options: {
+    baselineFragments?: SubtitlesFragment[]
     rawFragments: SubtitlesFragment[]
     getVideoElement: () => HTMLVideoElement | null
     getSourceLanguage: () => string
   }) {
     this.rawFragments = options.rawFragments
+    this.processedFragments = [...(options.baselineFragments ?? [])]
     this.getVideoElement = options.getVideoElement
     this.getSourceLanguage = options.getSourceLanguage
   }

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -62,6 +62,7 @@ export class UniversalVideoAdapter {
     void this.renderTranslateButton()
 
     await this.initializeScheduler()
+    void this.getOrLoadSourceSubtitles().catch(() => {})
     await this.tryAutoStartSubtitles()
     this.setupNavigationListener()
   }
@@ -75,9 +76,10 @@ export class UniversalVideoAdapter {
   }
 
   downloadSourceSubtitles = async () => {
-    const subtitles = this.getProcessedSourceSubtitles(await this.getSourceSubtitles())
+    await this.getOrLoadSourceSubtitles()
+
     await downloadSubtitlesAsSrt({
-      subtitles,
+      subtitles: this.sourceProcessedSubtitles,
       pageTitle: document.title || "",
       videoId: this.config.getVideoId?.(),
     })
@@ -123,9 +125,10 @@ export class UniversalVideoAdapter {
     this.subtitlesScheduler.hide()
   }
 
-  private async getSourceSubtitles(): Promise<SubtitlesFragment[]> {
+  private async getOrLoadSourceSubtitles(): Promise<SubtitlesFragment[]> {
     const currentVideoId = this.config.getVideoId?.() ?? null
     const useSameTrack = await this.subtitlesFetcher.shouldUseSameTrack()
+
     if (useSameTrack && this.sourceVideoId === currentVideoId && this.sourceSubtitles.length > 0) {
       return this.sourceSubtitles
     }
@@ -140,23 +143,15 @@ export class UniversalVideoAdapter {
     }
 
     this.sourceVideoId = currentVideoId
-    this.clearSourceProcessedSubtitles()
     this.sourceSubtitles = subtitles
+    this.sourceProcessedSubtitles = this.buildSourceProcessedSubtitles(subtitles)
+
     return subtitles
   }
 
-  private getProcessedSourceSubtitles(rawSubtitles: SubtitlesFragment[]): SubtitlesFragment[] {
-    if (this.sourceProcessedSubtitles.length > 0) {
-      return this.sourceProcessedSubtitles
-    }
-
-    const processedFragments = optimizeSubtitles(
-      rawSubtitles,
-      this.subtitlesFetcher.getSourceLanguage(),
-    )
-    this.sourceProcessedSubtitles = processedFragments
-
-    return processedFragments
+  private buildSourceProcessedSubtitles(rawSubtitles: SubtitlesFragment[]): SubtitlesFragment[] {
+    const sourceLanguage = this.subtitlesFetcher.getSourceLanguage()
+    return optimizeSubtitles(rawSubtitles, sourceLanguage)
   }
 
   private clearSourceProcessedSubtitles() {
@@ -206,6 +201,7 @@ export class UniversalVideoAdapter {
       void this.renderTranslateButton()
 
       await this.initializeScheduler()
+      void this.getOrLoadSourceSubtitles().catch(() => {})
       await this.tryAutoStartSubtitles()
     }
   }
@@ -326,7 +322,8 @@ export class UniversalVideoAdapter {
 
       this.subtitlesScheduler?.setState("loading")
 
-      this.sessionSubtitles = await this.getSourceSubtitles()
+      await this.getOrLoadSourceSubtitles()
+      this.sessionSubtitles = this.sourceSubtitles
 
       await this.processSubtitles()
       if (analyticsContext) {
@@ -372,14 +369,16 @@ export class UniversalVideoAdapter {
     }
 
     if (useAiSegmentation) {
+      this.sessionProcessedFragments = [...this.sourceProcessedSubtitles]
       this.segmentationPipeline = new SegmentationPipeline({
+        baselineFragments: this.sourceProcessedSubtitles,
         rawFragments: this.sessionSubtitles,
         getVideoElement: () => this.subtitlesScheduler?.getVideoElement() ?? null,
         getSourceLanguage: () => this.subtitlesFetcher.getSourceLanguage(),
       })
     }
     else {
-      this.sessionProcessedFragments = this.getProcessedSourceSubtitles(this.sessionSubtitles)
+      this.sessionProcessedFragments = [...this.sourceProcessedSubtitles]
     }
 
     this.translationCoordinator = new TranslationCoordinator({

--- a/src/utils/subtitles/fetchers/youtube/index.ts
+++ b/src/utils/subtitles/fetchers/youtube/index.ts
@@ -20,7 +20,6 @@ import {
 } from "@/utils/constants/subtitles"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
 import { OverlaySubtitlesError } from "@/utils/subtitles/errors"
-import { optimizeSubtitles } from "@/utils/subtitles/processor/optimizer"
 import { getYoutubeVideoId } from "@/utils/subtitles/video-id"
 import { detectFormat } from "./format-detector"
 import { filterNoiseFromEvents } from "./noise-filter"
@@ -354,6 +353,6 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
       ? parseScrollingAsrSubtitles(filteredEvents, this.sourceLanguage)
       : parseStandardSubtitles(filteredEvents)
 
-    return optimizeSubtitles(fragments, this.sourceLanguage)
+    return fragments
   }
 }


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [x] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

- Reuse prefetched source subtitles across download and translation startup instead of fetching and processing them separately.
- Move source subtitle optimization to `UniversalVideoAdapter`, so the YouTube fetcher returns parsed source fragments and the adapter owns the baseline processed subtitles.
- Seed AI segmentation with baseline processed subtitles so unfinished AI chunks continue to fall back to code-segmented subtitles.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing
## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

N/A

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- This PR intentionally focuses on subtitle source/session refactoring only. The YouTube subtitle fetch speed optimization will be handled in a follow-up PR.
