### PR TITLE
fix(extension): allow preload distance up to 10000px

### DIFF
--- a/.changeset/soft-badgers-sit.md
+++ b/.changeset/soft-badgers-sit.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(extension): allow the page pre-translate preload distance to be set up to 10000px

--- a/src/types/config/__tests__/translate-preload.test.ts
+++ b/src/types/config/__tests__/translate-preload.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { preloadConfigSchema } from "../translate"
+
+describe("preload config validation", () => {
+  it("allows a preload margin up to 10000 pixels", () => {
+    const result = preloadConfigSchema.safeParse({
+      margin: 10000,
+      threshold: 0,
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects a preload margin above 10000 pixels", () => {
+    const result = preloadConfigSchema.safeParse({
+      margin: 10001,
+      threshold: 0,
+    })
+
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/utils/constants/translate.ts
+++ b/src/utils/constants/translate.ts
@@ -17,7 +17,7 @@ export const DEFAULT_BATCH_CONFIG = {
 export const DEFAULT_AUTO_TRANSLATE_SHORTCUT_KEY = "Alt+E"
 
 export const MIN_PRELOAD_MARGIN = 0
-export const MAX_PRELOAD_MARGIN = 5000
+export const MAX_PRELOAD_MARGIN = 10000
 export const DEFAULT_PRELOAD_MARGIN = 1000
 
 export const MIN_PRELOAD_THRESHOLD = 0


### PR DESCRIPTION
## Summary
- raise the page pre-translate preload distance limit from 5000px to 10000px
- add a regression test that accepts 10000 and still rejects 10001
- add a patch changeset for the extension release

## Screenshots
Captured from the real local extension options page at `Translation -> Pre-translate Range` after scrolling to the changed section.

| Before | After |
| --- | --- |
| ![Before: entering 10000 shows the <=5000 error toast](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog/preload-margin-max-10000/20260412-005346-before.png) | ![After: entering 10000 is accepted with no error toast](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog/preload-margin-max-10000/20260412-005346-after.png) |

## Validation
- `SKIP_FREE_API=true pnpm test src/types/config/__tests__/translate-preload.test.ts src/types/config/__tests__/config-provider-enabled.test.ts`
- `pnpm exec eslint src/types/config/__tests__/translate-preload.test.ts src/types/config/translate.ts src/utils/constants/translate.ts`
- `pnpm type-check`
- `git diff --check`
- `git push -u origin HEAD` (pre-push ran `nx run @read-frog/extension:lint`, `nx run @read-frog/extension:type-check`, and `nx run @read-frog/extension:test`; 113 test files / 991 tests passed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the max pre-translate preload distance from 5000px to 10000px in the extension, fixing the error when users enter 10000 in Translation → Pre-translate Range.

- **Bug Fixes**
  - Raise `MAX_PRELOAD_MARGIN` to 10000.
  - Add tests to accept 10000 and reject 10001.
  - Add a patch changeset for `@read-frog/extension`.

<sup>Written for commit 788edfb5ce8ce09f6865726e65f1f67ee68f5433. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

