### PR TITLE
fix(auth): include credentials for API auth client

### DIFF
--- a/.changeset/quick-frogs-auth.md
+++ b/.changeset/quick-frogs-auth.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(auth): include credentials for API auth client

--- a/src/utils/auth/auth-client.ts
+++ b/src/utils/auth/auth-client.ts
@@ -38,6 +38,7 @@ export const authClient = createAuthClient({
   baseURL: env.WXT_API_URL,
   basePath: AUTH_BASE_PATH,
   fetchOptions: {
+    credentials: "include",
     customFetchImpl: createCustomFetch({
       enabled: true,
       groupKey: "auth",


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

The extension auth client already reads its API origin from `env.WXT_API_URL`, whose production value points at `https://api.readfrog.app`. To make Better Auth requests consistently include the session cookies for that API authority, this PR adds `credentials: "include"` to the auth client's fetch options.

The existing background custom fetch remains in place and continues to use the shared auth request group. A patch changeset is included for `@read-frog/extension`.

## Related Issue

N/A

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

- `pnpm type-check`
- Push pre-flight checks completed for the branch: `lint`, `type-check`, and `test`
- Test suite passed during push: `118` files, `1026` tests

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The companion website PR prevents `www.readfrog.app/api/*` paths from being localized, but this extension fix keeps the normal auth flow on `api.readfrog.app`.
