### PR TITLE
style(options): widen sync conflict dialog

### DIFF
--- a/.changeset/sharp-frogs-widen.md
+++ b/.changeset/sharp-frogs-widen.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+style(options): widen Google Drive sync conflict dialog

--- a/src/entrypoints/options/pages/config/google-drive-sync/components/unresolved-dialog.tsx
+++ b/src/entrypoints/options/pages/config/google-drive-sync/components/unresolved-dialog.tsx
@@ -94,7 +94,7 @@ function DialogContent({ onResolved, onCancelled }: DialogContentProps) {
   const canConfirm = status.isValid && !isConfirming
 
   return (
-    <AlertDialogContent className="w-[min(80rem,calc(100vw-2rem))] max-w-none max-h-[90vh] flex flex-col overflow-hidden">
+    <AlertDialogContent className="data-[size=default]:max-w-[calc(100vw-2rem)] data-[size=default]:md:max-w-2xl data-[size=default]:lg:max-w-4xl data-[size=default]:xl:max-w-5xl max-h-[90vh] flex flex-col overflow-hidden">
       <AlertDialogHeader>
         <AlertDialogTitle className="flex items-center gap-2">
           <Icon icon="mdi:alert" className="size-5 text-yellow-500" />


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [x] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Widen the Google Drive config sync conflict-resolution dialog so nested configuration diffs have more room to breathe.

The width override now stays local to the conflict dialog, following the Add New Provider pattern, instead of changing the shared AlertDialog component. The dialog remains responsive with a viewport-based cap on small screens and larger max widths on medium and larger screens.

## Related Issue

N/A

## How Has This Been Tested?

- [ ] Added unit tests
- [ ] Verified through manual testing

Validated with automated checks:

- `pnpm lint src/entrypoints/options/pages/config/google-drive-sync/components/unresolved-dialog.tsx`
- `pnpm type-check`
- `WXT_SKIP_ENV_VALIDATION=true pnpm build`
- pre-push hook: `lint`, `type-check`, and `test` (`118` files / `1040` tests passed)

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Includes a patch changeset for the user-visible UI adjustment.
