### PR TITLE
feat(subtitles): add subtitle style settings panel

### DIFF
--- a/.changeset/golden-styles-shine.md
+++ b/.changeset/golden-styles-shine.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(subtitles): add subtitle style settings panel with Trancy-inspired UI

--- a/src/components/ui/base-ui/select.tsx
+++ b/src/components/ui/base-ui/select.tsx
@@ -14,8 +14,8 @@ const selectTriggerVariants = cva(
   {
     variants: {
       variant: {
-        default: "shadow-xs border-input data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 focus-visible:ring-3 aria-invalid:ring-3",
-        dark: "border-white/10 bg-white/6 text-white/92 hover:bg-white/10 focus-visible:border-white/18 focus-visible:ring-white/18 focus-visible:ring-1",
+        default: "shadow-xs border-input data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 focus-visible:ring-3 aria-invalid:ring-3 [&_[data-slot=select-icon]]:text-muted-foreground",
+        dark: "border-white/10 bg-white/6 text-white/92 hover:bg-white/10 focus-visible:border-white/18 focus-visible:ring-white/18 focus-visible:ring-1 [&_[data-slot=select-icon]]:text-white/62",
       },
       size: {
         default: "h-8",
@@ -94,8 +94,9 @@ function SelectTrigger({
     >
       {children}
       <SelectPrimitive.Icon
+        data-slot="select-icon"
         render={
-          <IconChevronDown className={cn("size-4 pointer-events-none", variant === "dark" ? "text-white/62" : "text-muted-foreground")} />
+          <IconChevronDown className="size-4 pointer-events-none" />
         }
       />
     </SelectPrimitive.Trigger>

--- a/src/components/ui/base-ui/select.tsx
+++ b/src/components/ui/base-ui/select.tsx
@@ -1,11 +1,63 @@
+import type { VariantProps } from "class-variance-authority"
 import { Select as SelectPrimitive } from "@base-ui/react/select"
 import { IconCheck, IconChevronDown, IconChevronUp } from "@tabler/icons-react"
 
+import { cva } from "class-variance-authority"
 import * as React from "react"
 import { SHARED_POPUP_CLOSED_STATE_CLASS } from "@/components/ui/base-ui/popup-animation-classes"
 import { cn } from "@/utils/styles/utils"
 
 const Select = SelectPrimitive.Root
+
+const selectTriggerVariants = cva(
+  "gap-1.5 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-sm transition-colors select-none flex w-fit items-center justify-between whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "shadow-xs border-input data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 focus-visible:ring-3 aria-invalid:ring-3",
+        dark: "border-white/10 bg-white/6 text-white/92 hover:bg-white/10 focus-visible:border-white/18 focus-visible:ring-white/18 focus-visible:ring-1",
+      },
+      size: {
+        default: "h-8",
+        sm: "h-7 rounded-[min(var(--radius-md),10px)]",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+)
+
+const selectContentVariants = cva(
+  "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-36 rounded-lg shadow-md duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto data-[align-trigger=true]:animate-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-popover text-popover-foreground ring-foreground/10 ring-1",
+        dark: "bg-[rgba(24,26,30,0.96)] text-white/90 ring-white/10 ring-1 backdrop-blur-xl",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+)
+
+const selectItemVariants = cva(
+  "gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground",
+        dark: "focus:bg-white/10 focus:text-white",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+)
 
 function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
   return (
@@ -29,26 +81,21 @@ function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
 
 function SelectTrigger({
   className,
+  variant = "default",
   size = "default",
   children,
   ...props
-}: SelectPrimitive.Trigger.Props & {
-  size?: "sm" | "default"
-}) {
+}: SelectPrimitive.Trigger.Props & VariantProps<typeof selectTriggerVariants>) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
-      data-size={size}
-      className={cn(
-        "shadow-xs border-input data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 gap-1.5 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-sm transition-colors select-none focus-visible:ring-3 aria-invalid:ring-3 data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4 flex w-fit items-center justify-between whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
-      )}
+      className={cn(selectTriggerVariants({ variant, size, className }))}
       {...props}
     >
       {children}
       <SelectPrimitive.Icon
         render={
-          <IconChevronDown className="text-muted-foreground size-4 pointer-events-none" />
+          <IconChevronDown className={cn("size-4 pointer-events-none", variant === "dark" ? "text-white/62" : "text-muted-foreground")} />
         }
       />
     </SelectPrimitive.Trigger>
@@ -58,6 +105,7 @@ function SelectTrigger({
 function SelectContent({
   container,
   className,
+  variant = "default",
   children,
   positionerClassName,
   side = "bottom",
@@ -68,6 +116,7 @@ function SelectContent({
   ...props
 }: SelectPrimitive.Popup.Props
   & Pick<SelectPrimitive.Portal.Props, "container">
+  & VariantProps<typeof selectContentVariants>
   & {
     positionerClassName?: string
   }
@@ -83,12 +132,12 @@ function SelectContent({
         align={align}
         alignOffset={alignOffset}
         alignItemWithTrigger={alignItemWithTrigger}
-        className={cn("isolate z-50", positionerClassName)}
+        className={cn("pointer-events-auto isolate z-50", positionerClassName)}
       >
         <SelectPrimitive.Popup
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
-          className={cn("bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-lg shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto data-[align-trigger=true]:animate-none", SHARED_POPUP_CLOSED_STATE_CLASS, className)}
+          className={cn(selectContentVariants({ variant }), SHARED_POPUP_CLOSED_STATE_CLASS, className)}
           {...props}
         >
           <SelectScrollUpButton />
@@ -115,16 +164,14 @@ function SelectLabel({
 
 function SelectItem({
   className,
+  variant = "default",
   children,
   ...props
-}: SelectPrimitive.Item.Props) {
+}: SelectPrimitive.Item.Props & VariantProps<typeof selectItemVariants>) {
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
-      className={cn(
-        "focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-        className,
-      )}
+      className={cn(selectItemVariants({ variant, className }))}
       {...props}
     >
       <SelectPrimitive.ItemText className="flex flex-1 gap-2 shrink-0 whitespace-nowrap">

--- a/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/panel-shell.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/panel-shell.tsx
@@ -66,7 +66,7 @@ export function PanelShell({
   return (
     <div
       ref={rootRef}
-      className="absolute inset-0 z-40 pointer-events-none overflow-visible font-light"
+      className="absolute inset-0 z-40 pointer-events-none overflow-visible font-light [container-type:size]"
     >
       <Activity mode={open ? "visible" : "hidden"}>
         <div
@@ -79,7 +79,8 @@ export function PanelShell({
           <div
             ref={panelRef}
             data-slot="subtitles-settings-panel"
-            className="bg-popover text-popover-foreground border-border pointer-events-auto relative isolate z-40 w-[min(17rem,calc(100vw-2rem))] overflow-hidden rounded-[20px] border shadow-floating backdrop-blur-2xl"
+            className="bg-popover text-popover-foreground border-border pointer-events-auto relative isolate z-40 flex w-[min(19rem,calc(100vw-2rem))] flex-col overflow-hidden rounded-[20px] border shadow-floating backdrop-blur-2xl"
+            style={{ maxHeight: `calc(100cqh - ${bottomOffset}px - 1rem)` }}
           >
             {header && (
               <div className="border-border flex items-center gap-3 border-b px-4 pt-3 pb-3">
@@ -94,13 +95,13 @@ export function PanelShell({
                   <IconChevronLeft className="size-4" />
                 </Button>
 
-                <div className="min-w-0 truncate text-sm font-medium">
+                <div className="min-w-0 truncate text-xs font-medium">
                   {header.title}
                 </div>
               </div>
             )}
 
-            <div className="min-h-0 overflow-hidden">
+            <div className="min-h-0 flex-1 overflow-y-auto">
               {transition
                 ? (
                     <TransitionContent direction={transition.direction} transitionKey={transition.key}>

--- a/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/views/index.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/views/index.tsx
@@ -20,7 +20,6 @@ export const SUBPAGES: SubpageConfig[] = [
     title: i18n.t("options.videoSubtitles.style.title"),
     icon: <IconAdjustmentsHorizontal className="size-4" />,
     component: StyleView,
-    hidden: true,
   },
 ]
 

--- a/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/views/style.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/views/style.tsx
@@ -1,9 +1,250 @@
+import type { ReactNode } from "react"
+import type { SubtitlesDisplayMode, SubtitlesFontFamily, SubtitlesTranslationPosition, SubtitleTextStyle } from "@/types/config/subtitles"
 import { i18n } from "#imports"
+import { IconLanguage, IconRefresh, IconSettings, IconSubtitles } from "@tabler/icons-react"
+import { deepmerge } from "deepmerge-ts"
+import { useAtom } from "jotai"
+import { Activity, use } from "react"
+import { Button } from "@/components/ui/base-ui/button"
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/base-ui/select"
+import { Slider } from "@/components/ui/base-ui/slider"
+import { configFieldsAtomMap } from "@/utils/atoms/config"
+import {
+  DEFAULT_BACKGROUND_OPACITY,
+  DEFAULT_DISPLAY_MODE,
+  DEFAULT_FONT_FAMILY,
+  DEFAULT_FONT_SCALE,
+  DEFAULT_FONT_WEIGHT,
+  DEFAULT_SUBTITLE_COLOR,
+  DEFAULT_TRANSLATION_POSITION,
+  MAX_BACKGROUND_OPACITY,
+  MAX_FONT_SCALE,
+  MAX_FONT_WEIGHT,
+  MIN_BACKGROUND_OPACITY,
+  MIN_FONT_SCALE,
+  MIN_FONT_WEIGHT,
+  SUBTITLE_FONT_FAMILIES,
+} from "@/utils/constants/subtitles"
+import { ShadowWrapperContext } from "@/utils/react-shadow-host/create-shadow-host"
+import { subtitlesStore } from "../../../atoms"
+
+const SELECT_TRIGGER_CLASS = "min-w-[5.5rem] text-[13px] [&_[data-slot=select-value]]:text-white/92"
+const SELECT_CONTENT_CLASS = "[&_[role=option]]:text-[13px]"
+const SLIDER_CLASS = "[&_[role=slider]]:bg-[#d8a94b] [&_[role=slider]]:border-0 [&_[role=slider]]:shadow-[0_2px_4px_rgba(0,0,0,0.3)] [&_[data-slot=slider-track]]:bg-white/10 [&_[data-slot=slider-range]]:bg-[#d8a94b]"
+
+const FONT_FAMILY_OPTIONS = Object.keys(SUBTITLE_FONT_FAMILIES) as SubtitlesFontFamily[]
+
+function SettingsGroup({ icon, title, onReset, children }: {
+  icon: ReactNode
+  title: string
+  onReset: () => void
+  children: ReactNode
+}) {
+  return (
+    <div className="mb-4">
+      <div className="mb-1.5 flex items-center justify-between px-0.5">
+        <div className="flex items-center gap-1.5 text-[13px] font-medium text-white/90">
+          {icon}
+          {title}
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={onReset}
+          className="cursor-pointer text-white/62 hover:bg-white/8 hover:text-white/90"
+        >
+          <IconRefresh className="size-3.5" />
+        </Button>
+      </div>
+      <div className="divide-y divide-white/6 rounded-xl bg-white/[0.04]">
+        {children}
+      </div>
+    </div>
+  )
+}
+
+function SettingRow({ label, children }: { label: string, children: ReactNode }) {
+  return (
+    <div className="flex items-center justify-between px-3 py-2.5">
+      <span className="text-[13px] text-white/92">{label}</span>
+      {children}
+    </div>
+  )
+}
+
+function SliderRow({ label, value, display, min, max, step, onChange }: {
+  label: string
+  value: number
+  display: string
+  min: number
+  max: number
+  step: number
+  onChange: (v: number) => void
+}) {
+  return (
+    <div className="px-3 py-2.5">
+      <div className="mb-3.5 flex items-center justify-between">
+        <span className="text-[13px] text-white/92">{label}</span>
+        <span className="text-[12px] text-white/62">{display}</span>
+      </div>
+      <Slider
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onValueChange={v => onChange(v as number)}
+        className={SLIDER_CLASS}
+      />
+    </div>
+  )
+}
+
+function TextStyleGroup({ icon, title, textStyle, onChange, onReset, portalContainer }: {
+  icon: ReactNode
+  title: string
+  textStyle: SubtitleTextStyle
+  onChange: (patch: Partial<SubtitleTextStyle>) => void
+  onReset: () => void
+  portalContainer: HTMLElement | null
+}) {
+  return (
+    <SettingsGroup icon={icon} title={title} onReset={onReset}>
+      <SliderRow
+        label={i18n.t("options.videoSubtitles.style.fontScale")}
+        value={textStyle.fontScale}
+        display={`${textStyle.fontScale}%`}
+        min={MIN_FONT_SCALE}
+        max={MAX_FONT_SCALE}
+        step={10}
+        onChange={v => onChange({ fontScale: v })}
+      />
+
+      <SettingRow label={i18n.t("options.videoSubtitles.style.color")}>
+        <input
+          type="color"
+          value={textStyle.color}
+          onChange={e => onChange({ color: e.target.value })}
+          className="h-6 w-6 cursor-pointer rounded border border-white/15 bg-transparent p-0.5"
+        />
+      </SettingRow>
+
+      <SettingRow label={i18n.t("options.videoSubtitles.style.fontFamily")}>
+        <Select value={textStyle.fontFamily} onValueChange={v => v && onChange({ fontFamily: v as SubtitlesFontFamily })}>
+          <SelectTrigger variant="dark" size="sm" className={SELECT_TRIGGER_CLASS}>
+            <SelectValue>{textStyle.fontFamily}</SelectValue>
+          </SelectTrigger>
+          <SelectContent variant="dark" container={portalContainer} className={SELECT_CONTENT_CLASS}>
+            <SelectGroup>
+              {FONT_FAMILY_OPTIONS.map(key => (
+                <SelectItem key={key} variant="dark" value={key}>{key}</SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </SettingRow>
+
+      <SliderRow
+        label={i18n.t("options.videoSubtitles.style.fontWeight")}
+        value={textStyle.fontWeight}
+        display={String(textStyle.fontWeight)}
+        min={MIN_FONT_WEIGHT}
+        max={MAX_FONT_WEIGHT}
+        step={100}
+        onChange={v => onChange({ fontWeight: v })}
+      />
+    </SettingsGroup>
+  )
+}
+
+const DEFAULT_TEXT_STYLE: SubtitleTextStyle = {
+  fontFamily: DEFAULT_FONT_FAMILY,
+  fontScale: DEFAULT_FONT_SCALE,
+  color: DEFAULT_SUBTITLE_COLOR,
+  fontWeight: DEFAULT_FONT_WEIGHT,
+}
 
 export function StyleView() {
+  const [config, setConfig] = useAtom(configFieldsAtomMap.videoSubtitles, { store: subtitlesStore })
+  const portalContainer = use(ShadowWrapperContext)
+  const { displayMode, translationPosition, container } = config.style
+
+  const updateStyle = (patch: Record<string, unknown>) => {
+    void setConfig(deepmerge(config, { style: patch }))
+  }
+
   return (
-    <div className="text-muted-foreground px-4 py-4 text-sm leading-6">
-      {i18n.t("options.videoSubtitles.style.description")}
+    <div className="min-h-[calc(100cqh-6rem)] px-3 pb-4 pt-3">
+      <SettingsGroup
+        icon={<IconSettings className="size-3.5" />}
+        title={i18n.t("options.videoSubtitles.style.generalSettings")}
+        onReset={() => updateStyle({
+          displayMode: DEFAULT_DISPLAY_MODE,
+          translationPosition: DEFAULT_TRANSLATION_POSITION,
+          container: { backgroundOpacity: DEFAULT_BACKGROUND_OPACITY },
+        })}
+      >
+        <SettingRow label={i18n.t("options.videoSubtitles.style.displayMode.title")}>
+          <Select value={displayMode} onValueChange={(v: SubtitlesDisplayMode | null) => v && updateStyle({ displayMode: v })}>
+            <SelectTrigger variant="dark" size="sm" className={SELECT_TRIGGER_CLASS}>
+              <SelectValue>{i18n.t(`options.videoSubtitles.style.displayMode.${displayMode}`)}</SelectValue>
+            </SelectTrigger>
+            <SelectContent variant="dark" container={portalContainer} className={SELECT_CONTENT_CLASS}>
+              <SelectGroup>
+                <SelectItem variant="dark" value="bilingual">{i18n.t("options.videoSubtitles.style.displayMode.bilingual")}</SelectItem>
+                <SelectItem variant="dark" value="originalOnly">{i18n.t("options.videoSubtitles.style.displayMode.originalOnly")}</SelectItem>
+                <SelectItem variant="dark" value="translationOnly">{i18n.t("options.videoSubtitles.style.displayMode.translationOnly")}</SelectItem>
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </SettingRow>
+
+        <Activity mode={displayMode === "bilingual" ? "visible" : "hidden"}>
+          <SettingRow label={i18n.t("options.videoSubtitles.style.translationPosition.title")}>
+            <Select value={translationPosition} onValueChange={(v: SubtitlesTranslationPosition | null) => v && updateStyle({ translationPosition: v })}>
+              <SelectTrigger variant="dark" size="sm" className={SELECT_TRIGGER_CLASS}>
+                <SelectValue>{i18n.t(`options.videoSubtitles.style.translationPosition.${translationPosition}`)}</SelectValue>
+              </SelectTrigger>
+              <SelectContent variant="dark" container={portalContainer} className={SELECT_CONTENT_CLASS}>
+                <SelectGroup>
+                  <SelectItem variant="dark" value="above">{i18n.t("options.videoSubtitles.style.translationPosition.above")}</SelectItem>
+                  <SelectItem variant="dark" value="below">{i18n.t("options.videoSubtitles.style.translationPosition.below")}</SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </SettingRow>
+        </Activity>
+
+        <SliderRow
+          label={i18n.t("options.videoSubtitles.style.backgroundOpacity")}
+          value={container.backgroundOpacity}
+          display={`${container.backgroundOpacity}%`}
+          min={MIN_BACKGROUND_OPACITY}
+          max={MAX_BACKGROUND_OPACITY}
+          step={5}
+          onChange={v => updateStyle({ container: { backgroundOpacity: v } })}
+        />
+      </SettingsGroup>
+
+      <TextStyleGroup
+        type="main"
+        icon={<IconSubtitles className="size-3.5" />}
+        title={i18n.t("options.videoSubtitles.style.mainSubtitle")}
+        textStyle={config.style.main}
+        onChange={patch => updateStyle({ main: patch })}
+        onReset={() => updateStyle({ main: DEFAULT_TEXT_STYLE })}
+        portalContainer={portalContainer}
+      />
+
+      <TextStyleGroup
+        type="translation"
+        icon={<IconLanguage className="size-3.5" />}
+        title={i18n.t("options.videoSubtitles.style.translationSubtitle")}
+        textStyle={config.style.translation}
+        onChange={patch => updateStyle({ translation: patch })}
+        onReset={() => updateStyle({ translation: DEFAULT_TEXT_STYLE })}
+        portalContainer={portalContainer}
+      />
     </div>
   )
 }

--- a/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/views/style.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/views/style.tsx
@@ -30,7 +30,7 @@ import { subtitlesStore } from "../../../atoms"
 
 const SELECT_TRIGGER_CLASS = "min-w-[5.5rem] text-[13px] [&_[data-slot=select-value]]:text-white/92"
 const SELECT_CONTENT_CLASS = "[&_[role=option]]:text-[13px]"
-const SLIDER_CLASS = "[&_[role=slider]]:bg-[#d8a94b] [&_[role=slider]]:border-0 [&_[role=slider]]:shadow-[0_2px_4px_rgba(0,0,0,0.3)] [&_[data-slot=slider-track]]:bg-white/10 [&_[data-slot=slider-range]]:bg-[#d8a94b]"
+const SLIDER_CLASS = "[&_[role=slider]]:bg-white [&_[role=slider]]:border-0 [&_[role=slider]]:shadow-[0_2px_4px_rgba(0,0,0,0.3)] [&_[data-slot=slider-track]]:bg-white/10 [&_[data-slot=slider-range]]:bg-white/60"
 
 const FONT_FAMILY_OPTIONS = Object.keys(SUBTITLE_FONT_FAMILIES) as SubtitlesFontFamily[]
 

--- a/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/views/style.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/views/style.tsx
@@ -227,7 +227,6 @@ export function StyleView() {
       </SettingsGroup>
 
       <TextStyleGroup
-        type="main"
         icon={<IconSubtitles className="size-3.5" />}
         title={i18n.t("options.videoSubtitles.style.mainSubtitle")}
         textStyle={config.style.main}
@@ -237,7 +236,6 @@ export function StyleView() {
       />
 
       <TextStyleGroup
-        type="translation"
         icon={<IconLanguage className="size-3.5" />}
         title={i18n.t("options.videoSubtitles.style.translationSubtitle")}
         textStyle={config.style.translation}

--- a/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/views/style.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/views/style.tsx
@@ -30,7 +30,7 @@ import { subtitlesStore } from "../../../atoms"
 
 const SELECT_TRIGGER_CLASS = "min-w-[5.5rem] text-[13px] [&_[data-slot=select-value]]:text-white/92"
 const SELECT_CONTENT_CLASS = "[&_[role=option]]:text-[13px]"
-const SLIDER_CLASS = "[&_[role=slider]]:bg-white [&_[role=slider]]:border-0 [&_[role=slider]]:shadow-[0_2px_4px_rgba(0,0,0,0.3)] [&_[data-slot=slider-track]]:bg-white/10 [&_[data-slot=slider-range]]:bg-white/60"
+const SLIDER_CLASS = "[&_[role=slider]]:border-0 [&_[role=slider]]:shadow-[0_2px_4px_rgba(0,0,0,0.3)]"
 
 const FONT_FAMILY_OPTIONS = Object.keys(SUBTITLE_FONT_FAMILIES) as SubtitlesFontFamily[]
 


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)

## Description

Add a subtitle style settings subpage to the video player overlay panel, accessible via the "字幕样式" entry in the subtitles settings menu.

**Three grouped setting cards:**
- **通用设置** (General): display mode, translation position (Activity-controlled visibility), background opacity
- **主字幕** (Main Subtitles): font scale, color, font family, font weight
- **翻译字幕** (Translation Subtitles): same controls as main

**Key details:**
- Each group has a reset button to restore defaults
- Settings read/write via shared `configFieldsAtomMap.videoSubtitles` atoms — changes apply in real-time and sync with the options page
- Panel uses CSS container queries (`100cqh`) to size relative to the video container, not the viewport
- Select portals render inside the shadow DOM via `ShadowWrapperContext` for correct styling
- Adds `dark` variant to Select component (trigger, content, item) via CVA for dark overlay contexts
- Panel shell gets `overflow-y-auto` + `max-height` constraint to support scrollable subpages
- Font family options derived from existing `SUBTITLE_FONT_FAMILIES` mapping constant

https://github.com/user-attachments/assets/dfd910fb-bc5f-44c0-b40e-c19498aad456

## How Has This Been Tested?

- [x] Verified through manual testing
- [x] Type-check passes
- [x] All 118 test files pass (1033 tests)

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.