### PR TITLE
fix: stop recommending unsupported qwen thinking option for cerebras

### DIFF
--- a/.changeset/cold-falcons-wave.md
+++ b/.changeset/cold-falcons-wave.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(cerebras): stop sending or recommending unsupported `enableThinking` option for Qwen models

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx
@@ -166,6 +166,27 @@ describe("providerOptionsField", () => {
     )
   })
 
+  it("does not show stripped Cerebras Qwen recommendations in the placeholder", () => {
+    render(
+      <ProviderOptionsFieldHarness
+        initialConfig={{
+          ...baseProviderConfig,
+          provider: "cerebras",
+          model: {
+            model: "qwen-3-32b",
+            isCustomModel: false,
+            customModel: null,
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByLabelText("provider-options-editor")).toHaveAttribute(
+      "placeholder",
+      JSON.stringify({ field: "value" }, null, 2),
+    )
+  })
+
   it("syncs the editor when an external update arrives, even if the saved value is unchanged", async () => {
     const externalProviderOptions = { enableThinking: false }
 

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx
@@ -37,6 +37,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="plain-model"
         onApply={vi.fn()}
       />,
@@ -51,6 +52,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="gpt-5.3-chat-latest"
         onApply={vi.fn()}
       />,
@@ -65,6 +67,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     const { rerender } = render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="gpt-5-mini"
         onApply={vi.fn()}
       />,
@@ -78,6 +81,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     rerender(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="gpt-5.4-mini"
         onApply={vi.fn()}
       />,
@@ -98,6 +102,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="gpt-5.4-mini"
         onApply={onApply}
       />,
@@ -121,6 +126,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="huggingface"
         modelId="moonshotai/Kimi-K2-Instruct"
         onApply={vi.fn()}
       />,
@@ -129,5 +135,20 @@ describe("providerOptionsRecommendationTrigger", () => {
     expect(screen.getByRole("button", {
       name: "options.apiProviders.form.providerOptionsRecommendationTrigger",
     })).toBeInTheDocument()
+  })
+
+  it("does not render stripped Qwen recommendations for Cerebras", () => {
+    render(
+      <ProviderOptionsRecommendationTrigger
+        providerId="provider-1"
+        provider="cerebras"
+        modelId="qwen-3-32b"
+        onApply={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByRole("button", {
+      name: "options.apiProviders.form.providerOptionsRecommendationTrigger",
+    })).not.toBeInTheDocument()
   })
 })

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/provider-options-recommendation-trigger.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/provider-options-recommendation-trigger.tsx
@@ -18,6 +18,7 @@ import { cn } from "@/utils/styles/utils"
 
 interface ProviderOptionsRecommendationTriggerProps {
   providerId: string
+  provider: string
   modelId?: string | null
   currentProviderOptions?: Record<string, JSONValue>
   onApply: (options: Record<string, JSONValue>) => void
@@ -27,6 +28,7 @@ const FLASH_DURATION_MS = 1400
 
 export function ProviderOptionsRecommendationTrigger({
   providerId,
+  provider,
   modelId,
   currentProviderOptions,
   onApply,
@@ -56,8 +58,8 @@ export function ProviderOptionsRecommendationTrigger({
     if (!modelId?.trim()) {
       return undefined
     }
-    return getRecommendedProviderOptionsMatch(modelId.trim())
-  }, [modelId])
+    return getRecommendedProviderOptionsMatch(modelId.trim(), provider)
+  }, [modelId, provider])
 
   const recommendationJson = useMemo(() => {
     if (!recommendation) {

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/provider-options-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/provider-options-field.tsx
@@ -100,7 +100,7 @@ export const ProviderOptionsField = withForm({
 
     const modelId = resolveModelId(providerConfig.model)
     const placeholderText = (() => {
-      const recommendedOptions = getRecommendedProviderOptions(modelId ?? "")
+      const recommendedOptions = getRecommendedProviderOptions(modelId ?? "", providerConfig.provider)
       return recommendedOptions
         ? JSON.stringify(recommendedOptions, null, 2)
         : JSON.stringify({ field: "value" }, null, 2)

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
@@ -31,6 +31,7 @@ export const TranslateModelSelector = withForm({
     const recommendationTrigger = (
       <ProviderOptionsRecommendationTrigger
         providerId={providerConfig.id}
+        provider={providerConfig.provider}
         modelId={modelId}
         currentProviderOptions={providerConfig.providerOptions}
         onApply={applyRecommendedProviderOptions}

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -187,6 +187,9 @@ describe("getProviderOptions", () => {
 
       const deepinfraOptions = getProviderOptions("Qwen/Qwen2.5-72B-Instruct", "deepinfra")
       expect(deepinfraOptions.deepinfra?.enableThinking).toBe(false)
+
+      const cerebrasOptions = getProviderOptions("qwen-3-32b", "cerebras")
+      expect(cerebrasOptions).toEqual({})
     })
 
     it("should apply broadened Kimi defaults to provider-prefixed model ids", () => {
@@ -236,6 +239,20 @@ describe("getProviderOptions", () => {
     it("should use user options as-is without merging matched defaults", () => {
       const options = getProviderOptionsWithOverride("qwen3-max", "alibaba", { foo: "bar" })
       expect(options).toEqual({ alibaba: { foo: "bar" } })
+    })
+
+    it("should strip unsupported Cerebras provider options from user overrides", () => {
+      const options = getProviderOptionsWithOverride("qwen-3-32b", "cerebras", {
+        enableThinking: false,
+        foo: "bar",
+      })
+
+      expect(options).toEqual({ cerebras: { foo: "bar" } })
+    })
+
+    it("should drop unsupported Cerebras-only recommendations when no user override exists", () => {
+      const options = getProviderOptionsWithOverride("qwen-3-32b", "cerebras")
+      expect(options).toBeUndefined()
     })
 
     it("should normalize common OpenAI-compatible snake_case aliases", () => {
@@ -292,6 +309,13 @@ describe("getProviderOptions", () => {
       })
 
       expect(getRecommendedProviderOptionsMatch("qwen3.5-flash")?.options).toEqual({
+        enableThinking: false,
+      })
+    })
+
+    it("should suppress recommendation metadata when Cerebras strips all matched options", () => {
+      expect(getRecommendedProviderOptionsMatch("qwen-3-32b", "cerebras")).toBeUndefined()
+      expect(getRecommendedProviderOptionsMatch("qwen/qwen3-32b", "groq")?.options).toEqual({
         enableThinking: false,
       })
     })

--- a/src/utils/providers/options.ts
+++ b/src/utils/providers/options.ts
@@ -14,6 +14,10 @@ const OPENAI_COMPATIBLE_OPTION_ALIASES = {
   verbosity: "textVerbosity",
 } as const satisfies Record<string, string>
 
+const UNSUPPORTED_PROVIDER_OPTION_KEYS = {
+  cerebras: new Set(["enableThinking"]),
+} as const satisfies Record<string, ReadonlySet<string>>
+
 function normalizeUserProviderOptions(
   provider: string,
   userOptions: Record<string, JSONValue>,
@@ -41,14 +45,49 @@ function normalizeUserProviderOptions(
   return changed ? normalizedOptions : userOptions
 }
 
+function stripUnsupportedProviderOptions(
+  provider: string,
+  options: Record<string, JSONValue>,
+): Record<string, JSONValue> {
+  const unsupportedKeys = UNSUPPORTED_PROVIDER_OPTION_KEYS[provider as keyof typeof UNSUPPORTED_PROVIDER_OPTION_KEYS]
+  if (!unsupportedKeys) {
+    return options
+  }
+
+  let changed = false
+  const sanitizedOptions: Record<string, JSONValue> = {}
+
+  for (const [key, value] of Object.entries(options)) {
+    if (unsupportedKeys.has(key)) {
+      changed = true
+      continue
+    }
+
+    sanitizedOptions[key] = value
+  }
+
+  return changed ? sanitizedOptions : options
+}
+
 /**
  * Detect the recommended provider options for a given model.
  * First match wins - more specific patterns should be placed first in MODEL_OPTIONS.
  */
-export function getRecommendedProviderOptionsMatch(model: string): RecommendedProviderOptionsMatch | undefined {
+export function getRecommendedProviderOptionsMatch(
+  model: string,
+  provider?: string,
+): RecommendedProviderOptionsMatch | undefined {
   for (const [matchIndex, { pattern, options }] of LLM_MODEL_OPTIONS.entries()) {
     if (pattern.test(model)) {
-      return { matchIndex, options }
+      const sanitizedOptions = provider
+        ? stripUnsupportedProviderOptions(provider, options)
+        : options
+
+      if (Object.keys(sanitizedOptions).length === 0) {
+        return undefined
+      }
+
+      return { matchIndex, options: sanitizedOptions }
     }
   }
 }
@@ -56,8 +95,11 @@ export function getRecommendedProviderOptionsMatch(model: string): RecommendedPr
 /**
  * Get the recommended provider options payload without wrapping it by provider id.
  */
-export function getRecommendedProviderOptions(model: string): Record<string, JSONValue> | undefined {
-  return getRecommendedProviderOptionsMatch(model)?.options
+export function getRecommendedProviderOptions(
+  model: string,
+  provider?: string,
+): Record<string, JSONValue> | undefined {
+  return getRecommendedProviderOptionsMatch(model, provider)?.options
 }
 
 /**
@@ -67,7 +109,7 @@ export function getProviderOptions(
   model: string,
   provider: string,
 ): Record<string, Record<string, JSONValue>> {
-  const options = getRecommendedProviderOptions(model)
+  const options = getRecommendedProviderOptions(model, provider)
   if (!options) {
     return {}
   }
@@ -86,10 +128,15 @@ export function getProviderOptionsWithOverride(
   userOptions?: Record<string, JSONValue>,
 ): Record<string, Record<string, JSONValue>> | undefined {
   if (userOptions !== undefined) {
-    return { [provider]: normalizeUserProviderOptions(provider, userOptions) }
+    return {
+      [provider]: stripUnsupportedProviderOptions(
+        provider,
+        normalizeUserProviderOptions(provider, userOptions),
+      ),
+    }
   }
 
-  const recommendedOptions = getRecommendedProviderOptions(model)
+  const recommendedOptions = getRecommendedProviderOptions(model, provider)
   if (!recommendedOptions) {
     return undefined
   }


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [x] ✅ Test related (test)
- [x] 🧠 AI model related (ai)

## Description

Fix the Cerebras Qwen regression reported in #1327.

Root cause:
- Qwen recommendation matching is model-name based, so Cerebras Qwen models were also inheriting the broad `{ enableThinking: false }` default.
- Cerebras does not accept `enableThinking`, so requests could fail even though the model itself is a non-thinking variant.

This PR:
- strips unsupported `enableThinking` from Cerebras provider options at runtime, including user overrides
- makes provider-option recommendations provider-aware so Cerebras Qwen no longer shows/apply the unsupported recommendation in the UI
- keeps the existing broad Qwen recommendation behavior for providers that still support it
- adds regression tests for runtime option resolution and the provider-options UI
- includes a patch changeset

## Related Issue

Closes #1327

## How Has This Been Tested?

- [x] Added/updated unit tests
- [ ] Verified through manual testing

Targeted verification:

```bash
SKIP_FREE_API=true pnpm exec vitest run \
  src/utils/constants/__tests__/model.test.ts \
  src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx \
  src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx \
  src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx

pnpm exec tsc --noEmit --pretty false
```

Additional note:
- the local pre-push full-suite hook is currently blocked by unrelated existing failures in `src/utils/host/translate/ui/__tests__/spinner.test.ts`, which also reproduce on a clean `origin/main` baseline.

## Screenshots

N/A (non-UI visual change)

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My changes follow the project code style
- [x] My changes do not intentionally break existing functionality
- [x] If AI-generated, I have reviewed and verified the result


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending or recommending the unsupported `enableThinking` option for Cerebras Qwen models to prevent request failures. Fixes the Cerebras Qwen regression and makes recommendations provider-aware while keeping the existing Qwen default for other providers.

- **Bug Fixes**
  - Strip `enableThinking` from Cerebras provider options at runtime, including user overrides.
  - Make recommendations provider-aware; UI no longer shows the Qwen thinking suggestion for Cerebras, and placeholders fall back to a generic example.
  - Add regression tests for option resolution and the provider-options UI.

<sup>Written for commit 93bc9d0b14673b74444edc1e6015c3d9450f47a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

