### PR TITLE
fix(selection-toolbar): add more cursor clearance after text selection

### DIFF
--- a/.changeset/bright-tools-begin.md
+++ b/.changeset/bright-tools-begin.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection-toolbar): add more cursor clearance after text selection

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
@@ -682,6 +682,27 @@ describe("selectionToolbar - positioning logic", () => {
     })
   })
 
+  it("should keep the bottom-right toolbar below the cursor to reduce accidental clicks", async () => {
+    render(
+      <div>
+        <SelectionToolbar />
+        <div data-testid="test-element">Test content</div>
+      </div>,
+    )
+
+    const target = screen.getByTestId("test-element")
+    const toolbar = getToolbarElement()
+    mockToolbarDimensions(toolbar, 200, 50)
+
+    await triggerMouseDownAndUp(target, 100, 100, 200, 200)
+
+    await waitFor(() => {
+      const topValue = Number.parseInt(toolbar.style.top)
+
+      expect(topValue - 200).toBeGreaterThanOrEqual(20)
+    })
+  })
+
   it("should position toolbar at bottom-left when selecting from top-right to bottom-left", async () => {
     render(
       <div>

--- a/src/entrypoints/selection.content/selection-toolbar/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/index.tsx
@@ -199,18 +199,18 @@ function applyDirectionOffset(
   tooltipWidth: number,
   tooltipHeight: number,
 ): { x: number, y: number } {
-  const MARGIN = 12
+  const CURSOR_CLEARANCE = 20
   switch (direction) {
     case SelectionDirection.BOTTOM_RIGHT:
-      return { x: baseX - MARGIN, y: baseY + MARGIN }
+      return { x: baseX, y: baseY + CURSOR_CLEARANCE }
     case SelectionDirection.BOTTOM_LEFT:
-      return { x: baseX - tooltipWidth + MARGIN, y: baseY + MARGIN }
+      return { x: baseX - tooltipWidth, y: baseY + CURSOR_CLEARANCE }
     case SelectionDirection.TOP_RIGHT:
-      return { x: baseX - MARGIN, y: baseY - tooltipHeight - MARGIN }
+      return { x: baseX, y: baseY - tooltipHeight - CURSOR_CLEARANCE }
     case SelectionDirection.TOP_LEFT:
-      return { x: baseX - tooltipWidth + MARGIN, y: baseY - tooltipHeight - MARGIN }
+      return { x: baseX - tooltipWidth, y: baseY - tooltipHeight - CURSOR_CLEARANCE }
     default:
-      return { x: baseX - MARGIN, y: baseY + MARGIN }
+      return { x: baseX, y: baseY + CURSOR_CLEARANCE }
   }
 }
 


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [x] ✅ Test related (test)

## Description

- increase the selection toolbar cursor clearance after text selection so the toolbar opens farther below the release point
- keep the horizontal alignment change you made so the toolbar no longer shifts left in the bottom-right and top-right cases
- add regression coverage for the updated bottom-right placement behavior
- add a patch changeset for the extension package

## Related Issue

- No linked issue

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Commands run:
- `pnpm test src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx`
- `pnpm exec eslint src/entrypoints/selection.content/selection-toolbar/index.tsx src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx`
- `git push -u origin fix/selection-toolbar-cursor-clearance` (pre-push hook ran `eslint`, `tsc --noEmit`, and full `vitest run`)

## Screenshots

- N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- The toolbar now keeps a 20px vertical gap from the cursor in the bottom-right case.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the selection toolbar’s cursor clearance to 20px after text selection to reduce accidental clicks. Preserves right-edge alignment so the toolbar no longer shifts left in bottom-right and top-right cases.

- **Bug Fixes**
  - Increase vertical gap to 20px across all placements.
  - Add a unit test to cover bottom-right placement behavior.
  - Publish a patch changeset for `@read-frog/extension`.

<sup>Written for commit 291ffbed60b20b8e49f6bb5d33a354794387d576. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

