### PR TITLE
fix(translate): avoid redundant skip-language LLM detection

### DIFF
--- a/.changeset/fresh-guests-sit.md
+++ b/.changeset/fresh-guests-sit.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): avoid redundant skip-language LLM detection for llm page providers

--- a/src/utils/host/translate/__tests__/translate-variants.test.ts
+++ b/src/utils/host/translate/__tests__/translate-variants.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+
+const {
+  mockDetectLanguage,
+  mockGetLocalConfig,
+  mockGetOrCreateWebPageContext,
+  mockShouldSkipByLanguage,
+  mockTranslateTextCore,
+} = vi.hoisted(() => ({
+  mockDetectLanguage: vi.fn(),
+  mockGetLocalConfig: vi.fn(),
+  mockGetOrCreateWebPageContext: vi.fn(),
+  mockShouldSkipByLanguage: vi.fn(),
+  mockTranslateTextCore: vi.fn(),
+}))
+
+vi.mock("@/utils/config/storage", () => ({
+  getLocalConfig: mockGetLocalConfig,
+}))
+
+vi.mock("@/utils/content/language", () => ({
+  detectLanguage: mockDetectLanguage,
+}))
+
+vi.mock("@/utils/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+vi.mock("../webpage-context", () => ({
+  getOrCreateWebPageContext: mockGetOrCreateWebPageContext,
+}))
+
+vi.mock("../translate-text", async () => {
+  const actual = await vi.importActual<typeof import("../translate-text")>("../translate-text")
+  return {
+    ...actual,
+    shouldSkipByLanguage: mockShouldSkipByLanguage,
+    translateTextCore: mockTranslateTextCore,
+  }
+})
+
+function createConfig(translateProviderId: string) {
+  return {
+    ...DEFAULT_CONFIG,
+    translate: {
+      ...DEFAULT_CONFIG.translate,
+      providerId: translateProviderId,
+      page: {
+        ...DEFAULT_CONFIG.translate.page,
+        skipLanguages: ["jpn"],
+      },
+    },
+    languageDetection: {
+      ...DEFAULT_CONFIG.languageDetection,
+      mode: "llm" as const,
+    },
+  }
+}
+
+describe("translateTextForPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockDetectLanguage.mockResolvedValue("eng")
+    mockGetOrCreateWebPageContext.mockResolvedValue(null)
+    mockShouldSkipByLanguage.mockResolvedValue(false)
+    mockTranslateTextCore.mockResolvedValue("translated text")
+  })
+
+  it("disables LLM skip-language detection when the page translation provider is an LLM", async () => {
+    mockGetLocalConfig.mockResolvedValue(createConfig("openai-default"))
+
+    const { translateTextForPage } = await import("../translate-variants")
+    const text = "This text is long enough."
+
+    await translateTextForPage(text)
+
+    expect(mockShouldSkipByLanguage).toHaveBeenCalledTimes(1)
+    expect(mockShouldSkipByLanguage).toHaveBeenCalledWith(text, ["jpn"], false)
+  })
+
+  it("keeps LLM skip-language detection enabled for non-LLM page translation providers", async () => {
+    mockGetLocalConfig.mockResolvedValue(createConfig("microsoft-translate-default"))
+
+    const { translateTextForPage } = await import("../translate-variants")
+    const text = "This text is long enough."
+
+    await translateTextForPage(text)
+
+    expect(mockShouldSkipByLanguage).toHaveBeenCalledTimes(1)
+    expect(mockShouldSkipByLanguage).toHaveBeenCalledWith(text, ["jpn"], true)
+  })
+})

--- a/src/utils/host/translate/translate-variants.ts
+++ b/src/utils/host/translate/translate-variants.ts
@@ -76,10 +76,11 @@ async function translateTextUsingPageConfig(
   // Skip translation if text is in skipLanguages list (page translation only)
   const { skipLanguages } = config.translate.page
   if (skipLanguages.length > 0 && preparedText.length >= MIN_LENGTH_FOR_SKIP_LLM_DETECTION) {
+    const enableSkipLanguageLLMDetection = config.languageDetection.mode === "llm" && !isLLMProviderConfig(providerConfig)
     const shouldSkip = await shouldSkipByLanguage(
       preparedText,
       skipLanguages,
-      config.languageDetection.mode === "llm",
+      enableSkipLanguageLLMDetection,
     )
     if (shouldSkip) {
       logger.info(`translateTextForPage: skipping translation because text is in skip language list. text: ${preparedText}`)


### PR DESCRIPTION
Closes #1353
Related: #1110

## Summary
- disable skip-language LLM detection when the active page translation provider is itself an LLM provider
- keep skip-language LLM detection enabled for non-LLM translation providers
- add focused regression coverage for both provider paths and include a patch changeset

## Why
Current `main` still calls `shouldSkipByLanguage(preparedText, skipLanguages, config.languageDetection.mode === "llm")` inside `src/utils/host/translate/translate-variants.ts`, so page translation can make an extra LLM language-detection call before the real LLM translation call.

For the behavior reported in #1353, the skip-language check should stay franc-only when page translation itself is using an LLM provider. Non-LLM translation providers should continue using the configured LLM language detection path.

## Implementation
- gate `shouldSkipByLanguage(...)` with `config.languageDetection.mode === "llm" && !isLLMProviderConfig(providerConfig)` in `src/utils/host/translate/translate-variants.ts`
- add `src/utils/host/translate/__tests__/translate-variants.test.ts` to assert:
  - `openai-default` -> `shouldSkipByLanguage(..., false)`
  - `microsoft-translate-default` -> `shouldSkipByLanguage(..., true)`
- add `.changeset/fresh-guests-sit.md`

## Validation
- `SKIP_FREE_API=true pnpm exec vitest run --configLoader runner src/utils/host/translate/__tests__/skip-language.test.ts src/utils/host/translate/__tests__/translate-variants.test.ts`
- `pnpm exec eslint src/utils/host/translate/translate-variants.ts src/utils/host/translate/__tests__/translate-variants.test.ts`
- `pnpm run type-check`
- pre-push hook: `nx run @read-frog/extension:lint`
- pre-push hook: `nx run @read-frog/extension:type-check`
- pre-push hook: `nx run @read-frog/extension:test`
