### PR TITLE
fix(selection): close language selector dropdown after selection

### DIFF
--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/target-language-selector.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/target-language-selector.tsx
@@ -1,8 +1,9 @@
+import type { LanguageItem } from "@/components/language-combobox-options"
 import { i18n } from "#imports"
 import { Combobox as ComboboxPrimitive } from "@base-ui/react"
 import { IconChevronDown } from "@tabler/icons-react"
 import { useAtom } from "jotai"
-import { useMemo } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { filterLanguage, getTargetLanguageItems } from "@/components/language-combobox-options"
 import { Button } from "@/components/ui/base-ui/button"
 import {
@@ -25,17 +26,23 @@ export function TargetLanguageSelector() {
     [language.targetCode, languageItems],
   )
   const title = currentItem?.label ?? i18n.t("side.targetLang")
+  const [open, setOpen] = useState(false)
+  const onValueChange = useCallback((item: LanguageItem | null) => {
+    if (!item || item.value === "auto" || item.value === language.targetCode) {
+      setOpen(false)
+      return
+    }
+
+    void setLanguage({ targetCode: item.value })
+    setOpen(false)
+  }, [language.targetCode, setLanguage])
 
   return (
     <Combobox
+      open={open}
+      onOpenChange={setOpen}
       value={currentItem}
-      onValueChange={(item) => {
-        if (!item || item.value === "auto" || item.value === language.targetCode) {
-          return
-        }
-
-        void setLanguage({ targetCode: item.value })
-      }}
+      onValueChange={onValueChange}
       items={languageItems}
       filter={filterLanguage}
       autoHighlight


### PR DESCRIPTION
Fix target language selector dropdown not closing after selecting a language 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the target language selector in the selection toolbar so the dropdown closes after choosing a language. Improves UX by dismissing the popover on selection and ignoring no-op choices.

- **Bug Fixes**
  - Control the `Combobox` open state with local state and `onOpenChange` from `@base-ui/react`.
  - Close the dropdown in `onValueChange` and update `targetCode`.
  - Also close on null, `auto`, or same language selections to avoid no-op updates.

<sup>Written for commit 2cd37481c95b7dde290d1152f6fa03963e992f30. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

