### PR TITLE
fix(subtitles): stabilize youtube controls positioning

### DIFF
--- a/src/entrypoints/subtitles.content/platforms/index.ts
+++ b/src/entrypoints/subtitles.content/platforms/index.ts
@@ -1,5 +1,5 @@
 export interface ControlsConfig {
-  findVideoContainer?: () => HTMLElement | null
+  findPlayerContainer?: () => HTMLElement | null
   measureHeight: (container: HTMLElement) => number
   checkVisibility: (container: HTMLElement) => boolean
 }

--- a/src/entrypoints/subtitles.content/platforms/youtube/config.ts
+++ b/src/entrypoints/subtitles.content/platforms/youtube/config.ts
@@ -13,6 +13,7 @@ interface YoutubeConfigOptions {
 
 export function getYoutubeConfig(options: YoutubeConfigOptions = {}): PlatformConfig {
   const { embedded } = options
+  const findPlayerContainer = () => document.querySelector<HTMLElement>("#movie_player.html5-video-player, #movie_player")
 
   return {
     embedded,
@@ -33,11 +34,10 @@ export function getYoutubeConfig(options: YoutubeConfigOptions = {}): PlatformCo
 
     controls: embedded
       ? {
-          findVideoContainer: () => document.querySelector<HTMLElement>("#movie_player"),
-          measureHeight: () => {
-            const wrapper = document.querySelector(".quick-actions-wrapper")
-            const player = document.querySelector("#movie_player")
-            const progressBar = player?.querySelector(".ytp-progress-bar-container")
+          findPlayerContainer,
+          measureHeight: (container) => {
+            const wrapper = container.querySelector(".quick-actions-wrapper")
+            const progressBar = container.querySelector(".ytp-progress-bar-container")
             if (!wrapper || !progressBar)
               return DEFAULT_CONTROLS_HEIGHT
             return wrapper.getBoundingClientRect().top - progressBar.getBoundingClientRect().top
@@ -45,15 +45,14 @@ export function getYoutubeConfig(options: YoutubeConfigOptions = {}): PlatformCo
           checkVisibility: () => true,
         }
       : {
+          findPlayerContainer,
           measureHeight: (container) => {
-            const player = container.closest(".html5-video-player")
-            const progressBar = player?.querySelector(".ytp-progress-bar-container")
+            const progressBar = container.querySelector(".ytp-progress-bar-container")
             const controlsBar = progressBar?.parentElement
             return controlsBar?.getBoundingClientRect().height ?? DEFAULT_CONTROLS_HEIGHT
           },
           checkVisibility: (container) => {
-            const player = container.closest(".html5-video-player")
-            return !!player && !player.classList.contains("ytp-autohide")
+            return !container.classList.contains("ytp-autohide")
           },
         },
 

--- a/src/entrypoints/subtitles.content/ui/__tests__/use-vertical-drag.test.ts
+++ b/src/entrypoints/subtitles.content/ui/__tests__/use-vertical-drag.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest"
+import {
+  calculateAnchorPosition,
+  getControlsOffsetPercent,
+  getMaxPositionPercent,
+  getSubtitlePositionStyle,
+} from "../use-vertical-drag"
+
+function createRect({
+  top,
+  bottom,
+  height,
+}: {
+  top: number
+  bottom: number
+  height: number
+}): DOMRect {
+  return {
+    x: 0,
+    y: top,
+    top,
+    right: 0,
+    bottom,
+    left: 0,
+    width: 1000,
+    height,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
+describe("useVerticalDrag helpers", () => {
+  it("subtracts controls offset from bottom anchored baseline position", () => {
+    const position = calculateAnchorPosition({
+      videoRect: createRect({ top: 0, bottom: 1000, height: 1000 }),
+      containerRect: createRect({ top: 850, bottom: 900, height: 50 }),
+      controlsVisible: true,
+      controlsHeight: 60,
+    })
+
+    expect(position).toEqual({
+      anchor: "bottom",
+      percent: 4,
+    })
+  })
+
+  it("reserves controls height when clamping bottom anchored positions", () => {
+    expect(getMaxPositionPercent({
+      videoHeight: 1000,
+      containerHeight: 100,
+      controlsVisible: false,
+      controlsHeight: 60,
+      anchor: "bottom",
+    })).toBe(90)
+
+    expect(getMaxPositionPercent({
+      videoHeight: 1000,
+      containerHeight: 100,
+      controlsVisible: true,
+      controlsHeight: 60,
+      anchor: "bottom",
+    })).toBe(84)
+  })
+
+  it("only applies controls offset percent to bottom anchored rendering", () => {
+    expect(getControlsOffsetPercent(true, 60, 1000, "bottom")).toBe(6)
+    expect(getControlsOffsetPercent(true, 60, 1000, "top")).toBe(0)
+    expect(getControlsOffsetPercent(false, 60, 1000, "bottom")).toBe(0)
+  })
+
+  it("keeps saved baseline position separate from controls shift in render style", () => {
+    expect(getSubtitlePositionStyle(
+      { anchor: "bottom", percent: 10 },
+      true,
+      60,
+      1000,
+    )).toEqual({
+      bottom: "16%",
+      top: "unset",
+    })
+
+    expect(getSubtitlePositionStyle(
+      { anchor: "top", percent: 12 },
+      true,
+      60,
+      1000,
+    )).toEqual({
+      bottom: "unset",
+      top: "12%",
+    })
+  })
+})

--- a/src/entrypoints/subtitles.content/ui/player-container.ts
+++ b/src/entrypoints/subtitles.content/ui/player-container.ts
@@ -1,0 +1,15 @@
+import type { ControlsConfig } from "@/entrypoints/subtitles.content/platforms"
+import { getContainingShadowRoot } from "@/utils/host/dom/node"
+
+export function resolvePlayerContainer(
+  element: HTMLElement | null,
+  controlsConfig?: ControlsConfig,
+): HTMLElement | null {
+  const playerContainer = controlsConfig?.findPlayerContainer?.()
+  if (playerContainer)
+    return playerContainer
+
+  const shadowRoot = element ? getContainingShadowRoot(element) : null
+  const shadowHost = shadowRoot?.host as HTMLElement | undefined
+  return shadowHost?.parentElement ?? null
+}

--- a/src/entrypoints/subtitles.content/ui/subtitles-view.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-view.tsx
@@ -50,6 +50,7 @@ export function SubtitlesView({ showContent }: SubtitlesViewProps) {
   const setVideoSubtitles = useSetAtom(configFieldsAtomMap.videoSubtitles)
 
   const { refs, windowStyle, positionStyle, isDragging } = useVerticalDrag({
+    controlsConfig,
     controlsVisible,
     controlsHeight,
     onDragEnd: pos => void setVideoSubtitles({ position: pos }),

--- a/src/entrypoints/subtitles.content/ui/use-controls-visible.ts
+++ b/src/entrypoints/subtitles.content/ui/use-controls-visible.ts
@@ -1,6 +1,6 @@
 import type { ControlsConfig } from "@/entrypoints/subtitles.content/platforms"
 import { useEffect, useEffectEvent, useState } from "react"
-import { getContainingShadowRoot } from "@/utils/host/dom/node"
+import { resolvePlayerContainer } from "./player-container"
 
 interface ControlsInfo {
   controlsVisible: boolean
@@ -17,36 +17,44 @@ export function useControlsInfo(
     if (!controlsConfig)
       return
 
-    setInfo({
+    const nextInfo = {
       controlsVisible: controlsConfig.checkVisibility(container),
       controlsHeight: controlsConfig.measureHeight(container),
-    })
+    }
+
+    setInfo(prev => prev.controlsVisible === nextInfo.controlsVisible && prev.controlsHeight === nextInfo.controlsHeight
+      ? prev
+      : nextInfo)
   })
 
   const setupObserver = useEffectEvent(() => {
     if (!controlsConfig)
       return
 
-    const element = elementRef.current
-    const shadowRoot = element ? getContainingShadowRoot(element) : null
-    const shadowHost = shadowRoot?.host as HTMLElement | undefined
-    const videoContainer = shadowHost?.parentElement ?? controlsConfig.findVideoContainer?.()
-    if (!videoContainer)
+    const playerContainer = resolvePlayerContainer(elementRef.current, controlsConfig)
+    if (!playerContainer)
       return
 
-    updateInfo(videoContainer)
+    updateInfo(playerContainer)
 
     const observer = new MutationObserver(() => {
-      updateInfo(videoContainer)
+      updateInfo(playerContainer)
     })
 
-    observer.observe(videoContainer, {
+    observer.observe(playerContainer, {
       attributes: true,
       attributeFilter: ["class"],
-      subtree: true,
     })
 
-    return () => observer.disconnect()
+    const resizeObserver = new ResizeObserver(() => {
+      updateInfo(playerContainer)
+    })
+    resizeObserver.observe(playerContainer)
+
+    return () => {
+      observer.disconnect()
+      resizeObserver.disconnect()
+    }
   })
 
   useEffect(() => {

--- a/src/entrypoints/subtitles.content/ui/use-vertical-drag.ts
+++ b/src/entrypoints/subtitles.content/ui/use-vertical-drag.ts
@@ -290,7 +290,7 @@ export function useVerticalDrag({
 
   useEffect(() => {
     clampPosition()
-  }, [clampPosition, controlsVisible, controlsHeight, position.anchor])
+  }, [controlsVisible, controlsHeight, position.anchor])
 
   const positionStyle = getSubtitlePositionStyle(position, controlsVisible, controlsHeight, windowStyle.height)
 

--- a/src/entrypoints/subtitles.content/ui/use-vertical-drag.ts
+++ b/src/entrypoints/subtitles.content/ui/use-vertical-drag.ts
@@ -1,10 +1,11 @@
 import type { RefObject } from "react"
 import type { SubtitlePosition } from "../atoms"
+import type { ControlsConfig } from "@/entrypoints/subtitles.content/platforms"
 import { useAtom } from "jotai"
 import { useEffect, useEffectEvent, useRef, useState } from "react"
 import { DEFAULT_SUBTITLE_POSITION } from "@/utils/constants/subtitles"
-import { getContainingShadowRoot } from "@/utils/host/dom/node"
 import { subtitlesPositionAtom } from "../atoms"
+import { resolvePlayerContainer } from "./player-container"
 
 const BASE_FONT_RATIO = 0.03
 
@@ -33,18 +34,23 @@ interface AnchorPositionContext {
   controlsHeight: number
 }
 
-function getVideoContainer(element: HTMLElement): HTMLElement | null {
-  const rootNode = getContainingShadowRoot(element)
-  const shadowHost = rootNode?.host as HTMLElement | undefined
-  return shadowHost?.parentElement ?? null
+interface MaxPositionPercentContext {
+  videoHeight: number
+  containerHeight: number
+  controlsVisible: boolean
+  controlsHeight: number
+  anchor: SubtitlePosition["anchor"]
 }
 
-function getRects(containerRef: RefObject<HTMLDivElement | null>): Rects | null {
+function getRects(
+  containerRef: RefObject<HTMLDivElement | null>,
+  controlsConfig?: ControlsConfig,
+): Rects | null {
   const container = containerRef.current
   if (!container)
     return null
 
-  const videoContainer = getVideoContainer(container)
+  const videoContainer = resolvePlayerContainer(container, controlsConfig)
   if (!videoContainer)
     return null
 
@@ -56,7 +62,31 @@ function getRects(containerRef: RefObject<HTMLDivElement | null>): Rects | null 
   }
 }
 
-function calculateAnchorPosition(ctx: AnchorPositionContext): SubtitlePosition {
+export function getControlsOffsetPercent(
+  controlsVisible: boolean,
+  controlsHeight: number,
+  videoHeight: number,
+  anchor: SubtitlePosition["anchor"],
+): number {
+  if (!controlsVisible || anchor !== "bottom" || videoHeight <= 0)
+    return 0
+
+  return (controlsHeight / videoHeight) * 100
+}
+
+export function getMaxPositionPercent(ctx: MaxPositionPercentContext): number {
+  const { videoHeight, containerHeight, controlsVisible, controlsHeight, anchor } = ctx
+  if (videoHeight <= 0)
+    return 0
+
+  const reservedHeight = controlsVisible && anchor === "bottom"
+    ? controlsHeight
+    : 0
+
+  return ((videoHeight - containerHeight - reservedHeight) / videoHeight) * 100
+}
+
+export function calculateAnchorPosition(ctx: AnchorPositionContext): SubtitlePosition {
   const { videoRect, containerRect, controlsVisible, controlsHeight } = ctx
   const videoHeight = videoRect.height
 
@@ -73,19 +103,43 @@ function calculateAnchorPosition(ctx: AnchorPositionContext): SubtitlePosition {
 
   const subtitleBottom = videoHeight - (containerRect.bottom - videoRect.top)
   const subtitleBottomPercent = (subtitleBottom / videoHeight) * 100
-  const controlsOffsetPercent = controlsVisible ? (controlsHeight / videoHeight) * 100 : 0
+  const controlsOffsetPercent = getControlsOffsetPercent(controlsVisible, controlsHeight, videoHeight, "bottom")
   const percent = subtitleBottomPercent - controlsOffsetPercent
 
   return { percent: Math.max(0, percent), anchor: "bottom" }
 }
 
+export function getSubtitlePositionStyle(
+  position: SubtitlePosition,
+  controlsVisible: boolean,
+  controlsHeight: number,
+  videoHeight: number,
+): SubtitlePositionStyle {
+  const controlsOffsetPercent = getControlsOffsetPercent(
+    controlsVisible,
+    controlsHeight,
+    videoHeight,
+    position.anchor,
+  )
+
+  return position.anchor === "top"
+    ? { top: `${position.percent}%`, bottom: "unset" }
+    : { bottom: `${position.percent + controlsOffsetPercent}%`, top: "unset" }
+}
+
 interface UseVerticalDragOptions {
+  controlsConfig?: ControlsConfig
   controlsVisible: boolean
   controlsHeight: number
   onDragEnd?: (position: SubtitlePosition) => void
 }
 
-export function useVerticalDrag({ controlsVisible, controlsHeight, onDragEnd }: UseVerticalDragOptions) {
+export function useVerticalDrag({
+  controlsConfig,
+  controlsVisible,
+  controlsHeight,
+  onDragEnd,
+}: UseVerticalDragOptions) {
   const containerRef = useRef<HTMLDivElement>(null)
   const handleRef = useRef<HTMLDivElement>(null)
   const isDraggingRef = useRef(false)
@@ -100,7 +154,7 @@ export function useVerticalDrag({ controlsVisible, controlsHeight, onDragEnd }: 
   })
 
   const updateWindowStyle = useEffectEvent(() => {
-    const rects = getRects(containerRef)
+    const rects = getRects(containerRef, controlsConfig)
     if (!rects)
       return
 
@@ -126,7 +180,7 @@ export function useVerticalDrag({ controlsVisible, controlsHeight, onDragEnd }: 
     if (!isDraggingRef.current)
       return
 
-    const rects = getRects(containerRef)
+    const rects = getRects(containerRef, controlsConfig)
     if (!rects)
       return
 
@@ -143,10 +197,13 @@ export function useVerticalDrag({ controlsVisible, controlsHeight, onDragEnd }: 
       ? startPositionRef.current.percent - deltaPercent
       : startPositionRef.current.percent + deltaPercent
 
-    const reservedHeight = controlsVisible && startPositionRef.current.anchor === "bottom"
-      ? controlsHeight
-      : 0
-    const maxPercent = ((videoHeight - containerRect.height - reservedHeight) / videoHeight) * 100
+    const maxPercent = getMaxPositionPercent({
+      videoHeight,
+      containerHeight: containerRect.height,
+      controlsVisible,
+      controlsHeight,
+      anchor: startPositionRef.current.anchor,
+    })
     newPercent = Math.max(0, Math.min(maxPercent, newPercent))
 
     // Check if we need to switch anchor (crossed midline)
@@ -178,12 +235,18 @@ export function useVerticalDrag({ controlsVisible, controlsHeight, onDragEnd }: 
   })
 
   const clampPosition = useEffectEvent(() => {
-    const rects = getRects(containerRef)
+    const rects = getRects(containerRef, controlsConfig)
     if (!rects)
       return
 
     const { videoRect, containerRect } = rects
-    const maxPercent = ((videoRect.height - containerRect.height) / videoRect.height) * 100
+    const maxPercent = getMaxPositionPercent({
+      videoHeight: videoRect.height,
+      containerHeight: containerRect.height,
+      controlsVisible,
+      controlsHeight,
+      anchor: position.anchor,
+    })
     const clampedPercent = Math.max(0, Math.min(maxPercent, position.percent))
 
     if (position.percent !== clampedPercent) {
@@ -197,7 +260,7 @@ export function useVerticalDrag({ controlsVisible, controlsHeight, onDragEnd }: 
     if (!handle || !container)
       return
 
-    const videoContainer = getVideoContainer(container)
+    const videoContainer = resolvePlayerContainer(container, controlsConfig)
 
     handle.addEventListener("mousedown", onMouseDown)
     window.addEventListener("mousemove", onMouseMove)
@@ -225,13 +288,11 @@ export function useVerticalDrag({ controlsVisible, controlsHeight, onDragEnd }: 
     return setupListeners()
   }, [])
 
-  const controlsOffsetPercent = controlsVisible && position.anchor === "bottom" && windowStyle.height > 0
-    ? (controlsHeight / windowStyle.height) * 100
-    : 0
+  useEffect(() => {
+    clampPosition()
+  }, [clampPosition, controlsVisible, controlsHeight, position.anchor])
 
-  const positionStyle: SubtitlePositionStyle = position.anchor === "top"
-    ? { top: `${position.percent}%`, bottom: "unset" }
-    : { bottom: `${position.percent + controlsOffsetPercent}%`, top: "unset" }
+  const positionStyle = getSubtitlePositionStyle(position, controlsVisible, controlsHeight, windowStyle.height)
 
   return {
     refs: { container: containerRef, handle: handleRef },


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Stabilize YouTube subtitle positioning by separating the persisted subtitle position from the runtime controls offset.

This updates the subtitle positioning model so the saved bottom position is no longer tightly coupled to the controls-driven shift, which makes the overlay less sensitive to YouTube controls visibility changes and player/container instability after in-page navigation.

Key changes:
- use a stable player container lookup for subtitle controls and layout measurement
- keep the persisted subtitle baseline separate from the runtime controls shift
- unify bottom-anchor clamping and rendering math so controls space is handled consistently
- reduce unnecessary controls state updates by only updating when visibility or height actually changes
- add focused tests for bottom-anchor offset and controls reserve-space behavior

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #1420

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [x] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- Local validation:
  - `pnpm type-check`
  - `pnpm test src/entrypoints/subtitles.content/ui/__tests__/use-vertical-drag.test.ts`
  - pre-push checks also ran project `lint`, `type-check`, and full `vitest run`
- The targeted lint step reported one existing-style warning about including a `useEffectEvent` function in a dependency array, but the push completed and all required checks passed.
- This PR focuses on the YouTube subtitle overlay positioning path and does not intentionally change the embedded/iframe subtitle flow.
