### PR TITLE
fix(subtitles): force dark theme for subtitle UI

### DIFF
--- a/.changeset/subtitles-ui-forced-dark.md
+++ b/.changeset/subtitles-ui-forced-dark.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(subtitles): force dark theme for subtitle UI

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -15,11 +15,9 @@ export const ThemeContext = createContext<ThemeContextI | undefined>(undefined)
 export function ThemeProvider({
   children,
   container,
-  forcedTheme,
 }: {
   children: React.ReactNode
   container?: HTMLElement
-  forcedTheme?: Theme
 }) {
   const [themeMode, setThemeMode] = useAtom(themeModeAtom)
 
@@ -36,11 +34,9 @@ export function ThemeProvider({
     () => !!window?.matchMedia?.("(prefers-color-scheme: dark)")?.matches,
   )
 
-  const resolvedTheme: Theme = themeMode === "system"
+  const theme: Theme = themeMode === "system"
     ? (prefersDark ? "dark" : "light")
     : themeMode
-
-  const theme: Theme = forcedTheme ?? resolvedTheme
 
   // Apply theme to document or shadow root container
   useLayoutEffect(() => {

--- a/src/components/ui/base-ui/select.tsx
+++ b/src/components/ui/base-ui/select.tsx
@@ -1,63 +1,11 @@
-import type { VariantProps } from "class-variance-authority"
 import { Select as SelectPrimitive } from "@base-ui/react/select"
 import { IconCheck, IconChevronDown, IconChevronUp } from "@tabler/icons-react"
 
-import { cva } from "class-variance-authority"
 import * as React from "react"
 import { SHARED_POPUP_CLOSED_STATE_CLASS } from "@/components/ui/base-ui/popup-animation-classes"
 import { cn } from "@/utils/styles/utils"
 
 const Select = SelectPrimitive.Root
-
-const selectTriggerVariants = cva(
-  "gap-1.5 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-sm transition-colors select-none flex w-fit items-center justify-between whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-  {
-    variants: {
-      variant: {
-        default: "shadow-xs border-input data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 focus-visible:ring-3 aria-invalid:ring-3 [&_[data-slot=select-icon]]:text-muted-foreground",
-        dark: "border-white/10 bg-white/6 text-white/92 hover:bg-white/10 focus-visible:border-white/18 focus-visible:ring-white/18 focus-visible:ring-1 [&_[data-slot=select-icon]]:text-white/62",
-      },
-      size: {
-        default: "h-8",
-        sm: "h-7 rounded-[min(var(--radius-md),10px)]",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  },
-)
-
-const selectContentVariants = cva(
-  "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 min-w-36 rounded-lg shadow-md duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto data-[align-trigger=true]:animate-none",
-  {
-    variants: {
-      variant: {
-        default: "bg-popover text-popover-foreground ring-foreground/10 ring-1",
-        dark: "bg-[rgba(24,26,30,0.96)] text-white/90 ring-white/10 ring-1 backdrop-blur-xl",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  },
-)
-
-const selectItemVariants = cva(
-  "gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-  {
-    variants: {
-      variant: {
-        default: "focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground",
-        dark: "focus:bg-white/10 focus:text-white",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-    },
-  },
-)
 
 function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
   return (
@@ -81,15 +29,20 @@ function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
 
 function SelectTrigger({
   className,
-  variant = "default",
   size = "default",
   children,
   ...props
-}: SelectPrimitive.Trigger.Props & VariantProps<typeof selectTriggerVariants>) {
+}: SelectPrimitive.Trigger.Props & {
+  size?: "sm" | "default"
+}) {
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"
-      className={cn(selectTriggerVariants({ variant, size, className }))}
+      data-size={size}
+      className={cn(
+        "shadow-xs border-input data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 gap-1.5 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-sm transition-colors select-none focus-visible:ring-3 aria-invalid:ring-3 data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:gap-1.5 [&_[data-slot=select-icon]]:text-muted-foreground [&_svg:not([class*='size-'])]:size-4 flex w-fit items-center justify-between whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
+      )}
       {...props}
     >
       {children}
@@ -106,7 +59,6 @@ function SelectTrigger({
 function SelectContent({
   container,
   className,
-  variant = "default",
   children,
   positionerClassName,
   side = "bottom",
@@ -117,7 +69,6 @@ function SelectContent({
   ...props
 }: SelectPrimitive.Popup.Props
   & Pick<SelectPrimitive.Portal.Props, "container">
-  & VariantProps<typeof selectContentVariants>
   & {
     positionerClassName?: string
   }
@@ -138,7 +89,7 @@ function SelectContent({
         <SelectPrimitive.Popup
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
-          className={cn(selectContentVariants({ variant }), SHARED_POPUP_CLOSED_STATE_CLASS, className)}
+          className={cn("bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-lg shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto data-[align-trigger=true]:animate-none", SHARED_POPUP_CLOSED_STATE_CLASS, className)}
           {...props}
         >
           <SelectScrollUpButton />
@@ -165,14 +116,16 @@ function SelectLabel({
 
 function SelectItem({
   className,
-  variant = "default",
   children,
   ...props
-}: SelectPrimitive.Item.Props & VariantProps<typeof selectItemVariants>) {
+}: SelectPrimitive.Item.Props) {
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
-      className={cn(selectItemVariants({ variant, className }))}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 relative flex w-full cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        className,
+      )}
       {...props}
     >
       <SelectPrimitive.ItemText className="flex flex-1 gap-2 shrink-0 whitespace-nowrap">

--- a/src/entrypoints/subtitles.content/renderer/mount-subtitles-ui.tsx
+++ b/src/entrypoints/subtitles.content/renderer/mount-subtitles-ui.tsx
@@ -3,12 +3,12 @@ import type { PlatformConfig } from "@/entrypoints/subtitles.content/platforms"
 import ReactDOM from "react-dom/client"
 import { Toaster } from "sonner"
 import themeCSS from "@/assets/styles/theme.css?inline"
-import { ThemeProvider } from "@/components/providers/theme-provider"
 import { REACT_SHADOW_HOST_CLASS } from "@/utils/constants/dom-labels"
-import { SUBTITLES_FORCED_THEME } from "@/utils/constants/subtitles"
+import { SUBTITLES_THEME } from "@/utils/constants/subtitles"
 import { waitForElement } from "@/utils/dom/wait-for-element"
 import { ShadowWrapperContext } from "@/utils/react-shadow-host/create-shadow-host"
 import { ShadowHostBuilder } from "@/utils/react-shadow-host/shadow-host-builder"
+import { applyTheme } from "@/utils/theme"
 import { SubtitlesContainer } from "../ui/subtitles-container"
 import { SubtitlesProviders } from "../ui/subtitles-ui-context"
 
@@ -73,6 +73,7 @@ export async function mountSubtitlesUI(
     },
   })
   const reactContainer = hostBuilder.build()
+  applyTheme(reactContainer, SUBTITLES_THEME)
 
   const reactRoot = ReactDOM.createRoot(reactContainer)
 
@@ -85,12 +86,10 @@ export async function mountSubtitlesUI(
 
   const app = (
     <ShadowWrapperContext value={reactContainer}>
-      <ThemeProvider container={reactContainer} forcedTheme={SUBTITLES_FORCED_THEME}>
-        <SubtitlesProviders adapter={adapter}>
-          <SubtitlesContainer />
-          <Toaster richColors className="z-2147483647 notranslate" />
-        </SubtitlesProviders>
-      </ThemeProvider>
+      <SubtitlesProviders adapter={adapter}>
+        <SubtitlesContainer />
+        <Toaster richColors className="z-2147483647 notranslate" />
+      </SubtitlesProviders>
     </ShadowWrapperContext>
   )
 

--- a/src/entrypoints/subtitles.content/renderer/mount-subtitles-ui.tsx
+++ b/src/entrypoints/subtitles.content/renderer/mount-subtitles-ui.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "sonner"
 import themeCSS from "@/assets/styles/theme.css?inline"
 import { ThemeProvider } from "@/components/providers/theme-provider"
 import { REACT_SHADOW_HOST_CLASS } from "@/utils/constants/dom-labels"
+import { SUBTITLES_FORCED_THEME } from "@/utils/constants/subtitles"
 import { waitForElement } from "@/utils/dom/wait-for-element"
 import { ShadowWrapperContext } from "@/utils/react-shadow-host/create-shadow-host"
 import { ShadowHostBuilder } from "@/utils/react-shadow-host/shadow-host-builder"
@@ -84,7 +85,7 @@ export async function mountSubtitlesUI(
 
   const app = (
     <ShadowWrapperContext value={reactContainer}>
-      <ThemeProvider container={reactContainer}>
+      <ThemeProvider container={reactContainer} forcedTheme={SUBTITLES_FORCED_THEME}>
         <SubtitlesProviders adapter={adapter}>
           <SubtitlesContainer />
           <Toaster richColors className="z-2147483647 notranslate" />

--- a/src/entrypoints/subtitles.content/renderer/render-translate-button.tsx
+++ b/src/entrypoints/subtitles.content/renderer/render-translate-button.tsx
@@ -1,6 +1,6 @@
 import type { SubtitlesProvidersAdapter } from "../ui/subtitles-ui-context"
 import themeCSS from "@/assets/styles/theme.css?inline"
-import { SUBTITLES_FORCED_THEME, TRANSLATE_BUTTON_CONTAINER_ID } from "@/utils/constants/subtitles"
+import { SUBTITLES_THEME, TRANSLATE_BUTTON_CONTAINER_ID } from "@/utils/constants/subtitles"
 import { createReactShadowHost } from "@/utils/react-shadow-host/create-shadow-host"
 import { SubtitlesSettingsPanel } from "../ui/subtitles-settings-panel"
 import { SubtitlesTranslateButton } from "../ui/subtitles-translate-button"
@@ -16,7 +16,7 @@ const wrapperCSS = `
     margin: 0;
     padding: 0;
   }
-  .${SUBTITLES_FORCED_THEME} {
+  .${SUBTITLES_THEME} {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -32,7 +32,7 @@ const embedWrapperCSS = `
     position: relative;
     height: 100%;
   }
-  .${SUBTITLES_FORCED_THEME} {
+  .${SUBTITLES_THEME} {
     display: flex;
     align-items: center;
     height: 100%;
@@ -58,7 +58,6 @@ export function renderSubtitlesTranslateButton(adapter: SubtitlesProvidersAdapte
     position: "inline",
     inheritStyles: false,
     cssContent: [themeCSS, adapter.embedded ? embedWrapperCSS : wrapperCSS],
-    forcedTheme: SUBTITLES_FORCED_THEME,
     ...(adapter.embedded && { style: { position: "relative" } }),
   }) as HTMLDivElement
 

--- a/src/entrypoints/subtitles.content/renderer/render-translate-button.tsx
+++ b/src/entrypoints/subtitles.content/renderer/render-translate-button.tsx
@@ -1,6 +1,6 @@
 import type { SubtitlesProvidersAdapter } from "../ui/subtitles-ui-context"
 import themeCSS from "@/assets/styles/theme.css?inline"
-import { TRANSLATE_BUTTON_CONTAINER_ID } from "@/utils/constants/subtitles"
+import { SUBTITLES_FORCED_THEME, TRANSLATE_BUTTON_CONTAINER_ID } from "@/utils/constants/subtitles"
 import { createReactShadowHost } from "@/utils/react-shadow-host/create-shadow-host"
 import { SubtitlesSettingsPanel } from "../ui/subtitles-settings-panel"
 import { SubtitlesTranslateButton } from "../ui/subtitles-translate-button"
@@ -16,7 +16,7 @@ const wrapperCSS = `
     margin: 0;
     padding: 0;
   }
-  .light, .dark {
+  .${SUBTITLES_FORCED_THEME} {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -32,7 +32,7 @@ const embedWrapperCSS = `
     position: relative;
     height: 100%;
   }
-  .light, .dark {
+  .${SUBTITLES_FORCED_THEME} {
     display: flex;
     align-items: center;
     height: 100%;
@@ -58,7 +58,8 @@ export function renderSubtitlesTranslateButton(adapter: SubtitlesProvidersAdapte
     position: "inline",
     inheritStyles: false,
     cssContent: [themeCSS, adapter.embedded ? embedWrapperCSS : wrapperCSS],
-    ...(adapter.embedded && { style: { position: "relative" }, forcedTheme: "dark" as const }),
+    forcedTheme: SUBTITLES_FORCED_THEME,
+    ...(adapter.embedded && { style: { position: "relative" } }),
   }) as HTMLDivElement
 
   shadowHost.id = TRANSLATE_BUTTON_CONTAINER_ID

--- a/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/views/style.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/views/style.tsx
@@ -28,7 +28,7 @@ import {
 import { ShadowWrapperContext } from "@/utils/react-shadow-host/create-shadow-host"
 import { subtitlesStore } from "../../../atoms"
 
-const SELECT_TRIGGER_CLASS = "min-w-[5.5rem] text-[13px] [&_[data-slot=select-value]]:text-white/92"
+const SELECT_TRIGGER_CLASS = "min-w-[5.5rem] text-[13px] text-popover-foreground [&_[data-slot=select-value]]:text-popover-foreground [&_[data-slot=select-icon]]:text-muted-foreground"
 const SELECT_CONTENT_CLASS = "[&_[role=option]]:text-[13px]"
 const SLIDER_CLASS = "[&_[role=slider]]:border-0 [&_[role=slider]]:shadow-[0_2px_4px_rgba(0,0,0,0.3)]"
 
@@ -43,7 +43,7 @@ function SettingsGroup({ icon, title, onReset, children }: {
   return (
     <div className="mb-4">
       <div className="mb-1.5 flex items-center justify-between px-0.5">
-        <div className="flex items-center gap-1.5 text-[13px] font-medium text-white/90">
+        <div className="text-popover-foreground flex items-center gap-1.5 text-[13px] font-medium">
           {icon}
           {title}
         </div>
@@ -52,12 +52,12 @@ function SettingsGroup({ icon, title, onReset, children }: {
           variant="ghost"
           size="icon-sm"
           onClick={onReset}
-          className="cursor-pointer text-white/62 hover:bg-white/8 hover:text-white/90"
+          className="text-muted-foreground hover:bg-accent/60 hover:text-popover-foreground cursor-pointer"
         >
           <IconRefresh className="size-3.5" />
         </Button>
       </div>
-      <div className="divide-y divide-white/6 rounded-xl bg-white/[0.04]">
+      <div className="bg-muted/50 divide-border rounded-xl border divide-y">
         {children}
       </div>
     </div>
@@ -67,7 +67,7 @@ function SettingsGroup({ icon, title, onReset, children }: {
 function SettingRow({ label, children }: { label: string, children: ReactNode }) {
   return (
     <div className="flex items-center justify-between px-3 py-2.5">
-      <span className="text-[13px] text-white/92">{label}</span>
+      <span className="text-popover-foreground text-[13px]">{label}</span>
       {children}
     </div>
   )
@@ -85,8 +85,8 @@ function SliderRow({ label, value, display, min, max, step, onChange }: {
   return (
     <div className="px-3 py-2.5">
       <div className="mb-3.5 flex items-center justify-between">
-        <span className="text-[13px] text-white/92">{label}</span>
-        <span className="text-[12px] text-white/62">{display}</span>
+        <span className="text-popover-foreground text-[13px]">{label}</span>
+        <span className="text-muted-foreground text-[12px]">{display}</span>
       </div>
       <Slider
         min={min}
@@ -125,19 +125,19 @@ function TextStyleGroup({ icon, title, textStyle, onChange, onReset, portalConta
           type="color"
           value={textStyle.color}
           onChange={e => onChange({ color: e.target.value })}
-          className="h-6 w-6 cursor-pointer rounded border border-white/15 bg-transparent p-0.5"
+          className="border-input bg-background h-6 w-6 cursor-pointer rounded border p-0.5"
         />
       </SettingRow>
 
       <SettingRow label={i18n.t("options.videoSubtitles.style.fontFamily")}>
         <Select value={textStyle.fontFamily} onValueChange={v => v && onChange({ fontFamily: v as SubtitlesFontFamily })}>
-          <SelectTrigger variant="dark" size="sm" className={SELECT_TRIGGER_CLASS}>
+          <SelectTrigger size="sm" className={SELECT_TRIGGER_CLASS}>
             <SelectValue>{textStyle.fontFamily}</SelectValue>
           </SelectTrigger>
-          <SelectContent variant="dark" container={portalContainer} className={SELECT_CONTENT_CLASS}>
+          <SelectContent container={portalContainer} className={SELECT_CONTENT_CLASS}>
             <SelectGroup>
               {FONT_FAMILY_OPTIONS.map(key => (
-                <SelectItem key={key} variant="dark" value={key}>{key}</SelectItem>
+                <SelectItem key={key} value={key}>{key}</SelectItem>
               ))}
             </SelectGroup>
           </SelectContent>
@@ -186,14 +186,14 @@ export function StyleView() {
       >
         <SettingRow label={i18n.t("options.videoSubtitles.style.displayMode.title")}>
           <Select value={displayMode} onValueChange={(v: SubtitlesDisplayMode | null) => v && updateStyle({ displayMode: v })}>
-            <SelectTrigger variant="dark" size="sm" className={SELECT_TRIGGER_CLASS}>
+            <SelectTrigger size="sm" className={SELECT_TRIGGER_CLASS}>
               <SelectValue>{i18n.t(`options.videoSubtitles.style.displayMode.${displayMode}`)}</SelectValue>
             </SelectTrigger>
-            <SelectContent variant="dark" container={portalContainer} className={SELECT_CONTENT_CLASS}>
+            <SelectContent container={portalContainer} className={SELECT_CONTENT_CLASS}>
               <SelectGroup>
-                <SelectItem variant="dark" value="bilingual">{i18n.t("options.videoSubtitles.style.displayMode.bilingual")}</SelectItem>
-                <SelectItem variant="dark" value="originalOnly">{i18n.t("options.videoSubtitles.style.displayMode.originalOnly")}</SelectItem>
-                <SelectItem variant="dark" value="translationOnly">{i18n.t("options.videoSubtitles.style.displayMode.translationOnly")}</SelectItem>
+                <SelectItem value="bilingual">{i18n.t("options.videoSubtitles.style.displayMode.bilingual")}</SelectItem>
+                <SelectItem value="originalOnly">{i18n.t("options.videoSubtitles.style.displayMode.originalOnly")}</SelectItem>
+                <SelectItem value="translationOnly">{i18n.t("options.videoSubtitles.style.displayMode.translationOnly")}</SelectItem>
               </SelectGroup>
             </SelectContent>
           </Select>
@@ -202,13 +202,13 @@ export function StyleView() {
         <Activity mode={displayMode === "bilingual" ? "visible" : "hidden"}>
           <SettingRow label={i18n.t("options.videoSubtitles.style.translationPosition.title")}>
             <Select value={translationPosition} onValueChange={(v: SubtitlesTranslationPosition | null) => v && updateStyle({ translationPosition: v })}>
-              <SelectTrigger variant="dark" size="sm" className={SELECT_TRIGGER_CLASS}>
+              <SelectTrigger size="sm" className={SELECT_TRIGGER_CLASS}>
                 <SelectValue>{i18n.t(`options.videoSubtitles.style.translationPosition.${translationPosition}`)}</SelectValue>
               </SelectTrigger>
-              <SelectContent variant="dark" container={portalContainer} className={SELECT_CONTENT_CLASS}>
+              <SelectContent container={portalContainer} className={SELECT_CONTENT_CLASS}>
                 <SelectGroup>
-                  <SelectItem variant="dark" value="above">{i18n.t("options.videoSubtitles.style.translationPosition.above")}</SelectItem>
-                  <SelectItem variant="dark" value="below">{i18n.t("options.videoSubtitles.style.translationPosition.below")}</SelectItem>
+                  <SelectItem value="above">{i18n.t("options.videoSubtitles.style.translationPosition.above")}</SelectItem>
+                  <SelectItem value="below">{i18n.t("options.videoSubtitles.style.translationPosition.below")}</SelectItem>
                 </SelectGroup>
               </SelectContent>
             </Select>

--- a/src/utils/constants/subtitles.ts
+++ b/src/utils/constants/subtitles.ts
@@ -65,6 +65,8 @@ export const DEFAULT_DISPLAY_MODE = "bilingual" as const
 export const DEFAULT_TRANSLATION_POSITION = "above" as const
 export const DEFAULT_CONTROLS_HEIGHT = 60
 export const DEFAULT_SUBTITLE_POSITION = { percent: 10, anchor: "bottom" } as const
+// Subtitle controls sit on top of arbitrary host pages, so keep their theme fixed for readability.
+export const SUBTITLES_FORCED_THEME = "dark" as const
 
 // Font family mapping
 export const SUBTITLE_FONT_FAMILIES = {

--- a/src/utils/constants/subtitles.ts
+++ b/src/utils/constants/subtitles.ts
@@ -66,7 +66,7 @@ export const DEFAULT_TRANSLATION_POSITION = "above" as const
 export const DEFAULT_CONTROLS_HEIGHT = 60
 export const DEFAULT_SUBTITLE_POSITION = { percent: 10, anchor: "bottom" } as const
 // Subtitle controls sit on top of arbitrary host pages, so keep their theme fixed for readability.
-export const SUBTITLES_FORCED_THEME = "dark" as const
+export const SUBTITLES_THEME = "dark" as const
 
 // Font family mapping
 export const SUBTITLE_FONT_FAMILIES = {

--- a/src/utils/react-shadow-host/create-shadow-host.tsx
+++ b/src/utils/react-shadow-host/create-shadow-host.tsx
@@ -1,7 +1,5 @@
-import type { Theme } from "@/types/config/theme"
 import { createContext } from "react"
 import ReactDOM from "react-dom/client"
-
 import { ThemeProvider } from "@/components/providers/theme-provider"
 import { TooltipProvider } from "@/components/ui/base-ui/tooltip"
 import { REACT_SHADOW_HOST_CLASS } from "../constants/dom-labels"
@@ -17,10 +15,9 @@ export function createReactShadowHost(
     className?: string
     cssContent?: string[]
     style?: Partial<CSSStyleDeclaration>
-    forcedTheme?: Theme
   },
 ) {
-  const { className, position, inheritStyles, cssContent, style, forcedTheme } = options
+  const { className, position, inheritStyles, cssContent, style } = options
 
   const shadowHost = document.createElement("div")
   if (className)
@@ -41,7 +38,7 @@ export function createReactShadowHost(
   const root = ReactDOM.createRoot(innerReactContainer)
   const wrappedComponent = (
     <ShadowWrapperContext value={innerReactContainer}>
-      <ThemeProvider container={innerReactContainer} forcedTheme={forcedTheme}>
+      <ThemeProvider container={innerReactContainer}>
         <TooltipProvider>
           {component}
         </TooltipProvider>


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

- force the subtitle UI to use a shared dark theme constant across watch and embed containers
- replace the subtitle style settings panel's hardcoded white colors with semantic tokens
- remove the unused `Select` dark variant and related cva wrappers added in `feat(subtitles): add subtitle style settings panel (#1388)`

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

- Follow-up cleanup for `feat(subtitles): add subtitle style settings panel (#1388)`
