### PR TITLE
docs(readme): remove outdated Afdian note

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,8 +308,6 @@ Every donation helps us build a better language learning experience. Thank you f
 
 [![Sponsors][sponsor-image]][sponsor-link]
 
-(will support Afdian in the future)
-
 <div align="right">
 
 [![Back to top][back-to-top]](#readme-top)


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [x] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

- remove the outdated `(will support Afdian in the future)` line from the English README sponsors section
- keep the Chinese README unchanged because it does not contain a corresponding note

## Related Issue

Closes #

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

Manual verification:
- checked the README diff in a clean worktree created from `origin/main`
- searched `README*.md` to confirm the outdated Afdian note is no longer present

## Screenshots

N/A (README-only change)

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This branch was created from the latest `origin/main` in a separate worktree so the user’s dirty main checkout stays untouched.
