### PR TITLE
feat(popup): search languages in popup selectors

### DIFF
--- a/.changeset/searchable-popup-languages.md
+++ b/.changeset/searchable-popup-languages.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(popup): search languages in popup selectors

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@ai-sdk/togetherai": "^2.0.45",
     "@ai-sdk/vercel": "^2.0.43",
     "@ai-sdk/xai": "^3.0.83",
+    "@babel/runtime": "^7.29.2",
     "@base-ui/react": "^1.4.1",
     "@codemirror/lang-css": "^6.3.1",
     "@codemirror/lang-json": "^6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@ai-sdk/xai':
         specifier: ^3.0.83
         version: 3.0.83(zod@4.3.6)
+      '@babel/runtime':
+        specifier: ^7.29.2
+        version: 7.29.2
       '@base-ui/react':
         specifier: ^1.4.1
         version: 1.4.1(@date-fns/tz@1.4.1)(@types/react@19.2.14)(date-fns@4.1.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -786,10 +789,6 @@ packages:
 
   '@babel/runtime@7.28.2':
     resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/runtime@7.28.4':
-    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.2':
@@ -8132,8 +8131,6 @@ snapshots:
 
   '@babel/runtime@7.28.2': {}
 
-  '@babel/runtime@7.28.4': {}
-
   '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.28.6':
@@ -10077,7 +10074,7 @@ snapshots:
 
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
       '@testing-library/dom': 10.4.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
@@ -10269,8 +10266,8 @@ snapshots:
 
   '@typescript-eslint/project-service@8.57.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.57.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.57.0
+      '@typescript-eslint/tsconfig-utils': 8.59.0(typescript@6.0.3)
+      '@typescript-eslint/types': 8.59.0
       debug: 4.4.3
       typescript: 6.0.3
     transitivePeerDependencies:

--- a/src/entrypoints/popup/components/language-options-selector.tsx
+++ b/src/entrypoints/popup/components/language-options-selector.tsx
@@ -1,20 +1,26 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
+import type { LanguageItem } from "@/components/language-combobox-options"
 import { i18n } from "#imports"
+import { Combobox as ComboboxPrimitive } from "@base-ui/react"
 import { Icon } from "@iconify/react"
 import {
   LANG_CODE_TO_EN_NAME,
   LANG_CODE_TO_LOCALE_NAME,
   langCodeISO6393Schema,
 } from "@read-frog/definitions"
+import { IconChevronDown } from "@tabler/icons-react"
 import { useAtom, useAtomValue } from "jotai"
+import { useMemo } from "react"
+import { filterLanguage } from "@/components/language-combobox-options"
+import { Button } from "@/components/ui/base-ui/button"
 import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/base-ui/select"
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "@/components/ui/base-ui/combobox"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { detectedCodeAtom } from "@/utils/atoms/detected-code"
 
@@ -22,82 +28,154 @@ function langCodeLabel(langCode: LangCodeISO6393) {
   return `${LANG_CODE_TO_EN_NAME[langCode]} (${LANG_CODE_TO_LOCALE_NAME[langCode]})`
 }
 
-const langSelectorTriggerClasses = "!h-14 w-30 rounded-lg shadow-xs pr-2 gap-1"
+function createLanguageItem(code: LangCodeISO6393): LanguageItem<LangCodeISO6393> {
+  return {
+    value: code,
+    label: langCodeLabel(code),
+    name: LANG_CODE_TO_EN_NAME[code],
+  }
+}
+
+const langSelectorTriggerClasses = "!h-14 w-30 rounded-lg shadow-xs pr-2 gap-1 justify-between bg-transparent"
 
 const langSelectorContentClasses = "flex flex-col items-start text-base font-medium min-w-0 flex-1"
+
+function LanguageComboboxTrigger({
+  label,
+  subtitle,
+  ariaLabel,
+}: {
+  label: string
+  subtitle: string
+  ariaLabel: string
+}) {
+  return (
+    <ComboboxPrimitive.Trigger
+      render={(
+        <Button
+          type="button"
+          variant="outline"
+          className={langSelectorTriggerClasses}
+          aria-label={ariaLabel}
+          title={label}
+        />
+      )}
+    >
+      <div className={langSelectorContentClasses}>
+        <span className="truncate w-full text-left">{label}</span>
+        <span className="text-sm text-neutral-500">{subtitle}</span>
+      </div>
+      <IconChevronDown className="size-4 text-muted-foreground" />
+    </ComboboxPrimitive.Trigger>
+  )
+}
 
 export default function LanguageOptionsSelector() {
   const [language, setLanguage] = useAtom(configFieldsAtomMap.language)
   const detectedCode = useAtomValue(detectedCodeAtom)
+  const targetLanguageItems = useMemo(
+    () => langCodeISO6393Schema.options.map(createLanguageItem),
+    [],
+  )
+  const sourceLanguageItems = useMemo<LanguageItem[]>(
+    () => [
+      {
+        value: "auto",
+        label: langCodeLabel(detectedCode),
+        name: LANG_CODE_TO_EN_NAME[detectedCode],
+      },
+      ...targetLanguageItems,
+    ],
+    [detectedCode, targetLanguageItems],
+  )
+  const currentSourceItem = useMemo(
+    () => sourceLanguageItems.find(item => item.value === language.sourceCode) ?? sourceLanguageItems[0] ?? null,
+    [language.sourceCode, sourceLanguageItems],
+  )
+  const currentTargetItem = useMemo(
+    () => targetLanguageItems.find(item => item.value === language.targetCode) ?? null,
+    [language.targetCode, targetLanguageItems],
+  )
 
-  const handleSourceLangChange = (newLangCode: LangCodeISO6393 | "auto" | null) => {
-    if (!newLangCode)
+  const handleSourceLangChange = (item: LanguageItem | null) => {
+    if (!item || item.value === language.sourceCode)
       return
-    void setLanguage({ sourceCode: newLangCode })
+    void setLanguage({ sourceCode: item.value })
   }
 
-  const handleTargetLangChange = (newLangCode: LangCodeISO6393 | null) => {
-    if (!newLangCode)
+  const handleTargetLangChange = (item: LanguageItem | null) => {
+    if (!item || item.value === "auto" || item.value === language.targetCode)
       return
-    void setLanguage({ targetCode: newLangCode })
+    void setLanguage({ targetCode: item.value })
   }
 
   const sourceLangLabel
     = language.sourceCode === "auto"
-      ? `${langCodeLabel(detectedCode)} (auto)`
-      : langCodeLabel(language.sourceCode)
+      ? `${currentSourceItem?.label ?? langCodeLabel(detectedCode)} (auto)`
+      : currentSourceItem?.label ?? langCodeLabel(language.sourceCode)
 
-  const targetLangLabel = langCodeLabel(language.targetCode)
+  const targetLangLabel = currentTargetItem?.label ?? langCodeLabel(language.targetCode)
 
   return (
     <div className="flex items-center justify-between">
-      <Select value={language.sourceCode} onValueChange={handleSourceLangChange}>
-        <SelectTrigger className={langSelectorTriggerClasses}>
-          <div className={langSelectorContentClasses}>
-            <SelectValue render={<span className="truncate w-full" />}>
-              {sourceLangLabel}
-            </SelectValue>
-            <span className="text-sm text-neutral-500">
-              {language.sourceCode === "auto"
-                ? i18n.t("popup.autoLang")
-                : i18n.t("popup.sourceLang")}
-            </span>
-          </div>
-        </SelectTrigger>
-        <SelectContent className="rounded-lg shadow-md w-72">
-          <SelectGroup>
-            <SelectItem value="auto">
-              {langCodeLabel(detectedCode)}
-              <AutoLangCell />
-            </SelectItem>
-            {langCodeISO6393Schema.options.map(key => (
-              <SelectItem key={key} value={key}>
-                {langCodeLabel(key)}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-        </SelectContent>
-      </Select>
+      <Combobox
+        value={currentSourceItem}
+        onValueChange={handleSourceLangChange}
+        items={sourceLanguageItems}
+        filter={filterLanguage}
+        autoHighlight
+      >
+        <LanguageComboboxTrigger
+          label={sourceLangLabel}
+          subtitle={language.sourceCode === "auto"
+            ? i18n.t("popup.autoLang")
+            : i18n.t("popup.sourceLang")}
+          ariaLabel={i18n.t("popup.sourceLang")}
+        />
+        <ComboboxContent className="rounded-lg shadow-md w-72">
+          <ComboboxInput
+            showTrigger={false}
+            placeholder={i18n.t("translationHub.searchLanguages")}
+          />
+          <ComboboxList>
+            {(item: LanguageItem) => (
+              <ComboboxItem key={item.value} value={item}>
+                {item.label}
+                {item.value === "auto" && <AutoLangCell />}
+              </ComboboxItem>
+            )}
+          </ComboboxList>
+          <ComboboxEmpty>{i18n.t("translationHub.noLanguagesFound")}</ComboboxEmpty>
+        </ComboboxContent>
+      </Combobox>
       <Icon icon="tabler:arrow-right" className="h-4 w-4 text-neutral-500" />
-      <Select value={language.targetCode} onValueChange={handleTargetLangChange}>
-        <SelectTrigger className={langSelectorTriggerClasses}>
-          <div className={langSelectorContentClasses}>
-            <SelectValue render={<span className="truncate w-full" />}>
-              {targetLangLabel}
-            </SelectValue>
-            <span className="text-sm text-neutral-500">{i18n.t("popup.targetLang")}</span>
-          </div>
-        </SelectTrigger>
-        <SelectContent className="rounded-lg shadow-md w-72">
-          <SelectGroup>
-            {langCodeISO6393Schema.options.map(key => (
-              <SelectItem key={key} value={key}>
-                {langCodeLabel(key)}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-        </SelectContent>
-      </Select>
+      <Combobox
+        value={currentTargetItem}
+        onValueChange={handleTargetLangChange}
+        items={targetLanguageItems}
+        filter={filterLanguage}
+        autoHighlight
+      >
+        <LanguageComboboxTrigger
+          label={targetLangLabel}
+          subtitle={i18n.t("popup.targetLang")}
+          ariaLabel={i18n.t("popup.targetLang")}
+        />
+        <ComboboxContent className="rounded-lg shadow-md w-72">
+          <ComboboxInput
+            showTrigger={false}
+            placeholder={i18n.t("translationHub.searchLanguages")}
+          />
+          <ComboboxList>
+            {(item: LanguageItem<LangCodeISO6393>) => (
+              <ComboboxItem key={item.value} value={item}>
+                {item.label}
+              </ComboboxItem>
+            )}
+          </ComboboxList>
+          <ComboboxEmpty>{i18n.t("translationHub.noLanguagesFound")}</ComboboxEmpty>
+        </ComboboxContent>
+      </Combobox>
     </div>
   )
 }


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Adds searchable language pickers to the popup language selector so users can quickly find source and target languages instead of scrolling through the full language list.

This PR:

- replaces the popup source and target language dropdowns with the shared Base UI combobox pattern
- adds search inputs to both popup language menus using the existing language filtering helper
- preserves the auto-detected source language option and keeps its `auto` badge visible in search results
- keeps the compact popup trigger layout with language labels, source/target subtitles, and a chevron affordance
- adds a patch changeset for `@read-frog/extension`

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

N/A

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

Manual verification performed:

- `SKIP_FREE_API=true pnpm type-check`
- `SKIP_FREE_API=true pnpm lint`
- `SKIP_FREE_API=true pnpm test` — 117 passed, 1 skipped locally
- `SKIP_FREE_API=true pnpm build` — completed successfully; existing Vite chunk-size warnings only
- pre-push hook validation via `git push` (`nx lint`, `nx type-check`, `vitest run`) — 118 passed in hook

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

N/A

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- The branch has been pushed to `origin/feat/searchable-popup-language-combobox`.
- PR URL: https://github.com/mengxi-ream/read-frog/pull/new/feat/searchable-popup-language-combobox
