### PR TITLE
fix(extension): restore google translate provider support

### DIFF
--- a/.changeset/google-translate-provider.md
+++ b/.changeset/google-translate-provider.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(extension): restore Google Translate provider support

--- a/src/entrypoints/options/pages/general/feature-providers-config.tsx
+++ b/src/entrypoints/options/pages/general/feature-providers-config.tsx
@@ -21,9 +21,8 @@ function needsApiKeyWarning(providerConfig: ProviderConfig | null): boolean {
     && !providerConfig.apiKey
 }
 
-function FeatureProviderField({ featureKey, excludeProviderTypes }: {
+function FeatureProviderField({ featureKey }: {
   featureKey: FeatureKey
-  excludeProviderTypes?: string[]
 }) {
   const config = useAtomValue(configAtom)
   const setConfig = useSetAtom(writeConfigAtom)
@@ -34,9 +33,8 @@ function FeatureProviderField({ featureKey, excludeProviderTypes }: {
 
   const providers = useMemo(() =>
     filterEnabledProvidersConfig(providersConfig)
-      .filter(p => def.isProvider(p.provider))
-      .filter(p => !excludeProviderTypes?.includes(p.provider)),
-  [providersConfig, def, excludeProviderTypes])
+      .filter(p => def.isProvider(p.provider)),
+  [providersConfig, def])
 
   return (
     <Field>
@@ -111,8 +109,6 @@ function CustomActionProviderFields() {
 }
 
 export default function FeatureProvidersConfig() {
-  const config = useAtomValue(configAtom)
-
   return (
     <ConfigCard
       id="feature-providers"
@@ -122,7 +118,6 @@ export default function FeatureProvidersConfig() {
       <div className="space-y-4">
         <FeatureProviderField
           featureKey="translate"
-          excludeProviderTypes={config.translate.mode === "translationOnly" ? ["google-translate"] : undefined}
         />
         <FeatureProviderField featureKey="videoSubtitles" />
         <FeatureProviderField featureKey="selectionToolbar.translate" />

--- a/src/entrypoints/options/pages/translation/translation-mode.tsx
+++ b/src/entrypoints/options/pages/translation/translation-mode.tsx
@@ -1,7 +1,7 @@
 import type { TranslationMode as TranslationModeType } from "@/types/config/translate"
 import { i18n } from "#imports"
 import { deepmerge } from "deepmerge-ts"
-import { useAtom, useAtomValue } from "jotai"
+import { useAtom } from "jotai"
 import {
   Select,
   SelectContent,
@@ -12,7 +12,6 @@ import {
 } from "@/components/ui/base-ui/select"
 import { TRANSLATION_MODES } from "@/types/config/translate"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
-import { filterEnabledProvidersConfig, getLLMProvidersConfig, getProviderConfigById } from "@/utils/config/helpers"
 import { ConfigCard } from "../../components/config-card"
 
 export function TranslationMode() {
@@ -25,39 +24,11 @@ export function TranslationMode() {
 
 function TranslationModeSelector() {
   const [translateConfig, setTranslateConfig] = useAtom(configFieldsAtomMap.translate)
-  const providersConfig = useAtomValue(configFieldsAtomMap.providersConfig)
   const currentMode = translateConfig.mode
 
   const handleModeChange = (mode: TranslationModeType | null) => {
     if (!mode)
       return
-    const currentProvider = getProviderConfigById(providersConfig, translateConfig.providerId)
-
-    if (mode === "translationOnly" && currentProvider && currentProvider.provider === "google-translate") {
-      const enabledProviders = filterEnabledProvidersConfig(providersConfig)
-
-      const microsoftProvider = enabledProviders.find(p => p.provider === "microsoft-translate")
-      if (microsoftProvider) {
-        void setTranslateConfig(
-          deepmerge(translateConfig, {
-            mode,
-            providerId: microsoftProvider.id,
-          }),
-        )
-        return
-      }
-
-      const llmProviders = getLLMProvidersConfig(enabledProviders)
-      if (llmProviders.length > 0) {
-        void setTranslateConfig(
-          deepmerge(translateConfig, {
-            mode,
-            providerId: llmProviders[0].id,
-          }),
-        )
-        return
-      }
-    }
 
     void setTranslateConfig(
       deepmerge(translateConfig, { mode }),

--- a/src/entrypoints/popup/components/translate-provider-field.tsx
+++ b/src/entrypoints/popup/components/translate-provider-field.tsx
@@ -12,11 +12,9 @@ export default function TranslateProviderField() {
   const providersConfig = useAtomValue(configFieldsAtomMap.providersConfig)
 
   const providers = useMemo(() => {
-    const exclude = translateConfig.mode === "translationOnly" ? ["google-translate"] : undefined
     return filterEnabledProvidersConfig(providersConfig)
       .filter(p => isTranslateProvider(p.provider))
-      .filter(p => !exclude?.includes(p.provider))
-  }, [providersConfig, translateConfig.mode])
+  }, [providersConfig])
 
   return (
     <div className="flex items-center justify-between gap-2">

--- a/src/entrypoints/popup/components/translation-mode-selector.tsx
+++ b/src/entrypoints/popup/components/translation-mode-selector.tsx
@@ -1,7 +1,7 @@
 import type { TranslationMode as TranslationModeType } from "@/types/config/translate"
 import { i18n } from "#imports"
 import { deepmerge } from "deepmerge-ts"
-import { useAtom, useAtomValue } from "jotai"
+import { useAtom } from "jotai"
 import { HelpTooltip } from "@/components/help-tooltip"
 import {
   Select,
@@ -13,43 +13,14 @@ import {
 } from "@/components/ui/base-ui/select"
 import { TRANSLATION_MODES } from "@/types/config/translate"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
-import { filterEnabledProvidersConfig, getLLMProvidersConfig, getProviderConfigById } from "@/utils/config/helpers"
 
 export default function TranslationModeSelector() {
   const [translateConfig, setTranslateConfig] = useAtom(configFieldsAtomMap.translate)
-  const providersConfig = useAtomValue(configFieldsAtomMap.providersConfig)
   const currentMode = translateConfig.mode
 
   const handleModeChange = (mode: TranslationModeType | null) => {
     if (!mode)
       return
-    const currentProvider = getProviderConfigById(providersConfig, translateConfig.providerId)
-
-    if (mode === "translationOnly" && currentProvider && currentProvider.provider === "google-translate") {
-      const enabledProviders = filterEnabledProvidersConfig(providersConfig)
-
-      const microsoftProvider = enabledProviders.find(p => p.provider === "microsoft-translate")
-      if (microsoftProvider) {
-        void setTranslateConfig(
-          deepmerge(translateConfig, {
-            mode,
-            providerId: microsoftProvider.id,
-          }),
-        )
-        return
-      }
-
-      const llmProviders = getLLMProvidersConfig(enabledProviders)
-      if (llmProviders.length > 0) {
-        void setTranslateConfig(
-          deepmerge(translateConfig, {
-            mode,
-            providerId: llmProviders[0].id,
-          }),
-        )
-        return
-      }
-    }
 
     void setTranslateConfig(
       deepmerge(translateConfig, { mode }),

--- a/src/types/config/__tests__/config-provider-enabled.test.ts
+++ b/src/types/config/__tests__/config-provider-enabled.test.ts
@@ -14,7 +14,7 @@ function getIssuePaths(input: unknown) {
 describe("config provider enabled validation", () => {
   it("fails when a built-in feature uses a disabled provider", () => {
     const providersConfig = DEFAULT_CONFIG.providersConfig.map((provider) => {
-      if (provider.id === "microsoft-translate-default") {
+      if (provider.id === "google-translate-default") {
         return { ...provider, enabled: false }
       }
       return provider

--- a/src/utils/constants/config.ts
+++ b/src/utils/constants/config.ts
@@ -52,7 +52,7 @@ export const DEFAULT_CONFIG: Config = {
   },
   providersConfig: DEFAULT_PROVIDER_CONFIG_LIST,
   translate: {
-    providerId: "microsoft-translate-default",
+    providerId: "google-translate-default",
     mode: "bilingual",
     node: {
       enabled: false,
@@ -107,7 +107,7 @@ export const DEFAULT_CONFIG: Config = {
     features: {
       translate: {
         enabled: true,
-        providerId: "microsoft-translate-default",
+        providerId: "google-translate-default",
       },
       speak: {
         enabled: true,
@@ -126,7 +126,7 @@ export const DEFAULT_CONFIG: Config = {
   },
   inputTranslation: {
     enabled: true,
-    providerId: "microsoft-translate-default",
+    providerId: "google-translate-default",
     fromLang: "targetCode",
     toLang: "sourceCode",
     enableCycle: false,
@@ -135,7 +135,7 @@ export const DEFAULT_CONFIG: Config = {
   videoSubtitles: {
     enabled: true,
     autoStart: false,
-    providerId: "microsoft-translate-default",
+    providerId: "google-translate-default",
     style: {
       displayMode: DEFAULT_DISPLAY_MODE,
       translationPosition: DEFAULT_TRANSLATION_POSITION,

--- a/src/utils/host/translate/api/google-legacy.ts
+++ b/src/utils/host/translate/api/google-legacy.ts
@@ -1,0 +1,60 @@
+export async function googleTranslateLegacySingle(
+  sourceText: string,
+  fromLang: string,
+  toLang: string,
+): Promise<string> {
+  const params = {
+    client: "gtx",
+    sl: fromLang,
+    tl: toLang,
+    dt: "t",
+    strip: 1,
+    nonced: 1,
+    q: encodeURIComponent(sourceText),
+  }
+
+  const queryString = Object.keys(params)
+    .map(key => `${key}=${params[key as keyof typeof params]}`)
+    .join("&")
+
+  const resp = await fetch(
+    `https://translate.googleapis.com/translate_a/single?${queryString}`,
+    {
+      method: "GET",
+    },
+  ).catch((error) => {
+    throw new Error(`Network error during translation: ${error.message}`)
+  })
+
+  if (!resp.ok) {
+    const errorText = await resp
+      .text()
+      .catch(() => "Unable to read error response")
+    throw new Error(
+      `Translation request failed: ${resp.status} ${resp.statusText}${
+        errorText ? ` - ${errorText}` : ""
+      }`,
+    )
+  }
+
+  try {
+    const result = await resp.json()
+
+    if (!Array.isArray(result) || !Array.isArray(result[0])) {
+      throw new TypeError("Unexpected response format from translation API")
+    }
+
+    const translatedText = result[0]
+      .filter(Array.isArray)
+      .map(chunk => chunk[0])
+      .filter(Boolean)
+      .join("")
+
+    return translatedText
+  }
+  catch (error) {
+    throw new Error(
+      `Failed to parse translation response: ${(error as Error).message}`,
+    )
+  }
+}

--- a/src/utils/host/translate/api/google.ts
+++ b/src/utils/host/translate/api/google.ts
@@ -1,56 +1,57 @@
+import { attachRequestErrorMeta } from "@/utils/request/retry-policy"
+
+const GOOGLE_TRANSLATE_HTML_URL = "https://translate-pa.googleapis.com/v1/translateHtml"
+const GOOGLE_TRANSLATE_HTML_API_KEY = "AIzaSyATBXajvzQLTDHEQbcpq0Ihe0vWDHmO520"
+const GOOGLE_TRANSLATE_HTML_CLIENT = "wt_lib"
+
 export async function googleTranslate(
   sourceText: string,
   fromLang: string,
   toLang: string,
 ): Promise<string> {
-  const params = {
-    client: "gtx",
-    sl: fromLang,
-    tl: toLang,
-    dt: "t",
-    strip: 1,
-    nonced: 1,
-    q: encodeURIComponent(sourceText),
-  }
-
-  const queryString = Object.keys(params)
-    .map(key => `${key}=${params[key as keyof typeof params]}`)
-    .join("&")
-
   const resp = await fetch(
-    `https://translate.googleapis.com/translate_a/single?${queryString}`,
+    GOOGLE_TRANSLATE_HTML_URL,
     {
-      method: "GET",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json+protobuf",
+        "X-Goog-API-Key": GOOGLE_TRANSLATE_HTML_API_KEY,
+      },
+      body: JSON.stringify([
+        [[sourceText], fromLang, toLang],
+        GOOGLE_TRANSLATE_HTML_CLIENT,
+      ]),
     },
   ).catch((error) => {
-    throw new Error(`Network error during translation: ${error.message}`)
+    throw attachRequestErrorMeta(
+      new Error(`Network error during translation: ${error.message}`),
+      { kind: "network", isRetryable: true },
+    )
   })
 
   if (!resp.ok) {
     const errorText = await resp
       .text()
       .catch(() => "Unable to read error response")
-    throw new Error(
-      `Translation request failed: ${resp.status} ${resp.statusText}${
+    throw attachRequestErrorMeta(
+      new Error(`Translation request failed: ${resp.status} ${resp.statusText}${
         errorText ? ` - ${errorText}` : ""
-      }`,
+      }`),
+      {
+        statusCode: resp.status,
+        responseHeaders: resp.headers,
+      },
     )
   }
 
   try {
     const result = await resp.json()
 
-    if (!Array.isArray(result) || !Array.isArray(result[0])) {
+    if (!Array.isArray(result) || !Array.isArray(result[0]) || typeof result[0][0] !== "string") {
       throw new TypeError("Unexpected response format from translation API")
     }
 
-    const translatedText = result[0]
-      .filter(Array.isArray)
-      .map(chunk => chunk[0])
-      .filter(Boolean)
-      .join("")
-
-    return translatedText
+    return result[0][0]
   }
   catch (error) {
     throw new Error(


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Restores Google Translate as a fully supported extension translation provider.

- Switches the active Google adapter from the legacy `translate_a/single` GET endpoint to the `translateHtml` POST endpoint.
- Keeps the old single-endpoint implementation in `google-legacy.ts` for manual rollback/reference, without exporting it from the active Google adapter.
- Makes Google Translate the default provider for translate, feature translate, input translation, and video subtitles.
- Allows Google Translate to remain selectable when translation mode is set to translation-only, instead of filtering it out or automatically switching providers.
- Updates provider-enabled validation coverage to match the new default Google provider.

## Related Issue

Closes #1414


## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Commands run:

- `pnpm type-check`
- `pnpm lint`
- `SKIP_FREE_API=true pnpm test`
- pre-push hook: `nx run @read-frog/extension:lint`
- pre-push hook: `nx run @read-frog/extension:type-check`
- pre-push hook: `nx run @read-frog/extension:test`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The PR description file is local-only and should not be committed.
