### PR TITLE
fix(page-translation): rewalk revealed accordion content

### DIFF
--- a/.changeset/rare-accordions-rewalk.md
+++ b/.changeset/rare-accordions-rewalk.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(page-translation): re-walk revealed accordion content

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -156,7 +156,7 @@ function deepQueryTopLevelSelectorImpl(
 }
 
 function isBlockedForTraversal(element: HTMLElement): boolean {
-  return element.hidden
+  return Boolean(element.hidden)
     || element.getAttribute("aria-hidden") === "true"
     || element.classList.contains("closed")
 }

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -1,0 +1,307 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { PageTranslationManager } from "../page-translation"
+
+const {
+  mockDeepQueryTopLevelSelector,
+  mockGetDetectedCodeFromStorage,
+  mockGetLocalConfig,
+  mockGetOrCreateWebPageContext,
+  mockHasNoWalkAncestor,
+  mockIsDontWalkIntoAndDontTranslateAsChildElement,
+  mockIsDontWalkIntoButTranslateAsChildElement,
+  mockRemoveAllTranslatedWrapperNodes,
+  mockSendMessage,
+  mockTranslateTextForPageTitle,
+  mockTranslateWalkedElement,
+  mockValidateTranslationConfigAndToast,
+  mockWalkAndLabelElement,
+} = vi.hoisted(() => ({
+  mockGetDetectedCodeFromStorage: vi.fn(),
+  mockGetLocalConfig: vi.fn(),
+  mockGetOrCreateWebPageContext: vi.fn(),
+  mockDeepQueryTopLevelSelector: vi.fn(),
+  mockHasNoWalkAncestor: vi.fn(),
+  mockIsDontWalkIntoAndDontTranslateAsChildElement: vi.fn(),
+  mockIsDontWalkIntoButTranslateAsChildElement: vi.fn(),
+  mockWalkAndLabelElement: vi.fn(),
+  mockRemoveAllTranslatedWrapperNodes: vi.fn(),
+  mockTranslateWalkedElement: vi.fn(),
+  mockTranslateTextForPageTitle: vi.fn(),
+  mockValidateTranslationConfigAndToast: vi.fn(),
+  mockSendMessage: vi.fn(),
+}))
+
+vi.mock("@/utils/config/languages", () => ({
+  getDetectedCodeFromStorage: mockGetDetectedCodeFromStorage,
+}))
+
+vi.mock("@/utils/config/storage", () => ({
+  getLocalConfig: mockGetLocalConfig,
+}))
+
+vi.mock("@/utils/crypto-polyfill", () => ({
+  getRandomUUID: () => "walk-id",
+}))
+
+vi.mock("@/utils/host/dom/filter", () => ({
+  hasNoWalkAncestor: mockHasNoWalkAncestor,
+  isDontWalkIntoAndDontTranslateAsChildElement: mockIsDontWalkIntoAndDontTranslateAsChildElement,
+  isDontWalkIntoButTranslateAsChildElement: mockIsDontWalkIntoButTranslateAsChildElement,
+  isHTMLElement: (node: unknown) => node instanceof HTMLElement,
+}))
+
+vi.mock("@/utils/host/dom/find", () => ({
+  deepQueryTopLevelSelector: mockDeepQueryTopLevelSelector,
+}))
+
+vi.mock("@/utils/host/dom/traversal", () => ({
+  walkAndLabelElement: mockWalkAndLabelElement,
+}))
+
+vi.mock("@/utils/host/translate/node-manipulation", () => ({
+  removeAllTranslatedWrapperNodes: mockRemoveAllTranslatedWrapperNodes,
+  translateWalkedElement: mockTranslateWalkedElement,
+}))
+
+vi.mock("@/utils/host/translate/translate-text", () => ({
+  validateTranslationConfigAndToast: mockValidateTranslationConfigAndToast,
+}))
+
+vi.mock("@/utils/host/translate/translate-variants", () => ({
+  translateTextForPageTitle: mockTranslateTextForPageTitle,
+}))
+
+vi.mock("@/utils/host/translate/webpage-context", () => ({
+  getOrCreateWebPageContext: mockGetOrCreateWebPageContext,
+}))
+
+vi.mock("@/utils/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+vi.mock("@/utils/message", () => ({
+  sendMessage: mockSendMessage,
+}))
+
+const intersectionObservers: MockIntersectionObserver[] = []
+
+class MockIntersectionObserver {
+  observe = vi.fn((target: Element) => {
+    this.targets.add(target)
+  })
+
+  unobserve = vi.fn((target: Element) => {
+    this.targets.delete(target)
+  })
+
+  disconnect = vi.fn(() => {
+    this.targets.clear()
+  })
+
+  private readonly targets = new Set<Element>()
+
+  constructor(
+    private readonly callback: IntersectionObserverCallback,
+    _options?: IntersectionObserverInit,
+  ) {
+    intersectionObservers.push(this)
+  }
+
+  async triggerIntersect(target: Element): Promise<void> {
+    await this.callback([{
+      isIntersecting: true,
+      target,
+    } as IntersectionObserverEntry], this as unknown as IntersectionObserver)
+  }
+}
+
+async function flushDomUpdates(): Promise<void> {
+  await Promise.resolve()
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await Promise.resolve()
+}
+
+function deepQueryTopLevelSelectorImpl(
+  root: Document | ShadowRoot | HTMLElement,
+  selectorFn: (element: HTMLElement) => boolean,
+): HTMLElement[] {
+  if (root instanceof Document) {
+    return root.body ? deepQueryTopLevelSelectorImpl(root.body, selectorFn) : []
+  }
+
+  if (root instanceof HTMLElement && selectorFn(root)) {
+    return [root]
+  }
+
+  const result: HTMLElement[] = []
+
+  if (root instanceof HTMLElement && root.shadowRoot) {
+    result.push(...deepQueryTopLevelSelectorImpl(root.shadowRoot, selectorFn))
+  }
+
+  for (const child of root.children) {
+    if (child instanceof HTMLElement) {
+      result.push(...deepQueryTopLevelSelectorImpl(child, selectorFn))
+    }
+  }
+
+  return result
+}
+
+function isBlockedForTraversal(element: HTMLElement): boolean {
+  return element.hidden
+    || element.getAttribute("aria-hidden") === "true"
+    || element.classList.contains("closed")
+}
+
+function walkAndLabelVisibleParagraphs(element: HTMLElement, walkId: string) {
+  if (isBlockedForTraversal(element)) {
+    return {
+      forceBlock: false,
+      isInlineNode: false,
+    }
+  }
+
+  element.setAttribute("data-read-frog-walked", walkId)
+
+  for (const child of element.children) {
+    if (child instanceof HTMLElement) {
+      walkAndLabelVisibleParagraphs(child, walkId)
+    }
+  }
+
+  if (element.tagName === "P" && element.textContent?.trim()) {
+    element.setAttribute("data-read-frog-paragraph", "")
+  }
+
+  return {
+    forceBlock: false,
+    isInlineNode: false,
+  }
+}
+
+describe("pageTranslationManager mutation re-walk", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    intersectionObservers.length = 0
+
+    document.head.innerHTML = ""
+    document.body.innerHTML = ""
+    document.title = ""
+
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver)
+
+    mockGetDetectedCodeFromStorage.mockResolvedValue("eng")
+    mockGetLocalConfig.mockResolvedValue(DEFAULT_CONFIG)
+    mockGetOrCreateWebPageContext.mockResolvedValue({
+      url: window.location.href,
+      webTitle: "",
+      webContent: "",
+    })
+    mockHasNoWalkAncestor.mockReturnValue(false)
+    mockIsDontWalkIntoButTranslateAsChildElement.mockReturnValue(false)
+    mockIsDontWalkIntoAndDontTranslateAsChildElement.mockImplementation((element: HTMLElement) => isBlockedForTraversal(element))
+    mockDeepQueryTopLevelSelector.mockImplementation(deepQueryTopLevelSelectorImpl)
+    mockWalkAndLabelElement.mockImplementation((element: HTMLElement, walkId: string) => walkAndLabelVisibleParagraphs(element, walkId))
+    mockTranslateTextForPageTitle.mockResolvedValue("")
+    mockValidateTranslationConfigAndToast.mockReturnValue(true)
+    mockSendMessage.mockResolvedValue(undefined)
+  })
+
+  it("observes and translates hidden accordion content after it becomes visible", async () => {
+    document.body.innerHTML = `
+      <section id="accordion" hidden>
+        <p id="panel">Accordion body</p>
+      </section>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observer = intersectionObservers[0]
+    const accordion = document.getElementById("accordion") as HTMLElement
+    const panel = document.getElementById("panel") as HTMLElement
+
+    expect(observer.observe).not.toHaveBeenCalled()
+
+    accordion.removeAttribute("hidden")
+    await flushDomUpdates()
+
+    expect(observer.observe).toHaveBeenCalledWith(panel)
+
+    await observer.triggerIntersect(panel)
+    await flushDomUpdates()
+
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(panel, "walk-id", DEFAULT_CONFIG)
+
+    manager.stop()
+  })
+
+  it("observes and translates aria-hidden accordion content after it becomes visible", async () => {
+    document.body.innerHTML = `
+      <section id="accordion" aria-hidden="true">
+        <p id="panel">Accordion body</p>
+      </section>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observer = intersectionObservers[0]
+    const accordion = document.getElementById("accordion") as HTMLElement
+    const panel = document.getElementById("panel") as HTMLElement
+
+    expect(observer.observe).not.toHaveBeenCalled()
+
+    accordion.setAttribute("aria-hidden", "false")
+    await flushDomUpdates()
+
+    expect(observer.observe).toHaveBeenCalledWith(panel)
+
+    await observer.triggerIntersect(panel)
+    await flushDomUpdates()
+
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(panel, "walk-id", DEFAULT_CONFIG)
+
+    manager.stop()
+  })
+
+  it("keeps style/class based re-walk behavior for existing hidden panels", async () => {
+    document.body.innerHTML = `
+      <section id="accordion" class="closed">
+        <p id="panel">Accordion body</p>
+      </section>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observer = intersectionObservers[0]
+    const accordion = document.getElementById("accordion") as HTMLElement
+    const panel = document.getElementById("panel") as HTMLElement
+
+    expect(observer.observe).not.toHaveBeenCalled()
+
+    accordion.classList.remove("closed")
+    await flushDomUpdates()
+
+    expect(observer.observe).toHaveBeenCalledWith(panel)
+
+    await observer.triggerIntersect(panel)
+    await flushDomUpdates()
+
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(panel, "walk-id", DEFAULT_CONFIG)
+
+    manager.stop()
+  })
+})

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts
@@ -38,6 +38,7 @@ vi.mock("@/utils/config/storage", () => ({
 
 vi.mock("@/utils/host/dom/filter", () => ({
   hasNoWalkAncestor: vi.fn().mockReturnValue(false),
+  isDontWalkIntoAndDontTranslateAsChildElement: vi.fn().mockReturnValue(false),
   isDontWalkIntoButTranslateAsChildElement: vi.fn().mockReturnValue(false),
   isHTMLElement: (node: unknown) => node instanceof HTMLElement,
 }))

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -1,4 +1,5 @@
 import type { FeatureUsageContext } from "@/types/analytics"
+import type { Config } from "@/types/config/config"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { isLLMProviderConfig } from "@/types/config/provider"
 import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
@@ -7,7 +8,7 @@ import { getLocalConfig } from "@/utils/config/storage"
 import { CONTENT_WRAPPER_CLASS } from "@/utils/constants/dom-labels"
 import { resolveProviderConfig } from "@/utils/constants/feature-providers"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
-import { hasNoWalkAncestor, isDontWalkIntoButTranslateAsChildElement, isHTMLElement } from "@/utils/host/dom/filter"
+import { hasNoWalkAncestor, isDontWalkIntoAndDontTranslateAsChildElement, isDontWalkIntoButTranslateAsChildElement, isHTMLElement } from "@/utils/host/dom/filter"
 import { deepQueryTopLevelSelector } from "@/utils/host/dom/find"
 import { walkAndLabelElement } from "@/utils/host/dom/traversal"
 import { removeAllTranslatedWrapperNodes, translateWalkedElement } from "@/utils/host/translate/node-manipulation"
@@ -59,7 +60,7 @@ export class PageTranslationManager implements IPageTranslationManager {
   private mutationObservers: MutationObserver[] = []
   private walkId: string | null = null
   private intersectionOptions: IntersectionObserverInit
-  private dontWalkIntoElementsCache = new WeakSet<HTMLElement>()
+  private walkBlockedElementsCache = new WeakSet<HTMLElement>()
   private titleObserver: MutationObserver | null = null
   private lastSourceTitle: string | null = null
   private lastAppliedTranslatedTitle: string | null = null
@@ -153,8 +154,8 @@ export class PageTranslationManager implements IPageTranslationManager {
       }, this.intersectionOptions)
 
       // Initialize walkability state for existing elements
-      this.addDontWalkIntoElements(document.body)
-      await this.observerTopLevelParagraphs(document.body)
+      this.addWalkBlockedElements(document.body, config)
+      await this.observerTopLevelParagraphs(document.body, config)
 
       // Start observing mutations from document.body and all shadow roots
       this.observeMutations(document.body)
@@ -189,7 +190,7 @@ export class PageTranslationManager implements IPageTranslationManager {
 
     this.isPageTranslating = false
     this.walkId = null
-    this.dontWalkIntoElementsCache = new WeakSet()
+    this.walkBlockedElementsCache = new WeakSet()
     this.stopDocumentTitleTracking()
 
     if (this.intersectionObserver) {
@@ -386,12 +387,12 @@ export class PageTranslationManager implements IPageTranslationManager {
     }
   }
 
-  private async observerTopLevelParagraphs(container: HTMLElement): Promise<void> {
+  private async observerTopLevelParagraphs(container: HTMLElement, existingConfig?: Config): Promise<void> {
     const observer = this.intersectionObserver
     if (!this.walkId || !observer)
       return
 
-    const config = await getLocalConfig()
+    const config = existingConfig ?? await getLocalConfig()
     if (!config) {
       logger.error("Global config is not initialized")
       return
@@ -454,33 +455,39 @@ export class PageTranslationManager implements IPageTranslationManager {
   }
 
   /**
-   * Handle style/class attribute changes and only trigger observation
-   * when element transitions from "don't walk into" to "walkable"
+   * Track the same blocked states that the traversal skips, so hidden accordion
+   * panels can be re-walked when the site reveals an existing subtree.
    */
-  private didChangeToWalkable(element: HTMLElement): boolean {
-    const wasDontWalkInto = this.dontWalkIntoElementsCache.has(element)
-    const isDontWalkIntoNow = isDontWalkIntoButTranslateAsChildElement(element)
+  private isWalkBlockedElement(element: HTMLElement, config: Config): boolean {
+    return isDontWalkIntoButTranslateAsChildElement(element)
+      || isDontWalkIntoAndDontTranslateAsChildElement(element, config)
+  }
+
+  /**
+   * Handle attribute changes and only trigger observation
+   * when element transitions from blocked to walkable.
+   */
+  private didChangeToWalkable(element: HTMLElement, config: Config): boolean {
+    const wasWalkBlocked = this.walkBlockedElementsCache.has(element)
+    const isWalkBlockedNow = this.isWalkBlockedElement(element, config)
 
     // Update cache with current state
-    if (isDontWalkIntoNow) {
-      this.dontWalkIntoElementsCache.add(element)
+    if (isWalkBlockedNow) {
+      this.walkBlockedElementsCache.add(element)
     }
     else {
-      this.dontWalkIntoElementsCache.delete(element)
+      this.walkBlockedElementsCache.delete(element)
     }
 
-    // Only trigger observation if element transitioned from "don't walk into" to "walkable"
-    // wasDontWalkInto === true means it was previously not walkable
-    // isDontWalkIntoNow === false means it's now walkable
-    return wasDontWalkInto === true && isDontWalkIntoNow === false
+    return wasWalkBlocked === true && isWalkBlockedNow === false
   }
 
   /**
    * Initialize walkability state for an element and its descendants
    */
-  private addDontWalkIntoElements(element: HTMLElement): void {
-    const dontWalkIntoElements = deepQueryTopLevelSelector(element, isDontWalkIntoButTranslateAsChildElement)
-    dontWalkIntoElements.forEach(el => this.dontWalkIntoElementsCache.add(el))
+  private addWalkBlockedElements(element: HTMLElement, config: Config): void {
+    const walkBlockedElements = deepQueryTopLevelSelector(element, el => this.isWalkBlockedElement(el, config))
+    walkBlockedElements.forEach(el => this.walkBlockedElementsCache.add(el))
   }
 
   /**
@@ -488,37 +495,52 @@ export class PageTranslationManager implements IPageTranslationManager {
    */
   private observeMutations(container: HTMLElement): void {
     const mutationObserver = new MutationObserver((records) => {
-      for (const rec of records) {
-        if (rec.type === "childList") {
-          rec.addedNodes.forEach((node) => {
-            if (isHTMLElement(node)) {
-              this.addDontWalkIntoElements(node)
-              void this.observerTopLevelParagraphs(node)
-              this.observeIsolatedDescendantsMutations(node)
-            }
-          })
-        }
-        else if (
-          rec.type === "attributes"
-          && (rec.attributeName === "style" || rec.attributeName === "class")
-        ) {
-          const el = rec.target
-          if (isHTMLElement(el) && this.didChangeToWalkable(el)) {
-            void this.observerTopLevelParagraphs(el)
-          }
-        }
-      }
+      void this.handleMutationRecords(records)
     })
 
     mutationObserver.observe(container, {
       childList: true,
       subtree: true,
       attributes: true,
-      attributeFilter: ["style", "class"],
+      attributeFilter: ["style", "class", "hidden", "aria-hidden"],
     })
 
     this.mutationObservers.push(mutationObserver)
     this.observeIsolatedDescendantsMutations(container)
+  }
+
+  private async handleMutationRecords(records: MutationRecord[]): Promise<void> {
+    const config = await getLocalConfig()
+    if (!config) {
+      logger.error("Global config is not initialized")
+      return
+    }
+
+    for (const rec of records) {
+      if (rec.type === "childList") {
+        rec.addedNodes.forEach((node) => {
+          if (isHTMLElement(node)) {
+            this.addWalkBlockedElements(node, config)
+            void this.observerTopLevelParagraphs(node, config)
+            this.observeIsolatedDescendantsMutations(node)
+          }
+        })
+      }
+      else if (this.isWalkabilityAttributeMutation(rec)) {
+        const el = rec.target
+        if (isHTMLElement(el) && this.didChangeToWalkable(el, config)) {
+          void this.observerTopLevelParagraphs(el, config)
+        }
+      }
+    }
+  }
+
+  private isWalkabilityAttributeMutation(record: MutationRecord): boolean {
+    return record.type === "attributes"
+      && (record.attributeName === "style"
+        || record.attributeName === "class"
+        || record.attributeName === "hidden"
+        || record.attributeName === "aria-hidden")
   }
 
   /**


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [x] ✅ Test related (test)

## Description

This fixes page translation for accordion/collapsible content that already exists in the DOM but is skipped during the initial page walk because it is hidden.

The page translation mutation path now:

- tracks the same traversal-blocked states used by the real DOM walker, including `hidden`, `aria-hidden`, and CSS hidden states
- reads the current config once per mutation batch and passes it explicitly instead of caching config on the manager
- observes `hidden` and `aria-hidden` attributes in addition to `style` and `class`
- re-walks a subtree when it transitions from blocked to walkable

This intentionally does not include any layout/clipping repair; it only fixes the observer/re-walk detection issue.

## Related Issue

Closes #1358

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Validation run locally:

- `SKIP_FREE_API=true pnpm exec vitest run src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts`
- `pnpm exec eslint src/entrypoints/host.content/translation-control/page-translation.ts src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts`
- `pnpm exec tsc --noEmit`
- `WXT_SKIP_ENV_VALIDATION=true pnpm build:edge`
- pre-push hook: `nx` lint, type-check, and full test suite (`123` files, `1079` tests)

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This is scoped to the detection/re-walk problem only. The separate layout overflow/clipping behavior on fixed-height accordion containers is intentionally deferred.
