### PR TITLE
fix(page-translation): rewalk revealed accordion content

### DIFF
--- a/.changeset/cyan-cameras-cheer.md
+++ b/.changeset/cyan-cameras-cheer.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(page-translation): re-walk hidden accordion content after it becomes visible

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -1,0 +1,266 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { PageTranslationManager } from "../page-translation"
+
+const {
+  mockDeepQueryTopLevelSelector,
+  mockGetDetectedCodeFromStorage,
+  mockGetLocalConfig,
+  mockHasNoWalkAncestor,
+  mockIsDontWalkIntoAndDontTranslateAsChildElement,
+  mockIsDontWalkIntoButTranslateAsChildElement,
+  mockRemoveAllTranslatedWrapperNodes,
+  mockSendMessage,
+  mockTranslateTextForPageTitle,
+  mockTranslateWalkedElement,
+  mockValidateTranslationConfigAndToast,
+  mockWalkAndLabelElement,
+} = vi.hoisted(() => ({
+  mockGetDetectedCodeFromStorage: vi.fn(),
+  mockGetLocalConfig: vi.fn(),
+  mockDeepQueryTopLevelSelector: vi.fn(),
+  mockHasNoWalkAncestor: vi.fn(),
+  mockIsDontWalkIntoAndDontTranslateAsChildElement: vi.fn(),
+  mockIsDontWalkIntoButTranslateAsChildElement: vi.fn(),
+  mockWalkAndLabelElement: vi.fn(),
+  mockRemoveAllTranslatedWrapperNodes: vi.fn(),
+  mockTranslateWalkedElement: vi.fn(),
+  mockTranslateTextForPageTitle: vi.fn(),
+  mockValidateTranslationConfigAndToast: vi.fn(),
+  mockSendMessage: vi.fn(),
+}))
+
+vi.mock("@/utils/config/languages", () => ({
+  getDetectedCodeFromStorage: mockGetDetectedCodeFromStorage,
+}))
+
+vi.mock("@/utils/config/storage", () => ({
+  getLocalConfig: mockGetLocalConfig,
+}))
+
+vi.mock("@/utils/crypto-polyfill", () => ({
+  getRandomUUID: () => "walk-id",
+}))
+
+vi.mock("@/utils/host/dom/filter", () => ({
+  hasNoWalkAncestor: mockHasNoWalkAncestor,
+  isDontWalkIntoAndDontTranslateAsChildElement: mockIsDontWalkIntoAndDontTranslateAsChildElement,
+  isDontWalkIntoButTranslateAsChildElement: mockIsDontWalkIntoButTranslateAsChildElement,
+  isHTMLElement: (node: unknown) => node instanceof HTMLElement,
+}))
+
+vi.mock("@/utils/host/dom/find", () => ({
+  deepQueryTopLevelSelector: mockDeepQueryTopLevelSelector,
+}))
+
+vi.mock("@/utils/host/dom/traversal", () => ({
+  walkAndLabelElement: mockWalkAndLabelElement,
+}))
+
+vi.mock("@/utils/host/translate/node-manipulation", () => ({
+  removeAllTranslatedWrapperNodes: mockRemoveAllTranslatedWrapperNodes,
+  translateWalkedElement: mockTranslateWalkedElement,
+}))
+
+vi.mock("@/utils/host/translate/translate-text", () => ({
+  validateTranslationConfigAndToast: mockValidateTranslationConfigAndToast,
+}))
+
+vi.mock("@/utils/host/translate/translate-variants", () => ({
+  translateTextForPageTitle: mockTranslateTextForPageTitle,
+}))
+
+vi.mock("@/utils/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+vi.mock("@/utils/message", () => ({
+  sendMessage: mockSendMessage,
+}))
+
+const intersectionObservers: MockIntersectionObserver[] = []
+
+class MockIntersectionObserver {
+  observe = vi.fn((target: Element) => {
+    this.targets.add(target)
+  })
+  unobserve = vi.fn((target: Element) => {
+    this.targets.delete(target)
+  })
+  disconnect = vi.fn(() => {
+    this.targets.clear()
+  })
+  private readonly targets = new Set<Element>()
+
+  constructor(
+    private readonly callback: IntersectionObserverCallback,
+    _options?: IntersectionObserverInit,
+  ) {
+    intersectionObservers.push(this)
+  }
+
+  async triggerIntersect(target: Element): Promise<void> {
+    await this.callback([{
+      isIntersecting: true,
+      target,
+    } as IntersectionObserverEntry], this as unknown as IntersectionObserver)
+  }
+}
+
+async function flushDomUpdates(): Promise<void> {
+  await Promise.resolve()
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await Promise.resolve()
+}
+
+function deepQueryTopLevelSelectorImpl(
+  root: Document | ShadowRoot | HTMLElement,
+  selectorFn: (element: HTMLElement) => boolean,
+): HTMLElement[] {
+  if (root instanceof Document) {
+    return root.body ? deepQueryTopLevelSelectorImpl(root.body, selectorFn) : []
+  }
+
+  const result: HTMLElement[] = []
+  const children = root instanceof ShadowRoot ? [...root.children] : [...root.children]
+
+  if (root instanceof HTMLElement && selectorFn(root)) {
+    return [root]
+  }
+
+  if (root instanceof HTMLElement && root.shadowRoot) {
+    result.push(...deepQueryTopLevelSelectorImpl(root.shadowRoot, selectorFn))
+  }
+
+  for (const child of children) {
+    if (child instanceof HTMLElement) {
+      result.push(...deepQueryTopLevelSelectorImpl(child, selectorFn))
+    }
+  }
+
+  return result
+}
+
+function isBlockedByVisibilityState(element: HTMLElement): boolean {
+  return element.hidden || element.getAttribute("aria-hidden") === "true"
+}
+
+function walkAndLabelVisibleParagraphs(element: HTMLElement, walkId: string) {
+  if (isBlockedByVisibilityState(element)) {
+    return {
+      forceBlock: false,
+      isInlineNode: false,
+    }
+  }
+
+  element.setAttribute("data-read-frog-walked", walkId)
+
+  for (const child of element.children) {
+    if (child instanceof HTMLElement) {
+      walkAndLabelVisibleParagraphs(child, walkId)
+    }
+  }
+
+  if (element.tagName === "P" && element.textContent?.trim()) {
+    element.setAttribute("data-read-frog-paragraph", "")
+  }
+
+  return {
+    forceBlock: false,
+    isInlineNode: false,
+  }
+}
+
+describe("pageTranslationManager mutation rewalk", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    intersectionObservers.length = 0
+
+    document.head.innerHTML = ""
+    document.body.innerHTML = ""
+    document.title = ""
+
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver)
+
+    mockGetDetectedCodeFromStorage.mockResolvedValue("eng")
+    mockGetLocalConfig.mockResolvedValue(DEFAULT_CONFIG)
+    mockHasNoWalkAncestor.mockReturnValue(false)
+    mockIsDontWalkIntoButTranslateAsChildElement.mockReturnValue(false)
+    mockIsDontWalkIntoAndDontTranslateAsChildElement.mockImplementation((element: HTMLElement) => {
+      return isBlockedByVisibilityState(element)
+    })
+    mockDeepQueryTopLevelSelector.mockImplementation(deepQueryTopLevelSelectorImpl)
+    mockWalkAndLabelElement.mockImplementation((element: HTMLElement, walkId: string) => {
+      return walkAndLabelVisibleParagraphs(element, walkId)
+    })
+    mockTranslateTextForPageTitle.mockResolvedValue("")
+    mockValidateTranslationConfigAndToast.mockReturnValue(true)
+    mockSendMessage.mockResolvedValue(undefined)
+  })
+
+  it("observes and translates accordion content after removing hidden", async () => {
+    document.body.innerHTML = `
+      <section id="accordion" hidden>
+        <p id="panel">Accordion body</p>
+      </section>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observer = intersectionObservers[0]
+    const accordion = document.getElementById("accordion") as HTMLElement
+    const panel = document.getElementById("panel") as HTMLElement
+
+    expect(observer.observe).not.toHaveBeenCalled()
+
+    accordion.removeAttribute("hidden")
+    await flushDomUpdates()
+
+    expect(observer.observe).toHaveBeenCalledWith(panel)
+
+    await observer.triggerIntersect(panel)
+    await flushDomUpdates()
+
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(panel, "walk-id", DEFAULT_CONFIG)
+
+    manager.stop()
+  })
+
+  it("observes and translates accordion content after aria-hidden becomes false", async () => {
+    document.body.innerHTML = `
+      <section id="accordion" aria-hidden="true">
+        <p id="panel">Accordion body</p>
+      </section>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observer = intersectionObservers[0]
+    const accordion = document.getElementById("accordion") as HTMLElement
+    const panel = document.getElementById("panel") as HTMLElement
+
+    expect(observer.observe).not.toHaveBeenCalled()
+
+    accordion.setAttribute("aria-hidden", "false")
+    await flushDomUpdates()
+
+    expect(observer.observe).toHaveBeenCalledWith(panel)
+
+    await observer.triggerIntersect(panel)
+    await flushDomUpdates()
+
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(panel, "walk-id", DEFAULT_CONFIG)
+
+    manager.stop()
+  })
+})

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -1,4 +1,5 @@
 import type { FeatureUsageContext } from "@/types/analytics"
+import type { Config } from "@/types/config/config"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { isLLMProviderConfig } from "@/types/config/provider"
 import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
@@ -7,7 +8,7 @@ import { getLocalConfig } from "@/utils/config/storage"
 import { CONTENT_WRAPPER_CLASS } from "@/utils/constants/dom-labels"
 import { resolveProviderConfig } from "@/utils/constants/feature-providers"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
-import { hasNoWalkAncestor, isDontWalkIntoButTranslateAsChildElement, isHTMLElement } from "@/utils/host/dom/filter"
+import { hasNoWalkAncestor, isDontWalkIntoAndDontTranslateAsChildElement, isDontWalkIntoButTranslateAsChildElement, isHTMLElement } from "@/utils/host/dom/filter"
 import { deepQueryTopLevelSelector } from "@/utils/host/dom/find"
 import { walkAndLabelElement } from "@/utils/host/dom/traversal"
 import { removeAllTranslatedWrapperNodes, translateWalkedElement } from "@/utils/host/translate/node-manipulation"
@@ -59,7 +60,8 @@ export class PageTranslationManager implements IPageTranslationManager {
   private mutationObservers: MutationObserver[] = []
   private walkId: string | null = null
   private intersectionOptions: IntersectionObserverInit
-  private dontWalkIntoElementsCache = new WeakSet<HTMLElement>()
+  private walkBlockedElementsCache = new WeakSet<HTMLElement>()
+  private activeConfig: Config | null = null
   private titleObserver: MutationObserver | null = null
   private lastSourceTitle: string | null = null
   private lastAppliedTranslatedTitle: string | null = null
@@ -125,6 +127,7 @@ export class PageTranslationManager implements IPageTranslationManager {
         enabled: true,
       })
 
+      this.activeConfig = config
       this.isPageTranslating = true
       await this.primeDocumentTitleContext(
         config.translate.enableAIContentAware && isLLMProviderConfig(providerConfig),
@@ -189,7 +192,8 @@ export class PageTranslationManager implements IPageTranslationManager {
 
     this.isPageTranslating = false
     this.walkId = null
-    this.dontWalkIntoElementsCache = new WeakSet()
+    this.walkBlockedElementsCache = new WeakSet()
+    this.activeConfig = null
     this.stopDocumentTitleTracking()
 
     if (this.intersectionObserver) {
@@ -396,6 +400,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       logger.error("Global config is not initialized")
       return
     }
+    this.activeConfig = config
 
     // Skip if container has an ancestor that should not be walked into
     if (hasNoWalkAncestor(container, config))
@@ -454,33 +459,45 @@ export class PageTranslationManager implements IPageTranslationManager {
   }
 
   /**
-   * Handle style/class attribute changes and only trigger observation
-   * when element transitions from "don't walk into" to "walkable"
+   * Track whether an element is currently blocked from traversal.
+   */
+  private isWalkBlockedElement(element: HTMLElement): boolean {
+    if (isDontWalkIntoButTranslateAsChildElement(element)) {
+      return true
+    }
+
+    if (!this.activeConfig) {
+      return false
+    }
+
+    return isDontWalkIntoAndDontTranslateAsChildElement(element, this.activeConfig)
+  }
+
+  /**
+   * Handle attribute changes and only trigger observation
+   * when element transitions from blocked to walkable.
    */
   private didChangeToWalkable(element: HTMLElement): boolean {
-    const wasDontWalkInto = this.dontWalkIntoElementsCache.has(element)
-    const isDontWalkIntoNow = isDontWalkIntoButTranslateAsChildElement(element)
+    const wasWalkBlocked = this.walkBlockedElementsCache.has(element)
+    const isWalkBlockedNow = this.isWalkBlockedElement(element)
 
     // Update cache with current state
-    if (isDontWalkIntoNow) {
-      this.dontWalkIntoElementsCache.add(element)
+    if (isWalkBlockedNow) {
+      this.walkBlockedElementsCache.add(element)
     }
     else {
-      this.dontWalkIntoElementsCache.delete(element)
+      this.walkBlockedElementsCache.delete(element)
     }
 
-    // Only trigger observation if element transitioned from "don't walk into" to "walkable"
-    // wasDontWalkInto === true means it was previously not walkable
-    // isDontWalkIntoNow === false means it's now walkable
-    return wasDontWalkInto === true && isDontWalkIntoNow === false
+    return wasWalkBlocked === true && isWalkBlockedNow === false
   }
 
   /**
    * Initialize walkability state for an element and its descendants
    */
   private addDontWalkIntoElements(element: HTMLElement): void {
-    const dontWalkIntoElements = deepQueryTopLevelSelector(element, isDontWalkIntoButTranslateAsChildElement)
-    dontWalkIntoElements.forEach(el => this.dontWalkIntoElementsCache.add(el))
+    const walkBlockedElements = deepQueryTopLevelSelector(element, el => this.isWalkBlockedElement(el))
+    walkBlockedElements.forEach(el => this.walkBlockedElementsCache.add(el))
   }
 
   /**
@@ -500,7 +517,10 @@ export class PageTranslationManager implements IPageTranslationManager {
         }
         else if (
           rec.type === "attributes"
-          && (rec.attributeName === "style" || rec.attributeName === "class")
+          && (rec.attributeName === "style"
+            || rec.attributeName === "class"
+            || rec.attributeName === "hidden"
+            || rec.attributeName === "aria-hidden")
         ) {
           const el = rec.target
           if (isHTMLElement(el) && this.didChangeToWalkable(el)) {
@@ -514,7 +534,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: ["style", "class"],
+      attributeFilter: ["style", "class", "hidden", "aria-hidden"],
     })
 
     this.mutationObservers.push(mutationObserver)


### PR DESCRIPTION
## Summary
- re-walk page-translation subtrees when an existing element becomes walkable after `hidden` / `aria-hidden` visibility changes
- broaden the mutation observer's blocked-element cache to use the same hidden-element predicate as the main traversal path
- add focused regression tests for accordion panels that become visible after page translation already started

## Root cause
On current `main`, page translation correctly skips hidden accordion content during the initial traversal, but the re-walk path in `src/entrypoints/host.content/translation-control/page-translation.ts` only watched `style` / `class` mutations and only tracked `isDontWalkIntoButTranslateAsChildElement(...)` transitions.

For sites like `https://twenty.com/`, the accordion panel already exists in the DOM and is revealed by removing `hidden` / `aria-hidden` on the existing node. That means the revealed subtree never re-entered the page-translation walk, so the expanded answer stayed untranslated.

Fixes #1358.

## Validation
- `SKIP_FREE_API=true ./node_modules/.bin/vitest run --config vitest.page-translation.config.ts src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts` *(run locally with temporary test-only config/setup files; removed afterward so they are not part of this PR)*
- `git diff --check`
- `pnpm build:edge`

## Real screenshots
Raw before (`origin/main`, accordion expanded after page translation already started):
- https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog/issue-1358/20260421-before.png

Raw after (this branch, same site/accordion state):
- https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog/issue-1358/20260421-after.png

## DOM evidence from the screenshot runs
- Before (`origin/main`): expanded panel `panelWrapperCount = 0`; answer stayed English-only.
- After (this branch): expanded panel `panelWrapperCount = 1`; answer shows English plus Chinese translation.
