### PR TITLE
ci: fix stale on-hold label exemption

### DIFF
--- a/.github/workflows/stale-issue-pr.yml
+++ b/.github/workflows/stale-issue-pr.yml
@@ -18,9 +18,7 @@ jobs:
           # ---- Issue settings ----
           days-before-issue-stale: 30
           days-before-issue-close: 60
-          exempt-issue-labels: |
-            pinned
-            on-hold
+          exempt-issue-labels: pinned,on-hold
           stale-issue-message: |
             This issue has been inactive for 30 days and is now marked as stale.
             It will be automatically closed in 60 days if no further activity occurs.
@@ -37,7 +35,4 @@ jobs:
           close-pr-message: |
             Since it has been a long time without updates, the PR has been automatically closed.
             If you need to continue, please reopen or create a new PR.
-          exempt-pr-labels: |
-            pinned
-            WIP
-            on-hold
+          exempt-pr-labels: pinned,WIP,on-hold


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [x] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fixes the stale maintenance workflow so `actions/stale@v10` correctly recognizes `on-hold` as an exempt label.

`actions/stale@v10` parses `exempt-issue-labels` and `exempt-pr-labels` as comma-separated strings. The previous YAML multiline form was interpreted as one combined label value, so `on-hold` did not match and on-hold items could still be marked stale or closed.

This keeps all existing stale/close timing and messages unchanged.

## Related Issue

N/A

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

Manual checks:

- Reviewed the workflow diff to confirm only exemption label formatting changed.
- Ran `git diff --check`.
- Checked repo labels: `on-hold` exists; `pinned` and `WIP` are still configured as before but are not currently present as repo labels.
- `actionlint` is not installed locally, so workflow linting was skipped.

## Screenshots

N/A

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

No changeset is included because this is CI workflow maintenance and does not affect published packages.
