### PR TITLE
fix(selection-toolbar): derive custom action webpage context by session

### DIFF
--- a/.changeset/calm-cycles-wink.md
+++ b/.changeset/calm-cycles-wink.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection-toolbar): derive custom action webpage context by popover session

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/use-custom-action-execution.test.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/use-custom-action-execution.test.ts
@@ -1,10 +1,53 @@
 import type { CachedWebPageContext } from "@/utils/host/translate/webpage-context"
 // @vitest-environment jsdom
-import { describe, expect, it } from "vitest"
+import { act, render, screen, waitFor } from "@testing-library/react"
+import { createElement } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { isLLMProviderConfig } from "@/types/config/provider"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { CUSTOM_ACTION_CONTEXT_CHAR_LIMIT } from "../../../utils"
-import { buildCustomActionExecutionPlan } from "../use-custom-action-execution"
+import { buildCustomActionExecutionPlan, useCustomActionWebPageContext } from "../use-custom-action-execution"
+
+const getOrCreateWebPageContextMock = vi.fn()
+
+vi.mock("@/utils/host/translate/webpage-context", async () => {
+  const actual = await vi.importActual<typeof import("@/utils/host/translate/webpage-context")>(
+    "@/utils/host/translate/webpage-context",
+  )
+
+  return {
+    ...actual,
+    getOrCreateWebPageContext: (...args: unknown[]) => getOrCreateWebPageContextMock(...args),
+  }
+})
+
+function createDeferredPromise<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error?: unknown) => void
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+
+  return { promise, resolve, reject }
+}
+
+function WebPageContextProbe({
+  open,
+  popoverSessionKey,
+}: {
+  open: boolean
+  popoverSessionKey: number
+}) {
+  const webPageContext = useCustomActionWebPageContext(open, popoverSessionKey)
+  const status = webPageContext === undefined
+    ? "pending"
+    : webPageContext === null
+      ? "null"
+      : webPageContext.webTitle
+
+  return createElement("div", { "data-testid": "web-page-context" }, status)
+}
 
 function createCustomActionRequest() {
   const action = DEFAULT_CONFIG.selectionToolbar.customActions[0]
@@ -26,6 +69,100 @@ function createCustomActionRequest() {
     providerConfig,
   }
 }
+
+describe("useCustomActionWebPageContext", () => {
+  beforeEach(() => {
+    getOrCreateWebPageContextMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("ignores stale pending results after the popover closes and reopens", async () => {
+    const firstRequest = createDeferredPromise<CachedWebPageContext | null>()
+    const secondRequest = createDeferredPromise<CachedWebPageContext | null>()
+
+    getOrCreateWebPageContextMock
+      .mockImplementationOnce(() => firstRequest.promise)
+      .mockImplementationOnce(() => secondRequest.promise)
+
+    const { rerender } = render(createElement(WebPageContextProbe, { open: true, popoverSessionKey: 0 }))
+
+    expect(screen.getByTestId("web-page-context")).toHaveTextContent("pending")
+
+    rerender(createElement(WebPageContextProbe, { open: false, popoverSessionKey: 0 }))
+    rerender(createElement(WebPageContextProbe, { open: true, popoverSessionKey: 1 }))
+
+    expect(screen.getByTestId("web-page-context")).toHaveTextContent("pending")
+
+    await act(async () => {
+      firstRequest.resolve({
+        url: "https://example.com/first",
+        webTitle: "First page",
+        webContent: "First content",
+      })
+      await Promise.resolve()
+    })
+
+    expect(screen.getByTestId("web-page-context")).toHaveTextContent("pending")
+
+    await act(async () => {
+      secondRequest.resolve({
+        url: "https://example.com/second",
+        webTitle: "Second page",
+        webContent: "Second content",
+      })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("web-page-context")).toHaveTextContent("Second page")
+    })
+  })
+
+  it("returns to loading for a new popover session even when the previous session already resolved", async () => {
+    const firstRequest = createDeferredPromise<CachedWebPageContext | null>()
+    const secondRequest = createDeferredPromise<CachedWebPageContext | null>()
+
+    getOrCreateWebPageContextMock
+      .mockImplementationOnce(() => firstRequest.promise)
+      .mockImplementationOnce(() => secondRequest.promise)
+
+    const { rerender } = render(createElement(WebPageContextProbe, { open: true, popoverSessionKey: 0 }))
+
+    await act(async () => {
+      firstRequest.resolve({
+        url: "https://example.com/first",
+        webTitle: "First page",
+        webContent: "First content",
+      })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("web-page-context")).toHaveTextContent("First page")
+    })
+
+    rerender(createElement(WebPageContextProbe, { open: false, popoverSessionKey: 0 }))
+    rerender(createElement(WebPageContextProbe, { open: true, popoverSessionKey: 1 }))
+
+    expect(screen.getByTestId("web-page-context")).toHaveTextContent("pending")
+
+    await act(async () => {
+      secondRequest.resolve({
+        url: "https://example.com/second",
+        webTitle: "Second page",
+        webContent: "Second content",
+      })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("web-page-context")).toHaveTextContent("Second page")
+    })
+  })
+})
 
 describe("buildCustomActionExecutionPlan", () => {
   it("truncates paragraph context tokens and trusts the canonical webpage content", () => {

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/provider.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/provider.tsx
@@ -97,7 +97,7 @@ export function SelectionCustomActionProvider({
 
     return activeSession?.contextSnapshot.text || cleanSelection
   }, [activeSession?.contextSnapshot.text, cleanSelection])
-  const webPageContext = useCustomActionWebPageContext(isOpen)
+  const webPageContext = useCustomActionWebPageContext(isOpen, popoverSessionKey)
   const titleText = (webPageContext?.webTitle ?? document.title) || null
   const activeAction = useMemo(
     () => selectionToolbarConfig.customActions.find(action =>

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/use-custom-action-execution.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/use-custom-action-execution.ts
@@ -40,6 +40,11 @@ interface CustomActionExecutionPlan {
   executionContext: CustomActionExecutionContext | null
 }
 
+interface ResolvedWebPageContext {
+  popoverSessionKey: number
+  value: CachedWebPageContext | null
+}
+
 function scrollSelectionPopoverBodyToBottom(ref: RefObject<HTMLDivElement | null>) {
   requestAnimationFrame(() => {
     if (ref.current) {
@@ -108,12 +113,11 @@ export function buildCustomActionExecutionPlan(
   }
 }
 
-export function useCustomActionWebPageContext(open: boolean) {
-  const [webPageContext, setWebPageContext] = useState<CachedWebPageContext | null | undefined>(undefined)
+export function useCustomActionWebPageContext(open: boolean, popoverSessionKey: number) {
+  const [resolvedWebPageContext, setResolvedWebPageContext] = useState<ResolvedWebPageContext | null>(null)
 
   useEffect(() => {
     if (!open) {
-      setWebPageContext(undefined)
       return
     }
 
@@ -122,21 +126,31 @@ export function useCustomActionWebPageContext(open: boolean) {
     void getOrCreateWebPageContext()
       .then((nextContext) => {
         if (!isCancelled) {
-          setWebPageContext(nextContext)
+          setResolvedWebPageContext({
+            popoverSessionKey,
+            value: nextContext,
+          })
         }
       })
       .catch(() => {
         if (!isCancelled) {
-          setWebPageContext(null)
+          setResolvedWebPageContext({
+            popoverSessionKey,
+            value: null,
+          })
         }
       })
 
     return () => {
       isCancelled = true
     }
-  }, [open])
+  }, [open, popoverSessionKey])
 
-  return webPageContext
+  if (!open || resolvedWebPageContext?.popoverSessionKey !== popoverSessionKey) {
+    return undefined
+  }
+
+  return resolvedWebPageContext.value
 }
 
 export function useCustomActionExecution({


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

- derive custom action webpage context from the current popover session instead of resetting local state inside `useEffect`
- keep each reopen in the loading state until its own webpage-context request resolves, and ignore stale results from older sessions
- add regression tests for stale pending results and resolved-then-reopen behavior
- add a patch changeset for `@read-frog/extension`

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Tested with:

- `pnpm exec vitest run src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/use-custom-action-execution.test.ts`
- `pnpm exec eslint src/entrypoints/selection.content/selection-toolbar/custom-action-button/use-custom-action-execution.ts src/entrypoints/selection.content/selection-toolbar/custom-action-button/provider.tsx src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/use-custom-action-execution.test.ts`
- `pnpm exec vitest run src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx -t "custom action"`
- pre-push hook: `nx run @read-frog/extension:lint`, `nx run @read-frog/extension:type-check`, `nx run @read-frog/extension:test`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- this change is intentionally scoped to the custom action popover hook and does not change execution-plan semantics for `undefined`, `null`, or resolved webpage context values


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale webpage context in selection toolbar custom actions by scoping context to the active popover session. Each reopen stays in loading until its own request resolves; old results are ignored.

- **Bug Fixes**
  - Updated `useCustomActionWebPageContext` to accept `popoverSessionKey` and bind results to the current session; provider updated.
  - Returns `undefined` while the session is pending and only resolves for the matching session; drops stale responses.
  - Added unit tests for stale pending results and reopen-after-resolve scenarios.

<sup>Written for commit 2cc73e1e8c7e3905e19ab1fbbb3425a5870f9327. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

