### PR TITLE
fix(selection-toolbar): stabilize custom action provider switching

### DIFF
--- a/.changeset/tame-custom-action-provider-switch.md
+++ b/.changeset/tame-custom-action-provider-switch.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection-toolbar): keep custom AI action provider switches stable

--- a/src/entrypoints/background/__tests__/background-stream.test.ts
+++ b/src/entrypoints/background/__tests__/background-stream.test.ts
@@ -4,6 +4,24 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const streamTextMock = vi.fn()
 const outputObjectMock = vi.fn((params: Record<string, unknown>) => params)
 const getModelByIdMock = vi.fn()
+const loggerErrorMock = vi.fn()
+const parsePartialJsonMock = vi.fn(async (text: string | undefined) => {
+  if (!text) {
+    return { state: "undefined-input", value: undefined }
+  }
+
+  try {
+    return { state: "successful-parse", value: JSON.parse(text) }
+  }
+  catch {
+    try {
+      return { state: "repaired-parse", value: JSON.parse(`${text}}`) }
+    }
+    catch {
+      return { state: "failed-parse", value: undefined }
+    }
+  }
+})
 
 class MockNoOutputGeneratedError extends Error {
   static isInstance(error: unknown): error is MockNoOutputGeneratedError {
@@ -13,6 +31,7 @@ class MockNoOutputGeneratedError extends Error {
 
 vi.mock("ai", () => ({
   streamText: streamTextMock,
+  parsePartialJson: parsePartialJsonMock,
   NoOutputGeneratedError: MockNoOutputGeneratedError,
   Output: {
     object: outputObjectMock,
@@ -25,7 +44,7 @@ vi.mock("@/utils/providers/model", () => ({
 
 vi.mock("@/utils/logger", () => ({
   logger: {
-    error: vi.fn(),
+    error: loggerErrorMock,
   },
 }))
 
@@ -87,15 +106,16 @@ describe("background-stream", () => {
   it("streams structured object output from background", async () => {
     getModelByIdMock.mockResolvedValue("mock-model")
     streamTextMock.mockReturnValue({
-      partialOutputStream: (async function* () {
-        yield { score: 97 }
-        yield { score: 97, summary: "Strong argument structure" }
+      fullStream: (async function* () {
+        yield { type: "text-delta", text: "{\"score\":97" }
+        yield { type: "text-delta", text: ",\"summary\":\"Strong argument structure\"}" }
       })(),
-      output: Promise.resolve({
-        score: 97,
-        summary: "Strong argument structure",
-      }),
-      fullStream: (async function* () {})(),
+      get output() {
+        throw new Error("structured stream should not consume output separately")
+      },
+      get partialOutputStream() {
+        throw new Error("structured stream should not consume partialOutputStream separately")
+      },
     })
 
     const chunkSnapshots: BackgroundStructuredObjectStreamSnapshot[] = []
@@ -237,7 +257,9 @@ describe("background-stream", () => {
       options.onError?.({ error: rootCause })
       return {
         fullStream: (async function* () {})(),
-        output: Promise.reject(new MockNoOutputGeneratedError("No output generated. Check the stream for errors.")),
+        get output() {
+          throw new Error("text stream should not consume output separately")
+        },
       }
     })
 
@@ -292,6 +314,50 @@ describe("background-stream", () => {
       },
     })
     expect(mockPort.disconnect).toHaveBeenCalledTimes(1)
+  })
+
+  it("treats stream port disconnect aborts as expected cancellation", async () => {
+    getModelByIdMock.mockResolvedValue("mock-model")
+    let streamSignal: AbortSignal | undefined
+
+    streamTextMock.mockImplementation((options: { abortSignal?: AbortSignal }) => {
+      streamSignal = options.abortSignal
+      return {
+        fullStream: (async function* () {
+          await new Promise<void>((_resolve, reject) => {
+            options.abortSignal?.addEventListener("abort", () => {
+              reject(options.abortSignal?.reason ?? new DOMException("aborted", "AbortError"))
+            })
+          })
+        })(),
+        output: new Promise<string>(() => {}),
+      }
+    })
+
+    const { handleStreamTextPort } = await import("../background-stream")
+    const mockPort = createMockPort("stream-text")
+
+    handleStreamTextPort(mockPort.port as never)
+    const startPromise = mockPort.emitMessage({
+      type: "start",
+      requestId: "req-text-abort",
+      payload: {
+        providerId: "openai-default",
+        prompt: "Say hello",
+      },
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(streamTextMock).toHaveBeenCalledTimes(1)
+
+    mockPort.emitDisconnect()
+    await startPromise
+
+    expect(streamSignal?.aborted).toBe(true)
+    expect(loggerErrorMock).not.toHaveBeenCalled()
+    expect(mockPort.postMessage).not.toHaveBeenCalledWith(expect.objectContaining({
+      type: "error",
+    }))
   })
 
   it("returns error for invalid text start payload and disconnects", async () => {

--- a/src/entrypoints/background/background-stream.ts
+++ b/src/entrypoints/background/background-stream.ts
@@ -14,7 +14,7 @@ import type {
   StreamRuntimeOptions,
   ThinkingSnapshot,
 } from "@/types/background-stream"
-import { Output, streamText } from "ai"
+import { Output, parsePartialJson, streamText } from "ai"
 import { z } from "zod"
 import { BACKGROUND_STREAM_PORTS } from "@/types/background-stream"
 import { extractAISDKErrorMessage } from "@/utils/error/extract-message"
@@ -22,6 +22,15 @@ import { logger } from "@/utils/logger"
 import { getModelById } from "@/utils/providers/model"
 
 const invalidStreamStartPayloadMessage = "Invalid stream start payload"
+
+function createStreamAbortError(message: string) {
+  return new DOMException(message, "AbortError")
+}
+
+function isAbortLikeError(error: unknown) {
+  return (error instanceof DOMException && error.name === "AbortError")
+    || (error instanceof Error && error.name === "AbortError")
+}
 
 const streamPortStartEnvelopeSchema = z.object({
   type: z.literal("start"),
@@ -128,7 +137,7 @@ function createStreamPortHandler<TSerializablePayload, TResponse>(
     }
 
     disconnectListener = () => {
-      abortController.abort()
+      abortController.abort(createStreamAbortError("stream port disconnected"))
       cleanup()
     }
 
@@ -191,10 +200,12 @@ function createStreamPortHandler<TSerializablePayload, TResponse>(
       }
       catch (error) {
         const finalError = streamError ?? error
-        logger.error("[Background] Stream Function failed", finalError)
-        if (!abortController.signal.aborted) {
-          safePost({ type: "error", error: { message: extractAISDKErrorMessage(finalError) } })
+        if (abortController.signal.aborted || isAbortLikeError(finalError)) {
+          return
         }
+
+        logger.error("[Background] Stream Function failed", finalError)
+        safePost({ type: "error", error: { message: extractAISDKErrorMessage(finalError) } })
       }
       finally {
         cleanup()
@@ -223,6 +234,10 @@ function createStreamSnapshot<TOutput>(
       : output,
     thinking: { ...thinking },
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
 }
 
 export async function runStreamTextInBackground(
@@ -279,16 +294,18 @@ export async function runStreamTextInBackground(
         onChunk?.(createStreamSnapshot(cumulativeText, thinking))
         break
       }
+      case "error": {
+        throw part.error
+      }
     }
   }
 
-  const finalText = await result.output
   thinking = {
     ...thinking,
     status: "complete",
   }
 
-  return createStreamSnapshot(finalText, thinking)
+  return createStreamSnapshot(cumulativeText, thinking)
 }
 
 export async function runStructuredObjectStreamInBackground(
@@ -318,64 +335,60 @@ export async function runStructuredObjectStreamInBackground(
   for (const field of outputSchema) {
     schemaShape[field.name] = fieldTypeToZodSchema[field.type] ?? z.string().nullable()
   }
+  const objectSchema = z.object(schemaShape).strict()
 
   const result = streamText({
     ...(streamParams as Parameters<typeof streamText>[0]),
     model,
     output: Output.object({
-      schema: z.object(schemaShape).strict(),
+      schema: objectSchema,
     }),
     abortSignal: signal,
     onError: ({ error }) => {
       onError?.(error)
     },
   })
+  let cumulativeText = ""
 
-  const consumePartialOutput = async () => {
-    for await (const partial of result.partialOutputStream) {
-      if (signal?.aborted) {
-        throw new DOMException("stream aborted", "AbortError")
+  for await (const part of result.fullStream) {
+    if (signal?.aborted) {
+      throw new DOMException("stream aborted", "AbortError")
+    }
+
+    switch (part.type) {
+      case "text-delta": {
+        cumulativeText += part.text
+        const partial = await parsePartialJson(cumulativeText)
+        if (isRecord(partial.value)) {
+          cumulativeValue = { ...cumulativeValue, ...partial.value }
+          onChunk?.(createStreamSnapshot(cumulativeValue, thinking))
+        }
+        break
       }
-
-      if (partial && typeof partial === "object" && !Array.isArray(partial)) {
-        cumulativeValue = { ...cumulativeValue, ...partial }
+      case "reasoning-delta": {
+        thinking = {
+          status: "thinking",
+          text: thinking.text + part.text,
+        }
         onChunk?.(createStreamSnapshot(cumulativeValue, thinking))
+        break
+      }
+      case "reasoning-end": {
+        thinking = {
+          ...thinking,
+          status: "complete",
+        }
+        onChunk?.(createStreamSnapshot(cumulativeValue, thinking))
+        break
+      }
+      case "error": {
+        throw part.error
       }
     }
   }
 
-  const consumeFullStream = async () => {
-    for await (const part of result.fullStream) {
-      if (signal?.aborted) {
-        throw new DOMException("stream aborted", "AbortError")
-      }
-
-      switch (part.type) {
-        case "reasoning-delta": {
-          thinking = {
-            status: "thinking",
-            text: thinking.text + part.text,
-          }
-          onChunk?.(createStreamSnapshot(cumulativeValue, thinking))
-          break
-        }
-        case "reasoning-end": {
-          thinking = {
-            ...thinking,
-            status: "complete",
-          }
-          onChunk?.(createStreamSnapshot(cumulativeValue, thinking))
-          break
-        }
-      }
-    }
-  }
-
-  const [finalValue] = await Promise.all([
-    result.output,
-    consumePartialOutput(),
-    consumeFullStream(),
-  ])
+  const finalJson = await parsePartialJson(cumulativeText)
+  const finalValue = objectSchema.parse(finalJson.value)
 
   thinking = {
     ...thinking,

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
@@ -1131,6 +1131,56 @@ describe("selection toolbar requests", () => {
     })
   })
 
+  it("keeps a pending custom action request alive across a passive config refresh", async () => {
+    const pendingRun = createDeferredPromise<BackgroundStructuredObjectStreamSnapshot>()
+    const signals: AbortSignal[] = []
+
+    streamBackgroundStructuredObjectMock.mockImplementationOnce((_payload, options: { signal?: AbortSignal }) => {
+      signals.push(options.signal as AbortSignal)
+      return pendingRun.promise
+    })
+
+    const paragraph = document.createElement("p")
+    paragraph.textContent = "Selected text inside a paragraph."
+    document.body.appendChild(paragraph)
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    setSelectionState(store, { text: "Selected text", range: createRangeFor(paragraph) })
+    renderWithProviders(<SelectionToolbarCustomActionButtons />, store)
+
+    const actionName = DEFAULT_CONFIG.selectionToolbar.customActions[0]?.name
+    if (!actionName) {
+      throw new Error("Default custom action is missing")
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: actionName }))
+
+    await waitFor(() => {
+      expect(streamBackgroundStructuredObjectMock).toHaveBeenCalledTimes(1)
+    })
+
+    act(() => {
+      store.set(configAtom, cloneConfig(store.get(configAtom)))
+    })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(streamBackgroundStructuredObjectMock).toHaveBeenCalledTimes(1)
+    expect(signals[0]?.aborted).toBe(false)
+
+    await act(async () => {
+      pendingRun.resolve(createStructuredObjectSnapshot({ summary: "still alive" }))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("{\"summary\":\"still alive\"}")).toBeInTheDocument()
+    })
+  })
+
   it("reruns custom action requests from the footer and aborts the previous run", async () => {
     const firstRun = createDeferredPromise<BackgroundStructuredObjectStreamSnapshot>()
     const secondRun = createDeferredPromise<BackgroundStructuredObjectStreamSnapshot>()
@@ -1185,6 +1235,79 @@ describe("selection toolbar requests", () => {
     await waitFor(() => {
       expect(screen.getByText("{\"summary\":\"fresh\"}")).toBeInTheDocument()
     })
+  })
+
+  it("switches a custom action provider from the footer without aborting the replacement request", async () => {
+    const firstRun = createDeferredPromise<BackgroundStructuredObjectStreamSnapshot>()
+    const secondRun = createDeferredPromise<BackgroundStructuredObjectStreamSnapshot>()
+    const signals: AbortSignal[] = []
+
+    streamBackgroundStructuredObjectMock
+      .mockImplementationOnce((_payload, options: { signal?: AbortSignal }) => {
+        signals.push(options.signal as AbortSignal)
+        options.signal?.addEventListener("abort", () => {
+          firstRun.reject(new DOMException("aborted", "AbortError"))
+        })
+        return firstRun.promise
+      })
+      .mockImplementationOnce((_payload, options: { signal?: AbortSignal }) => {
+        signals.push(options.signal as AbortSignal)
+        return secondRun.promise
+      })
+
+    const paragraph = document.createElement("p")
+    paragraph.textContent = "Selected text inside a paragraph."
+    document.body.appendChild(paragraph)
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    setSelectionState(store, { text: "Selected text", range: createRangeFor(paragraph) })
+    renderWithProviders(<SelectionToolbarCustomActionButtons />, store)
+
+    const action = DEFAULT_CONFIG.selectionToolbar.customActions[0]
+    if (!action) {
+      throw new Error("Default custom action is missing")
+    }
+    const nextProviderId = findAlternateLLMProviderId(store.get(configAtom), action.providerId)
+    if (!nextProviderId) {
+      throw new Error("No alternate LLM provider available for custom action provider switch test")
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: action.name }))
+
+    await waitFor(() => {
+      expect(streamBackgroundStructuredObjectMock).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Change provider" }))
+
+    await waitFor(() => {
+      expect(streamBackgroundStructuredObjectMock).toHaveBeenCalledTimes(2)
+    })
+
+    expect(streamBackgroundStructuredObjectMock.mock.calls[1]?.[0]).toMatchObject({
+      providerId: nextProviderId,
+    })
+    expect(signals[0]?.aborted).toBe(true)
+
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(signals[1]?.aborted).toBe(false)
+
+    await act(async () => {
+      secondRun.resolve(createStructuredObjectSnapshot({ summary: "provider switched" }))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("{\"summary\":\"provider switched\"}")).toBeInTheDocument()
+    })
+    expect(screen.queryByRole("alert")).toBeNull()
+    expect(store.get(configAtom).selectionToolbar.customActions[0]?.providerId).toBe(nextProviderId)
   })
 
   it("shows a precheck alert when a custom action has no selected text", async () => {

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/use-custom-action-execution.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/use-custom-action-execution.ts
@@ -1,3 +1,4 @@
+import type { JSONValue } from "ai"
 import type { RefObject } from "react"
 import type { SelectionToolbarCustomActionRequestSlice } from "../atoms"
 import type { SelectionToolbarInlineError } from "../inline-error"
@@ -45,12 +46,50 @@ interface ResolvedWebPageContext {
   value: CachedWebPageContext | null
 }
 
+interface CustomActionExecutionRequest {
+  analytics: {
+    actionId: string
+    actionName: string
+    surface: AnalyticsSurface
+  }
+  key: string
+  payload: {
+    outputSchema: Array<{ name: string, type: SelectionToolbarCustomAction["outputSchema"][number]["type"] }>
+    prompt: string
+    providerId: string
+    providerOptions?: Record<string, Record<string, JSONValue>>
+    system: string
+    temperature?: number
+  }
+}
+
 function scrollSelectionPopoverBodyToBottom(ref: RefObject<HTMLDivElement | null>) {
   requestAnimationFrame(() => {
     if (ref.current) {
       ref.current.scrollTop = ref.current.scrollHeight
     }
   })
+}
+
+function normalizeExecutionKeyValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizeExecutionKeyValue)
+  }
+
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, nestedValue]) => nestedValue !== undefined)
+        .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+        .map(([key, nestedValue]) => [key, normalizeExecutionKeyValue(nestedValue)]),
+    )
+  }
+
+  return value
+}
+
+function stringifyExecutionRequestKey(value: Record<string, unknown>) {
+  return JSON.stringify(normalizeExecutionKeyValue(value))
 }
 
 export function buildCustomActionExecutionPlan(
@@ -153,6 +192,64 @@ export function useCustomActionWebPageContext(open: boolean, popoverSessionKey: 
   return resolvedWebPageContext.value
 }
 
+function buildCustomActionExecutionRequest({
+  analyticsSurface,
+  executionContext,
+  popoverSessionKey,
+  rerunNonce,
+}: {
+  analyticsSurface: AnalyticsSurface
+  executionContext: CustomActionExecutionContext
+  popoverSessionKey: number
+  rerunNonce: number
+}): CustomActionExecutionRequest {
+  const { action, providerConfig, promptTokens } = executionContext
+  const systemPrompt = buildSelectionToolbarCustomActionSystemPrompt(
+    action.systemPrompt,
+    promptTokens,
+    action.outputSchema,
+  )
+  const prompt = replaceSelectionToolbarCustomActionPromptTokens(action.prompt, promptTokens)
+  const modelName = resolveModelId(providerConfig.model) ?? ""
+  const providerOptions = getProviderOptionsWithOverride(
+    modelName,
+    providerConfig.provider,
+    providerConfig.providerOptions,
+  )
+  const outputSchema = action.outputSchema.map(({ name, type }) => ({ name, type }))
+
+  return {
+    analytics: {
+      actionId: action.id,
+      actionName: action.name,
+      surface: analyticsSurface,
+    },
+    key: stringifyExecutionRequestKey({
+      actionId: action.id,
+      analyticsSurface,
+      model: providerConfig.model,
+      outputSchema: action.outputSchema.map(({ description, name, type }) => ({ description, name, type })),
+      popoverSessionKey,
+      prompt,
+      promptTokens,
+      provider: providerConfig.provider,
+      providerId: providerConfig.id,
+      providerOptions,
+      rerunNonce,
+      system: systemPrompt,
+      temperature: providerConfig.temperature,
+    }),
+    payload: {
+      providerId: providerConfig.id,
+      system: systemPrompt,
+      prompt,
+      outputSchema,
+      providerOptions,
+      temperature: providerConfig.temperature,
+    },
+  }
+}
+
 export function useCustomActionExecution({
   analyticsSurface,
   bodyRef,
@@ -173,6 +270,19 @@ export function useCustomActionExecution({
   const [error, setError] = useState<SelectionToolbarInlineError | null>(null)
   const [thinking, setThinking] = useState<ThinkingSnapshot | null>(null)
   const lastRunKeyRef = useRef<string | null>(null)
+  const bodyRefRef = useRef(bodyRef)
+  bodyRefRef.current = bodyRef
+  const executionRequest = executionContext
+    ? buildCustomActionExecutionRequest({
+        analyticsSurface,
+        executionContext,
+        popoverSessionKey,
+        rerunNonce,
+      })
+    : null
+  const executionRequestRef = useRef<CustomActionExecutionRequest | null>(null)
+  executionRequestRef.current = executionRequest
+  const executionRequestKey = executionRequest?.key ?? null
 
   const resetSessionState = useCallback(() => {
     setIsRunning(false)
@@ -182,53 +292,34 @@ export function useCustomActionExecution({
   }, [])
 
   useEffect(() => {
-    if (!open || !executionContext) {
+    if (!open || !executionRequestKey) {
       return
     }
 
-    const nextRunKey = JSON.stringify({
-      actionId: executionContext.action.id,
-      paragraphs: executionContext.promptTokens.paragraphs,
-      popoverSessionKey,
-      providerId: executionContext.providerConfig.id,
-      rerunNonce,
-      selection: executionContext.promptTokens.selection,
-      targetLanguage: executionContext.promptTokens.targetLanguage,
-      webContent: executionContext.promptTokens.webContent,
-      webTitle: executionContext.promptTokens.webTitle,
-    })
-    if (lastRunKeyRef.current === nextRunKey) {
+    const request = executionRequestRef.current
+    if (!request || request.key !== executionRequestKey) {
       return
     }
-    lastRunKeyRef.current = nextRunKey
+
+    if (lastRunKeyRef.current === executionRequestKey) {
+      return
+    }
+    lastRunKeyRef.current = executionRequestKey
 
     let isCancelled = false
     const abortController = new AbortController()
-    const { action, providerConfig, promptTokens } = executionContext
+
     const analyticsContext = createFeatureUsageContext(
       ANALYTICS_FEATURE.CUSTOM_AI_ACTION,
-      analyticsSurface,
+      request.analytics.surface,
       Date.now(),
       {
-        action_id: action.id,
-        action_name: action.name,
+        action_id: request.analytics.actionId,
+        action_name: request.analytics.actionName,
       },
     )
 
     const run = async () => {
-      const systemPrompt = buildSelectionToolbarCustomActionSystemPrompt(
-        action.systemPrompt,
-        promptTokens,
-        action.outputSchema,
-      )
-      const prompt = replaceSelectionToolbarCustomActionPromptTokens(action.prompt, promptTokens)
-      const modelName = resolveModelId(providerConfig.model) ?? ""
-      const providerOptions = getProviderOptionsWithOverride(
-        modelName,
-        providerConfig.provider,
-        providerConfig.providerOptions,
-      )
-
       setIsRunning(true)
       setResult(null)
       setError(null)
@@ -239,14 +330,7 @@ export function useCustomActionExecution({
 
       try {
         const finalResult = await streamBackgroundStructuredObject(
-          {
-            providerId: providerConfig.id,
-            system: systemPrompt,
-            prompt,
-            outputSchema: action.outputSchema.map(({ name, type }) => ({ name, type })),
-            providerOptions,
-            temperature: providerConfig.temperature,
-          },
+          request.payload,
           {
             signal: abortController.signal,
             onChunk: (partial: BackgroundStructuredObjectStreamSnapshot) => {
@@ -256,7 +340,7 @@ export function useCustomActionExecution({
 
               setResult(partial.output)
               setThinking(partial.thinking)
-              scrollSelectionPopoverBodyToBottom(bodyRef)
+              scrollSelectionPopoverBodyToBottom(bodyRefRef.current)
             },
           },
         )
@@ -301,7 +385,7 @@ export function useCustomActionExecution({
       isCancelled = true
       abortController.abort()
     }
-  }, [analyticsSurface, bodyRef, executionContext, open, popoverSessionKey, rerunNonce])
+  }, [executionRequestKey, open])
 
   useEffect(() => {
     if (!open) {


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fixes Custom AI Action provider switching from the selection toolbar footer.

- Keys custom action execution by a stable serialized request payload instead of React object identity, so passive config refreshes no longer abort the active run.
- Keeps real request changes, including provider switches and regenerate actions, aborting the previous run and starting the replacement request.
- Consumes AI SDK `streamText()` results through `fullStream` only, avoiding duplicate `output` / `partialOutputStream` consumers that produced extra cancelled provider requests.
- Treats stream port disconnect aborts as expected cancellation while preserving real provider/API error reporting.

## Related Issue

fix #1344

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Validation run locally:

- `SKIP_FREE_API=true pnpm test src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/use-custom-action-execution.test.ts src/entrypoints/background/__tests__/background-stream.test.ts`
- `pnpm exec eslint src/entrypoints/background/background-stream.ts src/entrypoints/background/__tests__/background-stream.test.ts src/entrypoints/selection.content/selection-toolbar/custom-action-button/use-custom-action-execution.ts src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx`
- `pnpm type-check`
- `git diff --check`
- Pre-push hook: `nx run @read-frog/extension:lint`, `nx run @read-frog/extension:type-check`, `nx run @read-frog/extension:test` (118 files, 1029 tests passed)

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Includes a patch changeset for the user-visible selection toolbar bug fix.
