### PR TITLE
fix(extension): keep 408 and 409 retryable

### DIFF
--- a/src/utils/request/__tests__/request-queue.test.ts
+++ b/src/utils/request/__tests__/request-queue.test.ts
@@ -719,6 +719,39 @@ describe("requestQueue – retry policy and queue fail-fast drain", () => {
     await expect(firstPromise).rejects.toBe(error)
     await expect(secondPromise).rejects.toBe(error)
   })
+
+  it.each([408, 409])("retries transient %s errors before resolving", async (statusCode) => {
+    vi.useFakeTimers()
+    let attempts = 0
+
+    const q = new RequestQueue({
+      ...baseConfig,
+      rate: 10,
+      capacity: 1,
+      maxRetries: 2,
+      baseRetryDelayMs: 100,
+    })
+
+    const error = Object.assign(new Error(`HTTP ${statusCode}`), {
+      statusCode,
+    })
+
+    const promise = q.enqueue(() => {
+      attempts++
+      if (attempts === 1) {
+        return Promise.reject(error)
+      }
+      return Promise.resolve("success")
+    }, Date.now(), `transient-${statusCode}`)
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(attempts).toBe(1)
+
+    await vi.advanceTimersByTimeAsync(200)
+
+    expect(attempts).toBe(2)
+    await expect(promise).resolves.toBe("success")
+  })
 })
 
 // 12. Reconfigure the request queue

--- a/src/utils/request/__tests__/retry-policy.test.ts
+++ b/src/utils/request/__tests__/retry-policy.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+import { attachRequestErrorMeta, defaultRequestRetryPolicy, getRequestErrorMeta } from "../retry-policy"
+
+const retryContext = {
+  retryCount: 0,
+  maxRetries: 2,
+  baseRetryDelayMs: 100,
+  now: 0,
+}
+
+function errorWithStatus(statusCode: number) {
+  return Object.assign(new Error(`HTTP ${statusCode}`), { statusCode })
+}
+
+describe("request retry policy", () => {
+  it.each([
+    { statusCode: 408, kind: "timeout" },
+    { statusCode: 409, kind: "unknown" },
+  ] as const)("keeps $statusCode retryable instead of classifying it as bad-request", ({ statusCode, kind }) => {
+    const error = errorWithStatus(statusCode)
+
+    expect(getRequestErrorMeta(error)).toEqual(expect.objectContaining({
+      statusCode,
+      kind,
+    }))
+    expect(defaultRequestRetryPolicy.decide(error, retryContext)).toEqual(expect.objectContaining({
+      action: "retry",
+    }))
+  })
+
+  it("fails ordinary bad requests without retrying", () => {
+    expect(getRequestErrorMeta(errorWithStatus(400))).toEqual(expect.objectContaining({
+      statusCode: 400,
+      kind: "bad-request",
+    }))
+    expect(defaultRequestRetryPolicy.decide(errorWithStatus(400), retryContext)).toEqual({
+      action: "fail",
+    })
+  })
+
+  it.each([401, 403, 404, 429])("keeps %s as queue-fatal", (statusCode) => {
+    expect(defaultRequestRetryPolicy.decide(errorWithStatus(statusCode), retryContext)).toEqual({
+      action: "fail",
+      failQueue: true,
+    })
+  })
+
+  it("preserves explicit bad-request metadata precedence", () => {
+    const error = attachRequestErrorMeta(errorWithStatus(409), { kind: "bad-request" })
+
+    expect(getRequestErrorMeta(error)).toEqual(expect.objectContaining({
+      statusCode: 409,
+      kind: "bad-request",
+    }))
+    expect(defaultRequestRetryPolicy.decide(error, retryContext)).toEqual({
+      action: "fail",
+    })
+  })
+})

--- a/src/utils/request/retry-policy.ts
+++ b/src/utils/request/retry-policy.ts
@@ -256,6 +256,14 @@ function inferRequestErrorKind({ statusCode, message }: { statusCode?: number, m
     return "rate-limit"
   }
 
+  if (statusCode === 408) {
+    return "timeout"
+  }
+
+  if (statusCode === 409) {
+    return "unknown"
+  }
+
   if (statusCode !== undefined && statusCode >= 400 && statusCode < 500) {
     return "bad-request"
   }


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Follow-up to #1431. Keeps HTTP 408 and 409 out of the inferred bad-request classification so the retry policy's bounded retry branch remains reachable for transient timeout/conflict responses.

- Maps 408 to the existing timeout kind.
- Maps 409 to the existing unknown kind.
- Preserves explicit bad-request metadata precedence.

## Related Issue

Follow-up to #1431

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

- SKIP_FREE_API=true pnpm test -- src/utils/request/__tests__/retry-policy.test.ts src/utils/request/__tests__/request-queue.test.ts
- pre-push: lint, type-check, test

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

No extra changeset was added because this only fixes behavior introduced by the already-unreleased #1431 changeset.