### PR TITLE
fix(provider-options): skip unsupported Cerebras Qwen defaults

### DIFF
--- a/.changeset/cuddly-singers-clean.md
+++ b/.changeset/cuddly-singers-clean.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(provider-options): stop recommending unsupported Cerebras Qwen thinking fields

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx
@@ -145,6 +145,27 @@ describe("providerOptionsField", () => {
     )
   })
 
+  it("does not suggest unsupported Qwen provider options for Cerebras placeholders", () => {
+    render(
+      <ProviderOptionsFieldHarness
+        initialConfig={{
+          ...baseProviderConfig,
+          provider: "cerebras",
+          model: {
+            model: "qwen-3-235b-a22b-instruct-2507",
+            isCustomModel: false,
+            customModel: null,
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByLabelText("provider-options-editor")).toHaveAttribute(
+      "placeholder",
+      JSON.stringify({ field: "value" }, null, 2),
+    )
+  })
+
   it("matches recommendations by model name even when the provider differs", () => {
     render(
       <ProviderOptionsFieldHarness

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx
@@ -37,6 +37,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="plain-model"
         onApply={vi.fn()}
       />,
@@ -51,6 +52,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="gpt-5.3-chat-latest"
         onApply={vi.fn()}
       />,
@@ -65,6 +67,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     const { rerender } = render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="gpt-5-mini"
         onApply={vi.fn()}
       />,
@@ -78,6 +81,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     rerender(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="gpt-5.4-mini"
         onApply={vi.fn()}
       />,
@@ -98,6 +102,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="gpt-5.4-mini"
         onApply={onApply}
       />,
@@ -121,6 +126,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="huggingface"
         modelId="moonshotai/Kimi-K2-Instruct"
         onApply={vi.fn()}
       />,
@@ -129,5 +135,20 @@ describe("providerOptionsRecommendationTrigger", () => {
     expect(screen.getByRole("button", {
       name: "options.apiProviders.form.providerOptionsRecommendationTrigger",
     })).toBeInTheDocument()
+  })
+
+  it("does not render a trigger for Cerebras Qwen models that reject enableThinking", () => {
+    render(
+      <ProviderOptionsRecommendationTrigger
+        providerId="provider-1"
+        provider="cerebras"
+        modelId="qwen-3-235b-a22b-instruct-2507"
+        onApply={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByRole("button", {
+      name: "options.apiProviders.form.providerOptionsRecommendationTrigger",
+    })).not.toBeInTheDocument()
   })
 })

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/provider-options-recommendation-trigger.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/provider-options-recommendation-trigger.tsx
@@ -18,6 +18,7 @@ import { cn } from "@/utils/styles/utils"
 
 interface ProviderOptionsRecommendationTriggerProps {
   providerId: string
+  provider: string
   modelId?: string | null
   currentProviderOptions?: Record<string, JSONValue>
   onApply: (options: Record<string, JSONValue>) => void
@@ -27,6 +28,7 @@ const FLASH_DURATION_MS = 1400
 
 export function ProviderOptionsRecommendationTrigger({
   providerId,
+  provider,
   modelId,
   currentProviderOptions,
   onApply,
@@ -56,8 +58,8 @@ export function ProviderOptionsRecommendationTrigger({
     if (!modelId?.trim()) {
       return undefined
     }
-    return getRecommendedProviderOptionsMatch(modelId.trim())
-  }, [modelId])
+    return getRecommendedProviderOptionsMatch(modelId.trim(), provider)
+  }, [modelId, provider])
 
   const recommendationJson = useMemo(() => {
     if (!recommendation) {

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/provider-options-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/provider-options-field.tsx
@@ -100,7 +100,7 @@ export const ProviderOptionsField = withForm({
 
     const modelId = resolveModelId(providerConfig.model)
     const placeholderText = (() => {
-      const recommendedOptions = getRecommendedProviderOptions(modelId ?? "")
+      const recommendedOptions = getRecommendedProviderOptions(modelId ?? "", providerConfig.provider)
       return recommendedOptions
         ? JSON.stringify(recommendedOptions, null, 2)
         : JSON.stringify({ field: "value" }, null, 2)

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
@@ -31,6 +31,7 @@ export const TranslateModelSelector = withForm({
     const recommendationTrigger = (
       <ProviderOptionsRecommendationTrigger
         providerId={providerConfig.id}
+        provider={providerConfig.provider}
         modelId={modelId}
         currentProviderOptions={providerConfig.providerOptions}
         onApply={applyRecommendedProviderOptions}

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -189,6 +189,11 @@ describe("getProviderOptions", () => {
       expect(deepinfraOptions.deepinfra?.enableThinking).toBe(false)
     })
 
+    it("should skip Alibaba-style Qwen defaults for Cerebras models", () => {
+      const options = getProviderOptions("qwen-3-235b-a22b-instruct-2507", "cerebras")
+      expect(options).toEqual({})
+    })
+
     it("should apply broadened Kimi defaults to provider-prefixed model ids", () => {
       const huggingfaceOptions = getProviderOptions("moonshotai/Kimi-K2-Instruct", "huggingface")
       expect(huggingfaceOptions.huggingface?.thinking).toEqual({ type: "disabled" })
@@ -231,6 +236,11 @@ describe("getProviderOptions", () => {
     it("should fall back to recommendations when user options are undefined", () => {
       const options = getProviderOptionsWithOverride("qwen3-max", "alibaba")
       expect(options).toEqual({ alibaba: { enableThinking: false } })
+    })
+
+    it("should not auto-apply unsupported Cerebras Qwen defaults when user options are undefined", () => {
+      const options = getProviderOptionsWithOverride("qwen-3-235b-a22b-instruct-2507", "cerebras")
+      expect(options).toBeUndefined()
     })
 
     it("should use user options as-is without merging matched defaults", () => {
@@ -292,6 +302,13 @@ describe("getProviderOptions", () => {
       })
 
       expect(getRecommendedProviderOptionsMatch("qwen3.5-flash")?.options).toEqual({
+        enableThinking: false,
+      })
+    })
+
+    it("should suppress unsupported Qwen recommendations for Cerebras only", () => {
+      expect(getRecommendedProviderOptionsMatch("qwen-3-235b-a22b-instruct-2507", "cerebras")).toBeUndefined()
+      expect(getRecommendedProviderOptionsMatch("qwen/qwen3-32b", "groq")?.options).toEqual({
         enableThinking: false,
       })
     })

--- a/src/utils/providers/options.ts
+++ b/src/utils/providers/options.ts
@@ -14,6 +14,8 @@ const OPENAI_COMPATIBLE_OPTION_ALIASES = {
   verbosity: "textVerbosity",
 } as const satisfies Record<string, string>
 
+const PROVIDERS_WITHOUT_ENABLE_THINKING_RECOMMENDATIONS = new Set(["cerebras"])
+
 function normalizeUserProviderOptions(
   provider: string,
   userOptions: Record<string, JSONValue>,
@@ -41,13 +43,31 @@ function normalizeUserProviderOptions(
   return changed ? normalizedOptions : userOptions
 }
 
+function isRecommendationSupportedByProvider(
+  provider: string | undefined,
+  options: Record<string, JSONValue>,
+): boolean {
+  if (!provider) {
+    return true
+  }
+
+  if (PROVIDERS_WITHOUT_ENABLE_THINKING_RECOMMENDATIONS.has(provider) && "enableThinking" in options) {
+    return false
+  }
+
+  return true
+}
+
 /**
- * Detect the recommended provider options for a given model.
+ * Detect the recommended provider options for a given model/provider pair.
  * First match wins - more specific patterns should be placed first in MODEL_OPTIONS.
  */
-export function getRecommendedProviderOptionsMatch(model: string): RecommendedProviderOptionsMatch | undefined {
+export function getRecommendedProviderOptionsMatch(
+  model: string,
+  provider?: string,
+): RecommendedProviderOptionsMatch | undefined {
   for (const [matchIndex, { pattern, options }] of LLM_MODEL_OPTIONS.entries()) {
-    if (pattern.test(model)) {
+    if (pattern.test(model) && isRecommendationSupportedByProvider(provider, options)) {
       return { matchIndex, options }
     }
   }
@@ -56,8 +76,11 @@ export function getRecommendedProviderOptionsMatch(model: string): RecommendedPr
 /**
  * Get the recommended provider options payload without wrapping it by provider id.
  */
-export function getRecommendedProviderOptions(model: string): Record<string, JSONValue> | undefined {
-  return getRecommendedProviderOptionsMatch(model)?.options
+export function getRecommendedProviderOptions(
+  model: string,
+  provider?: string,
+): Record<string, JSONValue> | undefined {
+  return getRecommendedProviderOptionsMatch(model, provider)?.options
 }
 
 /**
@@ -67,7 +90,7 @@ export function getProviderOptions(
   model: string,
   provider: string,
 ): Record<string, Record<string, JSONValue>> {
-  const options = getRecommendedProviderOptions(model)
+  const options = getRecommendedProviderOptions(model, provider)
   if (!options) {
     return {}
   }
@@ -89,7 +112,7 @@ export function getProviderOptionsWithOverride(
     return { [provider]: normalizeUserProviderOptions(provider, userOptions) }
   }
 
-  const recommendedOptions = getRecommendedProviderOptions(model)
+  const recommendedOptions = getRecommendedProviderOptions(model, provider)
   if (!recommendedOptions) {
     return undefined
   }


### PR DESCRIPTION
## Summary
- suppress `enableThinking` runtime defaults/recommendations for Cerebras Qwen models that reject that field
- thread provider-aware recommendation lookup into the provider options UI so Cerebras no longer suggests the unsupported payload
- add focused regression tests plus a patch changeset

## Why
Issue #1327 reports that `qwen-3-235b-a22b-instruct-2507` on Cerebras still receives `body.enableThinking = false` on `1.32.2`, which Cerebras rejects. The current regression comes from the broadened model-name recommendation path: the Qwen recommendation is still useful for some providers, but not for Cerebras.

Fixes #1327.

## Validation
- `SKIP_FREE_API=true pnpm exec vitest run src/utils/constants/__tests__/model.test.ts src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx`
- `pnpm exec tsc --noEmit --pretty false`
- `SKIP_FREE_API=true pnpm test` *(currently blocked locally by unrelated existing failures in `src/utils/host/translate/ui/__tests__/spinner.test.ts`; this PR does not touch those files)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop recommending or applying Qwen `enableThinking` defaults for Cerebras and make provider-aware recommendations in the options UI. Prevents sending unsupported `body.enableThinking` to Cerebras (e.g., `qwen-3-235b-a22b-instruct-2507`). Fixes #1327.

- **Bug Fixes**
  - Filter recommendations by provider; `getRecommendedProviderOptions` and `getRecommendedProviderOptionsMatch` now accept a provider and skip Qwen thinking defaults for `cerebras`.
  - Update options UI to pass provider, hide the recommendation trigger for Cerebras Qwen models, and keep a generic placeholder.
  - Guard provider option merging to avoid auto-applying unsupported Cerebras defaults when user options are undefined.
  - Add focused regression tests and a patch changeset.

<sup>Written for commit ff4f9464bb20b349ce781f38006f459bfcfd99a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

