### PR TITLE
perf(extension): gate iframe content script injection

### DIFF
--- a/.changeset/quiet-frames-speedometer.md
+++ b/.changeset/quiet-frames-speedometer.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+perf(extension): gate iframe content script injection

--- a/src/entrypoints/background/__tests__/iframe-injection.test.ts
+++ b/src/entrypoints/background/__tests__/iframe-injection.test.ts
@@ -1,3 +1,4 @@
+import type { Config } from "@/types/config/config"
 import { browser, storage } from "#imports"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SITE_CONTROL_URL_WINDOW_KEY } from "@/utils/site-control"
@@ -55,6 +56,21 @@ function createDetails(overrides: Partial<NavigationDetails> = {}): NavigationDe
   }
 }
 
+function createConfig({ nodeTranslationEnabled = false }: { nodeTranslationEnabled?: boolean } = {}): Config {
+  return {
+    translate: {
+      node: {
+        enabled: nodeTranslationEnabled,
+      },
+    },
+    siteControl: {
+      mode: "blacklist",
+      blacklistPatterns: [],
+      whitelistPatterns: [],
+    },
+  } as unknown as Config
+}
+
 async function setupSubject() {
   const { setupIframeInjection } = await import("../iframe-injection")
   setupIframeInjection()
@@ -99,14 +115,29 @@ describe("setupIframeInjection", () => {
     executeScriptMock.mockResolvedValue(undefined)
   })
 
-  it("skips iframe injection when page translation is not enabled", async () => {
+  it("skips iframe injection when page translation and node translation are not enabled", async () => {
     const { onCompleted } = await setupSubject()
     storageGetItemMock.mockResolvedValue({ enabled: false })
+    getLocalConfigMock.mockResolvedValue(createConfig({ nodeTranslationEnabled: false }))
 
     await onCompleted(createDetails())
 
     expect(getAllFramesMock).not.toHaveBeenCalled()
     expect(executeScriptMock).not.toHaveBeenCalled()
+  })
+
+  it("injects host content when node translation is enabled without page translation", async () => {
+    const { onCompleted } = await setupSubject()
+    storageGetItemMock.mockResolvedValue({ enabled: false })
+    getLocalConfigMock.mockResolvedValue(createConfig({ nodeTranslationEnabled: true }))
+
+    await onCompleted(createDetails())
+
+    expect(executeScriptMock).toHaveBeenCalledTimes(2)
+    expect(executeScriptMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      target: { tabId: currentTabId, documentIds: ["doc-1"] },
+      files: ["/content-scripts/host.js"],
+    }))
   })
 
   it("injects each document once and targets documentIds when available", async () => {

--- a/src/entrypoints/background/__tests__/iframe-injection.test.ts
+++ b/src/entrypoints/background/__tests__/iframe-injection.test.ts
@@ -1,3 +1,4 @@
+import { browser, storage } from "#imports"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SITE_CONTROL_URL_WINDOW_KEY } from "@/utils/site-control"
 
@@ -6,38 +7,11 @@ const webNavigationOnBeforeNavigateAddListenerMock = vi.fn()
 const webNavigationOnCompletedAddListenerMock = vi.fn()
 const getAllFramesMock = vi.fn()
 const executeScriptMock = vi.fn()
+const storageGetItemMock = vi.fn()
 
 const getLocalConfigMock = vi.fn()
 const loggerErrorMock = vi.fn()
 const loggerWarnMock = vi.fn()
-
-const browserMock = {
-  tabs: {
-    onRemoved: {
-      addListener: tabsOnRemovedAddListenerMock,
-    },
-  },
-  webNavigation: {
-    onBeforeNavigate: {
-      addListener: webNavigationOnBeforeNavigateAddListenerMock,
-    },
-    onCompleted: {
-      addListener: webNavigationOnCompletedAddListenerMock,
-    },
-    getAllFrames: getAllFramesMock,
-  },
-  scripting: {
-    executeScript: executeScriptMock,
-  },
-}
-
-vi.mock("#imports", () => ({
-  browser: browserMock,
-}))
-
-vi.mock("wxt/browser", () => ({
-  browser: browserMock,
-}))
 
 vi.mock("@/utils/config/storage", () => ({
   getLocalConfig: getLocalConfigMock,
@@ -109,12 +83,30 @@ describe("setupIframeInjection", () => {
     vi.clearAllMocks()
     currentTabId += 1
 
+    browser.tabs.onRemoved.addListener = tabsOnRemovedAddListenerMock
+    browser.webNavigation.onBeforeNavigate.addListener = webNavigationOnBeforeNavigateAddListenerMock
+    browser.webNavigation.onCompleted.addListener = webNavigationOnCompletedAddListenerMock
+    browser.webNavigation.getAllFrames = getAllFramesMock
+    browser.scripting.executeScript = executeScriptMock
+    storage.getItem = storageGetItemMock
+
     getLocalConfigMock.mockResolvedValue(null)
     getAllFramesMock.mockResolvedValue([
       createFrame(0, "https://example.com/app", -1),
       createFrame(2, "https://example.com/frame"),
     ])
+    storageGetItemMock.mockResolvedValue({ enabled: true })
     executeScriptMock.mockResolvedValue(undefined)
+  })
+
+  it("skips iframe injection when page translation is not enabled", async () => {
+    const { onCompleted } = await setupSubject()
+    storageGetItemMock.mockResolvedValue({ enabled: false })
+
+    await onCompleted(createDetails())
+
+    expect(getAllFramesMock).not.toHaveBeenCalled()
+    expect(executeScriptMock).not.toHaveBeenCalled()
   })
 
   it("injects each document once and targets documentIds when available", async () => {
@@ -124,7 +116,7 @@ describe("setupIframeInjection", () => {
     await onCompleted(details)
     await onCompleted(details)
 
-    expect(executeScriptMock).toHaveBeenCalledTimes(3)
+    expect(executeScriptMock).toHaveBeenCalledTimes(2)
     expect(executeScriptMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
       target: { tabId: currentTabId, documentIds: ["doc-1"] },
       func: expect.any(Function),
@@ -141,7 +133,7 @@ describe("setupIframeInjection", () => {
 
     await onCompleted(createDetails({ documentId: undefined }))
 
-    expect(executeScriptMock).toHaveBeenCalledTimes(3)
+    expect(executeScriptMock).toHaveBeenCalledTimes(2)
     for (const [call] of executeScriptMock.mock.calls) {
       expect(call.target).toEqual({ tabId: currentTabId, frameIds: [2] })
     }
@@ -153,12 +145,12 @@ describe("setupIframeInjection", () => {
 
     await onCompleted(details)
     await onCompleted(details)
-    expect(executeScriptMock).toHaveBeenCalledTimes(3)
+    expect(executeScriptMock).toHaveBeenCalledTimes(2)
 
     onBeforeNavigate({ tabId: currentTabId, frameId: 2 })
     await onCompleted(details)
 
-    expect(executeScriptMock).toHaveBeenCalledTimes(6)
+    expect(executeScriptMock).toHaveBeenCalledTimes(4)
   })
 
   it("prunes injected records for frames that are no longer live", async () => {
@@ -194,10 +186,10 @@ describe("setupIframeInjection", () => {
       url: "https://example.com/old-frame",
     }))
 
-    expect(executeScriptMock).toHaveBeenCalledTimes(9)
+    expect(executeScriptMock).toHaveBeenCalledTimes(6)
     expect(executeScriptMock).toHaveBeenLastCalledWith(expect.objectContaining({
       target: { tabId: currentTabId, documentIds: ["doc-stale"] },
-      files: ["/content-scripts/selection.js"],
+      files: ["/content-scripts/host.js"],
     }))
   })
 
@@ -207,14 +199,14 @@ describe("setupIframeInjection", () => {
 
     await onCompleted(details)
     await onCompleted(details)
-    expect(executeScriptMock).toHaveBeenCalledTimes(3)
+    expect(executeScriptMock).toHaveBeenCalledTimes(2)
 
     onBeforeNavigate({ tabId: currentTabId, frameId: 0 })
     await onCompleted(details)
-    expect(executeScriptMock).toHaveBeenCalledTimes(6)
+    expect(executeScriptMock).toHaveBeenCalledTimes(4)
 
     onRemoved(currentTabId)
     await onCompleted(details)
-    expect(executeScriptMock).toHaveBeenCalledTimes(9)
+    expect(executeScriptMock).toHaveBeenCalledTimes(6)
   })
 })

--- a/src/entrypoints/background/__tests__/translation-signal.test.ts
+++ b/src/entrypoints/background/__tests__/translation-signal.test.ts
@@ -112,6 +112,34 @@ describe("translationMessage", () => {
     }, 42)
   })
 
+  it("injects current iframes when explicitly asked for a tab", async () => {
+    await setupSubject()
+
+    await getHandler("ensureIframeHostContentInjected")({
+      data: { tabId: 42 },
+    })
+
+    expect(injectHostContentIntoTabIframesMock).toHaveBeenCalledWith(42)
+  })
+
+  it("does not inject current iframes without a valid tab id", async () => {
+    await setupSubject()
+
+    await getHandler("ensureIframeHostContentInjected")({
+      data: {},
+      sender: {},
+    })
+
+    expect(injectHostContentIntoTabIframesMock).not.toHaveBeenCalled()
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      "Invalid tabId in ensureIframeHostContentInjected",
+      expect.objectContaining({
+        data: {},
+        sender: {},
+      }),
+    )
+  })
+
   it("waits for the top-frame manager to validate before enabling iframe injection", async () => {
     await setupSubject()
 

--- a/src/entrypoints/background/__tests__/translation-signal.test.ts
+++ b/src/entrypoints/background/__tests__/translation-signal.test.ts
@@ -1,0 +1,129 @@
+import { browser, storage } from "#imports"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { getTranslationStateKey } from "@/utils/constants/storage-keys"
+
+const sendMessageMock = vi.fn()
+const onMessageMock = vi.fn()
+const storageGetItemMock = vi.fn()
+const storageSetItemMock = vi.fn()
+const storageRemoveItemMock = vi.fn()
+const tabsOnRemovedAddListenerMock = vi.fn()
+const webNavigationOnCommittedAddListenerMock = vi.fn()
+const injectHostContentIntoTabIframesMock = vi.fn()
+const loggerErrorMock = vi.fn()
+const loggerWarnMock = vi.fn()
+const shouldEnableAutoTranslationMock = vi.fn()
+
+const messageHandlers = new Map<string, (msg: any) => any>()
+
+vi.mock("@/utils/message", () => ({
+  onMessage: onMessageMock,
+  sendMessage: sendMessageMock,
+}))
+
+vi.mock("@/utils/host/translate/auto-translation", () => ({
+  shouldEnableAutoTranslation: shouldEnableAutoTranslationMock,
+}))
+
+vi.mock("@/utils/logger", () => ({
+  logger: {
+    error: loggerErrorMock,
+    warn: loggerWarnMock,
+  },
+}))
+
+vi.mock("../iframe-injection", () => ({
+  injectHostContentIntoTabIframes: injectHostContentIntoTabIframesMock,
+}))
+
+function getHandler(name: string) {
+  const handler = messageHandlers.get(name)
+  if (!handler) {
+    throw new Error(`Expected message handler to be registered: ${name}`)
+  }
+  return handler
+}
+
+async function setupSubject() {
+  const { translationMessage } = await import("../translation-signal")
+  translationMessage()
+}
+
+describe("translationMessage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    messageHandlers.clear()
+
+    browser.tabs.onRemoved.addListener = tabsOnRemovedAddListenerMock
+    browser.webNavigation.onCommitted.addListener = webNavigationOnCommittedAddListenerMock
+    storage.getItem = storageGetItemMock
+    storage.setItem = storageSetItemMock
+    storage.removeItem = storageRemoveItemMock
+
+    onMessageMock.mockImplementation((name: string, handler: (msg: any) => any) => {
+      messageHandlers.set(name, handler)
+      return vi.fn()
+    })
+    sendMessageMock.mockResolvedValue(undefined)
+    storageGetItemMock.mockResolvedValue(undefined)
+    storageSetItemMock.mockResolvedValue(undefined)
+    storageRemoveItemMock.mockResolvedValue(undefined)
+    shouldEnableAutoTranslationMock.mockResolvedValue(false)
+  })
+
+  it("persists manager-enabled state and injects current iframes from the top frame", async () => {
+    await setupSubject()
+
+    await getHandler("setAndNotifyPageTranslationStateChangedByManager")({
+      data: { enabled: true },
+      sender: { tab: { id: 42 }, frameId: 0 },
+    })
+
+    expect(storageSetItemMock).toHaveBeenCalledWith(getTranslationStateKey(42), { enabled: true })
+    expect(sendMessageMock).toHaveBeenCalledWith("notifyTranslationStateChanged", { enabled: true }, 42)
+    expect(injectHostContentIntoTabIframesMock).toHaveBeenCalledWith(42)
+  })
+
+  it("does not reinject every iframe when an iframe manager echoes enabled state", async () => {
+    await setupSubject()
+
+    await getHandler("setAndNotifyPageTranslationStateChangedByManager")({
+      data: { enabled: true },
+      sender: { tab: { id: 42 }, frameId: 7 },
+    })
+
+    expect(storageSetItemMock).toHaveBeenCalledWith(getTranslationStateKey(42), { enabled: true })
+    expect(sendMessageMock).toHaveBeenCalledWith("notifyTranslationStateChanged", { enabled: true }, 42)
+    expect(injectHostContentIntoTabIframesMock).not.toHaveBeenCalled()
+  })
+
+  it("clears state immediately when a tab-level request disables page translation", async () => {
+    await setupSubject()
+
+    await getHandler("tryToSetEnablePageTranslationByTabId")({
+      data: { tabId: 42, enabled: false },
+    })
+
+    expect(storageSetItemMock).toHaveBeenCalledWith(getTranslationStateKey(42), { enabled: false })
+    expect(sendMessageMock).toHaveBeenCalledWith("notifyTranslationStateChanged", { enabled: false }, 42)
+    expect(sendMessageMock).toHaveBeenCalledWith("askManagerToTogglePageTranslation", {
+      enabled: false,
+      analyticsContext: undefined,
+    }, 42)
+  })
+
+  it("waits for the top-frame manager to validate before enabling iframe injection", async () => {
+    await setupSubject()
+
+    await getHandler("tryToSetEnablePageTranslationByTabId")({
+      data: { tabId: 42, enabled: true },
+    })
+
+    expect(storageSetItemMock).not.toHaveBeenCalled()
+    expect(injectHostContentIntoTabIframesMock).not.toHaveBeenCalled()
+    expect(sendMessageMock).toHaveBeenCalledWith("askManagerToTogglePageTranslation", {
+      enabled: true,
+      analyticsContext: undefined,
+    }, 42)
+  })
+})

--- a/src/entrypoints/background/context-menu.ts
+++ b/src/entrypoints/background/context-menu.ts
@@ -7,6 +7,7 @@ import { CONFIG_STORAGE_KEY } from "@/utils/constants/config"
 import { getTranslationStateKey, TRANSLATION_STATE_KEY_PREFIX } from "@/utils/constants/storage-keys"
 import { sendMessage } from "@/utils/message"
 import { ensureInitializedConfig } from "./config"
+import { getPageTranslationEnabled, setPageTranslationEnabled } from "./page-translation-state"
 
 export const MENU_ID_TRANSLATE = "read-frog-translate"
 export const MENU_ID_SELECTION_TRANSLATE = "read-frog-selection-translate"
@@ -194,14 +195,13 @@ async function handleContextMenuClick(
  * Handle translate menu click - toggle page translation
  */
 async function handleTranslateClick(tabId: number) {
-  const state = await storage.getItem<{ enabled: boolean }>(
-    getTranslationStateKey(tabId),
-  )
-  const isCurrentlyTranslated = state?.enabled ?? false
+  const isCurrentlyTranslated = await getPageTranslationEnabled(tabId)
   const newState = !isCurrentlyTranslated
 
-  // Update storage directly (instead of sending message to self)
-  await storage.setItem(getTranslationStateKey(tabId), { enabled: newState })
+  if (!newState) {
+    await setPageTranslationEnabled(tabId, false)
+    void sendMessage("notifyTranslationStateChanged", { enabled: false }, tabId)
+  }
 
   // Notify content script in that specific tab
   void sendMessage("askManagerToTogglePageTranslation", {
@@ -212,7 +212,7 @@ async function handleTranslateClick(tabId: number) {
   }, tabId)
 
   // Update menu title immediately
-  await updateTranslateMenuTitle(tabId)
+  await updateTranslateMenuTitle(tabId, newState)
 }
 
 async function handleSelectionTranslateClick(

--- a/src/entrypoints/background/iframe-injection.ts
+++ b/src/entrypoints/background/iframe-injection.ts
@@ -83,6 +83,21 @@ async function getFrameSnapshot(tabId: number): Promise<FrameInfoForSiteControl[
   return await browser.webNavigation.getAllFrames({ tabId }) ?? []
 }
 
+async function getShouldInjectHostContentIntoTabIframes(
+  tabId: number,
+  existingConfig?: Config | null,
+): Promise<{ config: Config | null, shouldInject: boolean }> {
+  const [isPageTranslationEnabled, config] = await Promise.all([
+    getPageTranslationEnabled(tabId),
+    existingConfig === undefined ? getLocalConfig() : Promise.resolve(existingConfig),
+  ])
+
+  return {
+    config,
+    shouldInject: isPageTranslationEnabled || Boolean(config?.translate.node.enabled),
+  }
+}
+
 async function injectHostContentIntoFrame(
   details: FrameInjectionDetails,
   frames?: FrameInfoForSiteControl[],
@@ -154,25 +169,22 @@ async function injectHostContentIntoFrame(
 }
 
 export async function injectHostContentIntoTabIframes(tabId: number) {
-  let isEnabled: boolean
+  let config: Config | null
+  let shouldInject: boolean
   try {
-    isEnabled = await getPageTranslationEnabled(tabId)
+    ({ config, shouldInject } = await getShouldInjectHostContentIntoTabIframes(tabId))
   }
   catch (error) {
-    logger.warn("[Background][IframeInjection] Failed to read page translation state", error)
+    logger.warn("[Background][IframeInjection] Failed to resolve iframe injection state", error)
     return
   }
 
-  if (!isEnabled)
+  if (!shouldInject)
     return
 
-  let config: Config | null
   let frames: FrameInfoForSiteControl[]
   try {
-    [config, frames] = await Promise.all([
-      getLocalConfig(),
-      getFrameSnapshot(tabId),
-    ])
+    frames = await getFrameSnapshot(tabId)
   }
   catch (error) {
     logger.error("[Background][IframeInjection] Failed to resolve tab iframe injection prerequisites", error)
@@ -203,7 +215,8 @@ export function setupIframeInjection() {
     clearFrameInjectedDocumentState(details.tabId, details.frameId)
   })
 
-  // Only inject into subframes after page translation is enabled for the tab.
+  // Only inject into subframes after page translation or hover/node translation
+  // is enabled for the tab.
   // This keeps iframe-heavy pages and benchmarks from paying content-script cost
   // before the feature is actually used.
   browser.webNavigation.onCompleted.addListener(async (details) => {
@@ -211,16 +224,18 @@ export function setupIframeInjection() {
     if (details.frameId === 0)
       return
 
+    let config: Config | null
+    let shouldInject: boolean
     try {
-      const isEnabled = await getPageTranslationEnabled(details.tabId)
-      if (!isEnabled)
+      ({ config, shouldInject } = await getShouldInjectHostContentIntoTabIframes(details.tabId))
+      if (!shouldInject)
         return
     }
     catch (error) {
-      logger.warn("[Background][IframeInjection] Failed to read page translation state", error)
+      logger.warn("[Background][IframeInjection] Failed to resolve iframe injection state", error)
       return
     }
 
-    await injectHostContentIntoFrame(details)
+    await injectHostContentIntoFrame(details, undefined, config)
   })
 }

--- a/src/entrypoints/background/iframe-injection.ts
+++ b/src/entrypoints/background/iframe-injection.ts
@@ -1,19 +1,27 @@
+import type { FrameInfoForSiteControl } from "./iframe-injection-utils"
+import type { Config } from "@/types/config/config"
 import { browser } from "#imports"
 import { getLocalConfig } from "@/utils/config/storage"
 import { logger } from "@/utils/logger"
 import { isSiteEnabled, SITE_CONTROL_URL_WINDOW_KEY } from "@/utils/site-control"
 import { resolveSiteControlUrl } from "./iframe-injection-utils"
+import { getPageTranslationEnabled } from "./page-translation-state"
 
 const pendingDocumentKeys = new Set<string>()
 const injectedDocumentKeysByFrame = new Map<string, string>()
 
-function getDocumentInjectionKey(details: { tabId: number, frameId: number, documentId?: string }) {
-  // Gracefully skip document-level deduplication when Chromium does not expose documentId.
-  if (!details.documentId) {
-    return null
-  }
+interface FrameInjectionDetails {
+  tabId: number
+  frameId: number
+  documentId?: string
+  parentFrameId?: number
+  url?: string
+}
 
-  return `${details.tabId}:${details.frameId}:${details.documentId}`
+function getDocumentInjectionKey(details: FrameInjectionDetails) {
+  // documentId is best, but getAllFrames may not expose it. Fall back to URL so
+  // explicit per-tab injections still dedupe until the frame navigates.
+  return `${details.tabId}:${details.frameId}:${details.documentId ?? details.url ?? "unknown"}`
 }
 
 function getFrameInjectionKey(details: { tabId: number, frameId: number }) {
@@ -63,12 +71,125 @@ function setInjectedSiteControlUrl(propertyName: string, siteControlUrl: string)
   ;(globalThis as Record<string, unknown>)[propertyName] = siteControlUrl
 }
 
-function getInjectionTarget(details: { tabId: number, frameId: number, documentId?: string }) {
+function getInjectionTarget(details: FrameInjectionDetails) {
   if (details.documentId) {
     return { tabId: details.tabId, documentIds: [details.documentId] }
   }
 
   return { tabId: details.tabId, frameIds: [details.frameId] }
+}
+
+async function getFrameSnapshot(tabId: number): Promise<FrameInfoForSiteControl[]> {
+  return await browser.webNavigation.getAllFrames({ tabId }) ?? []
+}
+
+async function injectHostContentIntoFrame(
+  details: FrameInjectionDetails,
+  frames?: FrameInfoForSiteControl[],
+  existingConfig?: Config | null,
+) {
+  const frameKey = getFrameInjectionKey(details)
+  const documentKey = getDocumentInjectionKey(details)
+
+  if (
+    pendingDocumentKeys.has(documentKey)
+    || injectedDocumentKeysByFrame.get(frameKey) === documentKey
+  ) {
+    return
+  }
+
+  pendingDocumentKeys.add(documentKey)
+
+  try {
+    let siteControlUrl: string | undefined
+
+    try {
+      const [config, frameSnapshot] = await Promise.all([
+        existingConfig === undefined ? getLocalConfig() : Promise.resolve(existingConfig),
+        frames === undefined ? getFrameSnapshot(details.tabId) : Promise.resolve(frames),
+      ])
+      const liveFrameIds = new Set(frameSnapshot.map(frame => frame.frameId))
+      liveFrameIds.add(details.frameId)
+      pruneInjectedFrames(details.tabId, liveFrameIds)
+
+      siteControlUrl = resolveSiteControlUrl(
+        details.frameId,
+        details.url,
+        frameSnapshot,
+        getParentFrameIdHint(details),
+      )
+
+      if (!siteControlUrl || !isSiteEnabled(siteControlUrl, config)) {
+        return
+      }
+    }
+    catch (error) {
+      logger.error("[Background][IframeInjection] Failed to resolve iframe injection prerequisites", error)
+      return
+    }
+
+    try {
+      const target = getInjectionTarget(details) as Parameters<typeof browser.scripting.executeScript>[0]["target"]
+
+      await browser.scripting.executeScript({
+        target,
+        func: setInjectedSiteControlUrl,
+        args: [SITE_CONTROL_URL_WINDOW_KEY, siteControlUrl],
+      })
+
+      await browser.scripting.executeScript({
+        target,
+        files: ["/content-scripts/host.js"],
+      })
+
+      injectedDocumentKeysByFrame.set(frameKey, documentKey)
+    }
+    catch (error) {
+      logger.warn("[Background][IframeInjection] Failed to inject iframe content scripts", error)
+    }
+  }
+  finally {
+    pendingDocumentKeys.delete(documentKey)
+  }
+}
+
+export async function injectHostContentIntoTabIframes(tabId: number) {
+  let isEnabled: boolean
+  try {
+    isEnabled = await getPageTranslationEnabled(tabId)
+  }
+  catch (error) {
+    logger.warn("[Background][IframeInjection] Failed to read page translation state", error)
+    return
+  }
+
+  if (!isEnabled)
+    return
+
+  let config: Config | null
+  let frames: FrameInfoForSiteControl[]
+  try {
+    [config, frames] = await Promise.all([
+      getLocalConfig(),
+      getFrameSnapshot(tabId),
+    ])
+  }
+  catch (error) {
+    logger.error("[Background][IframeInjection] Failed to resolve tab iframe injection prerequisites", error)
+    return
+  }
+
+  const liveFrameIds = new Set(frames.map(frame => frame.frameId))
+  pruneInjectedFrames(tabId, liveFrameIds)
+
+  await Promise.all(frames
+    .filter(frame => frame.frameId !== 0)
+    .map(frame => injectHostContentIntoFrame({
+      tabId,
+      frameId: frame.frameId,
+      parentFrameId: frame.parentFrameId,
+      url: frame.url,
+    }, frames, config)))
 }
 
 export function setupIframeInjection() {
@@ -82,86 +203,24 @@ export function setupIframeInjection() {
     clearFrameInjectedDocumentState(details.tabId, details.frameId)
   })
 
-  // Listen for iframe loads and inject content scripts programmatically
-  // This catches iframes that Chrome's manifest-based all_frames: true misses
-  // (e.g., dynamically created iframes, sandboxed iframes like edX)
+  // Only inject into subframes after page translation is enabled for the tab.
+  // This keeps iframe-heavy pages and benchmarks from paying content-script cost
+  // before the feature is actually used.
   browser.webNavigation.onCompleted.addListener(async (details) => {
     // Skip main frame (frameId === 0), only handle iframes
     if (details.frameId === 0)
       return
 
-    const frameKey = getFrameInjectionKey(details)
-    const documentKey = getDocumentInjectionKey(details)
-    if (documentKey) {
-      if (
-        pendingDocumentKeys.has(documentKey)
-        || injectedDocumentKeysByFrame.get(frameKey) === documentKey
-      ) {
-        return
-      }
-
-      pendingDocumentKeys.add(documentKey)
-    }
-
     try {
-      let siteControlUrl: string | undefined
-
-      try {
-        const config = await getLocalConfig()
-        const frames = await browser.webNavigation.getAllFrames({ tabId: details.tabId }) ?? []
-        const liveFrameIds = new Set(frames.map(frame => frame.frameId))
-        liveFrameIds.add(details.frameId)
-        pruneInjectedFrames(details.tabId, liveFrameIds)
-
-        siteControlUrl = resolveSiteControlUrl(
-          details.frameId,
-          details.url,
-          frames,
-          getParentFrameIdHint(details),
-        )
-
-        if (!siteControlUrl || !isSiteEnabled(siteControlUrl, config)) {
-          return
-        }
-      }
-      catch (error) {
-        logger.error("[Background][IframeInjection] Failed to resolve iframe injection prerequisites", error)
+      const isEnabled = await getPageTranslationEnabled(details.tabId)
+      if (!isEnabled)
         return
-      }
-
-      try {
-        const target = getInjectionTarget(details) as Parameters<typeof browser.scripting.executeScript>[0]["target"]
-
-        await browser.scripting.executeScript({
-          target,
-          func: setInjectedSiteControlUrl,
-          args: [SITE_CONTROL_URL_WINDOW_KEY, siteControlUrl],
-        })
-
-        // Inject host.content script into the iframe
-        await browser.scripting.executeScript({
-          target,
-          files: ["/content-scripts/host.js"],
-        })
-
-        // Inject selection.content script into the iframe
-        await browser.scripting.executeScript({
-          target,
-          files: ["/content-scripts/selection.js"],
-        })
-
-        if (documentKey) {
-          injectedDocumentKeysByFrame.set(frameKey, documentKey)
-        }
-      }
-      catch (error) {
-        logger.warn("[Background][IframeInjection] Failed to inject iframe content scripts", error)
-      }
     }
-    finally {
-      if (documentKey) {
-        pendingDocumentKeys.delete(documentKey)
-      }
+    catch (error) {
+      logger.warn("[Background][IframeInjection] Failed to read page translation state", error)
+      return
     }
+
+    await injectHostContentIntoFrame(details)
   })
 }

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -109,7 +109,7 @@ export default defineBackground({
     setupTTSPlaybackMessageHandlers()
     void initMockData()
 
-    // Setup programmatic injection for iframes that Chrome's manifest-based all_frames misses
+    // Setup on-demand iframe injection after page translation is enabled.
     setupIframeInjection()
   },
 })

--- a/src/entrypoints/background/page-translation-state.ts
+++ b/src/entrypoints/background/page-translation-state.ts
@@ -1,0 +1,17 @@
+import type { TranslationState } from "@/types/translation-state"
+import { storage } from "#imports"
+import { getTranslationStateKey } from "@/utils/constants/storage-keys"
+
+export async function getPageTranslationEnabled(tabId: number): Promise<boolean> {
+  const state = await storage.getItem<TranslationState>(
+    getTranslationStateKey(tabId),
+  )
+  return state?.enabled ?? false
+}
+
+export async function setPageTranslationEnabled(tabId: number, enabled: boolean): Promise<void> {
+  await storage.setItem<TranslationState>(
+    getTranslationStateKey(tabId),
+    { enabled },
+  )
+}

--- a/src/entrypoints/background/translation-signal.ts
+++ b/src/entrypoints/background/translation-signal.ts
@@ -1,5 +1,5 @@
+import type { FeatureUsageContext } from "@/types/analytics"
 import type { Config } from "@/types/config/config"
-import type { TranslationState } from "@/types/translation-state"
 import { browser, storage } from "#imports"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext } from "@/utils/analytics"
@@ -8,6 +8,22 @@ import { getTranslationStateKey } from "@/utils/constants/storage-keys"
 import { shouldEnableAutoTranslation } from "@/utils/host/translate/auto-translation"
 import { logger } from "@/utils/logger"
 import { onMessage, sendMessage } from "@/utils/message"
+import { injectHostContentIntoTabIframes } from "./iframe-injection"
+import { getPageTranslationEnabled, setPageTranslationEnabled } from "./page-translation-state"
+
+function notifyPageTranslationStateChanged(tabId: number, enabled: boolean) {
+  void sendMessage("notifyTranslationStateChanged", { enabled }, tabId)
+    .catch(error => logger.warn("Failed to notify page translation state change", error))
+}
+
+function requestManagerToTogglePageTranslation(
+  tabId: number,
+  enabled: boolean,
+  analyticsContext?: FeatureUsageContext,
+) {
+  void sendMessage("askManagerToTogglePageTranslation", { enabled, analyticsContext }, tabId)
+    .catch(error => logger.warn("Failed to ask page translation manager to toggle", error))
+}
 
 export function translationMessage() {
   onMessage("getEnablePageTranslationByTabId", async (msg) => {
@@ -26,7 +42,11 @@ export function translationMessage() {
 
   onMessage("tryToSetEnablePageTranslationByTabId", async (msg) => {
     const { tabId, enabled, analyticsContext } = msg.data
-    void sendMessage("askManagerToTogglePageTranslation", { enabled, analyticsContext }, tabId)
+    if (!enabled) {
+      await setPageTranslationEnabled(tabId, false)
+      notifyPageTranslationStateChanged(tabId, false)
+    }
+    requestManagerToTogglePageTranslation(tabId, enabled, analyticsContext)
   })
 
   onMessage("tryToSetEnablePageTranslationOnContentScript", async (msg) => {
@@ -34,7 +54,11 @@ export function translationMessage() {
     const { enabled, analyticsContext } = msg.data
     if (typeof tabId === "number") {
       logger.info("sending tryToSetEnablePageTranslationOnContentScript to manager", { enabled, tabId })
-      await sendMessage("askManagerToTogglePageTranslation", { enabled, analyticsContext }, tabId)
+      if (!enabled) {
+        await setPageTranslationEnabled(tabId, false)
+        notifyPageTranslationStateChanged(tabId, false)
+      }
+      requestManagerToTogglePageTranslation(tabId, enabled, analyticsContext)
     }
     else {
       logger.error("tabId is not a number", msg)
@@ -50,10 +74,11 @@ export function translationMessage() {
         return
       const shouldEnable = await shouldEnableAutoTranslation(url, detectedCodeOrUnd, config)
       if (shouldEnable) {
-        void sendMessage("askManagerToTogglePageTranslation", {
-          enabled: true,
-          analyticsContext: createFeatureUsageContext(ANALYTICS_FEATURE.PAGE_TRANSLATION, ANALYTICS_SURFACE.PAGE_AUTO),
-        }, tabId)
+        requestManagerToTogglePageTranslation(
+          tabId,
+          true,
+          createFeatureUsageContext(ANALYTICS_FEATURE.PAGE_TRANSLATION, ANALYTICS_SURFACE.PAGE_AUTO),
+        )
       }
     }
   })
@@ -62,11 +87,13 @@ export function translationMessage() {
     const tabId = msg.sender?.tab?.id
     const { enabled } = msg.data
     if (typeof tabId === "number") {
-      await storage.setItem<TranslationState>(
-        getTranslationStateKey(tabId),
-        { enabled },
-      )
-      void sendMessage("notifyTranslationStateChanged", { enabled }, tabId)
+      await setPageTranslationEnabled(tabId, enabled)
+      notifyPageTranslationStateChanged(tabId, enabled)
+
+      const senderFrameId = msg.sender?.frameId
+      if (enabled && (senderFrameId === 0 || senderFrameId === undefined)) {
+        void injectHostContentIntoTabIframes(tabId)
+      }
     }
     else {
       logger.error("tabId is not a number", msg)
@@ -75,10 +102,7 @@ export function translationMessage() {
 
   // === Helper Functions ===
   async function getTranslationState(tabId: number): Promise<boolean> {
-    const state = await storage.getItem<TranslationState>(
-      getTranslationStateKey(tabId),
-    )
-    return state?.enabled ?? false
+    return await getPageTranslationEnabled(tabId)
   }
 
   // === Cleanup ===

--- a/src/entrypoints/background/translation-signal.ts
+++ b/src/entrypoints/background/translation-signal.ts
@@ -40,6 +40,16 @@ export function translationMessage() {
     return false
   })
 
+  onMessage("ensureIframeHostContentInjected", async (msg) => {
+    const tabId = msg.data?.tabId ?? msg.sender?.tab?.id
+    if (typeof tabId === "number") {
+      await injectHostContentIntoTabIframes(tabId)
+      return
+    }
+
+    logger.error("Invalid tabId in ensureIframeHostContentInjected", msg)
+  })
+
   onMessage("tryToSetEnablePageTranslationByTabId", async (msg) => {
     const { tabId, enabled, analyticsContext } = msg.data
     if (!enabled) {

--- a/src/entrypoints/host.content/index.tsx
+++ b/src/entrypoints/host.content/index.tsx
@@ -12,7 +12,6 @@ declare global {
 export default defineContentScript({
   matches: ["*://*/*", "file:///*"],
   cssInjectionMode: "manual",
-  allFrames: true,
   async main(ctx) {
     // Prevent double injection (manifest-based + programmatic injection)
     if (window.__READ_FROG_HOST_INJECTED__)

--- a/src/entrypoints/host.content/runtime.ts
+++ b/src/entrypoints/host.content/runtime.ts
@@ -78,6 +78,15 @@ export async function bootstrapHostContent(ctx: ContentScriptContext, initialCon
     enabled ? void manager.start(window === window.top ? analyticsContext : undefined) : manager.stop()
   })
 
+  const cleanupFrameTranslationStateListener = window === window.top
+    ? () => {}
+    : onMessage("notifyTranslationStateChanged", (msg) => {
+        const { enabled } = msg.data
+        if (enabled === manager.isActive)
+          return
+        enabled ? void manager.start() : manager.stop()
+      })
+
   ctx.onInvalidated(() => {
     removeHostToast()
     cleanupUrlListener()
@@ -85,6 +94,7 @@ export async function bootstrapHostContent(ctx: ContentScriptContext, initialCon
     cleanupPageTranslationTriggers()
     cleanupTranslationShortcut()
     cleanupTranslationStateListener()
+    cleanupFrameTranslationStateListener()
     window.removeEventListener("extension:URLChange", handleExtensionUrlChange)
     window.__READ_FROG_HOST_INJECTED__ = false
     clearEffectiveSiteControlUrl()

--- a/src/entrypoints/host.content/runtime.ts
+++ b/src/entrypoints/host.content/runtime.ts
@@ -34,6 +34,10 @@ export async function bootstrapHostContent(ctx: ContentScriptContext, initialCon
 
   const cleanupTranslationShortcut = await bindTranslationShortcutKey(manager)
 
+  if (window === window.top && initialConfig?.translate.node.enabled) {
+    void sendMessage("ensureIframeHostContentInjected", {})
+  }
+
   // For late-loading iframes: check if translation is already enabled for this tab
   let translationEnabled = false
   try {

--- a/src/entrypoints/popup/components/node-translation-hotkey-selector.tsx
+++ b/src/entrypoints/popup/components/node-translation-hotkey-selector.tsx
@@ -1,4 +1,4 @@
-import { i18n } from "#imports"
+import { browser, i18n } from "#imports"
 import { deepmerge } from "deepmerge-ts"
 import { useAtom } from "jotai"
 import {
@@ -11,6 +11,7 @@ import {
 import { Switch } from "@/components/ui/base-ui/switch"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { HOTKEY_ICONS, HOTKEYS } from "@/utils/constants/hotkeys"
+import { sendMessage } from "@/utils/message"
 
 function HotkeyDisplay({ hotkey }: { hotkey: typeof HOTKEYS[number] }) {
   const icon = HOTKEY_ICONS[hotkey]
@@ -48,6 +49,18 @@ export default function NodeTranslationHotkeySelector() {
     configFieldsAtomMap.translate,
   )
 
+  const handleNodeTranslationEnabledChange = async (checked: boolean) => {
+    await setTranslateConfig(deepmerge(translateConfig, { node: { enabled: checked } }))
+
+    if (!checked)
+      return
+
+    const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })
+    if (typeof currentTab?.id === "number") {
+      void sendMessage("ensureIframeHostContentInjected", { tabId: currentTab.id })
+    }
+  }
+
   return (
     <div className="flex items-center justify-between gap-2">
       <Select
@@ -77,7 +90,7 @@ export default function NodeTranslationHotkeySelector() {
       </Select>
       <Switch
         checked={translateConfig.node.enabled}
-        onCheckedChange={checked => setTranslateConfig(deepmerge(translateConfig, { node: { enabled: checked } }))}
+        onCheckedChange={checked => void handleNodeTranslationEnabledChange(checked)}
       />
     </div>
   )

--- a/src/entrypoints/selection.content/index.tsx
+++ b/src/entrypoints/selection.content/index.tsx
@@ -85,7 +85,6 @@ async function mountSelectionUI(ctx: ContentScriptContext) {
 export default defineContentScript({
   matches: ["*://*/*", "file:///*"],
   cssInjectionMode: "ui",
-  allFrames: true,
   async main(ctx) {
     // Prevent double injection (manifest-based + programmatic injection)
     if (window.__READ_FROG_SELECTION_INJECTED__)

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -36,6 +36,7 @@ interface ProtocolMap {
   tryToSetEnablePageTranslationOnContentScript: (data: { enabled: boolean, analyticsContext?: FeatureUsageContext }) => void
   setAndNotifyPageTranslationStateChangedByManager: (data: { enabled: boolean }) => void
   notifyTranslationStateChanged: (data: { enabled: boolean }) => void
+  ensureIframeHostContentInjected: (data: { tabId?: number }) => void
   // for auto start page translation
   checkAndAskAutoPageTranslation: (data: { url: string, detectedCodeOrUnd: LangCodeISO6393 | "und" }) => void
   // ask host to start page translation


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [x] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fixes the Speedometer 3.0 regression caused by injecting heavy Read Frog content scripts into every iframe by default.

The change keeps the normal host and selection content scripts top-frame only, then injects iframe host runtime only after page translation is actually enabled for that tab. This avoids mounting the selection React UI and host script runtime in benchmark/test iframes, while preserving iframe translation after page translation starts. YouTube subtitle/interceptor iframe handling remains unchanged.

## Related Issue

Closes #1093

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Automated validation:

- `SKIP_FREE_API=true pnpm vitest run src/entrypoints/background/__tests__/iframe-injection.test.ts src/entrypoints/background/__tests__/translation-signal.test.ts src/entrypoints/background/__tests__/context-menu.test.ts`
- `SKIP_FREE_API=true pnpm type-check`
- `pnpm lint`
- `SKIP_FREE_API=true pnpm test`
- `WXT_SKIP_ENV_VALIDATION=true pnpm build`
- Pre-push hook also completed `lint`, `type-check`, and `test` successfully on this branch (`124` test files / `1084` tests passed).

### Speedometer 3.0 benchmark method

- Browser: Microsoft Edge `147.0.3912.86`.
- Benchmark URL: `https://browserbench.org/Speedometer3.0/?startAutomatically` with the default `iterationCount=10`.
- Ran 3 repeats per case with fresh temporary Edge profiles.
- Extension builds were loaded with `--disable-extensions-except=<path>` and `--load-extension=<path>`.
- Compared no extension, Read Frog `1.19.4`, downloaded Read Frog `1.33.1`, and this fixed local build.
- Full results saved at `/tmp/read-frog-speedometer-2026-04-28T20-03-06-999Z/summary.json`.

### Speedometer 3.0 results

| Case | Runs | Mean | Median | vs no-extension |
| --- | --- | ---: | ---: | ---: |
| no-extension | `47.7`, `39.1`, `39.7` | `42.17` | `39.70` | `0.0%` |
| read-frog-1.19.4 | `39.6`, `39.7`, `38.9` | `39.40` | `39.60` | `-6.6%` |
| read-frog-1.33.1-download | `22.3`, `21.7`, `21.7` | `21.90` | `21.70` | `-48.1%` |
| read-frog-fixed-local | `39.8`, `48.7`, `48.8` | `45.77` | `48.70` | `+8.5%` |

Key comparisons:

- `1.33.1-download` vs `1.19.4`: mean dropped from `39.40` to `21.90`, about `-44.4%`.
- `fixed-local` vs `1.33.1-download`: mean recovered from `21.90` to `45.77`, about `+109.0%`.
- Median shows the same pattern: `21.70` -> `48.70`.
- The fixed build is back near no-extension / `1.19.4` range, confirming the regression was caused by default all-frame content script injection.

### Version history smoke comparison

This is a quick positioning run only: `iterationCount=3`, one run per version, wider confidence interval than the main benchmark. It is useful for trend detection, not as the final score.

- Summary saved at `/tmp/read-frog-speedometer-2026-04-28T20-11-00-920Z/summary.json`.
- Result matched the same pattern: the regression appears in the all-frame injection era after `1.19.4`.

| Case | Score | vs no-extension |
| --- | ---: | ---: |
| no-extension | `37.0` | `0.0%` |
| read-frog-1.19.4 | `37.1` | `+0.3%` |
| read-frog-1.22.0-edge | `14.1` | `-61.9%` |
| read-frog-1.24.0 | `13.1` | `-64.6%` |
| read-frog-1.28.1 | `29.3` | `-20.8%` |
| read-frog-1.31.4 | `21.2` | `-42.7%` |
| read-frog-1.33.1-download | `21.2` | `-42.7%` |
| read-frog-fixed-local | `37.5` | `+1.4%` |

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This intentionally avoids a `browserbench.org` blacklist. The fix removes the iframe-heavy overhead generally instead of only hiding it from the benchmark.
