### PR TITLE
feat(extension): support YouTube embed subtitles on third-party sites

### DIFF
--- a/.changeset/youtube-embed-subtitles.md
+++ b/.changeset/youtube-embed-subtitles.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(extension): support YouTube embed subtitles on third-party sites

--- a/src/entrypoints/interceptor.content/index.ts
+++ b/src/entrypoints/interceptor.content/index.ts
@@ -2,7 +2,8 @@ import { defineContentScript } from "#imports"
 import { injectPlayerApi } from "./inject-player-api"
 
 export default defineContentScript({
-  matches: ["*://*.youtube.com/*"],
+  matches: ["*://*.youtube.com/*", "*://*.youtube-nocookie.com/*"],
+  allFrames: true,
   world: "MAIN",
   runAt: "document_start",
   main() {

--- a/src/entrypoints/interceptor.content/inject-player-api.ts
+++ b/src/entrypoints/interceptor.content/inject-player-api.ts
@@ -37,10 +37,15 @@ declare global {
 function findYoutubePlayer(): YouTubePlayer | null {
   return document.querySelector(
     ".html5-video-player.playing-mode, .html5-video-player.paused-mode",
-  )
+  ) ?? document.querySelector(".html5-video-player")
 }
 
 export function injectPlayerApi(): void {
+  if ((window as any).__READ_FROG_INTERCEPTOR_INJECTED__) {
+    return
+  }
+  ;(window as any).__READ_FROG_INTERCEPTOR_INJECTED__ = true
+
   setupTimedtextObserver()
   window.addEventListener("message", handleMessage)
 }

--- a/src/entrypoints/subtitles.content/index.tsx
+++ b/src/entrypoints/subtitles.content/index.tsx
@@ -9,7 +9,8 @@ declare global {
 }
 
 export default defineContentScript({
-  matches: ["*://*.youtube.com/*"],
+  matches: ["*://*.youtube.com/*", "*://*.youtube-nocookie.com/*"],
+  allFrames: true,
   cssInjectionMode: "manifest",
   async main(ctx) {
     if (window.__READ_FROG_SUBTITLES_INJECTED__)

--- a/src/entrypoints/subtitles.content/init-youtube-subtitles.ts
+++ b/src/entrypoints/subtitles.content/init-youtube-subtitles.ts
@@ -1,22 +1,33 @@
-import { YOUTUBE_NAVIGATE_FINISH_EVENT, YOUTUBE_WATCH_URL_PATTERN } from "@/utils/constants/subtitles"
+import { YOUTUBE_EMBED_PATH_PATTERN, YOUTUBE_NAVIGATE_FINISH_EVENT, YOUTUBE_WATCH_URL_PATTERN } from "@/utils/constants/subtitles"
 import { setupYoutubeSubtitles } from "./platforms/youtube"
-import { youtubeConfig } from "./platforms/youtube/config"
+import { getYoutubeConfig } from "./platforms/youtube/config"
 import { mountSubtitlesUI } from "./renderer/mount-subtitles-ui"
+
+function isYoutubeWatch(): boolean {
+  return window.location.href.includes(YOUTUBE_WATCH_URL_PATTERN)
+}
+
+function isYoutubeEmbed(): boolean {
+  return YOUTUBE_EMBED_PATH_PATTERN.test(window.location.pathname)
+}
 
 export function initYoutubeSubtitles() {
   let initialized = false
   let mountedAdapter: ReturnType<typeof setupYoutubeSubtitles> | null = null
 
+  const embedded = isYoutubeEmbed()
+  const config = getYoutubeConfig({ embedded })
+
   const tryInit = async () => {
-    if (!window.location.href.includes(YOUTUBE_WATCH_URL_PATTERN)) {
+    if (!isYoutubeWatch() && !embedded) {
       return
     }
 
     if (!mountedAdapter) {
-      mountedAdapter = setupYoutubeSubtitles()
+      mountedAdapter = setupYoutubeSubtitles(config)
     }
 
-    await mountSubtitlesUI({ adapter: mountedAdapter, config: youtubeConfig })
+    await mountSubtitlesUI({ adapter: mountedAdapter, config })
 
     if (initialized) {
       return
@@ -28,5 +39,7 @@ export function initYoutubeSubtitles() {
 
   void tryInit()
 
-  window.addEventListener(YOUTUBE_NAVIGATE_FINISH_EVENT, () => void tryInit())
+  if (!embedded) {
+    window.addEventListener(YOUTUBE_NAVIGATE_FINISH_EVENT, () => void tryInit())
+  }
 }

--- a/src/entrypoints/subtitles.content/platforms/index.ts
+++ b/src/entrypoints/subtitles.content/platforms/index.ts
@@ -4,6 +4,8 @@ export interface ControlsConfig {
 }
 
 export interface PlatformConfig {
+  embedded?: boolean
+
   selectors: {
     video: string
     playerContainer: string

--- a/src/entrypoints/subtitles.content/platforms/youtube/config.ts
+++ b/src/entrypoints/subtitles.content/platforms/youtube/config.ts
@@ -7,31 +7,43 @@ import {
 } from "@/utils/constants/subtitles"
 import { getYoutubeVideoId } from "@/utils/subtitles/video-id"
 
-export const youtubeConfig: PlatformConfig = {
-  selectors: {
-    video: "video.html5-main-video",
-    playerContainer: "#movie_player.html5-video-player",
-    controlsBar: "#movie_player .ytp-right-controls",
-    nativeSubtitles: YOUTUBE_NATIVE_SUBTITLES_CLASS,
-  },
+interface YoutubeConfigOptions {
+  embedded?: boolean
+}
 
-  events: {
-    navigateStart: YOUTUBE_NAVIGATE_START_EVENT,
-    navigateFinish: YOUTUBE_NAVIGATE_FINISH_EVENT,
-  },
+export function getYoutubeConfig(options: YoutubeConfigOptions = {}): PlatformConfig {
+  const { embedded } = options
 
-  controls: {
-    measureHeight: (container) => {
-      const player = container.closest(".html5-video-player")
-      const progressBar = player?.querySelector(".ytp-progress-bar-container")
-      const controlsBar = progressBar?.parentElement
-      return controlsBar?.getBoundingClientRect().height ?? DEFAULT_CONTROLS_HEIGHT
+  return {
+    embedded,
+
+    selectors: {
+      video: "video.html5-main-video",
+      playerContainer: "#movie_player.html5-video-player",
+      controlsBar: "#movie_player .ytp-right-controls",
+      nativeSubtitles: YOUTUBE_NATIVE_SUBTITLES_CLASS,
     },
-    checkVisibility: (container) => {
-      const player = container.closest(".html5-video-player")
-      return !!player && !player.classList.contains("ytp-autohide")
-    },
-  },
 
-  getVideoId: getYoutubeVideoId,
+    events: embedded
+      ? {}
+      : {
+          navigateStart: YOUTUBE_NAVIGATE_START_EVENT,
+          navigateFinish: YOUTUBE_NAVIGATE_FINISH_EVENT,
+        },
+
+    controls: {
+      measureHeight: (container) => {
+        const player = container.closest(".html5-video-player")
+        const progressBar = player?.querySelector(".ytp-progress-bar-container")
+        const controlsBar = progressBar?.parentElement
+        return controlsBar?.getBoundingClientRect().height ?? DEFAULT_CONTROLS_HEIGHT
+      },
+      checkVisibility: (container) => {
+        const player = container.closest(".html5-video-player")
+        return !!player && !player.classList.contains("ytp-autohide")
+      },
+    },
+
+    getVideoId: getYoutubeVideoId,
+  }
 }

--- a/src/entrypoints/subtitles.content/platforms/youtube/index.ts
+++ b/src/entrypoints/subtitles.content/platforms/youtube/index.ts
@@ -1,12 +1,12 @@
+import type { PlatformConfig } from "@/entrypoints/subtitles.content/platforms"
 import { YoutubeSubtitlesFetcher } from "@/utils/subtitles/fetchers"
 import { UniversalVideoAdapter } from "../../universal-adapter"
-import { youtubeConfig } from "./config"
 
-export function setupYoutubeSubtitles() {
+export function setupYoutubeSubtitles(config: PlatformConfig) {
   const subtitlesFetcher = new YoutubeSubtitlesFetcher()
 
   return new UniversalVideoAdapter({
-    config: youtubeConfig,
+    config,
     subtitlesFetcher,
   })
 }

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -62,7 +62,9 @@ export class UniversalVideoAdapter {
 
   async initialize() {
     void this.restorePosition()
-    void this.renderTranslateButton()
+    if (!this.config.embedded) {
+      void this.renderTranslateButton()
+    }
 
     await this.initializeScheduler()
     void this.getOrLoadSourceSubtitles().catch(() => {})
@@ -263,7 +265,25 @@ export class UniversalVideoAdapter {
     const config = await getLocalConfig()
     const autoStart = config?.videoSubtitles?.autoStart ?? false
 
-    if (!autoStart) {
+    if (!autoStart)
+      return
+
+    if (this.config.embedded) {
+      const video = this.subtitlesScheduler?.getVideoElement()
+      if (!video)
+        return
+
+      const start = () => {
+        video.removeEventListener("playing", start)
+        this.toggleSubtitlesWithSource(true, "auto")
+      }
+
+      if (!video.paused) {
+        this.toggleSubtitlesWithSource(true, "auto")
+      }
+      else {
+        video.addEventListener("playing", start)
+      }
       return
     }
 

--- a/src/utils/constants/subtitles.ts
+++ b/src/utils/constants/subtitles.ts
@@ -26,6 +26,7 @@ export const TRANSLATE_BUTTON_CLASS = "read-frog-subtitles-translate-button"
 
 // YouTube specific
 export const YOUTUBE_WATCH_URL_PATTERN = "youtube.com/watch"
+export const YOUTUBE_EMBED_PATH_PATTERN = /\/embed\/[^/?]+/
 export const YOUTUBE_NAVIGATE_START_EVENT = "yt-navigate-start"
 export const YOUTUBE_NAVIGATE_FINISH_EVENT = "yt-navigate-finish"
 export const YOUTUBE_NATIVE_SUBTITLES_CLASS = ".ytp-caption-window-container"


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)

## Description

Enable subtitle functionality for YouTube videos embedded on third-party websites (e.g., Udacity, Coursera, educational platforms).

### Changes

- **Content script injection**: Add `allFrames: true` to both `subtitles.content` and `interceptor.content` scripts, allowing them to inject into YouTube embed iframes on any page
- **Embed URL detection**: Detect `/embed/` path pattern to distinguish embed from watch pages
- **Platform-agnostic `embedded` flag**: Introduce `embedded?: boolean` in `PlatformConfig` instead of YouTube-specific page types, making it easy for other platforms to adopt
- **Auto-start on play**: In embed mode, wait for the video `playing` event before auto-starting subtitles (respects user's `autoStart` setting). This handles the timing issue where embed players haven't loaded captions until playback begins
- **Embed-specific config**: Skip SPA navigation listeners and translate button rendering in embed mode
- **Double-injection guard**: Prevent interceptor from running twice when both `allFrames` registration and other injection mechanisms fire
- **Fallback player selector**: Handle embed player's `unstarted-mode` state where `.playing-mode` / `.paused-mode` classes aren't present yet
- **Privacy-enhanced embeds**: Support `youtube-nocookie.com` domain

<img width="1186" height="874" alt="image" src="https://github.com/user-attachments/assets/a9cc4155-2e15-4ce0-b985-be6bf71758ef" />

## How Has This Been Tested?

- [x] Verified through manual testing

Tested on Udacity course pages with embedded YouTube videos. Confirmed:
- Content scripts inject into embed iframes
- Interceptor successfully patches XHR and captures timedtext URLs
- Subtitles auto-start when user plays the video
- No regression on youtube.com watch pages

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality

## Additional Information

This is the first step for embed support. Future work includes:
- Injecting a translate toggle button into the embed controls
- Dark theme adaptation for the settings panel in embed context
- Event click-through prevention for UI panels overlaying the video

🤖 Generated with [Claude Code](https://claude.com/claude-code)