### PR TITLE
fix: prune unsupported cerebras qwen provider options

### DIFF
--- a/.changeset/five-timers-grab.md
+++ b/.changeset/five-timers-grab.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+Prune unsupported Cerebras `enableThinking` provider options at runtime and suppress empty Qwen recommendations for Cerebras in the options UI.

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx
@@ -166,6 +166,27 @@ describe("providerOptionsField", () => {
     )
   })
 
+  it("falls back to the generic placeholder when a matched Cerebras recommendation is unsupported", () => {
+    render(
+      <ProviderOptionsFieldHarness
+        initialConfig={{
+          ...baseProviderConfig,
+          provider: "cerebras",
+          model: {
+            model: "qwen-3-235b-a22b-instruct-2507",
+            isCustomModel: false,
+            customModel: null,
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByLabelText("provider-options-editor")).toHaveAttribute(
+      "placeholder",
+      JSON.stringify({ field: "value" }, null, 2),
+    )
+  })
+
   it("syncs the editor when an external update arrives, even if the saved value is unchanged", async () => {
     const externalProviderOptions = { enableThinking: false }
 

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx
@@ -37,6 +37,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="plain-model"
         onApply={vi.fn()}
       />,
@@ -51,6 +52,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="gpt-5.3-chat-latest"
         onApply={vi.fn()}
       />,
@@ -65,6 +67,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     const { rerender } = render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="gpt-5-mini"
         onApply={vi.fn()}
       />,
@@ -78,6 +81,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     rerender(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="gpt-5.4-mini"
         onApply={vi.fn()}
       />,
@@ -98,6 +102,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="openai"
         modelId="gpt-5.4-mini"
         onApply={onApply}
       />,
@@ -121,6 +126,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
+        provider="huggingface"
         modelId="moonshotai/Kimi-K2-Instruct"
         onApply={vi.fn()}
       />,
@@ -129,5 +135,20 @@ describe("providerOptionsRecommendationTrigger", () => {
     expect(screen.getByRole("button", {
       name: "options.apiProviders.form.providerOptionsRecommendationTrigger",
     })).toBeInTheDocument()
+  })
+
+  it("does not render a trigger when a Cerebras recommendation prunes to nothing", () => {
+    render(
+      <ProviderOptionsRecommendationTrigger
+        providerId="provider-1"
+        provider="cerebras"
+        modelId="qwen-3-235b-a22b-instruct-2507"
+        onApply={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByRole("button", {
+      name: "options.apiProviders.form.providerOptionsRecommendationTrigger",
+    })).not.toBeInTheDocument()
   })
 })

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/provider-options-recommendation-trigger.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/provider-options-recommendation-trigger.tsx
@@ -18,6 +18,7 @@ import { cn } from "@/utils/styles/utils"
 
 interface ProviderOptionsRecommendationTriggerProps {
   providerId: string
+  provider: string
   modelId?: string | null
   currentProviderOptions?: Record<string, JSONValue>
   onApply: (options: Record<string, JSONValue>) => void
@@ -27,6 +28,7 @@ const FLASH_DURATION_MS = 1400
 
 export function ProviderOptionsRecommendationTrigger({
   providerId,
+  provider,
   modelId,
   currentProviderOptions,
   onApply,
@@ -56,8 +58,8 @@ export function ProviderOptionsRecommendationTrigger({
     if (!modelId?.trim()) {
       return undefined
     }
-    return getRecommendedProviderOptionsMatch(modelId.trim())
-  }, [modelId])
+    return getRecommendedProviderOptionsMatch(modelId.trim(), provider)
+  }, [modelId, provider])
 
   const recommendationJson = useMemo(() => {
     if (!recommendation) {

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/provider-options-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/provider-options-field.tsx
@@ -100,7 +100,7 @@ export const ProviderOptionsField = withForm({
 
     const modelId = resolveModelId(providerConfig.model)
     const placeholderText = (() => {
-      const recommendedOptions = getRecommendedProviderOptions(modelId ?? "")
+      const recommendedOptions = getRecommendedProviderOptions(modelId ?? "", providerConfig.provider)
       return recommendedOptions
         ? JSON.stringify(recommendedOptions, null, 2)
         : JSON.stringify({ field: "value" }, null, 2)

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
@@ -31,6 +31,7 @@ export const TranslateModelSelector = withForm({
     const recommendationTrigger = (
       <ProviderOptionsRecommendationTrigger
         providerId={providerConfig.id}
+        provider={providerConfig.provider}
         modelId={modelId}
         currentProviderOptions={providerConfig.providerOptions}
         onApply={applyRecommendedProviderOptions}

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -189,6 +189,11 @@ describe("getProviderOptions", () => {
       expect(deepinfraOptions.deepinfra?.enableThinking).toBe(false)
     })
 
+    it("should skip unsupported Qwen defaults for Cerebras", () => {
+      const cerebrasOptions = getProviderOptions("qwen-3-235b-a22b-instruct-2507", "cerebras")
+      expect(cerebrasOptions).toEqual({})
+    })
+
     it("should apply broadened Kimi defaults to provider-prefixed model ids", () => {
       const huggingfaceOptions = getProviderOptions("moonshotai/Kimi-K2-Instruct", "huggingface")
       expect(huggingfaceOptions.huggingface?.thinking).toEqual({ type: "disabled" })
@@ -269,6 +274,19 @@ describe("getProviderOptions", () => {
         },
       })
     })
+
+    it("should prune unsupported Cerebras provider options from user overrides", () => {
+      const options = getProviderOptionsWithOverride("qwen-3-235b-a22b-instruct-2507", "cerebras", {
+        enableThinking: false,
+        foo: "bar",
+      })
+
+      expect(options).toEqual({
+        cerebras: {
+          foo: "bar",
+        },
+      })
+    })
   })
 
   describe("recommendation metadata", () => {
@@ -286,14 +304,16 @@ describe("getProviderOptions", () => {
     })
 
     it("should expose recommendation matches for newly covered defaults", () => {
-      expect(getRecommendedProviderOptionsMatch("kimi-k2-turbo")?.options).toEqual({
+      expect(getRecommendedProviderOptionsMatch("kimi-k2-turbo", "moonshotai")?.options).toEqual({
         thinking: { type: "disabled" },
         reasoningHistory: "disabled",
       })
 
-      expect(getRecommendedProviderOptionsMatch("qwen3.5-flash")?.options).toEqual({
+      expect(getRecommendedProviderOptionsMatch("qwen3.5-flash", "alibaba")?.options).toEqual({
         enableThinking: false,
       })
+
+      expect(getRecommendedProviderOptionsMatch("qwen-3-235b-a22b-instruct-2507", "cerebras")).toBeUndefined()
     })
   })
 })

--- a/src/utils/providers/options.ts
+++ b/src/utils/providers/options.ts
@@ -8,6 +8,9 @@ export interface RecommendedProviderOptionsMatch {
 }
 
 const OPENAI_COMPATIBLE_PROVIDER_TYPES = new Set<string>(CUSTOM_LLM_PROVIDER_TYPES)
+const UNSUPPORTED_PROVIDER_OPTION_KEYS = {
+  cerebras: ["enableThinking"],
+} as const satisfies Partial<Record<string, readonly string[]>>
 
 const OPENAI_COMPATIBLE_OPTION_ALIASES = {
   reasoning_effort: "reasoningEffort",
@@ -41,14 +44,58 @@ function normalizeUserProviderOptions(
   return changed ? normalizedOptions : userOptions
 }
 
+function pruneUnsupportedProviderOptions(
+  provider: string,
+  options: Record<string, JSONValue>,
+): Record<string, JSONValue> {
+  const unsupportedKeys = UNSUPPORTED_PROVIDER_OPTION_KEYS[provider as keyof typeof UNSUPPORTED_PROVIDER_OPTION_KEYS]
+  if (!unsupportedKeys?.length) {
+    return options
+  }
+
+  let changed = false
+  const sanitizedOptions: Record<string, JSONValue> = {}
+
+  for (const [key, value] of Object.entries(options)) {
+    if (unsupportedKeys.includes(key)) {
+      changed = true
+      continue
+    }
+
+    sanitizedOptions[key] = value
+  }
+
+  return changed ? sanitizedOptions : options
+}
+
+function getSupportedProviderOptions(
+  options: Record<string, JSONValue>,
+  provider?: string,
+): Record<string, JSONValue> | undefined {
+  if (!provider) {
+    return options
+  }
+
+  const supportedOptions = pruneUnsupportedProviderOptions(provider, options)
+  return Object.keys(supportedOptions).length > 0 ? supportedOptions : undefined
+}
+
 /**
- * Detect the recommended provider options for a given model.
+ * Detect the recommended provider options for a given model/provider pair.
  * First match wins - more specific patterns should be placed first in MODEL_OPTIONS.
  */
-export function getRecommendedProviderOptionsMatch(model: string): RecommendedProviderOptionsMatch | undefined {
+export function getRecommendedProviderOptionsMatch(
+  model: string,
+  provider?: string,
+): RecommendedProviderOptionsMatch | undefined {
   for (const [matchIndex, { pattern, options }] of LLM_MODEL_OPTIONS.entries()) {
     if (pattern.test(model)) {
-      return { matchIndex, options }
+      const supportedOptions = getSupportedProviderOptions(options, provider)
+      if (!supportedOptions) {
+        return undefined
+      }
+
+      return { matchIndex, options: supportedOptions }
     }
   }
 }
@@ -56,8 +103,11 @@ export function getRecommendedProviderOptionsMatch(model: string): RecommendedPr
 /**
  * Get the recommended provider options payload without wrapping it by provider id.
  */
-export function getRecommendedProviderOptions(model: string): Record<string, JSONValue> | undefined {
-  return getRecommendedProviderOptionsMatch(model)?.options
+export function getRecommendedProviderOptions(
+  model: string,
+  provider?: string,
+): Record<string, JSONValue> | undefined {
+  return getRecommendedProviderOptionsMatch(model, provider)?.options
 }
 
 /**
@@ -67,7 +117,7 @@ export function getProviderOptions(
   model: string,
   provider: string,
 ): Record<string, Record<string, JSONValue>> {
-  const options = getRecommendedProviderOptions(model)
+  const options = getRecommendedProviderOptions(model, provider)
   if (!options) {
     return {}
   }
@@ -86,10 +136,15 @@ export function getProviderOptionsWithOverride(
   userOptions?: Record<string, JSONValue>,
 ): Record<string, Record<string, JSONValue>> | undefined {
   if (userOptions !== undefined) {
-    return { [provider]: normalizeUserProviderOptions(provider, userOptions) }
+    return {
+      [provider]: pruneUnsupportedProviderOptions(
+        provider,
+        normalizeUserProviderOptions(provider, userOptions),
+      ),
+    }
   }
 
-  const recommendedOptions = getRecommendedProviderOptions(model)
+  const recommendedOptions = getRecommendedProviderOptions(model, provider)
   if (!recommendedOptions) {
     return undefined
   }


### PR DESCRIPTION
## Summary
- prune unsupported `enableThinking` defaults for Cerebras Qwen models before runtime requests are built
- make provider-option recommendations provider-aware so Cerebras no longer shows the Qwen `enableThinking: false` suggestion in the options UI
- cover the runtime pruning and UI regression with targeted tests

## Root cause
`src/utils/constants/models.ts` still matches broad `qwen*` model names, and `src/utils/providers/options.ts` was reusing those recommendations for any provider. That meant Cerebras `qwen-3-235b-a22b-instruct-2507` inherited `enableThinking: false` even though Cerebras rejects `body.enableThinking`.

## Test Plan
- `SKIP_FREE_API=true pnpm exec vitest run src/utils/constants/__tests__/model.test.ts src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/utils/providers/options.ts src/utils/constants/__tests__/model.test.ts src/entrypoints/options/pages/api-providers/provider-config-form/provider-options-field.tsx src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx src/entrypoints/options/pages/api-providers/provider-config-form/components/provider-options-recommendation-trigger.tsx src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx`
- `git push -u origin hermes/issue-1327-20260413-070602` (pre-push hook: `nx run @read-frog/extension:lint`, `nx run @read-frog/extension:type-check`, `nx run @read-frog/extension:test`)

## UI Evidence
Real extension screenshots from the built unpacked extension on the API Providers page after adding/selecting **Cerebras** and expanding **Advanced Options**.

### Cerebras provider config
| Before (`origin/main`) | After (this branch) |
| --- | --- |
| ![Before: Cerebras still shows the Qwen recommendation button and `enableThinking: false` provider-options sample](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog-issue-1327-before-cerebras.png) | ![After: recommendation button is gone for Cerebras and Provider Options falls back to the generic sample instead of `enableThinking: false`](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog-issue-1327-after-cerebras.png) |

Closes #1327


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unsupported `enableThinking` for Cerebras Qwen models and stop showing Qwen-specific option suggestions for Cerebras. This prevents request rejections and falls back to the generic provider options placeholder in the UI.

- **Bug Fixes**
  - Provider-aware recommendations: match by model + provider and prune unsupported keys; Cerebras now hides Qwen recommendations.
  - Runtime sanitization: strip unsupported options (Cerebras `enableThinking`) from defaults and user overrides before requests.
  - UI: placeholder now uses provider-aware recommendations; Cerebras shows the generic sample instead of `enableThinking: false`.
  - Tests: added targeted tests for pruning and recommendation trigger visibility.

<sup>Written for commit b8cda5e04a015ee9d0abf88b62bf2555fe904791. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

