### PR TITLE
fix(dia): open options page via extension tab

### DIFF
--- a/.changeset/green-frogs-open.md
+++ b/.changeset/green-frogs-open.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: open options page in Dia browser

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev:firefox": "wxt -b firefox --mv3",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "postinstall": "wxt prepare",
+    "postinstall": "WXT_SKIP_ENV_VALIDATION=true wxt prepare",
     "test": "vitest run",
     "test:cov": "vitest run --coverage",
     "test:watch": "vitest",

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -3,6 +3,7 @@ import { browser, defineBackground } from "#imports"
 import { env } from "@/env"
 import { logger } from "@/utils/logger"
 import { onMessage } from "@/utils/message"
+import { openOptionsPage } from "@/utils/navigation"
 import { SessionCacheGroupRegistry } from "@/utils/session-cache/session-cache-group-registry"
 import { runAiSegmentSubtitles } from "./ai-segmentation"
 import { setupAnalyticsMessageHandlers } from "./analytics"
@@ -50,9 +51,9 @@ export default defineBackground({
       await browser.tabs.create({ url, active: active ?? true })
     })
 
-    onMessage("openOptionsPage", () => {
+    onMessage("openOptionsPage", async () => {
       logger.info("openOptionsPage")
-      void browser.runtime.openOptionsPage()
+      await openOptionsPage()
     })
 
     onMessage("aiSegmentSubtitles", async (message) => {

--- a/src/entrypoints/popup/app.tsx
+++ b/src/entrypoints/popup/app.tsx
@@ -1,6 +1,7 @@
-import { browser, i18n } from "#imports"
+import { i18n } from "#imports"
 import { Icon } from "@iconify/react"
 import { UserAccount } from "@/components/user-account"
+import { openOptionsPage } from "@/utils/navigation"
 import { version } from "../../../package.json"
 import { AISmartContext } from "./components/ai-smart-context"
 import { AlwaysTranslate } from "./components/always-translate"
@@ -44,7 +45,9 @@ function App() {
         <button
           type="button"
           className="flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 hover:bg-neutral-300 dark:hover:bg-neutral-700"
-          onClick={() => browser.runtime.openOptionsPage()}
+          onClick={() => {
+            void openOptionsPage()
+          }}
         >
           <Icon icon="tabler:settings" className="size-4" strokeWidth={1.6} />
           <span className="text-[13px] font-medium">

--- a/src/utils/__tests__/navigation.test.ts
+++ b/src/utils/__tests__/navigation.test.ts
@@ -1,0 +1,19 @@
+import { browser } from "#imports"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { openOptionsPage } from "../navigation"
+
+describe("navigation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    browser.tabs.create = vi.fn().mockResolvedValue({})
+  })
+
+  it("opens the options page as an extension tab", async () => {
+    await openOptionsPage()
+
+    expect(browser.tabs.create).toHaveBeenCalledWith({
+      active: true,
+      url: "chrome-extension://test-extension-id/options.html",
+    })
+  })
+})

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -3,6 +3,6 @@ import { browser } from "#imports"
 export async function openOptionsPage() {
   await browser.tabs.create({
     active: true,
-    url: browser.runtime.getURL("options.html"),
+    url: browser.runtime.getURL("/options.html"),
   })
 }

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -1,0 +1,8 @@
+import { browser } from "#imports"
+
+export async function openOptionsPage() {
+  await browser.tabs.create({
+    active: true,
+    url: browser.runtime.getURL("options.html"),
+  })
+}


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [x] 🔧 Build or dependencies update (build)

## Description

This PR fixes opening the extension options page in Dia by avoiding `browser.runtime.openOptionsPage()` and opening the extension options entry directly with `browser.tabs.create({ url: browser.runtime.getURL("/options.html") })`.

It also makes `postinstall` skip required production env validation while running `wxt prepare`, so local installs do not require production-only `WXT_*` values.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Commands run:

- `pnpm run postinstall`
- `SKIP_FREE_API=true pnpm exec vitest run src/utils/__tests__/navigation.test.ts`
- `pnpm exec eslint package.json src/utils/navigation.ts src/utils/__tests__/navigation.test.ts src/entrypoints/background/index.ts src/entrypoints/popup/app.tsx`
- `WXT_SKIP_ENV_VALIDATION=true pnpm build`
- `pnpm exec tsc --noEmit`
- Pre-push hook: `nx run @read-frog/extension:lint`, `nx run @read-frog/extension:type-check`, `nx run @read-frog/extension:test`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The local `web-ext.config.ts` for Dia remains ignored by git as intended.
