### PR TITLE
Fix/1327 unsupported thinking options

### DIFF
--- a/.changeset/fuzzy-parrots-rest.md
+++ b/.changeset/fuzzy-parrots-rest.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(models): skip unsupported thinking options for instruct variants

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx
@@ -117,7 +117,7 @@ describe("providerOptionsRecommendationTrigger", () => {
     expect(onApply).toHaveBeenCalledWith({ reasoningEffort: "none" })
   })
 
-  it("renders Kimi recommendations based on model name alone", () => {
+  it("does not render Kimi instruct recommendations based on model name alone", () => {
     render(
       <ProviderOptionsRecommendationTrigger
         providerId="provider-1"
@@ -126,8 +126,8 @@ describe("providerOptionsRecommendationTrigger", () => {
       />,
     )
 
-    expect(screen.getByRole("button", {
+    expect(screen.queryByRole("button", {
       name: "options.apiProviders.form.providerOptionsRecommendationTrigger",
-    })).toBeInTheDocument()
+    })).not.toBeInTheDocument()
   })
 })

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -133,14 +133,13 @@ describe("getProviderOptions", () => {
       expect(alibabaOptions.alibaba?.enableThinking).toBe(false)
     })
 
-    it("should apply broader Kimi defaults for Moonshot and Fireworks variants", () => {
+    it("should apply broader Kimi defaults for non-instruct Moonshot and Fireworks variants", () => {
       const moonshotTurboOptions = getProviderOptions("kimi-k2-turbo", "moonshotai")
       expect(moonshotTurboOptions.moonshotai?.thinking).toEqual({ type: "disabled" })
       expect(moonshotTurboOptions.moonshotai?.reasoningHistory).toBe("disabled")
 
       const moonshotInstructOptions = getProviderOptions("kimi-k2-instruct-0905", "moonshotai")
-      expect(moonshotInstructOptions.moonshotai?.thinking).toEqual({ type: "disabled" })
-      expect(moonshotInstructOptions.moonshotai?.reasoningHistory).toBe("disabled")
+      expect(moonshotInstructOptions).toEqual({})
 
       const fireworksThinkingOptions = getProviderOptions("accounts/fireworks/models/kimi-k2-thinking", "fireworks")
       expect(fireworksThinkingOptions.fireworks?.thinking).toEqual({ type: "disabled" })
@@ -173,6 +172,11 @@ describe("getProviderOptions", () => {
       expect(options).toEqual({})
     })
 
+    it("should not apply Alibaba Qwen defaults to Cerebras qwen-3 model ids", () => {
+      expect(getProviderOptions("qwen-3-235b-a22b-instruct-2507", "cerebras")).toEqual({})
+      expect(getProviderOptions("qwen-3-32b", "cerebras")).toEqual({})
+    })
+
     it("should return low/default-compatible reasoning settings for gpt-oss models", () => {
       const groqOptions = getProviderOptions("openai/gpt-oss-120b", "groq")
       expect(groqOptions.groq?.reasoningEffort).toBe("none")
@@ -189,10 +193,9 @@ describe("getProviderOptions", () => {
       expect(deepinfraOptions.deepinfra?.enableThinking).toBe(false)
     })
 
-    it("should apply broadened Kimi defaults to provider-prefixed model ids", () => {
+    it("should keep provider-prefixed Kimi instruct model ids untouched", () => {
       const huggingfaceOptions = getProviderOptions("moonshotai/Kimi-K2-Instruct", "huggingface")
-      expect(huggingfaceOptions.huggingface?.thinking).toEqual({ type: "disabled" })
-      expect(huggingfaceOptions.huggingface?.reasoningHistory).toBe("disabled")
+      expect(huggingfaceOptions).toEqual({})
     })
 
     it("should return empty object for non-matching models", () => {

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -187,17 +187,19 @@ export const LLM_MODEL_OPTIONS: Array<{
   },
 
   // Kimi K2 models - disable thinking/history by default.
+  // Keep instruct variants untouched; they should not receive Moonshot's `thinking` options.
   // Keep this broad because recommendation matching is model-name based rather than provider-scoped.
   {
-    pattern: /(?:^|\/)kimi-k2(?:[a-z0-9.-].*)?$/i,
+    pattern: /(?:^|\/)kimi-k2(?!-instruct(?:[a-z0-9.-].*)?$)(?:[a-z0-9.-].*)?$/i,
     options: { thinking: { type: "disabled" }, reasoningHistory: "disabled" } satisfies MoonshotAIProviderOptions as Record<string, JSONValue>,
   },
 
   // Qwen models - disable thinking by default.
   // Keep this broad because recommendation matching is model-name based rather than provider-scoped.
+  // Exclude Cerebras-style `qwen-3-*` ids; they do not support Alibaba's `enableThinking`.
   // Keep explicit thinking-only variants (for example `qwq-*` and `*-thinking`) untouched.
   {
-    pattern: /(?:^|\/)qwen(?!.*[/.-](?:thinking|qwq)(?:[/.-]|$)).*$/i,
+    pattern: /(?:^|\/)qwen(?!-3-)(?!.*[/.-](?:thinking|qwq)(?:[/.-]|$)).*$/i,
     options: { enableThinking: false } satisfies AlibabaProviderOptions as Record<string, JSONValue>,
   },
 


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [x] ✅ Test related (test)
- [x] 🧠 AI model related (ai)

## Description

This fixes provider option defaults that were attaching unsupported thinking-related fields to instruct and non-thinking models.

### What changed

- exclude Cerebras `qwen-3-*` model ids from the broad Qwen `enableThinking: false` default
- keep Kimi instruct variants out of the broad Moonshot `thinking` / `reasoningHistory` default
- update provider option regression tests to cover the unsupported Cerebras Qwen and Kimi instruct cases
- add a patch changeset for the extension package

## Related Issue

Closes #1327

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Validation run:
- `pnpm vitest run src/utils/constants/__tests__/model.test.ts`
- `pnpm vitest run src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx src/utils/constants/__tests__/model.test.ts`
- `pnpm type-check`
- `pnpm test`
- pre-push hook: `nx run @read-frog/extension:lint`
- pre-push hook: `nx run @read-frog/extension:type-check`
- pre-push hook: `nx run @read-frog/extension:test`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- The branch contains one fix commit and one follow-up test expectation commit because the full pre-push suite exposed a stale UI recommendation test for Kimi instruct models.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect provider defaults that added unsupported thinking options to non-thinking models. Kimi instruct and Cerebras Qwen-3 models no longer receive `thinking`, `reasoningHistory`, or `enableThinking` settings.

- **Bug Fixes**
  - Exclude `kimi-k2-instruct*` from Moonshot `thinking`/`reasoningHistory` defaults.
  - Exclude Cerebras `qwen-3-*` from Alibaba Qwen `enableThinking: false` default.
  - Updated provider option tests and added a patch changeset for `@read-frog/extension`.

<sup>Written for commit d492b4bf6ab89e9b4fd092da4bf826c21cb0bbe6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

