### PR TITLE
feat(providers): add per-provider request rate overrides

### DIFF
--- a/.changeset/wise-turtles-help.md
+++ b/.changeset/wise-turtles-help.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+Add per-provider request rate overrides in the API provider advanced settings and apply them to translation queues.

--- a/src/entrypoints/background/__tests__/provider-request-queue-override.test.ts
+++ b/src/entrypoints/background/__tests__/provider-request-queue-override.test.ts
@@ -1,0 +1,273 @@
+import type { APIProviderConfig } from "@/types/config/provider"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+
+const {
+  onMessageMock,
+  ensureInitializedConfigMock,
+  executeTranslateMock,
+  generateArticleSummaryMock,
+  putBatchRequestRecordMock,
+  articleSummaryCacheGetMock,
+  articleSummaryCachePutMock,
+  translationCacheGetMock,
+  translationCachePutMock,
+  requestQueueInstances,
+  batchQueueInstances,
+} = vi.hoisted(() => ({
+  onMessageMock: vi.fn(),
+  ensureInitializedConfigMock: vi.fn(),
+  executeTranslateMock: vi.fn(),
+  generateArticleSummaryMock: vi.fn(),
+  putBatchRequestRecordMock: vi.fn(),
+  articleSummaryCacheGetMock: vi.fn(),
+  articleSummaryCachePutMock: vi.fn(),
+  translationCacheGetMock: vi.fn(),
+  translationCachePutMock: vi.fn(),
+  requestQueueInstances: [] as Array<{ options: Record<string, unknown>, enqueue: ReturnType<typeof vi.fn>, setQueueOptions: ReturnType<typeof vi.fn> }>,
+  batchQueueInstances: [] as Array<{ options: Record<string, unknown>, enqueue: ReturnType<typeof vi.fn>, setBatchConfig: ReturnType<typeof vi.fn> }>,
+}))
+
+vi.mock("@/utils/message", () => ({
+  onMessage: onMessageMock,
+}))
+
+vi.mock("../config", () => ({
+  ensureInitializedConfig: ensureInitializedConfigMock,
+}))
+
+vi.mock("@/utils/host/translate/execute-translate", () => ({
+  executeTranslate: executeTranslateMock,
+}))
+
+vi.mock("@/utils/content/summary", () => ({
+  generateArticleSummary: generateArticleSummaryMock,
+}))
+
+vi.mock("@/utils/batch-request-record", () => ({
+  putBatchRequestRecord: putBatchRequestRecordMock,
+}))
+
+vi.mock("@/utils/db/dexie/db", () => ({
+  db: {
+    articleSummaryCache: {
+      get: articleSummaryCacheGetMock,
+      put: articleSummaryCachePutMock,
+    },
+    translationCache: {
+      get: translationCacheGetMock,
+      put: translationCachePutMock,
+    },
+  },
+}))
+
+vi.mock("@/utils/request/request-queue", () => ({
+  RequestQueue: class {
+    options: Record<string, unknown>
+    enqueue = vi.fn().mockResolvedValue("translated")
+    setQueueOptions = vi.fn()
+
+    constructor(options: Record<string, unknown>) {
+      this.options = options
+      requestQueueInstances.push(this)
+    }
+  },
+}))
+
+vi.mock("@/utils/request/batch-queue", () => ({
+  BatchQueue: class {
+    options: Record<string, unknown>
+    enqueue = vi.fn().mockResolvedValue("translated")
+    setBatchConfig = vi.fn()
+
+    constructor(options: Record<string, unknown>) {
+      this.options = options
+      batchQueueInstances.push(this)
+    }
+  },
+}))
+
+function getRegisteredMessageHandler(name: string) {
+  const registration = onMessageMock.mock.calls.find(call => call[0] === name)
+  if (!registration) {
+    throw new Error(`Message handler not registered: ${name}`)
+  }
+  return registration[1] as (message: { data: Record<string, unknown> }) => Promise<unknown>
+}
+
+const baseProviderConfig: APIProviderConfig = {
+  id: "openai-default",
+  name: "OpenAI",
+  provider: "openai",
+  enabled: true,
+  apiKey: "sk-test",
+  model: {
+    model: "gpt-5-mini",
+    isCustomModel: false,
+    customModel: null,
+  },
+}
+
+describe("provider request queue overrides", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    requestQueueInstances.length = 0
+    batchQueueInstances.length = 0
+
+    ensureInitializedConfigMock.mockResolvedValue({
+      ...DEFAULT_CONFIG,
+      videoSubtitles: {
+        ...DEFAULT_CONFIG.videoSubtitles,
+        requestQueueConfig: {
+          rate: 10,
+          capacity: 20,
+        },
+      },
+    })
+
+    executeTranslateMock.mockResolvedValue("translated")
+    generateArticleSummaryMock.mockResolvedValue("Generated summary")
+    putBatchRequestRecordMock.mockResolvedValue(undefined)
+    articleSummaryCacheGetMock.mockResolvedValue(undefined)
+    articleSummaryCachePutMock.mockResolvedValue(undefined)
+    translationCacheGetMock.mockResolvedValue(undefined)
+    translationCachePutMock.mockResolvedValue(undefined)
+  })
+
+  it("creates webpage translation queues with provider-specific request overrides", async () => {
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    await handler({
+      data: {
+        text: "hello",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: {
+          ...baseProviderConfig,
+          requestQueueConfig: {
+            rate: 1,
+            capacity: 2,
+          },
+        },
+        scheduleAt: Date.now(),
+        hash: "page-request",
+      },
+    })
+
+    expect(requestQueueInstances).toHaveLength(1)
+    expect(requestQueueInstances[0]?.options).toEqual(expect.objectContaining({
+      rate: 1,
+      capacity: 2,
+      timeoutMs: 20_000,
+      maxRetries: 2,
+      baseRetryDelayMs: 1_000,
+    }))
+  })
+
+  it("reuses the same provider queue and updates it when the override changes", async () => {
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    await handler({
+      data: {
+        text: "hello",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: {
+          ...baseProviderConfig,
+          requestQueueConfig: {
+            rate: 1,
+            capacity: 2,
+          },
+        },
+        scheduleAt: Date.now(),
+        hash: "page-request-a",
+      },
+    })
+
+    await handler({
+      data: {
+        text: "world",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: {
+          ...baseProviderConfig,
+          requestQueueConfig: {
+            rate: 3,
+            capacity: 4,
+          },
+        },
+        scheduleAt: Date.now(),
+        hash: "page-request-b",
+      },
+    })
+
+    expect(requestQueueInstances).toHaveLength(1)
+    expect(requestQueueInstances[0]?.setQueueOptions).toHaveBeenLastCalledWith({
+      rate: 3,
+      capacity: 4,
+    })
+  })
+
+  it("preserves provider overrides when the global webpage request config changes", async () => {
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const enqueueHandler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    await enqueueHandler({
+      data: {
+        text: "hello",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: {
+          ...baseProviderConfig,
+          requestQueueConfig: {
+            capacity: 2,
+          },
+        },
+        scheduleAt: Date.now(),
+        hash: "page-request",
+      },
+    })
+
+    const updateHandler = getRegisteredMessageHandler("setTranslateRequestQueueConfig")
+    await updateHandler({
+      data: {
+        rate: 99,
+        capacity: 100,
+      },
+    })
+
+    expect(requestQueueInstances[0]?.setQueueOptions).toHaveBeenLastCalledWith({
+      rate: 99,
+      capacity: 2,
+    })
+  })
+
+  it("uses the subtitles global request config as the fallback base before applying provider overrides", async () => {
+    const { setUpSubtitlesTranslationQueue } = await import("../translation-queues")
+    await setUpSubtitlesTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueSubtitlesTranslateRequest")
+    await handler({
+      data: {
+        text: "hello",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: {
+          ...baseProviderConfig,
+          requestQueueConfig: {
+            capacity: 2,
+          },
+        },
+        scheduleAt: Date.now(),
+        hash: "subtitle-request",
+      },
+    })
+
+    expect(requestQueueInstances).toHaveLength(1)
+    expect(requestQueueInstances[0]?.options).toEqual(expect.objectContaining({
+      rate: 10,
+      capacity: 2,
+    }))
+  })
+})

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -3,7 +3,7 @@ import type { LLMProviderConfig, ProviderConfig } from "@/types/config/provider"
 import type { BatchQueueConfig, RequestQueueConfig } from "@/types/config/translate"
 import type { SubtitlePromptContext, WebPagePromptContext } from "@/types/content"
 import type { PromptResolver } from "@/utils/host/translate/api/ai"
-import { isLLMProviderConfig } from "@/types/config/provider"
+import { isAPIProviderConfig, isLLMProviderConfig } from "@/types/config/provider"
 import { putBatchRequestRecord } from "@/utils/batch-request-record"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { BATCH_SEPARATOR } from "@/utils/constants/prompt"
@@ -158,7 +158,86 @@ interface TranslationQueueSetupConfig<TContext = unknown> {
   promptResolver: PromptResolver<TContext>
 }
 
-async function createTranslationQueues<TContext>(config: TranslationQueueSetupConfig<TContext>) {
+interface ProviderQueueBundle<TContext = unknown> {
+  requestQueue: RequestQueue
+  batchQueue: BatchQueue<TranslateBatchData<TContext>, string>
+  providerRequestQueueConfig?: Partial<RequestQueueConfig>
+}
+
+function getProviderRequestQueueConfigOverride(providerConfig: ProviderConfig): Partial<RequestQueueConfig> | undefined {
+  if (!isAPIProviderConfig(providerConfig)) {
+    return undefined
+  }
+
+  return providerConfig.requestQueueConfig
+}
+
+function mergeRequestQueueConfig(
+  baseConfig: RequestQueueConfig,
+  providerRequestQueueConfig?: Partial<RequestQueueConfig>,
+): RequestQueueConfig {
+  return {
+    ...baseConfig,
+    ...providerRequestQueueConfig,
+  }
+}
+
+function createProviderQueueRegistry<TContext>(config: TranslationQueueSetupConfig<TContext>) {
+  let globalRequestQueueConfig = { ...config.requestQueueConfig }
+  let globalBatchQueueConfig = { ...config.batchQueueConfig }
+  const queueBundleMap = new Map<string, ProviderQueueBundle<TContext>>()
+
+  return {
+    getOrCreateProviderQueues(providerConfig: ProviderConfig) {
+      const providerRequestQueueConfig = getProviderRequestQueueConfigOverride(providerConfig)
+      const mergedRequestQueueConfig = mergeRequestQueueConfig(globalRequestQueueConfig, providerRequestQueueConfig)
+      const existingBundle = queueBundleMap.get(providerConfig.id)
+
+      if (existingBundle) {
+        existingBundle.providerRequestQueueConfig = providerRequestQueueConfig
+        existingBundle.requestQueue.setQueueOptions(mergedRequestQueueConfig)
+        existingBundle.batchQueue.setBatchConfig(globalBatchQueueConfig)
+        return existingBundle
+      }
+
+      const queues = createTranslationQueues({
+        requestQueueConfig: mergedRequestQueueConfig,
+        batchQueueConfig: globalBatchQueueConfig,
+        promptResolver: config.promptResolver,
+      })
+      const nextBundle: ProviderQueueBundle<TContext> = {
+        ...queues,
+        providerRequestQueueConfig,
+      }
+      queueBundleMap.set(providerConfig.id, nextBundle)
+      return nextBundle
+    },
+    setGlobalRequestQueueConfig(nextConfig: Partial<RequestQueueConfig>) {
+      globalRequestQueueConfig = {
+        ...globalRequestQueueConfig,
+        ...nextConfig,
+      }
+
+      for (const bundle of queueBundleMap.values()) {
+        bundle.requestQueue.setQueueOptions(
+          mergeRequestQueueConfig(globalRequestQueueConfig, bundle.providerRequestQueueConfig),
+        )
+      }
+    },
+    setGlobalBatchQueueConfig(nextConfig: Partial<BatchQueueConfig>) {
+      globalBatchQueueConfig = {
+        ...globalBatchQueueConfig,
+        ...nextConfig,
+      }
+
+      for (const bundle of queueBundleMap.values()) {
+        bundle.batchQueue.setBatchConfig(globalBatchQueueConfig)
+      }
+    },
+  }
+}
+
+function createTranslationQueues<TContext>(config: TranslationQueueSetupConfig<TContext>) {
   const { rate, capacity } = config.requestQueueConfig
   const { maxCharactersPerBatch, maxItemsPerBatch } = config.batchQueueConfig
   const { promptResolver } = config
@@ -217,8 +296,7 @@ export async function setUpWebPageTranslationQueue() {
   const config = await ensureInitializedConfig()
 
   const { translate: { requestQueueConfig, batchQueueConfig } } = config ?? DEFAULT_CONFIG
-
-  const { requestQueue, batchQueue } = await createTranslationQueues({
+  const queueRegistry = createProviderQueueRegistry({
     requestQueueConfig,
     batchQueueConfig,
     promptResolver: getTranslatePrompt,
@@ -243,10 +321,12 @@ export async function setUpWebPageTranslationQueue() {
     }
 
     if (shouldUseBatchQueue(providerConfig)) {
+      const { batchQueue } = queueRegistry.getOrCreateProviderQueues(providerConfig)
       const data = { text, langConfig, providerConfig, hash, scheduleAt, context }
       result = await batchQueue.enqueue(data)
     }
     else {
+      const { requestQueue } = queueRegistry.getOrCreateProviderQueues(providerConfig)
       // Create thunk based on type and params
       const thunk = () => executeTranslate(text, langConfig, providerConfig, getTranslatePrompt)
       result = await requestQueue.enqueue(thunk, scheduleAt, hash)
@@ -271,17 +351,18 @@ export async function setUpWebPageTranslationQueue() {
       return null
     }
 
+    const { requestQueue } = queueRegistry.getOrCreateProviderQueues(providerConfig)
     return await getOrGenerateWebPageSummary(webTitle, webContent, providerConfig, requestQueue)
   })
 
   onMessage("setTranslateRequestQueueConfig", (message) => {
     const { data } = message
-    requestQueue.setQueueOptions(data)
+    queueRegistry.setGlobalRequestQueueConfig(data)
   })
 
   onMessage("setTranslateBatchQueueConfig", (message) => {
     const { data } = message
-    batchQueue.setBatchConfig(data)
+    queueRegistry.setGlobalBatchQueueConfig(data)
   })
 }
 
@@ -291,8 +372,7 @@ export async function setUpWebPageTranslationQueue() {
 export async function setUpSubtitlesTranslationQueue() {
   const config = await ensureInitializedConfig()
   const { videoSubtitles: { requestQueueConfig, batchQueueConfig } } = config ?? DEFAULT_CONFIG
-
-  const { requestQueue, batchQueue } = await createTranslationQueues({
+  const queueRegistry = createProviderQueueRegistry({
     requestQueueConfig,
     batchQueueConfig,
     promptResolver: getSubtitlesTranslatePrompt,
@@ -315,10 +395,12 @@ export async function setUpSubtitlesTranslationQueue() {
     }
 
     if (shouldUseBatchQueue(providerConfig)) {
+      const { batchQueue } = queueRegistry.getOrCreateProviderQueues(providerConfig)
       const data = { text, langConfig, providerConfig, hash, scheduleAt, context }
       result = await batchQueue.enqueue(data)
     }
     else {
+      const { requestQueue } = queueRegistry.getOrCreateProviderQueues(providerConfig)
       const thunk = () => executeTranslate(text, langConfig, providerConfig, getSubtitlesTranslatePrompt)
       result = await requestQueue.enqueue(thunk, scheduleAt, hash)
     }
@@ -341,16 +423,17 @@ export async function setUpSubtitlesTranslationQueue() {
       return null
     }
 
+    const { requestQueue } = queueRegistry.getOrCreateProviderQueues(providerConfig)
     return await getOrGenerateSubtitleSummary(videoTitle, subtitlesContext, providerConfig, requestQueue)
   })
 
   onMessage("setSubtitlesRequestQueueConfig", (message) => {
     const { data } = message
-    requestQueue.setQueueOptions(data)
+    queueRegistry.setGlobalRequestQueueConfig(data)
   })
 
   onMessage("setSubtitlesBatchQueueConfig", (message) => {
     const { data } = message
-    batchQueue.setBatchConfig(data)
+    queueRegistry.setGlobalBatchQueueConfig(data)
   })
 }

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/request-queue-override-field.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/request-queue-override-field.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import type { ReactNode } from "react"
+import type { APIProviderConfig } from "@/types/config/provider"
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import { useEffect, useState } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { formOpts, useAppForm } from "../form"
+import { RequestQueueOverrideField } from "../request-queue-override-field"
+
+vi.mock("#imports", () => ({
+  i18n: {
+    t: (key: string) => key,
+  },
+}))
+
+vi.mock("@/components/help-tooltip", () => ({
+  HelpTooltip: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}))
+
+const baseProviderConfig: APIProviderConfig = {
+  id: "provider-1",
+  name: "OpenAI",
+  enabled: true,
+  provider: "openai",
+  model: {
+    model: "gpt-5-mini",
+    isCustomModel: false,
+    customModel: null,
+  },
+}
+
+function RequestQueueOverrideFieldHarness({
+  initialConfig,
+}: {
+  initialConfig: APIProviderConfig
+}) {
+  const [providerConfig, setProviderConfig] = useState(initialConfig)
+  const form = useAppForm({
+    ...formOpts,
+    defaultValues: providerConfig,
+    onSubmit: async ({ value }) => {
+      setProviderConfig(value)
+    },
+  })
+
+  useEffect(() => {
+    form.reset(providerConfig)
+  }, [providerConfig, form])
+
+  return (
+    <>
+      <RequestQueueOverrideField form={form} />
+      <output aria-label="persisted-request-queue-config">{JSON.stringify(providerConfig.requestQueueConfig ?? null)}</output>
+    </>
+  )
+}
+
+describe("requestQueueOverrideField", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  it("persists a partial provider override without forcing other values", async () => {
+    render(<RequestQueueOverrideFieldHarness initialConfig={baseProviderConfig} />)
+
+    fireEvent.change(screen.getByRole("spinbutton", { name: /options.translation.requestQueueConfig.rate.title/ }), {
+      target: { value: "1" },
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+      await Promise.resolve()
+    })
+
+    expect(screen.getByLabelText("persisted-request-queue-config")).toHaveTextContent("{\"rate\":1}")
+  })
+
+  it("removes the override when every provider-specific value is cleared", async () => {
+    render(
+      <RequestQueueOverrideFieldHarness
+        initialConfig={{
+          ...baseProviderConfig,
+          requestQueueConfig: {
+            rate: 1,
+            capacity: 2,
+          },
+        }}
+      />,
+    )
+
+    fireEvent.change(screen.getByRole("spinbutton", { name: /options.translation.requestQueueConfig.rate.title/ }), {
+      target: { value: "" },
+    })
+    fireEvent.change(screen.getByRole("spinbutton", { name: /options.translation.requestQueueConfig.capacity.title/ }), {
+      target: { value: "" },
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+      await Promise.resolve()
+    })
+
+    expect(screen.getByLabelText("persisted-request-queue-config")).toHaveTextContent("null")
+  })
+})

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
@@ -37,6 +37,7 @@ import { ConnectionOptionsField } from "./connection-options-field"
 import { FeatureProviderSection } from "./feature-provider-section"
 import { formOpts, useAppForm } from "./form"
 import { ProviderOptionsField } from "./provider-options-field"
+import { RequestQueueOverrideField } from "./request-queue-override-field"
 import { TemperatureField } from "./temperature-field"
 import { TranslateModelSelector } from "./translate-model-selector"
 
@@ -167,6 +168,7 @@ export function ProviderConfigForm() {
           <FeatureProviderSection form={form} />
           {isLLM && (
             <AdvancedOptionsSection>
+              <RequestQueueOverrideField form={form} />
               <TemperatureField form={form} />
               <ProviderOptionsField form={form} />
             </AdvancedOptionsSection>

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/request-queue-override-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/request-queue-override-field.tsx
@@ -1,0 +1,140 @@
+import type { APIProviderConfig } from "@/types/config/provider"
+import type { RequestQueueConfig } from "@/types/config/translate"
+import { i18n } from "#imports"
+import { useStore } from "@tanstack/react-form"
+import { useEffect, useEffectEvent, useState } from "react"
+import { toast } from "sonner"
+import { HelpTooltip } from "@/components/help-tooltip"
+import { Field, FieldContent, FieldGroup, FieldLabel } from "@/components/ui/base-ui/field"
+import { Input } from "@/components/ui/base-ui/input"
+import { useDebouncedValue } from "@/hooks/use-debounced-value"
+import { isLLMProviderConfig } from "@/types/config/provider"
+import { requestQueueConfigSchema } from "@/types/config/translate"
+import { compactObject } from "@/types/utils"
+import { MIN_TRANSLATE_CAPACITY, MIN_TRANSLATE_RATE } from "@/utils/constants/translate"
+import { withForm } from "./form"
+
+type RequestQueueKey = keyof RequestQueueConfig
+
+type LocalRequestQueueValues = Record<RequestQueueKey, string>
+
+const propertyInfo = {
+  capacity: {
+    label: i18n.t("options.translation.requestQueueConfig.capacity.title"),
+    description: i18n.t("options.translation.requestQueueConfig.capacity.description"),
+    min: MIN_TRANSLATE_CAPACITY,
+  },
+  rate: {
+    label: i18n.t("options.translation.requestQueueConfig.rate.title"),
+    description: i18n.t("options.translation.requestQueueConfig.rate.description"),
+    min: MIN_TRANSLATE_RATE,
+  },
+} satisfies Record<RequestQueueKey, { label: string, description: string, min: number }>
+
+function toLocalValues(requestQueueConfig?: Partial<RequestQueueConfig>): LocalRequestQueueValues {
+  return {
+    capacity: requestQueueConfig?.capacity?.toString() ?? "",
+    rate: requestQueueConfig?.rate?.toString() ?? "",
+  }
+}
+
+function areSameRequestQueueConfig(
+  left?: Partial<RequestQueueConfig>,
+  right?: Partial<RequestQueueConfig>,
+): boolean {
+  return left?.capacity === right?.capacity && left?.rate === right?.rate
+}
+
+function parseRequestQueueOverride(localValues: LocalRequestQueueValues) {
+  const parsed = compactObject({
+    capacity: localValues.capacity === "" ? undefined : Number(localValues.capacity),
+    rate: localValues.rate === "" ? undefined : Number(localValues.rate),
+  }) as Partial<RequestQueueConfig>
+
+  const parseResult = requestQueueConfigSchema.partial().safeParse(parsed)
+  if (!parseResult.success) {
+    return { success: false as const, error: parseResult.error.issues[0]?.message ?? "Invalid request queue config" }
+  }
+
+  return {
+    success: true as const,
+    value: Object.keys(parsed).length > 0 ? parsed : undefined,
+  }
+}
+
+export const RequestQueueOverrideField = withForm({
+  ...{ defaultValues: {} as APIProviderConfig },
+  render: function Render({ form }) {
+    const providerConfig = useStore(form.store, state => state.values)
+    const isLLMProvider = isLLMProviderConfig(providerConfig)
+    const [localValues, setLocalValues] = useState(() => toLocalValues(providerConfig.requestQueueConfig))
+
+    const syncLocalValues = useEffectEvent(() => {
+      // eslint-disable-next-line react/set-state-in-effect
+      setLocalValues(toLocalValues(providerConfig.requestQueueConfig))
+    })
+
+    useEffect(() => {
+      syncLocalValues()
+    }, [providerConfig.id, providerConfig.requestQueueConfig?.capacity, providerConfig.requestQueueConfig?.rate])
+
+    const debouncedValues = useDebouncedValue(localValues, 500)
+
+    useEffect(() => {
+      const parseResult = parseRequestQueueOverride(debouncedValues)
+      if (!parseResult.success) {
+        const hasValue = Object.values(debouncedValues).some(value => value !== "")
+        if (hasValue) {
+          toast.error(parseResult.error)
+        }
+        return
+      }
+
+      if (areSameRequestQueueConfig(providerConfig.requestQueueConfig, parseResult.value)) {
+        return
+      }
+
+      form.setFieldValue("requestQueueConfig", parseResult.value)
+      void form.handleSubmit()
+    }, [debouncedValues, form, providerConfig.requestQueueConfig])
+
+    if (!isLLMProvider) {
+      return null
+    }
+
+    return (
+      <FieldGroup>
+        <div className="flex items-center gap-1.5">
+          <span>{i18n.t("options.apiProviders.form.requestQueueConfigOverride")}</span>
+          <HelpTooltip>{i18n.t("options.apiProviders.form.requestQueueConfigOverrideHint")}</HelpTooltip>
+        </div>
+        {(Object.keys(propertyInfo) as RequestQueueKey[]).map((property) => {
+          const info = propertyInfo[property]
+          const inputId = `provider-request-queue-${property}-${providerConfig.id}`
+
+          return (
+            <Field key={property} orientation="responsive">
+              <FieldContent className="self-center">
+                <FieldLabel htmlFor={inputId}>
+                  {info.label}
+                  <HelpTooltip>{info.description}</HelpTooltip>
+                </FieldLabel>
+              </FieldContent>
+              <Input
+                id={inputId}
+                className="w-40 shrink-0"
+                type="number"
+                min={info.min}
+                value={localValues[property]}
+                onChange={event => setLocalValues(prev => ({
+                  ...prev,
+                  [property]: event.target.value,
+                }))}
+              />
+            </Field>
+          )
+        })}
+      </FieldGroup>
+    )
+  },
+})

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -131,6 +131,8 @@ options:
         noModelsFound: No models found
       featureProviders: Feature Providers
       advancedOptions: Advanced Options
+      requestQueueConfigOverride: Request Rate Override
+      requestQueueConfigOverrideHint: Optional per-provider override for translation request rate. Leave values empty to use the global setting for the current feature.
       connectionOptionLabels:
         region: Region
       temperature: Temperature

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -131,6 +131,8 @@ options:
         noModelsFound: 未找到模型
       featureProviders: 功能提供商
       advancedOptions: 高级选项
+      requestQueueConfigOverride: 请求速率覆盖
+      requestQueueConfigOverrideHint: 可选的供应商专属翻译请求速率覆盖。留空时会使用当前功能的全局设置。
       connectionOptionLabels:
         region: 区域
       temperature: 温度

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -130,6 +130,8 @@ options:
         noModelsFound: 未找到模型
       featureProviders: 功能提供商
       advancedOptions: 進階選項
+      requestQueueConfigOverride: 請求速率覆寫
+      requestQueueConfigOverrideHint: 可選的提供者專屬翻譯請求速率覆寫。留空時會使用目前功能的全域設定。
       connectionOptionLabels:
         region: 區域
       temperature: 溫度

--- a/src/types/config/provider.ts
+++ b/src/types/config/provider.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 import { LLM_PROVIDER_MODELS, NON_API_TRANSLATE_PROVIDERS, NON_API_TRANSLATE_PROVIDERS_MAP, PURE_TRANSLATE_PROVIDERS } from "@/utils/constants/models"
+import { requestQueueConfigSchema } from "./translate"
 
 // Re-export for external consumers
 export { LLM_PROVIDER_MODELS, NON_API_TRANSLATE_PROVIDERS, NON_API_TRANSLATE_PROVIDERS_MAP, PURE_TRANSLATE_PROVIDERS }
@@ -124,6 +125,7 @@ export const baseAPIProviderConfigSchema = baseProviderConfigSchema.extend({
   temperature: z.number().min(0).optional(),
   providerOptions: z.record(z.string(), z.any()).optional(),
   connectionOptions: z.record(z.string(), z.any()).optional(),
+  requestQueueConfig: requestQueueConfigSchema.partial().optional(),
 })
 
 export const baseCustomLLMProviderConfigSchema = baseAPIProviderConfigSchema.extend({


### PR DESCRIPTION
## Summary
- add an optional per-provider request rate override section under API provider advanced settings
- merge provider-specific request queue overrides with the feature-level global request settings
- add regression tests for provider override persistence and queue selection behavior

## Before / After
| Before | After |
| --- | --- |
| ![Before](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog-issue-1383-before.png) | ![After](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog-issue-1383-after.png) |

## Test Plan
- `SKIP_FREE_API=true pnpm exec vitest run src/entrypoints/background/__tests__/translation-queues.test.ts src/entrypoints/background/__tests__/provider-request-queue-override.test.ts src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/request-queue-override-field.test.tsx`
- `pnpm type-check`

Closes #1383
