### PR TITLE
chore(zed): use workspace TypeScript SDK for vtsls

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -28,6 +28,16 @@
     // Add other languages as needed
   },
   "lsp": {
+    "vtsls": {
+      "settings": {
+        "typescript": {
+          "tsdk": "./node_modules/typescript/lib"
+        },
+        "vtsls": {
+          "autoUseWorkspaceTsdk": true
+        }
+      }
+    },
     "eslint": {
       "settings": {
         // Remove after https://github.com/zed-industries/zed/issues/49387


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [x] 📦 Other changes that do not modify src or test files (chore)

## Description

- Configure Zed's `vtsls` language server to use the workspace TypeScript SDK from `./node_modules/typescript/lib`.
- Enable `vtsls.autoUseWorkspaceTsdk` so Zed resolves TypeScript features against the repo's pinned TypeScript version instead of a global/default SDK.
- Keep editor behavior aligned with the project's toolchain and reduce mismatches when editing or diagnosing TypeScript files locally.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

Automated validation:
- `pnpm lint:fix` (via pre-commit hook)
- `nx run @read-frog/extension:lint` (via push hook, cached)
- `nx run @read-frog/extension:type-check` (via push hook, cached)
- `nx run @read-frog/extension:test` (via push hook, cached)
- JSONC parse check for `.zed/settings.json`

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

N/A

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- No changeset added because this only updates tracked editor workspace settings and does not affect released package behavior.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configured Zed’s `vtsls` to use the workspace TypeScript SDK (`./node_modules/typescript/lib`) and enabled `vtsls.autoUseWorkspaceTsdk`. This ensures Zed uses the repo’s pinned `typescript` version and avoids SDK mismatches.

<sup>Written for commit dbf58722e7272e17702cacb66a6a231e9dfbbd03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

