### PR TITLE
perf: optimize youtube subtitle fetching with fast-path fallback

### DIFF
--- a/.changeset/swift-bats-shake.md
+++ b/.changeset/swift-bats-shake.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+Optimize YouTube subtitle fetching by trying a fast timedtext fetch from the initial player data snapshot before falling back to the slower POT/wait flow.

--- a/src/utils/subtitles/__tests__/youtube-fetcher.test.ts
+++ b/src/utils/subtitles/__tests__/youtube-fetcher.test.ts
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { PLAYER_DATA_REQUEST_TYPE, PLAYER_DATA_RESPONSE_TYPE } from "@/utils/constants/subtitles"
 import { YoutubeSubtitlesFetcher } from "../fetchers/youtube"
 
 describe("youtube subtitles fetcher", () => {
   afterEach(() => {
     document.body.innerHTML = ""
+    vi.restoreAllMocks()
   })
 
   it("ignores unrelated postMessage events while waiting", async () => {
@@ -73,5 +74,88 @@ describe("youtube subtitles fetcher", () => {
     await expect(fetcher.fetch()).rejects.toThrow("subtitles.errors.noSubtitlesFound")
 
     fetcher.cleanup()
+  })
+
+  it("uses the initial player data snapshot for a fast fetch before fallback waits", async () => {
+    const fetcher = new YoutubeSubtitlesFetcher()
+
+    Object.defineProperty(window, "location", {
+      value: { search: "?v=test123", origin: "https://www.youtube.com", pathname: "/watch", hostname: "www.youtube.com" },
+      writable: true,
+    })
+
+    const playerData = {
+      videoId: "test123",
+      captionTracks: [{
+        baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=en",
+        languageCode: "en",
+        vssId: ".en",
+      }],
+      audioCaptionTracks: [],
+      device: null,
+      cver: null,
+      playerState: 0,
+      selectedTrackLanguageCode: "en",
+      cachedTimedtextUrl: null,
+    }
+
+    const requestPlayerDataSpy = vi.spyOn(fetcher as any, "requestPlayerData").mockResolvedValue({
+      success: true,
+      data: playerData,
+    })
+    const fetchWithRetrySpy = vi.spyOn(fetcher as any, "fetchWithRetry").mockResolvedValue([])
+    const processRawEventsSpy = vi.spyOn(fetcher as any, "processRawEvents").mockResolvedValue([])
+    const waitForPlayerStateSpy = vi.spyOn(fetcher as any, "waitForPlayerState").mockResolvedValue(undefined)
+    const getPlayerDataWithPotSpy = vi.spyOn(fetcher as any, "getPlayerDataWithPot").mockResolvedValue(playerData)
+
+    await expect(fetcher.fetch()).resolves.toEqual([])
+
+    expect(requestPlayerDataSpy).toHaveBeenCalledTimes(1)
+    expect(fetchWithRetrySpy).toHaveBeenCalledTimes(1)
+    expect(processRawEventsSpy).toHaveBeenCalledTimes(1)
+    expect(waitForPlayerStateSpy).not.toHaveBeenCalled()
+    expect(getPlayerDataWithPotSpy).not.toHaveBeenCalled()
+  })
+
+  it("falls back to the slower POT flow when the fast fetch fails", async () => {
+    const fetcher = new YoutubeSubtitlesFetcher()
+
+    Object.defineProperty(window, "location", {
+      value: { search: "?v=test123", origin: "https://www.youtube.com", pathname: "/watch", hostname: "www.youtube.com" },
+      writable: true,
+    })
+
+    const playerData = {
+      videoId: "test123",
+      captionTracks: [{
+        baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=en",
+        languageCode: "en",
+        vssId: ".en",
+      }],
+      audioCaptionTracks: [],
+      device: null,
+      cver: null,
+      playerState: 0,
+      selectedTrackLanguageCode: "en",
+      cachedTimedtextUrl: null,
+    }
+
+    vi.spyOn(fetcher as any, "requestPlayerData").mockResolvedValue({
+      success: true,
+      data: playerData,
+    })
+    const fetchWithRetrySpy = vi.spyOn(fetcher as any, "fetchWithRetry")
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce([])
+    const processRawEventsSpy = vi.spyOn(fetcher as any, "processRawEvents").mockResolvedValue([])
+    const waitForPlayerStateSpy = vi.spyOn(fetcher as any, "waitForPlayerState").mockResolvedValue(undefined)
+    const getPlayerDataWithPotSpy = vi.spyOn(fetcher as any, "getPlayerDataWithPot").mockResolvedValue(playerData)
+
+    await expect(fetcher.fetch()).resolves.toEqual([])
+
+    expect(fetchWithRetrySpy).toHaveBeenCalledTimes(2)
+    expect(processRawEventsSpy).toHaveBeenCalledTimes(1)
+    expect(waitForPlayerStateSpy).toHaveBeenCalledTimes(1)
+    expect(getPlayerDataWithPotSpy).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/utils/subtitles/__tests__/youtube-fetcher.test.ts
+++ b/src/utils/subtitles/__tests__/youtube-fetcher.test.ts
@@ -110,11 +110,50 @@ describe("youtube subtitles fetcher", () => {
 
     await expect(fetcher.fetch()).resolves.toEqual([])
 
-    expect(requestPlayerDataSpy).toHaveBeenCalledTimes(1)
+    expect(requestPlayerDataSpy).toHaveBeenCalledTimes(2)
     expect(fetchWithRetrySpy).toHaveBeenCalledTimes(1)
     expect(processRawEventsSpy).toHaveBeenCalledTimes(1)
     expect(waitForPlayerStateSpy).not.toHaveBeenCalled()
     expect(getPlayerDataWithPotSpy).not.toHaveBeenCalled()
+  })
+
+  it("returns cached subtitles before attempting a fast timedtext fetch", async () => {
+    const fetcher = new YoutubeSubtitlesFetcher()
+
+    Object.defineProperty(window, "location", {
+      value: { search: "?v=test123", origin: "https://www.youtube.com", pathname: "/watch", hostname: "www.youtube.com" },
+      writable: true,
+    })
+
+    const playerData = {
+      videoId: "test123",
+      captionTracks: [{
+        baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=en",
+        languageCode: "en",
+        vssId: ".en",
+      }],
+      audioCaptionTracks: [],
+      device: null,
+      cver: null,
+      playerState: 1,
+      selectedTrackLanguageCode: "en",
+      cachedTimedtextUrl: null,
+    }
+    const cachedSubtitles = [{ text: "cached", start: 0, end: 1 }]
+
+    ;(fetcher as any).subtitles = cachedSubtitles
+    ;(fetcher as any).cachedTrackHash = "test123:en::.en"
+
+    const requestPlayerDataSpy = vi.spyOn(fetcher as any, "requestPlayerData").mockResolvedValue({
+      success: true,
+      data: playerData,
+    })
+    const tryFastFetchSpy = vi.spyOn(fetcher as any, "tryFastFetch")
+
+    await expect(fetcher.fetch()).resolves.toEqual(cachedSubtitles)
+
+    expect(requestPlayerDataSpy).toHaveBeenCalledTimes(1)
+    expect(tryFastFetchSpy).not.toHaveBeenCalled()
   })
 
   it("falls back to the slower POT flow when the fast fetch fails", async () => {
@@ -154,6 +193,58 @@ describe("youtube subtitles fetcher", () => {
     await expect(fetcher.fetch()).resolves.toEqual([])
 
     expect(fetchWithRetrySpy).toHaveBeenCalledTimes(2)
+    expect(processRawEventsSpy).toHaveBeenCalledTimes(1)
+    expect(waitForPlayerStateSpy).toHaveBeenCalledTimes(1)
+    expect(getPlayerDataWithPotSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-selects the track from refreshed fallback player data", async () => {
+    const fetcher = new YoutubeSubtitlesFetcher()
+
+    Object.defineProperty(window, "location", {
+      value: { search: "?v=test123", origin: "https://www.youtube.com", pathname: "/watch", hostname: "www.youtube.com" },
+      writable: true,
+    })
+
+    const initialPlayerData = {
+      videoId: "test123",
+      captionTracks: [{
+        baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=en",
+        languageCode: "en",
+        vssId: ".en",
+      }],
+      audioCaptionTracks: [],
+      device: null,
+      cver: null,
+      playerState: 0,
+      selectedTrackLanguageCode: "en",
+      cachedTimedtextUrl: null,
+    }
+    const refreshedPlayerData = {
+      ...initialPlayerData,
+      captionTracks: [{
+        baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=fr",
+        languageCode: "fr",
+        vssId: ".fr",
+      }],
+      selectedTrackLanguageCode: "fr",
+    }
+
+    vi.spyOn(fetcher as any, "requestPlayerData").mockResolvedValue({
+      success: true,
+      data: initialPlayerData,
+    })
+    const fetchWithRetrySpy = vi.spyOn(fetcher as any, "fetchWithRetry")
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce([])
+    const processRawEventsSpy = vi.spyOn(fetcher as any, "processRawEvents").mockResolvedValue([])
+    const waitForPlayerStateSpy = vi.spyOn(fetcher as any, "waitForPlayerState").mockResolvedValue(undefined)
+    const getPlayerDataWithPotSpy = vi.spyOn(fetcher as any, "getPlayerDataWithPot").mockResolvedValue(refreshedPlayerData)
+
+    await expect(fetcher.fetch()).resolves.toEqual([])
+
+    expect(fetchWithRetrySpy).toHaveBeenCalledTimes(2)
+    expect(fetchWithRetrySpy.mock.calls[1]?.[0]).toContain("lang=fr")
     expect(processRawEventsSpy).toHaveBeenCalledTimes(1)
     expect(waitForPlayerStateSpy).toHaveBeenCalledTimes(1)
     expect(getPlayerDataWithPotSpy).toHaveBeenCalledTimes(1)

--- a/src/utils/subtitles/fetchers/youtube/index.ts
+++ b/src/utils/subtitles/fetchers/youtube/index.ts
@@ -183,7 +183,11 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     const currentHash = this.computeTrackHashFromPlayerData(videoId, playerData, track)
 
     if (!track) {
-      throw new OverlaySubtitlesError(i18n.t("subtitles.errors.noSubtitlesFound"))
+      return {
+        currentHash,
+        track: null,
+        events: null,
+      }
     }
 
     try {
@@ -194,11 +198,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
         events,
       }
     }
-    catch (error) {
-      if (error instanceof OverlaySubtitlesError) {
-        throw error
-      }
-
+    catch {
       return {
         currentHash,
         track,

--- a/src/utils/subtitles/fetchers/youtube/index.ts
+++ b/src/utils/subtitles/fetchers/youtube/index.ts
@@ -74,28 +74,27 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
       throw new OverlaySubtitlesError(i18n.t("subtitles.errors.videoNotFound"))
     }
 
-    const currentHash = await this.computeTrackHash()
+    const fastPathResult = await this.tryFastFetch(videoId)
+    const currentHash = fastPathResult.currentHash
 
     if (currentHash && this.subtitles.length > 0 && this.cachedTrackHash === currentHash) {
       return this.subtitles
     }
 
-    // Wait for player state >= 1 (video ready) BEFORE getting POT
-    // YouTube only makes timedtext XHR request when video is ready to play
-    await this.waitForPlayerState(videoId)
+    let resolvedTrack = fastPathResult.track
+    let events = fastPathResult.events
 
-    const playerData = await this.getPlayerDataWithPot(videoId)
+    if (!events) {
+      const fallbackResult = await this.fetchWithFallback(videoId, fastPathResult.track)
+      resolvedTrack = fallbackResult.track
+      events = fallbackResult.events
+    }
 
-    const track = this.selectTrack(playerData.captionTracks, playerData.selectedTrackLanguageCode)
-    if (!track) {
+    if (!resolvedTrack) {
       throw new OverlaySubtitlesError(i18n.t("subtitles.errors.noSubtitlesFound"))
     }
 
-    const potToken = extractPotToken(track, playerData)
-    const url = buildSubtitleUrl(track, playerData, potToken)
-    const events = await this.fetchWithRetry(url)
-
-    this.sourceLanguage = track.languageCode
+    this.sourceLanguage = resolvedTrack.languageCode
     this.subtitles = await this.processRawEvents(events)
     this.cachedTrackHash = currentHash
 
@@ -150,11 +149,84 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     }
 
     const track = this.selectTrack(response.data.captionTracks, response.data.selectedTrackLanguageCode)
+    return this.computeTrackHashFromPlayerData(videoId, response.data, track)
+  }
+
+  private computeTrackHashFromPlayerData(
+    videoId: string,
+    _playerData: PlayerData,
+    track: CaptionTrack | null,
+  ): string | null {
     if (!track) {
       return null
     }
 
     return `${videoId}:${track.languageCode}:${track.kind ?? ""}:${track.vssId}`
+  }
+
+  private async tryFastFetch(videoId: string): Promise<{
+    currentHash: string | null
+    track: CaptionTrack | null
+    events: YoutubeTimedText[] | null
+  }> {
+    const response = await this.requestPlayerData(videoId)
+    if (!response.success || !response.data) {
+      return {
+        currentHash: null,
+        track: null,
+        events: null,
+      }
+    }
+
+    const playerData = response.data
+    const track = this.selectTrack(playerData.captionTracks, playerData.selectedTrackLanguageCode)
+    const currentHash = this.computeTrackHashFromPlayerData(videoId, playerData, track)
+
+    if (!track) {
+      throw new OverlaySubtitlesError(i18n.t("subtitles.errors.noSubtitlesFound"))
+    }
+
+    try {
+      const events = await this.fetchTrackEvents(track, playerData)
+      return {
+        currentHash,
+        track,
+        events,
+      }
+    }
+    catch (error) {
+      if (error instanceof OverlaySubtitlesError) {
+        throw error
+      }
+
+      return {
+        currentHash,
+        track,
+        events: null,
+      }
+    }
+  }
+
+  private async fetchWithFallback(
+    videoId: string,
+    preferredTrack: CaptionTrack | null,
+  ): Promise<{
+    track: CaptionTrack
+    events: YoutubeTimedText[]
+  }> {
+    // Wait for player state >= 1 before retrying with the slower POT/timedtext flow.
+    await this.waitForPlayerState(videoId)
+
+    const playerData = await this.getPlayerDataWithPot(videoId)
+    const track = preferredTrack
+      ?? this.selectTrack(playerData.captionTracks, playerData.selectedTrackLanguageCode)
+
+    if (!track) {
+      throw new OverlaySubtitlesError(i18n.t("subtitles.errors.noSubtitlesFound"))
+    }
+
+    const events = await this.fetchTrackEvents(track, playerData)
+    return { track, events }
   }
 
   private async waitForPlayerState(videoId: string): Promise<void> {
@@ -205,6 +277,12 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     }
 
     return playerData
+  }
+
+  private async fetchTrackEvents(track: CaptionTrack, playerData: PlayerData): Promise<YoutubeTimedText[]> {
+    const potToken = extractPotToken(track, playerData)
+    const url = buildSubtitleUrl(track, playerData, potToken)
+    return this.fetchWithRetry(url)
   }
 
   private hasPotInAudioTracks(playerData: PlayerData): boolean {

--- a/src/utils/subtitles/fetchers/youtube/index.ts
+++ b/src/utils/subtitles/fetchers/youtube/index.ts
@@ -74,13 +74,13 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
       throw new OverlaySubtitlesError(i18n.t("subtitles.errors.videoNotFound"))
     }
 
-    const fastPathResult = await this.tryFastFetch(videoId)
-    const currentHash = fastPathResult.currentHash
+    const currentHash = await this.computeTrackHash()
 
     if (currentHash && this.subtitles.length > 0 && this.cachedTrackHash === currentHash) {
       return this.subtitles
     }
 
+    const fastPathResult = await this.tryFastFetch(videoId)
     let resolvedTrack = fastPathResult.track
     let events = fastPathResult.events
 
@@ -96,7 +96,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
 
     this.sourceLanguage = resolvedTrack.languageCode
     this.subtitles = await this.processRawEvents(events)
-    this.cachedTrackHash = currentHash
+    this.cachedTrackHash = this.buildTrackHash(videoId, resolvedTrack)
 
     return this.subtitles
   }
@@ -149,12 +149,11 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     }
 
     const track = this.selectTrack(response.data.captionTracks, response.data.selectedTrackLanguageCode)
-    return this.computeTrackHashFromPlayerData(videoId, response.data, track)
+    return this.buildTrackHash(videoId, track)
   }
 
-  private computeTrackHashFromPlayerData(
+  private buildTrackHash(
     videoId: string,
-    _playerData: PlayerData,
     track: CaptionTrack | null,
   ): string | null {
     if (!track) {
@@ -180,7 +179,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
 
     const playerData = response.data
     const track = this.selectTrack(playerData.captionTracks, playerData.selectedTrackLanguageCode)
-    const currentHash = this.computeTrackHashFromPlayerData(videoId, playerData, track)
+    const currentHash = this.buildTrackHash(videoId, track)
 
     if (!track) {
       return {
@@ -218,8 +217,8 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     await this.waitForPlayerState(videoId)
 
     const playerData = await this.getPlayerDataWithPot(videoId)
-    const track = preferredTrack
-      ?? this.selectTrack(playerData.captionTracks, playerData.selectedTrackLanguageCode)
+    const track = this.selectTrack(playerData.captionTracks, playerData.selectedTrackLanguageCode)
+      ?? preferredTrack
 
     if (!track) {
       throw new OverlaySubtitlesError(i18n.t("subtitles.errors.noSubtitlesFound"))


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [x] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Optimize the YouTube subtitle fetch flow by attempting a fast timedtext fetch from the initial `playerData` snapshot before entering the slower player-state / POT wait path.

This keeps the existing fallback behavior for cases where the fast fetch is not ready yet, while reducing the time to first subtitle request when the initial snapshot is already sufficient.

The change is scoped to the YouTube fetcher only:
- reuse the initial `playerData` snapshot for a fast-path subtitle fetch
- keep the existing slower fallback flow when the fast path fails
- extract the fast/fallback logic into helper methods to keep `fetch()` small and explicit
- add tests covering both fast-path success and fallback behavior

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [x] Added unit tests
- [x] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

N/A

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

This PR intentionally does not change adapter-related subtitle flow. It is limited to YouTube-specific fetch performance behavior.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up YouTube subtitle fetching by first trying a timedtext request from the initial player data snapshot, then falling back to the player-state + POT flow when needed. Restore the cached-subtitles short-circuit and correct fallback track selection, and add tests for fast-path, cache hit, and fallback selection.

<sup>Written for commit 7e5ca55723a823dd6db4b5430d139fb106c49192. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



