### PR TITLE
fix(extension): fail fast on queue-fatal request errors

### DIFF
--- a/.changeset/fail-fast-request-queue.md
+++ b/.changeset/fail-fast-request-queue.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(extension): fail fast on queue-fatal translation request errors

--- a/src/utils/error/extract-message.ts
+++ b/src/utils/error/extract-message.ts
@@ -40,11 +40,29 @@ export function extractAISDKErrorMessage(error: unknown): string {
       text?: unknown
     }
 
-    return getNonEmptyString(source.message)
-      ?? getNonEmptyString(source.responseBody)
-      ?? getNonEmptyString(source.text)
+    const message = getNonEmptyString(source.message)
+    const responseBody = getNonEmptyString(source.responseBody)
+    const text = getNonEmptyString(source.text)
+
+    if (isGenericAISDKErrorMessage(message)) {
+      return responseBody ?? text ?? message ?? "Unexpected error occurred"
+    }
+
+    return message
+      ?? responseBody
+      ?? text
       ?? "Unexpected error occurred"
   }
 
   return "Unexpected error occurred"
+}
+
+function isGenericAISDKErrorMessage(message: string | undefined): boolean {
+  if (!message) {
+    return true
+  }
+
+  const normalizedMessage = message.trim().toLowerCase()
+  return normalizedMessage === "something went wrong"
+    || normalizedMessage === "unexpected error occurred"
 }

--- a/src/utils/host/translate/api/__tests__/ai.test.ts
+++ b/src/utils/host/translate/api/__tests__/ai.test.ts
@@ -1,0 +1,91 @@
+import type { LLMProviderConfig } from "@/types/config/provider"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { getRequestErrorMeta } from "@/utils/request/retry-policy"
+import { aiTranslate } from "../ai"
+
+const mocks = vi.hoisted(() => ({
+  generateText: vi.fn(),
+  getModelById: vi.fn(),
+  resolveModelId: vi.fn(),
+  getProviderOptionsWithOverride: vi.fn(),
+}))
+
+vi.mock("ai", () => ({
+  generateText: mocks.generateText,
+}))
+
+vi.mock("@/utils/providers/model", () => ({
+  getModelById: mocks.getModelById,
+}))
+
+vi.mock("@/utils/providers/model-id", () => ({
+  resolveModelId: mocks.resolveModelId,
+}))
+
+vi.mock("@/utils/providers/options", () => ({
+  getProviderOptionsWithOverride: mocks.getProviderOptionsWithOverride,
+}))
+
+const providerConfig: LLMProviderConfig = {
+  id: "openai-default",
+  name: "OpenAI",
+  provider: "openai",
+  enabled: true,
+  apiKey: "sk-test",
+  model: { model: "gpt-5-mini", isCustomModel: false, customModel: null },
+}
+
+const promptResolver = vi.fn().mockResolvedValue({
+  systemPrompt: "system",
+  prompt: "prompt",
+})
+
+describe("aiTranslate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.getModelById.mockResolvedValue("model")
+    mocks.resolveModelId.mockReturnValue("gpt-5-mini")
+    mocks.getProviderOptionsWithOverride.mockReturnValue({})
+  })
+
+  it("preserves AI SDK error metadata for retry policy decisions", async () => {
+    const rateLimitedError = Object.assign(new Error("Too Many Requests"), {
+      statusCode: 429,
+      isRetryable: true,
+      responseHeaders: {
+        "retry-after": "2",
+      },
+    })
+    mocks.generateText.mockRejectedValue(rateLimitedError)
+
+    const error = await aiTranslate("hello", "Chinese", providerConfig, promptResolver).catch(error => error)
+
+    expect(error).toBe(rateLimitedError)
+    expect(getRequestErrorMeta(error)).toEqual(expect.objectContaining({
+      statusCode: 429,
+      isRetryable: true,
+      retryAfterMs: 2000,
+      kind: "rate-limit",
+    }))
+  })
+
+  it("preserves response body as the display message when the AI SDK message is generic", async () => {
+    const responseBody = "{\"code\":404,\"message\":\"模型 Kimi-K2-Instruct-09051 无效\",\"data\":{}}"
+    const invalidModelError = Object.assign(new Error("Something went wrong"), {
+      statusCode: 404,
+      isRetryable: false,
+      responseBody,
+    })
+    mocks.generateText.mockRejectedValue(invalidModelError)
+
+    const error = await aiTranslate("hello", "Chinese", providerConfig, promptResolver).catch(error => error)
+
+    expect(error).toBe(invalidModelError)
+    expect(error.message).toBe(responseBody)
+    expect(getRequestErrorMeta(error)).toEqual(expect.objectContaining({
+      statusCode: 404,
+      isRetryable: false,
+      kind: "bad-request",
+    }))
+  })
+})

--- a/src/utils/host/translate/api/ai.ts
+++ b/src/utils/host/translate/api/ai.ts
@@ -5,6 +5,7 @@ import { extractAISDKErrorMessage } from "@/utils/error/extract-message"
 import { getModelById } from "@/utils/providers/model"
 import { resolveModelId } from "@/utils/providers/model-id"
 import { getProviderOptionsWithOverride } from "@/utils/providers/options"
+import { attachRequestErrorMeta, getRequestErrorMeta } from "@/utils/request/retry-policy"
 
 const THINK_TAG_RE = /<\/think>([\s\S]*)/
 
@@ -43,6 +44,13 @@ export async function aiTranslate<TContext>(
     return finalTranslation
   }
   catch (error) {
-    throw new Error(extractAISDKErrorMessage(error))
+    const message = extractAISDKErrorMessage(error)
+    const meta = getRequestErrorMeta(error)
+    if (error instanceof Error) {
+      error.message = message
+      throw attachRequestErrorMeta(error, meta)
+    }
+
+    throw attachRequestErrorMeta(new Error(message), meta)
   }
 }

--- a/src/utils/request/__tests__/batch-queue.test.ts
+++ b/src/utils/request/__tests__/batch-queue.test.ts
@@ -508,16 +508,20 @@ describe("batchQueue – error handling", () => {
     expect(batchAttemptCount).toBe(3) // Initial + 2 retries before fallback
   })
 
-  it("falls back to individual immediately on request error (no retry)", async () => {
+  it("does not fall back to individual requests on request errors", async () => {
     vi.useFakeTimers()
     let batchAttemptCount = 0
+    const executeIndividual = vi.fn(async (data: TranslateBatchData) => {
+      const result = await executeTranslate(data.text, data.langConfig, data.providerConfig, mockPromptResolver)
+      return result
+    })
+
     mockExecuteTranslate.mockImplementation((text: string) => {
       const batchSeparator = `\n\n${BATCH_SEPARATOR}\n\n`
       if (text.includes(batchSeparator)) {
         batchAttemptCount++
         return Promise.reject(new Error("API error"))
       }
-      // Individual requests succeed
       return Promise.resolve(`individual-${text}`)
     })
 
@@ -525,10 +529,7 @@ describe("batchQueue – error handling", () => {
     const batchQueue = createBatchQueue(requestQueue, baseBatchConfig, {
       maxRetries: 3,
       enableFallbackToIndividual: true,
-      executeIndividual: async (data) => {
-        const result = await executeTranslate(data.text, data.langConfig, data.providerConfig, mockPromptResolver)
-        return result
-      },
+      executeIndividual,
     })
 
     const promises = [
@@ -549,9 +550,62 @@ describe("batchQueue – error handling", () => {
     vi.advanceTimersByTime(baseBatchConfig.batchDelay)
     vi.advanceTimersByTime(0)
 
-    const results = await Promise.all(promises)
-    expect(results).toEqual(["individual-Text1", "individual-Text2"])
+    await expect(Promise.all(promises)).rejects.toThrow("API error")
     expect(batchAttemptCount).toBe(1) // Only 1 attempt, no retry for request errors
+    expect(executeIndividual).not.toHaveBeenCalled()
+  })
+
+  it("does not fall back to individual requests after rate limit errors", async () => {
+    vi.useFakeTimers()
+    let batchAttemptCount = 0
+    const executeIndividual = vi.fn(async (data: TranslateBatchData) => {
+      const result = await executeTranslate(data.text, data.langConfig, data.providerConfig, mockPromptResolver)
+      return result
+    })
+    const rateLimitedError = Object.assign(new Error("Too Many Requests"), {
+      statusCode: 429,
+      responseHeaders: {
+        "retry-after": "2",
+      },
+    })
+
+    mockExecuteTranslate.mockImplementation((text: string) => {
+      const batchSeparator = `\n\n${BATCH_SEPARATOR}\n\n`
+      if (text.includes(batchSeparator)) {
+        batchAttemptCount++
+        return Promise.reject(rateLimitedError)
+      }
+      return Promise.resolve(`individual-${text}`)
+    })
+
+    const requestQueue = new RequestQueue(baseRequestQueueConfig)
+    const batchQueue = createBatchQueue(requestQueue, baseBatchConfig, {
+      maxRetries: 3,
+      enableFallbackToIndividual: true,
+      executeIndividual,
+    })
+
+    const promises = [
+      batchQueue.enqueue({
+        text: "Text1",
+        langConfig: sampleLangConfig,
+        providerConfig: sampleProviderConfig,
+        hash: "hash1",
+      }),
+      batchQueue.enqueue({
+        text: "Text2",
+        langConfig: sampleLangConfig,
+        providerConfig: sampleProviderConfig,
+        hash: "hash2",
+      }),
+    ]
+
+    vi.advanceTimersByTime(baseBatchConfig.batchDelay)
+    vi.advanceTimersByTime(0)
+
+    await expect(Promise.all(promises)).rejects.toBe(rateLimitedError)
+    expect(batchAttemptCount).toBe(1)
+    expect(executeIndividual).not.toHaveBeenCalled()
   })
 
   it("calls onError for each retry attempt on BatchCountMismatchError", async () => {

--- a/src/utils/request/__tests__/request-queue.test.ts
+++ b/src/utils/request/__tests__/request-queue.test.ts
@@ -14,6 +14,16 @@ function rejectThunk(error: any, delayMs = 0) {
     new Promise((_, rej) => setTimeout(rej, delayMs, error))
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
 // A basic queue config we reuse (easy to tweak per‑test)
 const baseConfig = {
   rate: 1, // 1 token / sec
@@ -426,7 +436,292 @@ describe("requestQueue – retry with timeout combined", () => {
   })
 })
 
-// 11. Reconfigure the request queue
+// 11. Retry policy and queue fail-fast drain
+describe("requestQueue – retry policy and queue fail-fast drain", () => {
+  it.each([
+    {
+      name: "400",
+      createError: () => Object.assign(new Error("Bad Request"), { statusCode: 400 }),
+    },
+    {
+      name: "isRetryable false",
+      createError: () => Object.assign(new Error("Do not retry"), { isRetryable: false }),
+    },
+  ])("fails only the current task for $name", async ({ createError }) => {
+    vi.useFakeTimers()
+    let attempts = 0
+
+    const q = new RequestQueue({
+      ...baseConfig,
+      rate: 10,
+      capacity: 1,
+      maxRetries: 2,
+      baseRetryDelayMs: 100,
+    })
+
+    const error = createError()
+    const completed: string[] = []
+
+    const firstPromise = q.enqueue(() => {
+      attempts++
+      return Promise.reject(error)
+    }, Date.now(), "current-only")
+    firstPromise.catch(() => {})
+
+    const secondPromise = q.enqueue(() => {
+      completed.push("second")
+      return Promise.resolve("second")
+    }, Date.now(), "second")
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(attempts).toBe(1)
+    expect(completed).toEqual(["second"])
+    await expect(firstPromise).rejects.toBe(error)
+    await expect(secondPromise).resolves.toBe("second")
+  })
+
+  it("drains waiting tasks immediately after a 429", async () => {
+    vi.useFakeTimers()
+
+    const q = new RequestQueue({
+      ...baseConfig,
+      rate: 10,
+      capacity: 1,
+      maxRetries: 2,
+      baseRetryDelayMs: 100,
+    })
+
+    const completed: string[] = []
+    const rateLimitedError = Object.assign(new Error("Too Many Requests"), {
+      statusCode: 429,
+      responseHeaders: {
+        "retry-after": "2",
+      },
+    })
+
+    const firstPromise = q.enqueue(
+      () => Promise.reject(rateLimitedError),
+      Date.now(),
+      "first",
+    )
+    firstPromise.catch(() => {})
+
+    const secondPromise = q.enqueue(
+      () => {
+        completed.push("second")
+        return Promise.resolve("second")
+      },
+      Date.now(),
+      "second",
+    )
+    secondPromise.catch(() => {})
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(completed).toEqual([])
+    await expect(firstPromise).rejects.toBe(rateLimitedError)
+    await expect(secondPromise).rejects.toBe(rateLimitedError)
+  })
+
+  it("drains other executing tasks immediately after a 429", async () => {
+    vi.useFakeTimers()
+
+    const q = new RequestQueue({
+      ...baseConfig,
+      rate: 10,
+      capacity: 2,
+      maxRetries: 2,
+      baseRetryDelayMs: 100,
+    })
+
+    const rateLimitedError = Object.assign(new Error("Too Many Requests"), {
+      statusCode: 429,
+    })
+    const secondDeferred = createDeferred<string>()
+
+    const firstPromise = q.enqueue(
+      () => Promise.reject(rateLimitedError),
+      Date.now(),
+      "first",
+    )
+    firstPromise.catch(() => {})
+
+    const secondPromise = q.enqueue(
+      () => secondDeferred.promise,
+      Date.now(),
+      "second",
+    )
+    secondPromise.catch(() => {})
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    await expect(firstPromise).rejects.toBe(rateLimitedError)
+    await expect(secondPromise).rejects.toBe(rateLimitedError)
+
+    secondDeferred.resolve("late success")
+    await vi.advanceTimersByTimeAsync(0)
+    await expect(secondPromise).rejects.toBe(rateLimitedError)
+  })
+
+  it("ignores drained in-flight failures and allows new enqueues after a 429", async () => {
+    vi.useFakeTimers()
+
+    const q = new RequestQueue({
+      ...baseConfig,
+      rate: 10,
+      capacity: 3,
+      maxRetries: 2,
+      baseRetryDelayMs: 100,
+    })
+
+    const rateLimitedError = Object.assign(new Error("Too Many Requests"), {
+      statusCode: 429,
+    })
+    const laterError = Object.assign(new Error("Unauthorized"), {
+      statusCode: 401,
+    })
+    const oldDeferred = createDeferred<string>()
+    const newDeferred = createDeferred<string>()
+
+    const firstPromise = q.enqueue(
+      () => Promise.reject(rateLimitedError),
+      Date.now(),
+      "first",
+    )
+    firstPromise.catch(() => {})
+
+    const oldPromise = q.enqueue(
+      () => oldDeferred.promise,
+      Date.now(),
+      "old",
+    )
+    oldPromise.catch(() => {})
+
+    await vi.advanceTimersByTimeAsync(0)
+    await expect(oldPromise).rejects.toBe(rateLimitedError)
+
+    const newPromise = q.enqueue(
+      () => newDeferred.promise,
+      Date.now(),
+      "new",
+    )
+
+    oldDeferred.reject(laterError)
+    await vi.advanceTimersByTimeAsync(0)
+
+    newDeferred.resolve("new success")
+    await vi.advanceTimersByTimeAsync(0)
+
+    await expect(firstPromise).rejects.toBe(rateLimitedError)
+    await expect(newPromise).resolves.toBe("new success")
+  })
+
+  it("does not let old in-flight task cleanup remove a new task with the same hash", async () => {
+    vi.useFakeTimers()
+
+    const q = new RequestQueue({
+      ...baseConfig,
+      rate: 10,
+      capacity: 3,
+      maxRetries: 2,
+      baseRetryDelayMs: 100,
+    })
+
+    const rateLimitedError = Object.assign(new Error("Too Many Requests"), {
+      statusCode: 429,
+    })
+    const oldDeferred = createDeferred<string>()
+    const newDeferred = createDeferred<string>()
+    let duplicateStarted = false
+
+    const firstPromise = q.enqueue(
+      () => Promise.reject(rateLimitedError),
+      Date.now(),
+      "first",
+    )
+    firstPromise.catch(() => {})
+
+    const oldPromise = q.enqueue(
+      () => oldDeferred.promise,
+      Date.now(),
+      "same",
+    )
+    oldPromise.catch(() => {})
+
+    await vi.advanceTimersByTimeAsync(0)
+    await expect(oldPromise).rejects.toBe(rateLimitedError)
+
+    const newPromise = q.enqueue(
+      () => newDeferred.promise,
+      Date.now(),
+      "same",
+    )
+
+    oldDeferred.resolve("old success")
+    await vi.advanceTimersByTimeAsync(0)
+
+    const duplicatePromise = q.enqueue(
+      () => {
+        duplicateStarted = true
+        return Promise.resolve("duplicate")
+      },
+      Date.now(),
+      "same",
+    )
+
+    expect(duplicatePromise).toBe(newPromise)
+    expect(duplicateStarted).toBe(false)
+
+    newDeferred.resolve("new success")
+    await vi.advanceTimersByTimeAsync(0)
+
+    await expect(firstPromise).rejects.toBe(rateLimitedError)
+    await expect(newPromise).resolves.toBe("new success")
+  })
+
+  it.each([401, 403, 404])("drains the current backlog after a %s", async (statusCode) => {
+    vi.useFakeTimers()
+
+    const q = new RequestQueue({
+      ...baseConfig,
+      rate: 10,
+      capacity: 1,
+      maxRetries: 2,
+      baseRetryDelayMs: 100,
+    })
+
+    const completed: string[] = []
+    const error = Object.assign(new Error(`HTTP ${statusCode}`), {
+      statusCode,
+    })
+
+    const firstPromise = q.enqueue(
+      () => Promise.reject(error),
+      Date.now(),
+      "first",
+    )
+    firstPromise.catch(() => {})
+
+    const secondPromise = q.enqueue(
+      () => {
+        completed.push("second")
+        return Promise.resolve("second")
+      },
+      Date.now(),
+      "second",
+    )
+    secondPromise.catch(() => {})
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(completed).toEqual([])
+    await expect(firstPromise).rejects.toBe(error)
+    await expect(secondPromise).rejects.toBe(error)
+  })
+})
+
+// 12. Reconfigure the request queue
 describe("requestQueue – reconfigure the request queue", () => {
   it("increase the request rate", async () => {
     vi.useFakeTimers()

--- a/src/utils/request/batch-queue.ts
+++ b/src/utils/request/batch-queue.ts
@@ -188,7 +188,7 @@ export class BatchQueue<T, R> {
         return this.executeBatchWithRetry(tasks, batchKey, retryCount + 1)
       }
 
-      if (this.enableFallbackToIndividual && this.executeIndividual) {
+      if (this.enableFallbackToIndividual && this.executeIndividual && err instanceof BatchCountMismatchError) {
         return this.executeFallbackIndividual(tasks, batchKey)
       }
 

--- a/src/utils/request/request-queue.ts
+++ b/src/utils/request/request-queue.ts
@@ -1,7 +1,9 @@
+import type { RequestRetryPolicy } from "./retry-policy"
 import { deepmerge } from "deepmerge-ts"
 import { requestQueueConfigSchema } from "@/types/config/translate"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
 import { BinaryHeapPQ } from "./priority-queue"
+import { defaultRequestRetryPolicy } from "./retry-policy"
 
 export interface RequestTask {
   id: string
@@ -12,7 +14,10 @@ export interface RequestTask {
   scheduleAt: number
   createdAt: number
   retryCount: number
+  drained: boolean
 }
+
+type QueuedRequestTask = RequestTask & { hash: string }
 
 export interface QueueOptions {
   rate: number // tokens/sec
@@ -20,13 +25,15 @@ export interface QueueOptions {
   timeoutMs: number
   maxRetries: number
   baseRetryDelayMs: number
+  retryPolicy?: RequestRetryPolicy
 }
 
 export class RequestQueue {
-  private waitingQueue: BinaryHeapPQ<RequestTask & { hash: string }>
-  private waitingTasks = new Map<string, RequestTask>()
-  private executingTasks = new Map<string, RequestTask>()
+  private waitingQueue: BinaryHeapPQ<QueuedRequestTask>
+  private waitingTasks = new Map<string, QueuedRequestTask>()
+  private executingTasks = new Map<string, QueuedRequestTask>()
   private nextScheduleTimer: NodeJS.Timeout | null = null
+  private retryPolicy: RequestRetryPolicy
 
   // token bucket
   private bucketTokens: number
@@ -34,9 +41,10 @@ export class RequestQueue {
 
   constructor(private options: QueueOptions) {
     this.options = options
+    this.retryPolicy = options.retryPolicy ?? defaultRequestRetryPolicy
     this.bucketTokens = options.capacity
     this.lastRefill = Date.now()
-    this.waitingQueue = new BinaryHeapPQ<RequestTask & { hash: string }>()
+    this.waitingQueue = new BinaryHeapPQ<QueuedRequestTask>()
   }
 
   enqueue<T>(thunk: () => Promise<T>, scheduleAt: number, hash: string): Promise<T> {
@@ -53,8 +61,9 @@ export class RequestQueue {
       reject = rej
     })
 
-    const task: RequestTask = {
+    const task: QueuedRequestTask = {
       id: getRandomUUID(),
+      hash,
       thunk,
       promise,
       resolve,
@@ -62,10 +71,11 @@ export class RequestQueue {
       scheduleAt,
       createdAt: Date.now(),
       retryCount: 0,
+      drained: false,
     }
 
     this.waitingTasks.set(hash, task)
-    this.waitingQueue.push({ ...task, hash }, scheduleAt)
+    this.waitingQueue.push(task, scheduleAt)
 
     // console.info(`✅ Task ${task.id} added to queue. Queue size: ${this.waitingQueue.size()}, waiting: ${this.waitingTasks.size}, executing: ${this.executingTasks.size}`)
 
@@ -74,13 +84,17 @@ export class RequestQueue {
   }
 
   setQueueOptions(options: Partial<QueueOptions>) {
-    const parseConfigStatus = requestQueueConfigSchema.partial().safeParse(options)
+    const { retryPolicy, ...queueOptions } = options
+    const parseConfigStatus = requestQueueConfigSchema.partial().safeParse(queueOptions)
     if (parseConfigStatus.error) {
       throw new Error(parseConfigStatus.error.issues[0].message)
     }
-    this.options = deepmerge(this.options, options) as QueueOptions
-    if (options.capacity) {
-      this.bucketTokens = options.capacity
+    this.options = deepmerge(this.options, queueOptions) as QueueOptions
+    if (retryPolicy) {
+      this.retryPolicy = retryPolicy
+    }
+    if (queueOptions.capacity) {
+      this.bucketTokens = queueOptions.capacity
       this.lastRefill = Date.now()
     }
   }
@@ -89,8 +103,10 @@ export class RequestQueue {
     this.refillTokens()
 
     while (this.bucketTokens >= 1 && this.waitingQueue.size() > 0) {
+      const now = Date.now()
+
       const task = this.waitingQueue.peek()
-      if (task && task.scheduleAt <= Date.now()) {
+      if (task && task.scheduleAt <= now) {
         this.waitingQueue.pop()
         this.waitingTasks.delete(task.hash)
         this.executingTasks.set(task.hash, task)
@@ -123,7 +139,7 @@ export class RequestQueue {
     }
   }
 
-  private async executeTask(task: RequestTask & { hash: string }) {
+  private async executeTask(task: QueuedRequestTask) {
     // console.info(`🏃 Starting execution of task ${task.id} (attempt ${task.retryCount + 1}) at ${Date.now()}`)
 
     let timeoutId: NodeJS.Timeout | null = null
@@ -150,7 +166,9 @@ export class RequestQueue {
       }
 
       // console.info(`✅ Task ${task.id} completed successfully at ${Date.now()}`)
-      task.resolve(result)
+      if (!task.drained) {
+        task.resolve(result)
+      }
     }
     catch (error) {
       // Clear timeout if it hasn't fired yet
@@ -161,22 +179,26 @@ export class RequestQueue {
 
       // console.error(`❌ Task ${task.id} failed at ${Date.now()}:`, error)
 
+      if (task.drained) {
+        return
+      }
+
+      const now = Date.now()
+      const decision = this.retryPolicy.decide(error, {
+        retryCount: task.retryCount,
+        maxRetries: this.options.maxRetries,
+        baseRetryDelayMs: this.options.baseRetryDelayMs,
+        now,
+      })
+
       // Check if we should retry
-      if (task.retryCount < this.options.maxRetries) {
+      if (decision.action === "retry") {
         task.retryCount++
-
-        // Calculate exponential backoff delay
-        const backoffDelayMs = this.options.baseRetryDelayMs * (2 ** (task.retryCount - 1))
-
-        // Add some jitter to prevent thundering herd
-        const jitter = Math.random() * 0.1 * backoffDelayMs
-        const delayMs = backoffDelayMs + jitter
-
         // Schedule retry
-        const retryAt = Date.now() + delayMs
+        const retryAt = now + decision.delayMs
         task.scheduleAt = retryAt
 
-        // console.warn(`🔄 Retrying task ${task.id} (attempt ${task.retryCount}/${this.options.maxRetries}) after ${Math.round(delayMs)}ms`)
+        // console.warn(`🔄 Retrying task ${task.id} (attempt ${task.retryCount}/${this.options.maxRetries}) after ${Math.round(decision.delayMs)}ms`)
 
         // Move task back to waiting queue for retry
         this.waitingTasks.set(task.hash, task)
@@ -186,7 +208,12 @@ export class RequestQueue {
       else {
         // Max retries exceeded, reject the promise
         // console.error(`💀 Task ${task.id} failed permanently after ${this.options.maxRetries} retries`)
-        task.reject(error)
+        if (decision.failQueue) {
+          this.failCurrentBacklog(error)
+        }
+        else {
+          task.reject(error)
+        }
       }
     }
     finally {
@@ -195,7 +222,9 @@ export class RequestQueue {
         clearTimeout(timeoutId)
       }
 
-      this.executingTasks.delete(task.hash)
+      if (this.executingTasks.get(task.hash) === task) {
+        this.executingTasks.delete(task.hash)
+      }
       this.schedule()
     }
   }
@@ -206,6 +235,33 @@ export class RequestQueue {
       return duplicateTask
     }
     return undefined
+  }
+
+  private failCurrentBacklog(error: unknown) {
+    if (this.nextScheduleTimer) {
+      clearTimeout(this.nextScheduleTimer)
+      this.nextScheduleTimer = null
+    }
+
+    for (const task of this.waitingTasks.values()) {
+      this.rejectDrainedTask(task, error)
+    }
+    this.waitingTasks.clear()
+    this.waitingQueue.clear()
+
+    for (const task of this.executingTasks.values()) {
+      this.rejectDrainedTask(task, error)
+    }
+    this.executingTasks.clear()
+  }
+
+  private rejectDrainedTask(task: QueuedRequestTask, error: unknown) {
+    if (task.drained) {
+      return
+    }
+
+    task.drained = true
+    task.reject(error)
   }
 
   private refillTokens() {

--- a/src/utils/request/retry-policy.ts
+++ b/src/utils/request/retry-policy.ts
@@ -1,0 +1,321 @@
+export type RequestErrorKind = "rate-limit" | "timeout" | "network" | "bad-request" | "unknown"
+
+export interface RequestErrorMeta {
+  statusCode?: number
+  responseHeaders?: Headers | Record<string, string>
+  isRetryable?: boolean
+  retryAfterMs?: number
+  kind?: RequestErrorKind
+}
+
+export interface RequestRetryContext {
+  retryCount: number
+  maxRetries: number
+  baseRetryDelayMs: number
+  now: number
+}
+
+export type RetryDecision
+  = | { action: "retry", delayMs: number }
+    | { action: "fail", failQueue?: boolean }
+
+export interface RequestRetryPolicy {
+  decide: (error: unknown, context: RequestRetryContext) => RetryDecision
+}
+
+export const REQUEST_ERROR_META = Symbol("requestErrorMeta")
+
+export const MAX_RETRY_AFTER_MS = 5 * 60_000
+
+interface RetryAwareError {
+  [REQUEST_ERROR_META]?: RequestErrorMeta
+  requestErrorMeta?: RequestErrorMeta
+  statusCode?: unknown
+  status?: unknown
+  response?: unknown
+  responseHeaders?: unknown
+  headers?: unknown
+  isRetryable?: unknown
+  retryAfterMs?: unknown
+  kind?: unknown
+  message?: unknown
+}
+
+const RATE_LIMIT_ERROR_RE = /\b429\b|too many requests|rate[ -]?limit/i
+const TIMEOUT_ERROR_RE = /timed? out|timeout/i
+const NETWORK_ERROR_RE = /network error|failed to fetch|fetch failed/i
+
+export function attachRequestErrorMeta<T extends Error>(error: T, meta: RequestErrorMeta): T {
+  Object.defineProperty(error, REQUEST_ERROR_META, {
+    value: {
+      ...getRequestErrorMeta(error),
+      ...meta,
+    },
+    configurable: true,
+  })
+  return error
+}
+
+export function getRequestErrorMeta(error: unknown): RequestErrorMeta {
+  const source = isObject(error) ? error as RetryAwareError : undefined
+  const attachedMeta = source?.[REQUEST_ERROR_META] ?? source?.requestErrorMeta
+  const response = isObject(source?.response) ? source.response as RetryAwareError : undefined
+
+  const statusCode = normalizeStatusCode(
+    attachedMeta?.statusCode
+    ?? source?.statusCode
+    ?? source?.status
+    ?? response?.statusCode
+    ?? response?.status,
+  )
+  const responseHeaders = normalizeHeaders(
+    attachedMeta?.responseHeaders
+    ?? source?.responseHeaders
+    ?? source?.headers
+    ?? response?.responseHeaders
+    ?? response?.headers,
+  )
+  const retryAfterMs = normalizeNonNegativeNumber(attachedMeta?.retryAfterMs ?? source?.retryAfterMs)
+    ?? getRetryAfterMsFromHeaders(responseHeaders)
+  const isRetryable = normalizeBoolean(attachedMeta?.isRetryable ?? source?.isRetryable)
+  const message = typeof source?.message === "string" ? source.message : ""
+  const kind = normalizeKind(attachedMeta?.kind ?? source?.kind)
+    ?? inferRequestErrorKind({ statusCode, message })
+
+  return removeUndefined({
+    statusCode,
+    responseHeaders,
+    retryAfterMs,
+    isRetryable,
+    kind,
+  })
+}
+
+export function getRetryAfterMs(meta: RequestErrorMeta, now = Date.now()): number | undefined {
+  const directRetryAfterMs = normalizeNonNegativeNumber(meta.retryAfterMs)
+  if (directRetryAfterMs !== undefined) {
+    return directRetryAfterMs
+  }
+
+  return getRetryAfterMsFromHeaders(meta.responseHeaders, now)
+}
+
+export function getHeaderValue(headers: RequestErrorMeta["responseHeaders"] | unknown, key: string): string | undefined {
+  if (!headers) {
+    return undefined
+  }
+
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    return headers.get(key) ?? headers.get(key.toLowerCase()) ?? undefined
+  }
+
+  const normalizedKey = key.toLowerCase()
+
+  if (Array.isArray(headers)) {
+    const entry = headers.find((header): header is [unknown, unknown] => {
+      return Array.isArray(header) && header.length >= 2 && String(header[0]).toLowerCase() === normalizedKey
+    })
+    const value = entry?.[1]
+    return typeof value === "string" ? value : undefined
+  }
+
+  if (isObject(headers)) {
+    const entry = Object.entries(headers).find(([headerKey]) => headerKey.toLowerCase() === normalizedKey)
+    const value = entry?.[1]
+    return typeof value === "string" ? value : undefined
+  }
+
+  return undefined
+}
+
+export function isRateLimitRequestError(error: unknown): boolean {
+  const meta = getRequestErrorMeta(error)
+  return meta.kind === "rate-limit" || meta.statusCode === 429
+}
+
+export const defaultRequestRetryPolicy: RequestRetryPolicy = {
+  decide(error, context) {
+    const meta = getRequestErrorMeta(error)
+
+    if (isQueueFatalRequestErrorMeta(meta)) {
+      return { action: "fail", failQueue: true }
+    }
+
+    if (context.retryCount >= context.maxRetries || !isRetryableRequestErrorMeta(meta)) {
+      return { action: "fail" }
+    }
+
+    const baseDelayMs = context.baseRetryDelayMs * (2 ** context.retryCount)
+    const delayMs = clampRetryDelay(withJitter(baseDelayMs, false))
+
+    return { action: "retry", delayMs }
+  },
+}
+
+function isQueueFatalRequestErrorMeta(meta: RequestErrorMeta): boolean {
+  if (meta.kind === "rate-limit" || meta.statusCode === 429) {
+    return true
+  }
+
+  return meta.statusCode === 401
+    || meta.statusCode === 403
+    || meta.statusCode === 404
+}
+
+function isRetryableRequestErrorMeta(meta: RequestErrorMeta): boolean {
+  if (typeof meta.isRetryable === "boolean") {
+    return meta.isRetryable
+  }
+
+  if (meta.kind === "bad-request") {
+    return false
+  }
+
+  if (meta.kind === "rate-limit" || meta.kind === "timeout" || meta.kind === "network") {
+    return true
+  }
+
+  const { statusCode } = meta
+  if (statusCode !== undefined) {
+    if (statusCode === 408 || statusCode === 409 || statusCode === 429 || statusCode >= 500) {
+      return true
+    }
+    if (statusCode >= 400 && statusCode < 500) {
+      return false
+    }
+  }
+
+  return true
+}
+
+function getRetryAfterMsFromHeaders(headers: RequestErrorMeta["responseHeaders"] | undefined, now = Date.now()): number | undefined {
+  const retryAfterMs = getHeaderValue(headers, "retry-after-ms")
+  if (retryAfterMs) {
+    const parsed = Number.parseFloat(retryAfterMs)
+    if (Number.isFinite(parsed) && parsed >= 0) {
+      return parsed
+    }
+  }
+
+  const retryAfter = getHeaderValue(headers, "retry-after")
+  if (!retryAfter) {
+    return undefined
+  }
+
+  const timeoutSeconds = Number.parseFloat(retryAfter)
+  if (Number.isFinite(timeoutSeconds) && timeoutSeconds >= 0) {
+    return timeoutSeconds * 1000
+  }
+
+  const parsedDateMs = Date.parse(retryAfter)
+  if (!Number.isNaN(parsedDateMs)) {
+    return Math.max(0, parsedDateMs - now)
+  }
+
+  return undefined
+}
+
+function normalizeHeaders(headers: unknown): RequestErrorMeta["responseHeaders"] | undefined {
+  if (!headers) {
+    return undefined
+  }
+
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    return headers
+  }
+
+  if (Array.isArray(headers)) {
+    const normalized: Record<string, string> = {}
+    for (const entry of headers) {
+      if (!Array.isArray(entry) || entry.length < 2) {
+        continue
+      }
+      const [key, value] = entry
+      if (typeof key === "string" && typeof value === "string") {
+        normalized[key] = value
+      }
+    }
+    return Object.keys(normalized).length > 0 ? normalized : undefined
+  }
+
+  if (isObject(headers)) {
+    const normalized: Record<string, string> = {}
+    for (const [key, value] of Object.entries(headers)) {
+      if (typeof value === "string") {
+        normalized[key] = value
+      }
+    }
+    return Object.keys(normalized).length > 0 ? normalized : undefined
+  }
+
+  return undefined
+}
+
+function inferRequestErrorKind({ statusCode, message }: { statusCode?: number, message: string }): RequestErrorKind {
+  if (statusCode === 429 || RATE_LIMIT_ERROR_RE.test(message)) {
+    return "rate-limit"
+  }
+
+  if (statusCode !== undefined && statusCode >= 400 && statusCode < 500) {
+    return "bad-request"
+  }
+
+  if (TIMEOUT_ERROR_RE.test(message)) {
+    return "timeout"
+  }
+
+  if (NETWORK_ERROR_RE.test(message)) {
+    return "network"
+  }
+
+  return "unknown"
+}
+
+function normalizeKind(value: unknown): RequestErrorKind | undefined {
+  return value === "rate-limit"
+    || value === "timeout"
+    || value === "network"
+    || value === "bad-request"
+    || value === "unknown"
+    ? value
+    : undefined
+}
+
+function normalizeStatusCode(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    return undefined
+  }
+  return value
+}
+
+function normalizeNonNegativeNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined
+  }
+  return value
+}
+
+function normalizeBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined
+}
+
+function isObject(value: unknown): value is object {
+  return typeof value === "object" && value !== null
+}
+
+function withJitter(delayMs: number, disabled: boolean): number {
+  if (disabled) {
+    return delayMs
+  }
+  return delayMs + Math.random() * 0.1 * delayMs
+}
+
+function clampRetryDelay(delayMs: number): number {
+  return Math.min(Math.max(0, delayMs), MAX_RETRY_AFTER_MS)
+}
+
+function removeUndefined<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as T
+}


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Stop translation request storms after upstream queue-fatal errors.

This PR adds request-layer error metadata and retry policy handling so the request queue can distinguish transient retryable failures from queue-fatal failures. For 429/rate-limit and provider configuration failures such as 401/403/404, the queue now fails the current backlog immediately instead of waiting on cooldowns or continuing to dispatch queued requests.

Key behavior changes:

- Preserve AI SDK status/header/retry metadata while keeping provider response bodies visible in user-facing error messages.
- Fail fast on 429/rate-limit, 401, 403, and 404 by rejecting queued and in-flight request promises for the current backlog.
- Do not block future user-initiated translation attempts after a backlog drain.
- Keep bounded retries for transient errors such as 408/409/5xx/network/timeout.
- Prevent batch queue fallback-to-individual for HTTP/upstream/rate-limit failures; fallback remains limited to batch count mismatch errors.

## Related Issue

Closes #1427
Closes #1289

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Commands run:

- `SKIP_FREE_API=true pnpm test src/utils/request/__tests__/request-queue.test.ts src/utils/request/__tests__/batch-queue.test.ts src/utils/host/translate/api/__tests__/ai.test.ts src/entrypoints/background/__tests__/translation-queues.test.ts`
- `SKIP_FREE_API=true pnpm type-check`
- targeted ESLint on changed files
- `SKIP_FREE_API=true pnpm test`
- `WXT_SKIP_ENV_VALIDATION=true SKIP_FREE_API=true pnpm build`
- pre-push hook: lint, type-check, test

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

`Retry-After` is still preserved in error metadata, but this PR intentionally does not use it to cooldown or block future queue entries. The user can retry manually; if the provider is still rate-limiting, the new backlog will fail fast again.
