### PR TITLE
fix(subtitles): align subtitle settings labels

### DIFF
--- a/.changeset/green-poems-wash.md
+++ b/.changeset/green-poems-wash.md
@@ -1,0 +1,4 @@
+"@read-frog/extension": patch
+---
+
+feat(subtitles): add source language setting for video subtitles

--- a/.changeset/green-poems-wash.md
+++ b/.changeset/green-poems-wash.md
@@ -1,4 +1,0 @@
-"@read-frog/extension": patch
----
-
-feat(subtitles): add source language setting for video subtitles

--- a/.changeset/sharp-windows-show.md
+++ b/.changeset/sharp-windows-show.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(subtitles): align subtitle settings labels

--- a/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/components/subpage-menu-entry.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/components/subpage-menu-entry.tsx
@@ -22,7 +22,7 @@ export function SubpageMenuEntry({
       className={cn("h-auto w-full justify-start rounded-[14px] px-2 py-2 text-left")}
     >
       <div className="flex items-center gap-3">
-        <div className="text-muted-foreground shrink-0">
+        <div className="text-muted-foreground flex size-5 shrink-0 items-center justify-center">
           {icon}
         </div>
 

--- a/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/components/subtitles-settings-item.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/components/subtitles-settings-item.tsx
@@ -19,7 +19,7 @@ export function SubtitlesSettingsItem({
         htmlFor={labelFor}
         className="font-light! flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md py-0.5 text-left text-[13px] leading-5 transition-colors"
       >
-        <div className="text-muted-foreground shrink-0">
+        <div className="text-muted-foreground flex size-5 shrink-0 items-center justify-center">
           {icon}
         </div>
         <div className="min-w-0 flex-1">

--- a/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/components/subtitles-settings-item.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/components/subtitles-settings-item.tsx
@@ -17,7 +17,7 @@ export function SubtitlesSettingsItem({
     <div className="hover:bg-muted/50 flex items-center gap-3 rounded-[14px] px-2 py-2 transition-colors">
       <Label
         htmlFor={labelFor}
-        className="font-light! flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md py-0.5 text-left text-[13px] leading-5 transition-colors"
+        className="font-light! flex min-w-0 flex-1 cursor-pointer items-center gap-3 rounded-md py-0.5 text-left text-[13px] leading-5 transition-colors"
       >
         <div className="text-muted-foreground flex size-5 shrink-0 items-center justify-center">
           {icon}


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [ ] ✨ New feature (feat)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

- fix inconsistent left alignment in the subtitles settings panel
- normalize the icon slot width for both toggle/action rows and subpage menu rows
- keep label text starting at the same horizontal position regardless of icon glyph width

## Related Issue

Closes #

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

## Screenshots

- before: labels in the subtitles settings panel start at different x positions
- after: labels align consistently across the menu sections

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- this PR is intentionally scoped to the alignment fix only
- the subtitle source language feature remains on a separate branch
