### PR TITLE
fix(extension): add animated subtitle format parser for YouTube kinetic typography

### DIFF
--- a/.changeset/animated-subtitle-parser.md
+++ b/.changeset/animated-subtitle-parser.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(extension): add animated subtitle format parser for YouTube kinetic typography

--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -16,17 +16,20 @@ export class SegmentationPipeline {
 
   private getVideoElement: () => HTMLVideoElement | null
   private getSourceLanguage: () => string
+  private preSegmented: boolean
 
   constructor(options: {
     baselineFragments?: SubtitlesFragment[]
     rawFragments: SubtitlesFragment[]
     getVideoElement: () => HTMLVideoElement | null
     getSourceLanguage: () => string
+    preSegmented?: boolean
   }) {
     this.rawFragments = options.rawFragments
     this.processedFragments = [...(options.baselineFragments ?? [])]
     this.getVideoElement = options.getVideoElement
     this.getSourceLanguage = options.getSourceLanguage
+    this.preSegmented = options.preSegmented ?? false
   }
 
   get isRunning(): boolean {
@@ -86,6 +89,11 @@ export class SegmentationPipeline {
       return false
 
     chunk.forEach(f => this.segmentedRawStarts.add(f.start))
+
+    if (this.preSegmented) {
+      this.replaceProcessedChunk(chunk, chunk)
+      return true
+    }
 
     try {
       const config = await getLocalConfig()

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -159,6 +159,8 @@ export class UniversalVideoAdapter {
   }
 
   private buildSourceProcessedSubtitles(rawSubtitles: SubtitlesFragment[]): SubtitlesFragment[] {
+    if (this.subtitlesFetcher.isPreSegmented?.())
+      return rawSubtitles
     const sourceLanguage = this.subtitlesFetcher.getSourceLanguage()
     return optimizeSubtitles(rawSubtitles, sourceLanguage)
   }
@@ -441,6 +443,7 @@ export class UniversalVideoAdapter {
         rawFragments: this.sessionSubtitles,
         getVideoElement: () => this.subtitlesScheduler?.getVideoElement() ?? null,
         getSourceLanguage: () => this.subtitlesFetcher.getSourceLanguage(),
+        preSegmented: this.subtitlesFetcher.isPreSegmented?.(),
       })
     }
     else {

--- a/src/utils/subtitles/__tests__/youtube-parsers.test.ts
+++ b/src/utils/subtitles/__tests__/youtube-parsers.test.ts
@@ -1,6 +1,7 @@
 import type { YoutubeTimedText } from "../fetchers/youtube/types"
 import { describe, expect, it } from "vitest"
 import { detectFormat } from "../fetchers/youtube/format-detector"
+import { parseAnimatedSubtitles } from "../fetchers/youtube/parser/animated-parser"
 import { parseKaraokeSubtitles } from "../fetchers/youtube/parser/karaoke-parser"
 import { parseScrollingAsrSubtitles } from "../fetchers/youtube/parser/scrolling-asr-parser"
 import { parseStylizedKaraokeSubtitles } from "../fetchers/youtube/parser/stylized-karaoke-parser"
@@ -45,6 +46,36 @@ describe("youTube Subtitle Parsers", () => {
 
     it("should return standard for empty events", () => {
       expect(detectFormat([])).toBe("standard")
+    })
+
+    it("should detect animated format (many short-duration events with wpWinPosId)", () => {
+      const events: YoutubeTimedText[] = Array.from({ length: 100 }, (_, i) => ({
+        tStartMs: 1000 + i * 67,
+        dDurationMs: 67,
+        wpWinPosId: 3 + (i % 20),
+        segs: [{ utf8: i % 5 === 0 ? "scrolling text" : "" }],
+      }))
+      expect(detectFormat(events)).toBe("animated")
+    })
+
+    it("should not detect animated for few events", () => {
+      const events: YoutubeTimedText[] = Array.from({ length: 10 }, (_, i) => ({
+        tStartMs: 1000 + i * 67,
+        dDurationMs: 67,
+        wpWinPosId: 3,
+        segs: [{ utf8: "text" }],
+      }))
+      expect(detectFormat(events)).not.toBe("animated")
+    })
+
+    it("should not detect animated for normal-duration events", () => {
+      const events: YoutubeTimedText[] = Array.from({ length: 100 }, (_, i) => ({
+        tStartMs: i * 3000,
+        dDurationMs: 2000,
+        wpWinPosId: 3,
+        segs: [{ utf8: "normal subtitle" }],
+      }))
+      expect(detectFormat(events)).not.toBe("animated")
     })
   })
 
@@ -424,6 +455,94 @@ describe("youTube Subtitle Parsers", () => {
       // Should split when character count reaches 30
       expect(result.length).toBeGreaterThan(1)
       expect(result[0].text.length).toBeLessThanOrEqual(30)
+    })
+  })
+
+  describe("animated Parser", () => {
+    it("should deduplicate consecutive identical text frames", () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 4688, dDurationMs: 67, wpWinPosId: 3, segs: [{ utf8: "閃避子彈！" }] },
+        { tStartMs: 4755, dDurationMs: 67, wpWinPosId: 4, segs: [{ utf8: "閃避子彈！" }] },
+        { tStartMs: 4822, dDurationMs: 67, wpWinPosId: 5, segs: [{ utf8: "閃避子彈！" }] },
+      ]
+      const result = parseAnimatedSubtitles(events)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].text).toBe("閃避子彈！")
+      expect(result[0].start).toBe(4688)
+      expect(result[0].end).toBe(4889)
+    })
+
+    it("should split when text changes between frames", () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 24008, dDurationMs: 67, wpWinPosId: 3, segs: [{ utf8: "現在向你道別吧！" }] },
+        { tStartMs: 24075, dDurationMs: 67, wpWinPosId: 4, segs: [{ utf8: "現在向你道別吧！" }] },
+        { tStartMs: 24200, dDurationMs: 67, wpWinPosId: 5, segs: [{ utf8: "沒人會聽到你的哀求！" }] },
+        { tStartMs: 24300, dDurationMs: 67, wpWinPosId: 6, segs: [{ utf8: "沒人會聽到你的哀求！" }] },
+      ]
+      const result = parseAnimatedSubtitles(events)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].text).toBe("現在向你道別吧！")
+      expect(result[0].end).toBeLessThanOrEqual(24200)
+      expect(result[1].text).toBe("沒人會聽到你的哀求！")
+    })
+
+    it("should skip events with empty text", () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 1000, dDurationMs: 67, wpWinPosId: 3, segs: [{ utf8: "" }] },
+        { tStartMs: 1067, dDurationMs: 67, wpWinPosId: 4, segs: [{ utf8: "" }] },
+        { tStartMs: 1134, dDurationMs: 67, wpWinPosId: 5, segs: [{ utf8: "Visible text." }] },
+      ]
+      const result = parseAnimatedSubtitles(events)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].text).toBe("Visible text.")
+    })
+
+    it("should handle single event", () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 1, dDurationMs: 3853, wpWinPosId: 2, segs: [{ utf8: "Warning: content may be disturbing." }] },
+      ]
+      const result = parseAnimatedSubtitles(events)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].text).toBe("Warning: content may be disturbing.")
+      expect(result[0].start).toBe(1)
+      expect(result[0].end).toBe(3854)
+    })
+
+    it("should clean zero-width spaces from text", () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 1000, dDurationMs: 67, wpWinPosId: 3, segs: [{ utf8: "Hello​ world​" }] },
+      ]
+      const result = parseAnimatedSubtitles(events)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].text).toBe("Hello world")
+    })
+
+    it("should fix overlap between fragments", () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 1000, dDurationMs: 5000, wpWinPosId: 3, segs: [{ utf8: "First" }] },
+        { tStartMs: 4000, dDurationMs: 67, wpWinPosId: 4, segs: [{ utf8: "Second" }] },
+      ]
+      const result = parseAnimatedSubtitles(events)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].end).toBe(4000)
+      expect(result[1].start).toBe(4000)
+    })
+
+    it("should merge segments from multiple segs in one event", () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 1000, dDurationMs: 67, wpWinPosId: 3, segs: [{ utf8: "" }, { utf8: "" }, { utf8: "你所有的進步" }, { utf8: "" }] },
+        { tStartMs: 1067, dDurationMs: 67, wpWinPosId: 4, segs: [{ utf8: "" }, { utf8: "" }, { utf8: "你所有的進步" }, { utf8: "" }] },
+      ]
+      const result = parseAnimatedSubtitles(events)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].text).toBe("你所有的進步")
     })
   })
 

--- a/src/utils/subtitles/fetchers/types.ts
+++ b/src/utils/subtitles/fetchers/types.ts
@@ -6,4 +6,5 @@ export interface SubtitlesFetcher {
   shouldUseSameTrack: () => Promise<boolean>
   getSourceLanguage: () => string
   hasAvailableSubtitles: () => Promise<boolean>
+  isPreSegmented?: () => boolean
 }

--- a/src/utils/subtitles/fetchers/youtube/format-detector.ts
+++ b/src/utils/subtitles/fetchers/youtube/format-detector.ts
@@ -1,6 +1,6 @@
 import type { YoutubeTimedText } from "./types"
 
-export type SubtitleFormat = "karaoke" | "karaoke-stylized" | "scrolling-asr" | "standard"
+export type SubtitleFormat = "animated" | "karaoke" | "karaoke-stylized" | "scrolling-asr" | "standard"
 
 const ZERO_WIDTH_SPACE_PATTERN = /\u200B/g
 const WHITESPACE_PATTERN = /\s+/g
@@ -124,12 +124,41 @@ function isScrollingAsrFormat(events: YoutubeTimedText[]): boolean {
   return events.some(event => event.wWinId !== undefined && event.aAppend === 1)
 }
 
+const ANIMATED_DURATION_THRESHOLD_MS = 100
+const ANIMATED_MIN_EVENTS = 50
+const ANIMATED_SHORT_DURATION_RATIO = 0.5
+
+/**
+ * Detect animated/kinetic typography subtitles.
+ * Feature: most events are ultra-short animation frames (< 100ms) with wpWinPosId.
+ * Used in music videos where text bounces/scrolls across the screen.
+ */
+function isAnimatedFormat(events: YoutubeTimedText[]): boolean {
+  if (events.length < ANIMATED_MIN_EVENTS)
+    return false
+
+  let shortWithPos = 0
+  for (const event of events) {
+    if (
+      event.wpWinPosId !== undefined
+      && (event.dDurationMs ?? 0) <= ANIMATED_DURATION_THRESHOLD_MS
+    ) {
+      shortWithPos += 1
+    }
+  }
+
+  return shortWithPos / events.length >= ANIMATED_SHORT_DURATION_RATIO
+}
+
 /**
  * Detect subtitle format type.
  */
 export function detectFormat(events: YoutubeTimedText[]): SubtitleFormat {
   if (!events || events.length === 0)
     return "standard"
+
+  if (isAnimatedFormat(events))
+    return "animated"
 
   if (isStylizedKaraokeFormat(events))
     return "karaoke-stylized"

--- a/src/utils/subtitles/fetchers/youtube/index.ts
+++ b/src/utils/subtitles/fetchers/youtube/index.ts
@@ -23,7 +23,7 @@ import { OverlaySubtitlesError } from "@/utils/subtitles/errors"
 import { getYoutubeVideoId } from "@/utils/subtitles/video-id"
 import { detectFormat } from "./format-detector"
 import { filterNoiseFromEvents } from "./noise-filter"
-import { parseKaraokeSubtitles, parseScrollingAsrSubtitles, parseStandardSubtitles, parseStylizedKaraokeSubtitles } from "./parser"
+import { parseAnimatedSubtitles, parseKaraokeSubtitles, parseScrollingAsrSubtitles, parseStandardSubtitles, parseStylizedKaraokeSubtitles } from "./parser"
 import { extractPotToken } from "./pot-token"
 import { youtubeSubtitlesResponseSchema } from "./types"
 import { buildSubtitleUrl } from "./url-builder"
@@ -66,6 +66,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
   private subtitles: SubtitlesFragment[] = []
   private sourceLanguage: string = ""
   private cachedTrackHash: string | null = null
+  private preSegmented: boolean = false
 
   async fetch(): Promise<SubtitlesFragment[]> {
     const videoId = getYoutubeVideoId()
@@ -104,10 +105,15 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     return this.sourceLanguage
   }
 
+  isPreSegmented(): boolean {
+    return this.preSegmented
+  }
+
   cleanup(): void {
     this.subtitles = []
     this.sourceLanguage = ""
     this.cachedTrackHash = null
+    this.preSegmented = false
   }
 
   async hasAvailableSubtitles(): Promise<boolean> {
@@ -415,6 +421,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     const config = await getLocalConfig()
     const enableAISegmentation = config?.videoSubtitles?.aiSegmentation ?? false
 
+    this.preSegmented = false
     const filteredEvents = filterNoiseFromEvents(events)
     const format = detectFormat(filteredEvents)
 
@@ -424,6 +431,11 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
 
     if (format === "karaoke-stylized") {
       return parseStylizedKaraokeSubtitles(filteredEvents)
+    }
+
+    if (format === "animated") {
+      this.preSegmented = true
+      return parseAnimatedSubtitles(filteredEvents)
     }
 
     if (enableAISegmentation) {

--- a/src/utils/subtitles/fetchers/youtube/parser/animated-parser.ts
+++ b/src/utils/subtitles/fetchers/youtube/parser/animated-parser.ts
@@ -1,0 +1,39 @@
+import type { SubtitlesFragment } from "../../../types"
+import type { YoutubeTimedText } from "../types"
+
+const ZERO_WIDTH_SPACE_PATTERN = /\u200B/g
+const WHITESPACE_PATTERN = /\s+/g
+
+function getEventText(event: YoutubeTimedText): string {
+  return (event.segs ?? [])
+    .map(seg => seg.utf8 || "")
+    .join("")
+    .replace(ZERO_WIDTH_SPACE_PATTERN, "")
+    .replace(WHITESPACE_PATTERN, " ")
+    .trim()
+}
+
+export function parseAnimatedSubtitles(events: YoutubeTimedText[]): SubtitlesFragment[] {
+  const fragments: SubtitlesFragment[] = []
+
+  for (const event of events) {
+    const text = getEventText(event)
+    if (!text)
+      continue
+
+    const start = event.tStartMs
+    const end = start + (event.dDurationMs ?? 0)
+    const last = fragments.at(-1)
+
+    if (last && last.text === text) {
+      last.end = end
+    }
+    else {
+      if (last && last.end > start)
+        last.end = start
+      fragments.push({ text, start, end })
+    }
+  }
+
+  return fragments
+}

--- a/src/utils/subtitles/fetchers/youtube/parser/index.ts
+++ b/src/utils/subtitles/fetchers/youtube/parser/index.ts
@@ -1,3 +1,4 @@
+export * from "./animated-parser"
 export * from "./karaoke-parser"
 export * from "./scrolling-asr-parser"
 export * from "./standard-parser"


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

YouTube music videos with animated/kinetic typography subtitles (`wireMagic: pb3`) encode text as rapid animation frames (~67ms each, ~15fps) with varying window positions. Each frame carries the currently visible subtitle phrase. Previously, these were misdetected as `karaoke-stylized` due to zero-width spaces in the text, causing the optimizer to merge short phrases into long unreadable blocks.

**Changes:**
- Add `animated` format detection: >50% of events have duration ≤100ms with `wpWinPosId`
- Add animated parser that deduplicates consecutive identical text frames into clean subtitle segments
- Prioritize animated detection before stylized-karaoke to prevent false positives
- Add `isPreSegmented()` to `SubtitlesFetcher` interface so animated subtitles skip the optimizer and AI segmentation pipeline (they are already correctly segmented per-frame)

**Result:** 8549 animation frame events → 161 clean subtitle segments with correct timing.

## Related Issue

Closes #1390

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The animated subtitle format is used in YouTube music videos where text bounces/scrolls across the screen. The timedtext JSON3 response contains thousands of short-duration events, each with the subtitle text visible at that animation frame. Different language tracks for the same video may have different data structures — the fix works by detecting the animation frame pattern and deduplicating consecutive identical text.