### PR TITLE
fix(provider-options): skip unsupported cerebras qwen defaults

### DIFF
--- a/.changeset/few-horns-tell.md
+++ b/.changeset/few-horns-tell.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(provider-options): skip unsupported Cerebras Qwen thinking defaults

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx
@@ -166,6 +166,27 @@ describe("providerOptionsField", () => {
     )
   })
 
+  it("does not suggest unsupported Cerebras Qwen provider options", () => {
+    render(
+      <ProviderOptionsFieldHarness
+        initialConfig={{
+          ...baseProviderConfig,
+          provider: "cerebras",
+          model: {
+            model: "qwen-3-235b-a22b-instruct-2507",
+            isCustomModel: false,
+            customModel: null,
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByLabelText("provider-options-editor")).toHaveAttribute(
+      "placeholder",
+      JSON.stringify({ field: "value" }, null, 2),
+    )
+  })
+
   it("syncs the editor when an external update arrives, even if the saved value is unchanged", async () => {
     const externalProviderOptions = { enableThinking: false }
 

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx
@@ -36,7 +36,7 @@ describe("providerOptionsRecommendationTrigger", () => {
   it("does not render a trigger when the current model has no recommendation", () => {
     render(
       <ProviderOptionsRecommendationTrigger
-        providerId="provider-1"
+        provider="openai"
         modelId="plain-model"
         onApply={vi.fn()}
       />,
@@ -50,7 +50,7 @@ describe("providerOptionsRecommendationTrigger", () => {
   it("does not render a trigger for GPT-5 chat-latest models", () => {
     render(
       <ProviderOptionsRecommendationTrigger
-        providerId="provider-1"
+        provider="openai"
         modelId="gpt-5.3-chat-latest"
         onApply={vi.fn()}
       />,
@@ -64,7 +64,7 @@ describe("providerOptionsRecommendationTrigger", () => {
   it("flashes once when the model starts matching a new recommendation rule", () => {
     const { rerender } = render(
       <ProviderOptionsRecommendationTrigger
-        providerId="provider-1"
+        provider="openai"
         modelId="gpt-5-mini"
         onApply={vi.fn()}
       />,
@@ -77,7 +77,7 @@ describe("providerOptionsRecommendationTrigger", () => {
 
     rerender(
       <ProviderOptionsRecommendationTrigger
-        providerId="provider-1"
+        provider="openai"
         modelId="gpt-5.4-mini"
         onApply={vi.fn()}
       />,
@@ -97,7 +97,7 @@ describe("providerOptionsRecommendationTrigger", () => {
 
     render(
       <ProviderOptionsRecommendationTrigger
-        providerId="provider-1"
+        provider="openai"
         modelId="gpt-5.4-mini"
         onApply={onApply}
       />,
@@ -120,7 +120,7 @@ describe("providerOptionsRecommendationTrigger", () => {
   it("renders Kimi recommendations based on model name alone", () => {
     render(
       <ProviderOptionsRecommendationTrigger
-        providerId="provider-1"
+        provider="huggingface"
         modelId="moonshotai/Kimi-K2-Instruct"
         onApply={vi.fn()}
       />,
@@ -129,5 +129,55 @@ describe("providerOptionsRecommendationTrigger", () => {
     expect(screen.getByRole("button", {
       name: "options.apiProviders.form.providerOptionsRecommendationTrigger",
     })).toBeInTheDocument()
+  })
+
+  it("does not render unsupported Cerebras Qwen recommendations", () => {
+    const onApply = vi.fn()
+
+    render(
+      <ProviderOptionsRecommendationTrigger
+        provider="cerebras"
+        modelId="qwen-3-235b-a22b-instruct-2507"
+        onApply={onApply}
+      />,
+    )
+
+    expect(screen.queryByRole("button", {
+      name: "options.apiProviders.form.providerOptionsRecommendationTrigger",
+    })).not.toBeInTheDocument()
+    expect(onApply).not.toHaveBeenCalled()
+  })
+
+  it("removes unsupported Cerebras Qwen recommendations when the provider changes", () => {
+    const onApply = vi.fn()
+    const { rerender } = render(
+      <ProviderOptionsRecommendationTrigger
+        provider="alibaba"
+        modelId="qwen-3-32b"
+        onApply={onApply}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", {
+      name: "options.apiProviders.form.providerOptionsRecommendationTrigger",
+    }))
+
+    expect(screen.getByTestId("provider-options-preview")).toHaveTextContent("\"enableThinking\": false")
+
+    rerender(
+      <ProviderOptionsRecommendationTrigger
+        provider="cerebras"
+        modelId="qwen-3-32b"
+        onApply={onApply}
+      />,
+    )
+
+    expect(screen.queryByRole("button", {
+      name: "options.apiProviders.form.providerOptionsRecommendationTrigger",
+    })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", {
+      name: "options.apiProviders.form.providerOptionsRecommendationApply",
+    })).not.toBeInTheDocument()
+    expect(onApply).not.toHaveBeenCalled()
   })
 })

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/provider-options-recommendation-trigger.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/provider-options-recommendation-trigger.tsx
@@ -17,7 +17,7 @@ import { getRecommendedProviderOptionsMatch } from "@/utils/providers/options"
 import { cn } from "@/utils/styles/utils"
 
 interface ProviderOptionsRecommendationTriggerProps {
-  providerId: string
+  provider: string
   modelId?: string | null
   currentProviderOptions?: Record<string, JSONValue>
   onApply: (options: Record<string, JSONValue>) => void
@@ -26,7 +26,7 @@ interface ProviderOptionsRecommendationTriggerProps {
 const FLASH_DURATION_MS = 1400
 
 export function ProviderOptionsRecommendationTrigger({
-  providerId,
+  provider,
   modelId,
   currentProviderOptions,
   onApply,
@@ -34,7 +34,7 @@ export function ProviderOptionsRecommendationTrigger({
   const [open, setOpen] = useState(false)
   const [isFlashing, setIsFlashing] = useState(false)
   const hasMountedRef = useRef(false)
-  const previousProviderIdRef = useRef(providerId)
+  const previousProviderRef = useRef(provider)
   const previousMatchIndexRef = useRef<number | undefined>(undefined)
 
   const closePopover = useEffectEvent(() => {
@@ -56,8 +56,8 @@ export function ProviderOptionsRecommendationTrigger({
     if (!modelId?.trim()) {
       return undefined
     }
-    return getRecommendedProviderOptionsMatch(modelId.trim())
-  }, [modelId])
+    return getRecommendedProviderOptionsMatch(modelId.trim(), provider)
+  }, [modelId, provider])
 
   const recommendationJson = useMemo(() => {
     if (!recommendation) {
@@ -82,13 +82,13 @@ export function ProviderOptionsRecommendationTrigger({
   useEffect(() => {
     if (!hasMountedRef.current) {
       hasMountedRef.current = true
-      previousProviderIdRef.current = providerId
+      previousProviderRef.current = provider
       previousMatchIndexRef.current = recommendation?.matchIndex
       return
     }
 
-    if (previousProviderIdRef.current !== providerId) {
-      previousProviderIdRef.current = providerId
+    if (previousProviderRef.current !== provider) {
+      previousProviderRef.current = provider
       previousMatchIndexRef.current = recommendation?.matchIndex
       stopFlashing()
       return
@@ -110,7 +110,7 @@ export function ProviderOptionsRecommendationTrigger({
 
       stopFlashing()
     }
-  }, [providerId, recommendation])
+  }, [provider, recommendation])
 
   if (!recommendation) {
     return null

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/provider-options-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/provider-options-field.tsx
@@ -100,7 +100,7 @@ export const ProviderOptionsField = withForm({
 
     const modelId = resolveModelId(providerConfig.model)
     const placeholderText = (() => {
-      const recommendedOptions = getRecommendedProviderOptions(modelId ?? "")
+      const recommendedOptions = getRecommendedProviderOptions(modelId ?? "", providerConfig.provider)
       return recommendedOptions
         ? JSON.stringify(recommendedOptions, null, 2)
         : JSON.stringify({ field: "value" }, null, 2)

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
@@ -30,7 +30,7 @@ export const TranslateModelSelector = withForm({
 
     const recommendationTrigger = (
       <ProviderOptionsRecommendationTrigger
-        providerId={providerConfig.id}
+        provider={providerConfig.provider}
         modelId={modelId}
         currentProviderOptions={providerConfig.providerOptions}
         onApply={applyRecommendedProviderOptions}

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -168,6 +168,14 @@ describe("getProviderOptions", () => {
       expect(nextOptions.alibaba?.enableThinking).toBe(false)
     })
 
+    it("should skip unsupported Cerebras Qwen enableThinking defaults", () => {
+      const instructOptions = getProviderOptions("qwen-3-235b-a22b-instruct-2507", "cerebras")
+      expect(instructOptions).toEqual({})
+
+      const qwen32bOptions = getProviderOptions("qwen-3-32b", "cerebras")
+      expect(qwen32bOptions).toEqual({})
+    })
+
     it("should keep explicit Alibaba thinking-only Qwen variants untouched", () => {
       const options = getProviderOptions("qwen3-thinking-2507", "alibaba")
       expect(options).toEqual({})
@@ -233,6 +241,11 @@ describe("getProviderOptions", () => {
       expect(options).toEqual({ alibaba: { enableThinking: false } })
     })
 
+    it("should not fall back to unsupported Cerebras Qwen recommendations", () => {
+      const options = getProviderOptionsWithOverride("qwen-3-235b-a22b-instruct-2507", "cerebras")
+      expect(options).toBeUndefined()
+    })
+
     it("should use user options as-is without merging matched defaults", () => {
       const options = getProviderOptionsWithOverride("qwen3-max", "alibaba", { foo: "bar" })
       expect(options).toEqual({ alibaba: { foo: "bar" } })
@@ -294,6 +307,10 @@ describe("getProviderOptions", () => {
       expect(getRecommendedProviderOptionsMatch("qwen3.5-flash")?.options).toEqual({
         enableThinking: false,
       })
+    })
+
+    it("should omit provider-specific recommendations when the provider does not support them", () => {
+      expect(getRecommendedProviderOptionsMatch("qwen-3-235b-a22b-instruct-2507", "cerebras")).toBeUndefined()
     })
   })
 })

--- a/src/utils/providers/options.ts
+++ b/src/utils/providers/options.ts
@@ -8,11 +8,45 @@ export interface RecommendedProviderOptionsMatch {
 }
 
 const OPENAI_COMPATIBLE_PROVIDER_TYPES = new Set<string>(CUSTOM_LLM_PROVIDER_TYPES)
+const UNSUPPORTED_RECOMMENDED_OPTION_KEYS: Partial<Record<string, readonly string[]>> = {
+  cerebras: ["enableThinking"],
+}
 
 const OPENAI_COMPATIBLE_OPTION_ALIASES = {
   reasoning_effort: "reasoningEffort",
   verbosity: "textVerbosity",
 } as const satisfies Record<string, string>
+
+function filterUnsupportedRecommendedOptions(
+  provider: string | undefined,
+  options: Record<string, JSONValue>,
+): Record<string, JSONValue> | undefined {
+  if (!provider) {
+    return options
+  }
+
+  const unsupportedKeys = UNSUPPORTED_RECOMMENDED_OPTION_KEYS[provider]
+  if (!unsupportedKeys?.length) {
+    return options
+  }
+
+  let filteredOptions: Record<string, JSONValue> | undefined
+
+  for (const unsupportedKey of unsupportedKeys) {
+    if (!(unsupportedKey in options)) {
+      continue
+    }
+
+    filteredOptions ??= { ...options }
+    delete filteredOptions[unsupportedKey]
+  }
+
+  if (!filteredOptions) {
+    return options
+  }
+
+  return Object.keys(filteredOptions).length > 0 ? filteredOptions : undefined
+}
 
 function normalizeUserProviderOptions(
   provider: string,
@@ -45,10 +79,18 @@ function normalizeUserProviderOptions(
  * Detect the recommended provider options for a given model.
  * First match wins - more specific patterns should be placed first in MODEL_OPTIONS.
  */
-export function getRecommendedProviderOptionsMatch(model: string): RecommendedProviderOptionsMatch | undefined {
+export function getRecommendedProviderOptionsMatch(
+  model: string,
+  provider?: string,
+): RecommendedProviderOptionsMatch | undefined {
   for (const [matchIndex, { pattern, options }] of LLM_MODEL_OPTIONS.entries()) {
     if (pattern.test(model)) {
-      return { matchIndex, options }
+      const filteredOptions = filterUnsupportedRecommendedOptions(provider, options)
+      if (!filteredOptions) {
+        return undefined
+      }
+
+      return { matchIndex, options: filteredOptions }
     }
   }
 }
@@ -56,8 +98,11 @@ export function getRecommendedProviderOptionsMatch(model: string): RecommendedPr
 /**
  * Get the recommended provider options payload without wrapping it by provider id.
  */
-export function getRecommendedProviderOptions(model: string): Record<string, JSONValue> | undefined {
-  return getRecommendedProviderOptionsMatch(model)?.options
+export function getRecommendedProviderOptions(
+  model: string,
+  provider?: string,
+): Record<string, JSONValue> | undefined {
+  return getRecommendedProviderOptionsMatch(model, provider)?.options
 }
 
 /**
@@ -67,7 +112,7 @@ export function getProviderOptions(
   model: string,
   provider: string,
 ): Record<string, Record<string, JSONValue>> {
-  const options = getRecommendedProviderOptions(model)
+  const options = getRecommendedProviderOptions(model, provider)
   if (!options) {
     return {}
   }
@@ -89,7 +134,7 @@ export function getProviderOptionsWithOverride(
     return { [provider]: normalizeUserProviderOptions(provider, userOptions) }
   }
 
-  const recommendedOptions = getRecommendedProviderOptions(model)
+  const recommendedOptions = getRecommendedProviderOptions(model, provider)
   if (!recommendedOptions) {
     return undefined
   }


### PR DESCRIPTION
## Summary
- filter recommended provider options by provider before wrapping them into AI SDK `providerOptions`
- stop Cerebras Qwen non-thinking models from inheriting `enableThinking: false`, which Cerebras rejects as `body.enableThinking`
- make the provider-options placeholder and recommendation popover provider-aware so the unsupported Cerebras suggestion is no longer shown/applied
- add regression coverage for runtime defaults, placeholder behavior, and recommendation-trigger behavior

## Test Plan
- `./node_modules/.bin/wxt prepare`
- `SKIP_FREE_API=true ./node_modules/.bin/vitest run --configLoader runner src/utils/constants/__tests__/model.test.ts src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx`
- `pnpm type-check`

Closes #1327


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents unsupported Cerebras Qwen thinking defaults from being suggested or applied by making provider option recommendations provider‑aware (closes #1327). Placeholders and the popover no longer include `enableThinking` for Cerebras, and tests cover the behavior.

- **Bug Fixes**
  - Filter recommended options by provider and drop unsupported keys (Cerebras: `enableThinking`).
  - Update provider options placeholder and recommendation popover to respect the selected provider.
  - Add regression tests for runtime defaults, placeholder text, and the recommendation trigger.

<sup>Written for commit 51f4e2756134a7d2fa4c21b2e3f5c2e88c3d18b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

