### PR TITLE
fix: Page freeze with a very large number of DOM elements

### DIFF
--- a/src/utils/content/__tests__/utils.test.ts
+++ b/src/utils/content/__tests__/utils.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest"
+import { removeDummyNodes } from "../utils"
+
+vi.mock("@/utils/config/storage", () => ({
+  getLocalConfig: vi.fn(async () => null),
+}))
+
+describe("removeDummyNodes", () => {
+  it("still removes nodes hidden by computed style", async () => {
+    const testDocument = document.implementation.createHTMLDocument("test")
+    const hidden = testDocument.createElement("div")
+    hidden.className = "stylesheet-hidden"
+    hidden.textContent = "hidden text"
+    testDocument.body.appendChild(hidden)
+
+    const originalGetComputedStyle = window.getComputedStyle.bind(window)
+    const getComputedStyleSpy = vi.spyOn(window, "getComputedStyle").mockImplementation((element) => {
+      const style = originalGetComputedStyle(element)
+      if (element === hidden) {
+        return new Proxy(style, {
+          get(target, prop, receiver) {
+            if (prop === "display")
+              return "none"
+            return Reflect.get(target, prop, receiver)
+          },
+        }) as CSSStyleDeclaration
+      }
+      return style
+    })
+
+    try {
+      await removeDummyNodes(testDocument)
+      expect(testDocument.body.textContent).not.toContain("hidden text")
+    }
+    finally {
+      getComputedStyleSpy.mockRestore()
+    }
+  })
+
+  it("does not inspect descendants after removing a hidden subtree", async () => {
+    const testDocument = document.implementation.createHTMLDocument("test")
+    const hiddenParent = testDocument.createElement("section")
+    hiddenParent.hidden = true
+    const child = testDocument.createElement("div")
+    child.textContent = "nested text"
+    hiddenParent.appendChild(child)
+    testDocument.body.appendChild(hiddenParent)
+
+    const checkedElements: Element[] = []
+    const originalGetComputedStyle = window.getComputedStyle.bind(window)
+    const getComputedStyleSpy = vi.spyOn(window, "getComputedStyle").mockImplementation((element) => {
+      checkedElements.push(element)
+      return originalGetComputedStyle(element)
+    })
+
+    try {
+      await removeDummyNodes(testDocument)
+      expect(testDocument.body.textContent).not.toContain("nested text")
+      expect(checkedElements).not.toContain(child)
+    }
+    finally {
+      getComputedStyleSpy.mockRestore()
+    }
+  })
+})

--- a/src/utils/content/utils.ts
+++ b/src/utils/content/utils.ts
@@ -11,7 +11,9 @@ export async function removeDummyNodes(root: Document) {
   const elements = root.querySelectorAll("*")
   const config = await getLocalConfig() ?? DEFAULT_CONFIG
   elements.forEach((element) => {
-    const isDontTranslate = isHTMLElement(element) && isDontWalkIntoAndDontTranslateAsChildElement(element, config)
+    const isDontTranslate = isHTMLElement(element) && isDontWalkIntoAndDontTranslateAsChildElement(element, config, {
+      includeComputedStyle: false,
+    })
     if (isDontTranslate) {
       element.remove()
     }

--- a/src/utils/content/utils.ts
+++ b/src/utils/content/utils.ts
@@ -8,16 +8,26 @@ const ZERO_WIDTH_CHARS_RE = /[\u200B-\u200D\uFEFF]/g
 const WHITESPACE_RUN_RE = /\s+/g
 
 export async function removeDummyNodes(root: Document) {
-  const elements = root.querySelectorAll("*")
   const config = await getLocalConfig() ?? DEFAULT_CONFIG
-  elements.forEach((element) => {
-    const isDontTranslate = isHTMLElement(element) && isDontWalkIntoAndDontTranslateAsChildElement(element, config, {
-      includeComputedStyle: false,
-    })
-    if (isDontTranslate) {
-      element.remove()
+
+  const removeDummyDescendants = (element: Element) => {
+    if (!isHTMLElement(element)) {
+      return
     }
-  })
+
+    if (isDontWalkIntoAndDontTranslateAsChildElement(element, config)) {
+      element.remove()
+      return
+    }
+
+    for (const child of Array.from(element.children)) {
+      removeDummyDescendants(child)
+    }
+  }
+
+  for (const child of Array.from(root.children)) {
+    removeDummyDescendants(child)
+  }
 }
 
 /**

--- a/src/utils/content/utils.ts
+++ b/src/utils/content/utils.ts
@@ -10,23 +10,18 @@ const WHITESPACE_RUN_RE = /\s+/g
 export async function removeDummyNodes(root: Document) {
   const config = await getLocalConfig() ?? DEFAULT_CONFIG
 
-  const removeDummyDescendants = (element: Element) => {
-    if (!isHTMLElement(element)) {
-      return
-    }
+  const stack = Array.from(root.children).reverse()
+  while (stack.length > 0) {
+    const element = stack.pop()
+    if (!element || !isHTMLElement(element))
+      continue
 
     if (isDontWalkIntoAndDontTranslateAsChildElement(element, config)) {
       element.remove()
-      return
+      continue
     }
 
-    for (const child of Array.from(element.children)) {
-      removeDummyDescendants(child)
-    }
-  }
-
-  for (const child of Array.from(root.children)) {
-    removeDummyDescendants(child)
+    stack.push(...Array.from(element.children).reverse())
   }
 }
 

--- a/src/utils/host/dom/__tests__/filter.test.ts
+++ b/src/utils/host/dom/__tests__/filter.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import type { Config } from "@/types/config/config"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import {
@@ -195,5 +195,36 @@ describe("isDontWalkIntoAndDontTranslateAsChildElement", () => {
     document.body.appendChild(nav)
     expect(isDontWalkIntoAndDontTranslateAsChildElement(nav, createConfig("main"))).toBe(true)
     document.body.removeChild(nav)
+  })
+
+  it("should skip computed style checks when disabled", () => {
+    const element = document.createElement("div")
+    const getComputedStyleSpy = vi.spyOn(window, "getComputedStyle")
+
+    try {
+      expect(isDontWalkIntoAndDontTranslateAsChildElement(element, DEFAULT_CONFIG, {
+        includeComputedStyle: false,
+      })).toBe(false)
+      expect(getComputedStyleSpy).not.toHaveBeenCalled()
+    }
+    finally {
+      getComputedStyleSpy.mockRestore()
+    }
+  })
+
+  it("should still detect hidden inline style when computed style checks are disabled", () => {
+    const element = document.createElement("div")
+    element.style.display = "none"
+    const getComputedStyleSpy = vi.spyOn(window, "getComputedStyle")
+
+    try {
+      expect(isDontWalkIntoAndDontTranslateAsChildElement(element, DEFAULT_CONFIG, {
+        includeComputedStyle: false,
+      })).toBe(true)
+      expect(getComputedStyleSpy).not.toHaveBeenCalled()
+    }
+    finally {
+      getComputedStyleSpy.mockRestore()
+    }
   })
 })

--- a/src/utils/host/dom/__tests__/filter.test.ts
+++ b/src/utils/host/dom/__tests__/filter.test.ts
@@ -197,14 +197,30 @@ describe("isDontWalkIntoAndDontTranslateAsChildElement", () => {
     document.body.removeChild(nav)
   })
 
-  it("should skip computed style checks when disabled", () => {
+  it("should detect stylesheet-hidden elements", () => {
+    const style = document.createElement("style")
+    style.textContent = ".read-frog-test-hidden { display: none; }"
+    document.head.appendChild(style)
     const element = document.createElement("div")
+    element.className = "read-frog-test-hidden"
+    document.body.appendChild(element)
+
+    try {
+      expect(isDontWalkIntoAndDontTranslateAsChildElement(element, DEFAULT_CONFIG)).toBe(true)
+    }
+    finally {
+      document.body.removeChild(element)
+      document.head.removeChild(style)
+    }
+  })
+
+  it("should skip computed style checks for hidden inline style", () => {
+    const element = document.createElement("div")
+    element.style.display = "none"
     const getComputedStyleSpy = vi.spyOn(window, "getComputedStyle")
 
     try {
-      expect(isDontWalkIntoAndDontTranslateAsChildElement(element, DEFAULT_CONFIG, {
-        includeComputedStyle: false,
-      })).toBe(false)
+      expect(isDontWalkIntoAndDontTranslateAsChildElement(element, DEFAULT_CONFIG)).toBe(true)
       expect(getComputedStyleSpy).not.toHaveBeenCalled()
     }
     finally {
@@ -212,15 +228,13 @@ describe("isDontWalkIntoAndDontTranslateAsChildElement", () => {
     }
   })
 
-  it("should still detect hidden inline style when computed style checks are disabled", () => {
+  it("should skip computed style checks for hidden attributes", () => {
     const element = document.createElement("div")
-    element.style.display = "none"
+    element.hidden = true
     const getComputedStyleSpy = vi.spyOn(window, "getComputedStyle")
 
     try {
-      expect(isDontWalkIntoAndDontTranslateAsChildElement(element, DEFAULT_CONFIG, {
-        includeComputedStyle: false,
-      })).toBe(true)
+      expect(isDontWalkIntoAndDontTranslateAsChildElement(element, DEFAULT_CONFIG)).toBe(true)
       expect(getComputedStyleSpy).not.toHaveBeenCalled()
     }
     finally {

--- a/src/utils/host/dom/filter.ts
+++ b/src/utils/host/dom/filter.ts
@@ -151,15 +151,7 @@ function isInsideContentContainer(element: HTMLElement): boolean {
   return false
 }
 
-interface DontWalkIntoElementOptions {
-  includeComputedStyle?: boolean
-}
-
-export function isDontWalkIntoAndDontTranslateAsChildElement(
-  element: HTMLElement,
-  config: Config,
-  options: DontWalkIntoElementOptions = {},
-): boolean {
+export function isDontWalkIntoAndDontTranslateAsChildElement(element: HTMLElement, config: Config): boolean {
   const dontWalkCustomElement = isCustomDontWalkIntoElement(element)
   const dontWalkContent = config.translate.page.range !== "all"
     && MAIN_CONTENT_IGNORE_TAGS.has(element.tagName)
@@ -174,10 +166,6 @@ export function isDontWalkIntoAndDontTranslateAsChildElement(
 
   if (dontWalkCustomElement || dontWalkContent || dontWalkInvalidTag || dontWalkHidden || dontWalkAriaHidden || dontWalkVisuallyHidden || dontWalkInlineStyle) {
     return true
-  }
-
-  if (options.includeComputedStyle === false) {
-    return false
   }
 
   const computedStyle = window.getComputedStyle(element)

--- a/src/utils/host/dom/filter.ts
+++ b/src/utils/host/dom/filter.ts
@@ -151,26 +151,37 @@ function isInsideContentContainer(element: HTMLElement): boolean {
   return false
 }
 
-export function isDontWalkIntoAndDontTranslateAsChildElement(element: HTMLElement, config: Config): boolean {
+interface DontWalkIntoElementOptions {
+  includeComputedStyle?: boolean
+}
+
+export function isDontWalkIntoAndDontTranslateAsChildElement(
+  element: HTMLElement,
+  config: Config,
+  options: DontWalkIntoElementOptions = {},
+): boolean {
   const dontWalkCustomElement = isCustomDontWalkIntoElement(element)
   const dontWalkContent = config.translate.page.range !== "all"
     && MAIN_CONTENT_IGNORE_TAGS.has(element.tagName)
     && !isInsideContentContainer(element)
   const dontWalkInvalidTag = DONT_WALK_AND_TRANSLATE_TAGS.has(element.tagName)
-  const dontWalkCSS
-    = window.getComputedStyle(element).display === "none"
-      || window.getComputedStyle(element).visibility === "hidden"
+  const dontWalkInlineStyle = element.style.display === "none" || element.style.visibility === "hidden"
   const dontWalkHidden = element.hidden
   const dontWalkAriaHidden = element.getAttribute("aria-hidden") === "true"
   const dontWalkVisuallyHidden = ["sr-only", "visually-hidden"].some(cls =>
     element.classList.contains(cls),
   )
 
-  if (dontWalkCustomElement || dontWalkContent || dontWalkInvalidTag || dontWalkCSS || dontWalkHidden || dontWalkAriaHidden || dontWalkVisuallyHidden) {
+  if (dontWalkCustomElement || dontWalkContent || dontWalkInvalidTag || dontWalkHidden || dontWalkAriaHidden || dontWalkVisuallyHidden || dontWalkInlineStyle) {
     return true
   }
 
-  return false
+  if (options.includeComputedStyle === false) {
+    return false
+  }
+
+  const computedStyle = window.getComputedStyle(element)
+  return computedStyle.display === "none" || computedStyle.visibility === "hidden"
 }
 
 export function isInlineTransNode(node: TransNode): boolean {


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [x] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

This changes reduces initial page-load overhead from DOM filtering.

The expensive part was not simply reading `display` or `visibility` itself.
My earlier assumption in the previous issue [#1375](https://github.com/mengxi-ream/read-frog/issues/1375) was imprecise.
The bottleneck was calling `getComputedStyle()` across a very large number of elements during the initial page scan.

<img width="1196" height="687" alt="1777019871_Code_a9yxsqjYKF" src="https://github.com/user-attachments/assets/8b1d78e3-7ec3-475f-a985-d4aca02e1938" />

This change:
1. Runs cheap DOM/attribute/inline-style checks first
2. Skips computed style checks in the `getDocumentInfo() -> removeDummyNodes()` path, which runs before translation starts and previously scanned every element on the page
3. Calls `getComputedStyle()` only when the normal traversal path still needs it. (And instead of calling it twice, call it once and caching)

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #1375 

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [x] Added unit tests
- [x] Verified through manual testing

## Screenshots
before:
<img width="1278" height="922" alt="1777006425_Obsidian_DdZBpiY76n" src="https://github.com/user-attachments/assets/6e5e43f8-b3ba-41b4-9b41-ae27f74f18c0" />
after:
<img width="1279" height="958" alt="1777019563_firefox_HRGEjR6f2q" src="https://github.com/user-attachments/assets/e2a5e036-693b-4205-8b9b-dda2de546405" />

Profiler comparison shows a substantial reduction in style flush / selector matching work on pages with very large DOMs.

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary *(Not relavent)*
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality *(I was written with function-level backward compatibility in mind)*
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->
