### PR TITLE
fix(subtitles): retry incomplete youtube fast-path fetches

### DIFF
--- a/.changeset/pretty-points-smoke.md
+++ b/.changeset/pretty-points-smoke.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+Fall back from YouTube's fast timedtext path when an unready player returns empty or trivially incomplete subtitles, avoiding stalled or partial subtitle loads.

--- a/src/utils/subtitles/__tests__/youtube-fetcher.test.ts
+++ b/src/utils/subtitles/__tests__/youtube-fetcher.test.ts
@@ -103,7 +103,11 @@ describe("youtube subtitles fetcher", () => {
       success: true,
       data: playerData,
     })
-    const fetchWithRetrySpy = vi.spyOn(fetcher as any, "fetchWithRetry").mockResolvedValue([])
+    const fastPathEvents = [
+      { tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: "hello" }] },
+      { tStartMs: 1000, dDurationMs: 1000, segs: [{ utf8: "world" }] },
+    ]
+    const fetchWithRetrySpy = vi.spyOn(fetcher as any, "fetchWithRetry").mockResolvedValue(fastPathEvents)
     const processRawEventsSpy = vi.spyOn(fetcher as any, "processRawEvents").mockResolvedValue([])
     const waitForPlayerStateSpy = vi.spyOn(fetcher as any, "waitForPlayerState").mockResolvedValue(undefined)
     const getPlayerDataWithPotSpy = vi.spyOn(fetcher as any, "getPlayerDataWithPot").mockResolvedValue(playerData)
@@ -115,6 +119,100 @@ describe("youtube subtitles fetcher", () => {
     expect(processRawEventsSpy).toHaveBeenCalledTimes(1)
     expect(waitForPlayerStateSpy).not.toHaveBeenCalled()
     expect(getPlayerDataWithPotSpy).not.toHaveBeenCalled()
+  })
+
+  it("falls back when the fast fetch returns empty events before the player is ready", async () => {
+    const fetcher = new YoutubeSubtitlesFetcher()
+
+    Object.defineProperty(window, "location", {
+      value: { search: "?v=test123", origin: "https://www.youtube.com", pathname: "/watch", hostname: "www.youtube.com" },
+      writable: true,
+    })
+
+    const playerData = {
+      videoId: "test123",
+      captionTracks: [{
+        baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=en",
+        languageCode: "en",
+        vssId: ".en",
+      }],
+      audioCaptionTracks: [],
+      device: null,
+      cver: null,
+      playerState: 0,
+      selectedTrackLanguageCode: "en",
+      cachedTimedtextUrl: null,
+    }
+    const fallbackEvents = [
+      { tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: "hello" }] },
+      { tStartMs: 1000, dDurationMs: 1000, segs: [{ utf8: "world" }] },
+    ]
+
+    vi.spyOn(fetcher as any, "requestPlayerData").mockResolvedValue({
+      success: true,
+      data: playerData,
+    })
+    const fetchWithRetrySpy = vi.spyOn(fetcher as any, "fetchWithRetry")
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(fallbackEvents)
+    const processRawEventsSpy = vi.spyOn(fetcher as any, "processRawEvents").mockResolvedValue([])
+    const waitForPlayerStateSpy = vi.spyOn(fetcher as any, "waitForPlayerState").mockResolvedValue(undefined)
+    const getPlayerDataWithPotSpy = vi.spyOn(fetcher as any, "getPlayerDataWithPot").mockResolvedValue(playerData)
+
+    await expect(fetcher.fetch()).resolves.toEqual([])
+
+    expect(fetchWithRetrySpy).toHaveBeenCalledTimes(2)
+    expect(processRawEventsSpy).toHaveBeenCalledWith(fallbackEvents)
+    expect(waitForPlayerStateSpy).toHaveBeenCalledTimes(1)
+    expect(getPlayerDataWithPotSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("falls back when the fast fetch only returns the first subtitle before the player is ready", async () => {
+    const fetcher = new YoutubeSubtitlesFetcher()
+
+    Object.defineProperty(window, "location", {
+      value: { search: "?v=test123", origin: "https://www.youtube.com", pathname: "/watch", hostname: "www.youtube.com" },
+      writable: true,
+    })
+
+    const playerData = {
+      videoId: "test123",
+      captionTracks: [{
+        baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=en",
+        languageCode: "en",
+        vssId: ".en",
+      }],
+      audioCaptionTracks: [],
+      device: null,
+      cver: null,
+      playerState: 0,
+      selectedTrackLanguageCode: "en",
+      cachedTimedtextUrl: null,
+    }
+    const fallbackEvents = [
+      { tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: "hello" }] },
+      { tStartMs: 1000, dDurationMs: 1000, segs: [{ utf8: "world" }] },
+    ]
+
+    vi.spyOn(fetcher as any, "requestPlayerData").mockResolvedValue({
+      success: true,
+      data: playerData,
+    })
+    const fetchWithRetrySpy = vi.spyOn(fetcher as any, "fetchWithRetry")
+      .mockResolvedValueOnce([
+        { tStartMs: 0, dDurationMs: 1000, segs: [{ utf8: "hello" }] },
+      ])
+      .mockResolvedValueOnce(fallbackEvents)
+    const processRawEventsSpy = vi.spyOn(fetcher as any, "processRawEvents").mockResolvedValue([])
+    const waitForPlayerStateSpy = vi.spyOn(fetcher as any, "waitForPlayerState").mockResolvedValue(undefined)
+    const getPlayerDataWithPotSpy = vi.spyOn(fetcher as any, "getPlayerDataWithPot").mockResolvedValue(playerData)
+
+    await expect(fetcher.fetch()).resolves.toEqual([])
+
+    expect(fetchWithRetrySpy).toHaveBeenCalledTimes(2)
+    expect(processRawEventsSpy).toHaveBeenCalledWith(fallbackEvents)
+    expect(waitForPlayerStateSpy).toHaveBeenCalledTimes(1)
+    expect(getPlayerDataWithPotSpy).toHaveBeenCalledTimes(1)
   })
 
   it("returns cached subtitles before attempting a fast timedtext fetch", async () => {

--- a/src/utils/subtitles/fetchers/youtube/index.ts
+++ b/src/utils/subtitles/fetchers/youtube/index.ts
@@ -83,7 +83,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     let resolvedTrack = fastPathResult.track
     let events = fastPathResult.events
 
-    if (!events) {
+    if (this.shouldFallbackFromFastPath(events, fastPathResult.playerState)) {
       const fallbackResult = await this.fetchWithFallback(videoId, fastPathResult.track)
       resolvedTrack = fallbackResult.track
       events = fallbackResult.events
@@ -94,7 +94,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     }
 
     this.sourceLanguage = resolvedTrack.languageCode
-    this.subtitles = await this.processRawEvents(events)
+    this.subtitles = await this.processRawEvents(events!)
     this.cachedTrackHash = this.buildTrackHash(videoId, resolvedTrack)
 
     return this.subtitles
@@ -164,6 +164,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
 
   private async tryFastFetch(videoId: string): Promise<{
     currentHash: string | null
+    playerState: number
     track: CaptionTrack | null
     events: YoutubeTimedText[] | null
   }> {
@@ -171,6 +172,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     if (!response.success || !response.data) {
       return {
         currentHash: null,
+        playerState: -1,
         track: null,
         events: null,
       }
@@ -183,6 +185,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     if (!track) {
       return {
         currentHash,
+        playerState: playerData.playerState,
         track: null,
         events: null,
       }
@@ -192,6 +195,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
       const events = await this.fetchTrackEvents(track, playerData)
       return {
         currentHash,
+        playerState: playerData.playerState,
         track,
         events,
       }
@@ -199,10 +203,30 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     catch {
       return {
         currentHash,
+        playerState: playerData.playerState,
         track,
         events: null,
       }
     }
+  }
+
+  private shouldFallbackFromFastPath(
+    events: YoutubeTimedText[] | null,
+    playerState: number,
+  ): boolean {
+    if (!events) {
+      return true
+    }
+
+    if (playerState >= 1) {
+      return false
+    }
+
+    const textEventCount = events.filter(event =>
+      event.segs?.some(seg => seg.utf8.trim().length > 0),
+    ).length
+
+    return textEventCount <= 1
   }
 
   private async fetchWithFallback(


### PR DESCRIPTION
## Summary
- fall back to the slower YouTube POT/player-state subtitle path when the fast timedtext path returns empty or only a single text event before the player is ready
- keep the fast path for ready players with substantive subtitle events
- add regression tests for empty and first-line-only fast-path results

## Why
On issue #1319, the reporter could still get `timedtext` 200 responses, but some videos showed loading forever, no subtitles, or only the first translated line. The current fetcher only retried when the fast path threw/returned null, so an unready-but-200 timedtext response could be accepted as final.

Fixes #1319

## Validation
- `SKIP_FREE_API=true pnpm vitest run src/utils/subtitles/__tests__/youtube-fetcher.test.ts`
- `pnpm eslint src/utils/subtitles/fetchers/youtube/index.ts src/utils/subtitles/__tests__/youtube-fetcher.test.ts`
- `pnpm tsc --noEmit`
- `git push` pre-push checks: `nx run @read-frog/extension:lint`, `nx run @read-frog/extension:type-check`, `nx run @read-frog/extension:test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fallback to the POT/player-state path when YouTube’s fast `timedtext` returns empty or only the first line before the player is ready, preventing stalled or partial subtitles. Fixes #1319.

- **Bug Fixes**
  - Detect incomplete fast-path results (empty or single text event) on unready players and fall back to POT/player-state.
  - Include `playerState` in fast fetch and gate fallback via `shouldFallbackFromFastPath`.
  - Add regression tests for empty and first-line-only fast-path responses.

<sup>Written for commit 98db9811e684b1bac15a8f89ab1aa0535bb27189. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

