### PR TITLE
fix(providers): scope Qwen enableThinking defaults to Alibaba

### DIFF
--- a/.changeset/tame-owls-relax.md
+++ b/.changeset/tame-owls-relax.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(providers): scope Qwen `enableThinking` recommendations to Alibaba

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx
@@ -145,14 +145,14 @@ describe("providerOptionsField", () => {
     )
   })
 
-  it("matches recommendations by model name even when the provider differs", () => {
+  it("does not show Alibaba-only Qwen recommendations for non-Alibaba providers", () => {
     render(
       <ProviderOptionsFieldHarness
         initialConfig={{
           ...baseProviderConfig,
-          provider: "groq",
+          provider: "cerebras",
           model: {
-            model: "qwen/qwen3-32b",
+            model: "qwen-3-235b-a22b-instruct-2507",
             isCustomModel: false,
             customModel: null,
           },
@@ -162,7 +162,7 @@ describe("providerOptionsField", () => {
 
     expect(screen.getByLabelText("provider-options-editor")).toHaveAttribute(
       "placeholder",
-      JSON.stringify({ enableThinking: false }, null, 2),
+      JSON.stringify({ field: "value" }, null, 2),
     )
   })
 

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx
@@ -37,6 +37,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        providerType="openai"
         modelId="plain-model"
         onApply={vi.fn()}
       />,
@@ -51,6 +52,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        providerType="openai"
         modelId="gpt-5.3-chat-latest"
         onApply={vi.fn()}
       />,
@@ -65,6 +67,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     const { rerender } = render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        providerType="openai"
         modelId="gpt-5-mini"
         onApply={vi.fn()}
       />,
@@ -78,6 +81,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     rerender(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        providerType="openai"
         modelId="gpt-5.4-mini"
         onApply={vi.fn()}
       />,
@@ -98,6 +102,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        providerType="openai"
         modelId="gpt-5.4-mini"
         onApply={onApply}
       />,
@@ -121,6 +126,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        providerType="huggingface"
         modelId="moonshotai/Kimi-K2-Instruct"
         onApply={vi.fn()}
       />,
@@ -129,5 +135,20 @@ describe("providerOptionsRecommendationTrigger", () => {
     expect(screen.getByRole("button", {
       name: "options.apiProviders.form.providerOptionsRecommendationTrigger",
     })).toBeInTheDocument()
+  })
+
+  it("does not render Alibaba-only Qwen recommendations for non-Alibaba providers", () => {
+    render(
+      <ProviderOptionsRecommendationTrigger
+        providerId="provider-1"
+        providerType="cerebras"
+        modelId="qwen-3-235b-a22b-instruct-2507"
+        onApply={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByRole("button", {
+      name: "options.apiProviders.form.providerOptionsRecommendationTrigger",
+    })).not.toBeInTheDocument()
   })
 })

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/provider-options-recommendation-trigger.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/provider-options-recommendation-trigger.tsx
@@ -18,6 +18,7 @@ import { cn } from "@/utils/styles/utils"
 
 interface ProviderOptionsRecommendationTriggerProps {
   providerId: string
+  providerType: string
   modelId?: string | null
   currentProviderOptions?: Record<string, JSONValue>
   onApply: (options: Record<string, JSONValue>) => void
@@ -27,6 +28,7 @@ const FLASH_DURATION_MS = 1400
 
 export function ProviderOptionsRecommendationTrigger({
   providerId,
+  providerType,
   modelId,
   currentProviderOptions,
   onApply,
@@ -56,8 +58,8 @@ export function ProviderOptionsRecommendationTrigger({
     if (!modelId?.trim()) {
       return undefined
     }
-    return getRecommendedProviderOptionsMatch(modelId.trim())
-  }, [modelId])
+    return getRecommendedProviderOptionsMatch(modelId.trim(), providerType)
+  }, [modelId, providerType])
 
   const recommendationJson = useMemo(() => {
     if (!recommendation) {

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/provider-options-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/provider-options-field.tsx
@@ -100,7 +100,7 @@ export const ProviderOptionsField = withForm({
 
     const modelId = resolveModelId(providerConfig.model)
     const placeholderText = (() => {
-      const recommendedOptions = getRecommendedProviderOptions(modelId ?? "")
+      const recommendedOptions = getRecommendedProviderOptions(modelId ?? "", providerConfig.provider)
       return recommendedOptions
         ? JSON.stringify(recommendedOptions, null, 2)
         : JSON.stringify({ field: "value" }, null, 2)

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
@@ -31,6 +31,7 @@ export const TranslateModelSelector = withForm({
     const recommendationTrigger = (
       <ProviderOptionsRecommendationTrigger
         providerId={providerConfig.id}
+        providerType={providerConfig.provider}
         modelId={modelId}
         currentProviderOptions={providerConfig.providerOptions}
         onApply={applyRecommendedProviderOptions}

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -181,12 +181,12 @@ describe("getProviderOptions", () => {
       expect(cerebrasOptions.cerebras?.reasoningEffort).toBe("none")
     })
 
-    it("should apply broadened Qwen defaults to provider-prefixed model ids", () => {
-      const groqOptions = getProviderOptions("qwen/qwen3-32b", "groq")
-      expect(groqOptions.groq?.enableThinking).toBe(false)
+    it("should keep Alibaba-only Qwen defaults off non-Alibaba providers", () => {
+      expect(getProviderOptions("qwen-3-235b-a22b-instruct-2507", "cerebras")).toEqual({})
 
-      const deepinfraOptions = getProviderOptions("Qwen/Qwen2.5-72B-Instruct", "deepinfra")
-      expect(deepinfraOptions.deepinfra?.enableThinking).toBe(false)
+      expect(getProviderOptions("qwen/qwen3-32b", "groq")).toEqual({})
+
+      expect(getProviderOptions("Qwen/Qwen2.5-72B-Instruct", "deepinfra")).toEqual({})
     })
 
     it("should apply broadened Kimi defaults to provider-prefixed model ids", () => {
@@ -233,6 +233,11 @@ describe("getProviderOptions", () => {
       expect(options).toEqual({ alibaba: { enableThinking: false } })
     })
 
+    it("should not fall back to Alibaba-only Qwen defaults for non-Alibaba providers", () => {
+      const options = getProviderOptionsWithOverride("qwen-3-235b-a22b-instruct-2507", "cerebras")
+      expect(options).toBeUndefined()
+    })
+
     it("should use user options as-is without merging matched defaults", () => {
       const options = getProviderOptionsWithOverride("qwen3-max", "alibaba", { foo: "bar" })
       expect(options).toEqual({ alibaba: { foo: "bar" } })
@@ -273,8 +278,8 @@ describe("getProviderOptions", () => {
 
   describe("recommendation metadata", () => {
     it("should expose the matched rule index for UI suggestion state", () => {
-      const gpt5Match = getRecommendedProviderOptionsMatch("gpt-5-mini")
-      const gpt51Match = getRecommendedProviderOptionsMatch("gpt-5.1")
+      const gpt5Match = getRecommendedProviderOptionsMatch("gpt-5-mini", "openai")
+      const gpt51Match = getRecommendedProviderOptionsMatch("gpt-5.1", "openai")
 
       expect(gpt5Match?.matchIndex).toBeTypeOf("number")
       expect(gpt51Match?.matchIndex).toBeTypeOf("number")
@@ -282,18 +287,20 @@ describe("getProviderOptions", () => {
     })
 
     it("should return undefined for models without recommendations", () => {
-      expect(getRecommendedProviderOptionsMatch("plain-model")).toBeUndefined()
+      expect(getRecommendedProviderOptionsMatch("plain-model", "openai")).toBeUndefined()
     })
 
     it("should expose recommendation matches for newly covered defaults", () => {
-      expect(getRecommendedProviderOptionsMatch("kimi-k2-turbo")?.options).toEqual({
+      expect(getRecommendedProviderOptionsMatch("kimi-k2-turbo", "moonshotai")?.options).toEqual({
         thinking: { type: "disabled" },
         reasoningHistory: "disabled",
       })
 
-      expect(getRecommendedProviderOptionsMatch("qwen3.5-flash")?.options).toEqual({
+      expect(getRecommendedProviderOptionsMatch("qwen3.5-flash", "alibaba")?.options).toEqual({
         enableThinking: false,
       })
+
+      expect(getRecommendedProviderOptionsMatch("qwen-3-235b-a22b-instruct-2507", "cerebras")).toBeUndefined()
     })
   })
 })

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -119,11 +119,12 @@ export function getOpenAIGPT5ReasoningEffortPolicy(model: string): OpenAIGPT5Rea
 /**
  * Model options configuration.
  * Flat list design: first match wins, more specific patterns should be placed first.
- * Options are matched by model name, not by provider.
+ * Options are matched by model name, with optional provider scoping for provider-specific defaults.
  */
 export const LLM_MODEL_OPTIONS: Array<{
   pattern: RegExp
   options: Record<string, JSONValue>
+  providers?: readonly string[]
 }> = [
   // Gemini - specific patterns first
   {
@@ -193,12 +194,12 @@ export const LLM_MODEL_OPTIONS: Array<{
     options: { thinking: { type: "disabled" }, reasoningHistory: "disabled" } satisfies MoonshotAIProviderOptions as Record<string, JSONValue>,
   },
 
-  // Qwen models - disable thinking by default.
-  // Keep this broad because recommendation matching is model-name based rather than provider-scoped.
+  // Alibaba Qwen models - disable thinking by default.
   // Keep explicit thinking-only variants (for example `qwq-*` and `*-thinking`) untouched.
   {
     pattern: /(?:^|\/)qwen(?!.*[/.-](?:thinking|qwq)(?:[/.-]|$)).*$/i,
     options: { enableThinking: false } satisfies AlibabaProviderOptions as Record<string, JSONValue>,
+    providers: ["alibaba"],
   },
 
   // GLM models - disable thinking (compatibility issues)

--- a/src/utils/providers/options.ts
+++ b/src/utils/providers/options.ts
@@ -45,9 +45,15 @@ function normalizeUserProviderOptions(
  * Detect the recommended provider options for a given model.
  * First match wins - more specific patterns should be placed first in MODEL_OPTIONS.
  */
-export function getRecommendedProviderOptionsMatch(model: string): RecommendedProviderOptionsMatch | undefined {
-  for (const [matchIndex, { pattern, options }] of LLM_MODEL_OPTIONS.entries()) {
+export function getRecommendedProviderOptionsMatch(
+  model: string,
+  provider: string,
+): RecommendedProviderOptionsMatch | undefined {
+  for (const [matchIndex, { pattern, options, providers }] of LLM_MODEL_OPTIONS.entries()) {
     if (pattern.test(model)) {
+      if (providers && !providers.includes(provider)) {
+        continue
+      }
       return { matchIndex, options }
     }
   }
@@ -56,8 +62,11 @@ export function getRecommendedProviderOptionsMatch(model: string): RecommendedPr
 /**
  * Get the recommended provider options payload without wrapping it by provider id.
  */
-export function getRecommendedProviderOptions(model: string): Record<string, JSONValue> | undefined {
-  return getRecommendedProviderOptionsMatch(model)?.options
+export function getRecommendedProviderOptions(
+  model: string,
+  provider: string,
+): Record<string, JSONValue> | undefined {
+  return getRecommendedProviderOptionsMatch(model, provider)?.options
 }
 
 /**
@@ -67,7 +76,7 @@ export function getProviderOptions(
   model: string,
   provider: string,
 ): Record<string, Record<string, JSONValue>> {
-  const options = getRecommendedProviderOptions(model)
+  const options = getRecommendedProviderOptions(model, provider)
   if (!options) {
     return {}
   }
@@ -89,7 +98,7 @@ export function getProviderOptionsWithOverride(
     return { [provider]: normalizeUserProviderOptions(provider, userOptions) }
   }
 
-  const recommendedOptions = getRecommendedProviderOptions(model)
+  const recommendedOptions = getRecommendedProviderOptions(model, provider)
   if (!recommendedOptions) {
     return undefined
   }


### PR DESCRIPTION
## Summary
- scope the Qwen `enableThinking: false` default back to Alibaba only
- make provider-option recommendation lookup provider-aware so runtime fallback, placeholder text, and the recommendation trigger stay consistent
- add regression tests plus a patch changeset

## Why
Issue #1327 is a regression of the earlier Cerebras/Qwen fix path.

After #1262 broadened Qwen recommendation matching by model name, non-Alibaba providers such as Cerebras could inherit the Alibaba-only `enableThinking: false` default. For `qwen-3-235b-a22b-instruct-2507`, that makes the request carry `body.enableThinking`, which Cerebras rejects as unsupported.

This patch restores the intended Alibaba-only scope for that Qwen recommendation while keeping the broader Kimi behavior unchanged.

Fixes #1327

## Validation
- `pnpm install --offline --frozen-lockfile`
- `SKIP_FREE_API=true pnpm exec vitest run src/utils/constants/__tests__/model.test.ts src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx`
- `pnpm exec eslint src/utils/providers/options.ts src/utils/constants/models.ts src/utils/constants/__tests__/model.test.ts src/entrypoints/options/pages/api-providers/provider-config-form/provider-options-field.tsx src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/components/provider-options-recommendation-trigger.tsx src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx`
- `pnpm type-check`
- `SKIP_FREE_API=true pnpm test`
- `git diff --check`

## UI Evidence
Real extension screenshots from the built unpacked extension on the API Providers page after adding/selecting **Cerebras** and expanding **Advanced Options**.

### Cerebras provider config
| Before (`origin/main`) | After (this PR branch) |
| --- | --- |
| ![Before: Cerebras still shows the Qwen recommendation button and `enableThinking: false` provider-options sample](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog-issue-1327-before-cerebras.png) | ![After: recommendation button is gone for Cerebras and Provider Options falls back to the generic sample instead of `enableThinking: false`](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog-issue-1327-after-cerebras.png) |
