### PR TITLE
fix: keep floating button close menu aligned

### DIFF
--- a/.changeset/clever-forks-smile.md
+++ b/.changeset/clever-forks-smile.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: keep floating button close menu aligned after reopening

--- a/src/entrypoints/side.content/components/floating-button/__tests__/index.test.tsx
+++ b/src/entrypoints/side.content/components/floating-button/__tests__/index.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react"
+import { atom } from "jotai"
+import { beforeAll, describe, expect, it, vi } from "vitest"
+import FloatingButton from ".."
+
+vi.mock("#imports", () => ({
+  browser: {
+    runtime: {
+      getURL: (path = "") => `chrome-extension://test-extension${path}`,
+    },
+  },
+  i18n: {
+    t: (key: string) => key,
+  },
+}))
+
+vi.mock("@/utils/atoms/config", () => ({
+  configFieldsAtomMap: {
+    floatingButton: atom({
+      enabled: true,
+      position: 0.66,
+      clickAction: "panel",
+      disabledFloatingButtonPatterns: [],
+    }),
+    sideContent: atom({ width: 360 }),
+  },
+}))
+
+vi.mock("../../../atoms", () => ({
+  enablePageTranslationAtom: atom({ enabled: false }),
+  isDraggingButtonAtom: atom(false),
+  isSideOpenAtom: atom(false),
+}))
+
+vi.mock("../../../index", () => ({
+  shadowWrapper: document.body,
+}))
+
+vi.mock("../translate-button", () => ({
+  default: ({ className }: { className?: string }) => (
+    <div data-testid="translate-button" className={className} />
+  ),
+}))
+
+vi.mock("../components/hidden-button", () => ({
+  default: ({ className, onClick }: { className?: string, onClick: () => void }) => (
+    <button type="button" data-testid="hidden-button" className={className} onClick={onClick} />
+  ),
+}))
+
+vi.mock("@/utils/message", () => ({
+  sendMessage: vi.fn(),
+}))
+
+beforeAll(() => {
+  class ResizeObserverMock {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  vi.stubGlobal("ResizeObserver", ResizeObserverMock)
+})
+
+describe("floatingButton close trigger", () => {
+  it("keeps the close trigger in the layout with visibility classes instead of display:none", () => {
+    render(<FloatingButton />)
+
+    const closeTrigger = screen.getByTitle("Close floating button")
+
+    expect(closeTrigger).toHaveClass("invisible")
+    expect(closeTrigger).toHaveClass("group-hover:visible")
+    expect(closeTrigger).not.toHaveClass("hidden")
+    expect(closeTrigger).not.toHaveClass("group-hover:block")
+  })
+
+  it("forces the close trigger visible while the dropdown is open", () => {
+    render(<FloatingButton />)
+
+    const closeTrigger = screen.getByTitle("Close floating button")
+    fireEvent.click(closeTrigger)
+
+    expect(closeTrigger).toHaveClass("visible")
+    expect(screen.getByText("options.floatingButtonAndToolbar.floatingButton.closeMenu.disableForSite")).toBeInTheDocument()
+  })
+})

--- a/src/entrypoints/side.content/components/floating-button/index.tsx
+++ b/src/entrypoints/side.content/components/floating-button/index.tsx
@@ -157,9 +157,9 @@ export default function FloatingButton() {
                 type="button"
                 title="Close floating button"
                 className={cn(
-                  "border-border absolute -top-1 -left-1 hidden cursor-pointer rounded-full border bg-neutral-100 dark:bg-neutral-900",
-                  "group-hover:block",
-                  isDropdownOpen && "block",
+                  "border-border absolute -top-1 -left-1 invisible cursor-pointer rounded-full border bg-neutral-100 dark:bg-neutral-900",
+                  "group-hover:visible",
+                  isDropdownOpen && "visible",
                 )}
                 onMouseDown={e => e.stopPropagation()} // 父级不会收到 mousedown
               />


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

This fixes a floating-button regression where the close menu opens in the wrong horizontal position after this sequence:

1. hover the frog avatar
2. click the close `x` once
3. click elsewhere to dismiss the menu
4. hover the frog avatar again
5. click the close `x` again

## Root cause

This bug was not just “menu positioning is wrong”; it was a reference-geometry continuity bug.

The floating button has two coupled behaviors:

1. the frog capsule itself slides horizontally between hidden and shown states with `translate-x-6 -> translate-x-0`
2. the close trigger was hidden with `display: none` (`hidden` / `block`)

Base UI positions the dropdown by continuously measuring the trigger element as the popup anchor. Internally:

- `MenuPositioner` delegates to `useAnchorPositioning`
- `useAnchorPositioning` uses Floating UI reference rects (`rects.reference`)
- Base UI’s `hideMiddleware` marks the anchor as hidden when the reference rect collapses to `width=0`, `height=0`, `x=0`, `y=0`

That means the moment the close trigger becomes `display:none`, the anchor stops being measurable. The important part is that this happens while the frog capsule is also sliding back to its hidden x-position.

So the positioning engine loses a continuous anchor during the close cycle:

- while visible, the shown-state trigger is at the hovered x-position
- after dismiss, the trigger disappears from layout entirely
- during that same interval, the frog capsule moves 24px right into its hidden resting state
- on the next open, the popup reuses geometry from that hidden-state cycle instead of reopening from the shown-state trigger position

That is why the bug is a consistent horizontal offset instead of a random jump, and why the measured delta is about the same as the capsule’s slide distance.

Measured on the second open in real browser runs:

- Before (`origin/main`): trigger `x=1393`, popup `x=1284`
- After (this branch): trigger `x=1393`, popup `x=1260.24`

The ~24px error matches the hidden/shown horizontal slide distance.

## Why this fix works

The fix changes the close trigger from `display:none` to `visibility:hidden` (`invisible` / `visible`).

That matters because `visibility:hidden`:

- keeps the same DOM node mounted
- keeps it in layout
- keeps `getBoundingClientRect()` stable and non-zero
- keeps it non-interactive to the user while hidden

So Base UI can keep tracking one continuous anchor even while the parent capsule slides between hidden and shown positions. When the menu reopens, it is positioned from the current visible trigger geometry instead of stale hidden-state geometry.

## Code changes

- switch the close trigger classes from `hidden/group-hover:block` to `invisible/group-hover:visible`
- keep `visible` while the dropdown is open
- add a focused regression test that prevents the trigger from being hidden with `display:none` again
- add a changeset

## Related Issue

Follow-up to #1255

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

### Automated checks

- `SKIP_FREE_API=true pnpm test src/entrypoints/side.content/components/floating-button/__tests__/index.test.tsx`
- `pnpm exec eslint src/entrypoints/side.content/components/floating-button/index.tsx src/entrypoints/side.content/components/floating-button/__tests__/index.test.tsx`
- `pnpm type-check`
- `pnpm build`
- push-time full repo test suite also passed (`1001` tests)

### Real-browser verification

Verified in Microsoft Edge with the locally built unpacked extension loaded through Playwright.

Repro sequence was the same in both runs:

1. open `https://example.com/`
2. hover the frog avatar
3. click the close `x`
4. click elsewhere to dismiss the menu
5. hover the frog avatar again
6. click the close `x` again

Measured popup position on the second open:

- Before (`origin/main`): trigger `x=1393`, popup `x=1284`
- After (this branch): trigger `x=1393`, popup `x=1260.24`

That puts the reopened popup back against the trigger instead of leaving it shifted right by ~24px.

## Screenshots

All screenshots below come from the real extension running in Edge on `example.com` after the second menu open in the repro flow above.

### Zoomed comparison

| Before | After |
| --- | --- |
| ![Before zoomed screenshot](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog/floating-button-menu-position/read-frog-floating-button-before-crop.png) | ![After zoomed screenshot](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog/floating-button-menu-position/read-frog-floating-button-after-crop.png) |

### Raw screenshots

- Before: ![Before raw screenshot](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog/floating-button-menu-position/read-frog-floating-button-before.png)
- After: ![After raw screenshot](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog/floating-button-menu-position/read-frog-floating-button-after.png)

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

N/A
