### PR TITLE
fix(extension): ensure webpage context returns markdown

### DIFF
--- a/.changeset/fix-defuddle-markdown.md
+++ b/.changeset/fix-defuddle-markdown.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(extension): ensure Defuddle webpage context returns Markdown

--- a/src/utils/host/translate/__tests__/webpage-context.test.ts
+++ b/src/utils/host/translate/__tests__/webpage-context.test.ts
@@ -2,7 +2,8 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-const { mockDefuddleConstructor, mockParse, mockWarn } = vi.hoisted(() => ({
+const { mockCreateMarkdownContent, mockDefuddleConstructor, mockParse, mockWarn } = vi.hoisted(() => ({
+  mockCreateMarkdownContent: vi.fn(),
   mockDefuddleConstructor: vi.fn(),
   mockParse: vi.fn(),
   mockWarn: vi.fn(),
@@ -16,8 +17,9 @@ vi.mock("@/utils/logger", () => ({
 
 async function loadModule() {
   vi.resetModules()
-  vi.doMock("defuddle", () => ({
+  vi.doMock("defuddle/full", () => ({
     __esModule: true,
+    createMarkdownContent: mockCreateMarkdownContent,
     default: class MockDefuddle {
       constructor(...args: unknown[]) {
         mockDefuddleConstructor(...args)
@@ -34,10 +36,15 @@ async function loadModule() {
 describe("getOrCreateWebPageContext", () => {
   beforeEach(() => {
     mockDefuddleConstructor.mockReset()
+    mockCreateMarkdownContent.mockReset()
     mockParse.mockReset()
     mockWarn.mockReset()
 
-    mockParse.mockReturnValue({ contentMarkdown: "# Readable page body" })
+    mockParse.mockReturnValue({
+      content: "<h1>Readable page body</h1>",
+      contentMarkdown: "# Readable page body",
+    })
+    mockCreateMarkdownContent.mockReturnValue("# Converted readable page body")
 
     document.title = "Original Title"
     document.body.innerHTML = "<main>Page body</main>"
@@ -69,10 +76,23 @@ describe("getOrCreateWebPageContext", () => {
 
     expect(result?.webContent).toBe("# Readable page body")
     expect(mockDefuddleConstructor).toHaveBeenCalledWith(document, {
-      markdown: true,
+      separateMarkdown: true,
       url: window.location.href,
       useAsync: false,
     })
+  })
+
+  it("converts Defuddle HTML content when a separate markdown field is missing", async () => {
+    mockParse.mockReturnValueOnce({ content: "<h1>Readable page body</h1>" })
+    const { getOrCreateWebPageContext } = await loadModule()
+
+    const result = await getOrCreateWebPageContext()
+
+    expect(result?.webContent).toBe("# Converted readable page body")
+    expect(mockCreateMarkdownContent).toHaveBeenCalledWith(
+      "<h1>Readable page body</h1>",
+      window.location.href,
+    )
   })
 
   it("refreshes the cached title and content after the URL changes", async () => {

--- a/src/utils/host/translate/webpage-context.ts
+++ b/src/utils/host/translate/webpage-context.ts
@@ -11,16 +11,17 @@ let cachedWebPageContext: CachedWebPageContext | null = null
 
 async function extractWebpageContent(): Promise<string> {
   try {
-    const { default: Defuddle } = await import("defuddle")
+    const { default: Defuddle, createMarkdownContent } = await import("defuddle/full")
     const result = new Defuddle(document, {
-      markdown: true,
+      separateMarkdown: true,
       url: window.location.href,
       useAsync: false,
     }).parse()
 
-    const markdownContent = result.contentMarkdown || result.content
-    if (markdownContent)
-      return markdownContent
+    if (result.contentMarkdown)
+      return result.contentMarkdown
+    if (result.content)
+      return createMarkdownContent(result.content, window.location.href)
   }
   catch (error) {
     logger.warn("Defuddle parsing failed, falling back to body text:", error)


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Ensures AI Content Aware webpage context receives Markdown from Defuddle instead of cleaned HTML.

- Dynamically imports `defuddle/full`, which includes Markdown conversion support.
- Requests `separateMarkdown: true` and prefers `contentMarkdown` when available.
- Converts fallback HTML content with `createMarkdownContent(...)` instead of returning HTML directly.
- Adds regression coverage for the missing-`contentMarkdown` fallback path.
- Adds a patch changeset for the extension package.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Commands run:

- `pnpm exec vitest run src/utils/host/translate/__tests__/webpage-context.test.ts`
- `pnpm type-check`
- `pnpm exec eslint src/utils/host/translate/webpage-context.ts src/utils/host/translate/__tests__/webpage-context.test.ts`
- Pre-push hook: `nx run @read-frog/extension:lint`
- Pre-push hook: `nx run @read-frog/extension:type-check`
- Pre-push hook: `nx run @read-frog/extension:test` (119 files, 1037 tests passed)

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This keeps the heavier Defuddle full bundle behind the existing dynamic import path, so it is only loaded when webpage context is requested.
