### PR TITLE
i18n(subtitles): rename zh-CN source subtitle download label

### DIFF
--- a/.changeset/bright-forks-hear.md
+++ b/.changeset/bright-forks-hear.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+i18n(subtitles): rename zh-CN source subtitle download label

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -991,7 +991,7 @@ shortcutKeySelector:
   placeholder: 请输入快捷键
 subtitles:
   actions:
-    downloadSource: 下载源字幕
+    downloadSource: 下载原字幕
   state:
     loading: Read Frog 字幕加载中
     error: 发生错误


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [x] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

- rename the zh-CN subtitle download label in the subtitles settings panel from `下载源字幕` to `下载原字幕`
- keep the existing translation key and download behavior unchanged
- add a patch changeset for the user-facing copy fix

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- copy-only change; no functional or behavior changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the zh-CN subtitle download label in the subtitles settings from “下载源字幕” to “下载原字幕” to fix wording. No behavior changes; translation key unchanged and a patch changeset added for `@read-frog/extension`.

<sup>Written for commit 15f63863314f4d3bb871716fcfc768808c54acb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

