### PR TITLE
perf(options): persist slider settings after drag commit

### DIFF
--- a/.changeset/smooth-sliders-commit.md
+++ b/.changeset/smooth-sliders-commit.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+perf(options): persist slider settings after drag commit

--- a/src/entrypoints/options/pages/selection-toolbar/selection-toolbar-opacity.tsx
+++ b/src/entrypoints/options/pages/selection-toolbar/selection-toolbar-opacity.tsx
@@ -1,5 +1,6 @@
 import { i18n } from "#imports"
 import { useAtom } from "jotai"
+import { useEffect, useState } from "react"
 import { Slider } from "@/components/ui/base-ui/slider"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { MAX_SELECTION_OVERLAY_OPACITY, MIN_SELECTION_OVERLAY_OPACITY } from "@/utils/constants/selection"
@@ -7,6 +8,12 @@ import { ConfigCard } from "../../components/config-card"
 
 export function SelectionToolbarOpacity() {
   const [selectionToolbar, setSelectionToolbar] = useAtom(configFieldsAtomMap.selectionToolbar)
+  const [draftOpacity, setDraftOpacity] = useState(selectionToolbar.opacity)
+
+  useEffect(() => {
+    // eslint-disable-next-line react/set-state-in-effect
+    setDraftOpacity(selectionToolbar.opacity)
+  }, [selectionToolbar.opacity])
 
   return (
     <ConfigCard
@@ -19,14 +26,17 @@ export function SelectionToolbarOpacity() {
           min={MIN_SELECTION_OVERLAY_OPACITY}
           max={MAX_SELECTION_OVERLAY_OPACITY}
           step={1}
-          value={selectionToolbar.opacity}
+          value={draftOpacity}
           onValueChange={(value) => {
+            setDraftOpacity(value as number)
+          }}
+          onValueCommitted={(value) => {
             void setSelectionToolbar({ opacity: value as number })
           }}
           className="flex-1"
         />
         <span className="w-10 text-sm text-right">
-          {selectionToolbar.opacity}
+          {draftOpacity}
           %
         </span>
       </div>

--- a/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/general-settings.tsx
+++ b/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/general-settings.tsx
@@ -3,6 +3,7 @@ import { i18n } from "#imports"
 import { Icon } from "@iconify/react"
 import { deepmerge } from "deepmerge-ts"
 import { useAtom } from "jotai"
+import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/base-ui/button"
 import { Card } from "@/components/ui/base-ui/card"
 import { Field, FieldGroup, FieldLabel } from "@/components/ui/base-ui/field"
@@ -20,6 +21,12 @@ const SLIDER_LABEL_CLASS_NAME = "text-sm whitespace-nowrap @xs/field-group:min-w
 export function GeneralSettings() {
   const [videoSubtitlesConfig, setVideoSubtitlesConfig] = useAtom(configFieldsAtomMap.videoSubtitles)
   const { displayMode, translationPosition, container } = videoSubtitlesConfig.style
+  const [draftBackgroundOpacity, setDraftBackgroundOpacity] = useState(container.backgroundOpacity)
+
+  useEffect(() => {
+    // eslint-disable-next-line react/set-state-in-effect
+    setDraftBackgroundOpacity(container.backgroundOpacity)
+  }, [container.backgroundOpacity])
 
   const handleDisplayModeChange = (value: SubtitlesDisplayMode | null) => {
     if (!value)
@@ -123,12 +130,13 @@ export function GeneralSettings() {
                   min={MIN_BACKGROUND_OPACITY}
                   max={MAX_BACKGROUND_OPACITY}
                   step={5}
-                  value={container.backgroundOpacity}
-                  onValueChange={value => handleContainerChange({ backgroundOpacity: value as number })}
+                  value={draftBackgroundOpacity}
+                  onValueChange={value => setDraftBackgroundOpacity(value as number)}
+                  onValueCommitted={value => handleContainerChange({ backgroundOpacity: value as number })}
                   className="flex-1"
                 />
                 <span className="w-10 text-sm text-right">
-                  {container.backgroundOpacity}
+                  {draftBackgroundOpacity}
                   %
                 </span>
               </div>

--- a/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/subtitles-text-style-form.tsx
+++ b/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/subtitles-text-style-form.tsx
@@ -2,6 +2,7 @@ import type { SubtitlesFontFamily, SubtitleTextStyle } from "@/types/config/subt
 import { i18n } from "#imports"
 import { deepmerge } from "deepmerge-ts"
 import { useAtom } from "jotai"
+import { useEffect, useState } from "react"
 import { Field, FieldGroup, FieldLabel } from "@/components/ui/base-ui/field"
 import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/base-ui/select"
 import { Slider } from "@/components/ui/base-ui/slider"
@@ -26,6 +27,18 @@ interface SubtitlesTextStyleFormProps {
 export function SubtitlesTextStyleForm({ type }: SubtitlesTextStyleFormProps) {
   const [videoSubtitlesConfig, setVideoSubtitlesConfig] = useAtom(configFieldsAtomMap.videoSubtitles)
   const textStyle = videoSubtitlesConfig.style[type]
+  const [draftFontScale, setDraftFontScale] = useState(textStyle.fontScale)
+  const [draftFontWeight, setDraftFontWeight] = useState(textStyle.fontWeight)
+
+  useEffect(() => {
+    // eslint-disable-next-line react/set-state-in-effect
+    setDraftFontScale(textStyle.fontScale)
+  }, [textStyle.fontScale])
+
+  useEffect(() => {
+    // eslint-disable-next-line react/set-state-in-effect
+    setDraftFontWeight(textStyle.fontWeight)
+  }, [textStyle.fontWeight])
 
   const handleChange = (style: Partial<SubtitleTextStyle>) => {
     void setVideoSubtitlesConfig(deepmerge(videoSubtitlesConfig, { style: { [type]: style } }))
@@ -71,12 +84,13 @@ export function SubtitlesTextStyleForm({ type }: SubtitlesTextStyleFormProps) {
               min={MIN_FONT_SCALE}
               max={MAX_FONT_SCALE}
               step={10}
-              value={textStyle.fontScale}
-              onValueChange={value => handleChange({ fontScale: value as number })}
+              value={draftFontScale}
+              onValueChange={value => setDraftFontScale(value as number)}
+              onValueCommitted={value => handleChange({ fontScale: value as number })}
               className="flex-1"
             />
             <span className="w-10 text-sm text-right">
-              {textStyle.fontScale}
+              {draftFontScale}
               %
             </span>
           </div>
@@ -91,11 +105,12 @@ export function SubtitlesTextStyleForm({ type }: SubtitlesTextStyleFormProps) {
               min={MIN_FONT_WEIGHT}
               max={MAX_FONT_WEIGHT}
               step={100}
-              value={textStyle.fontWeight}
-              onValueChange={value => handleChange({ fontWeight: value as number })}
+              value={draftFontWeight}
+              onValueChange={value => setDraftFontWeight(value as number)}
+              onValueCommitted={value => handleChange({ fontWeight: value as number })}
               className="flex-1"
             />
-            <span className="w-10 text-sm text-right">{textStyle.fontWeight}</span>
+            <span className="w-10 text-sm text-right">{draftFontWeight}</span>
           </div>
         </div>
       </Field>


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [x] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Persist config-backed option sliders only when the drag interaction commits instead of on every value change. This keeps slider thumbs and labels responsive with local draft state while avoiding repeated config/storage writes during dragging.

Updated sliders:

- Selection toolbar opacity
- Video subtitles background opacity
- Video subtitles font scale
- Video subtitles font weight

## Related Issue

N/A

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

Commands run:

- `pnpm lint src/entrypoints/options/pages/selection-toolbar/selection-toolbar-opacity.tsx src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/general-settings.tsx src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/subtitles-text-style-form.tsx`
- `pnpm type-check`
- `SKIP_FREE_API=true pnpm test`

Pre-push checks also ran:

- `nx run @read-frog/extension:lint`
- `nx run @read-frog/extension:type-check`
- `nx run @read-frog/extension:test`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Added a patch changeset for the options slider performance improvement.
