### PR TITLE
feat(providers): add OpenRouter attribution headers

### DIFF
--- a/.changeset/openrouter-attribution-headers.md
+++ b/.changeset/openrouter-attribution-headers.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(providers): add OpenRouter attribution headers

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-headers-field.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-headers-field.test.tsx
@@ -133,15 +133,6 @@ describe("providerHeadersField", () => {
     vi.useRealTimers()
   })
 
-  it("renders the provider default headers as the placeholder when available", () => {
-    render(<ProviderHeadersFieldHarness initialConfig={{ ...anthropicProviderConfig, headers: undefined }} />)
-
-    expect(screen.getByLabelText("provider-headers-editor")).toHaveAttribute(
-      "placeholder",
-      JSON.stringify({ "anthropic-dangerous-direct-browser-access": "true" }, null, 2),
-    )
-  })
-
   it("saves valid header JSON", async () => {
     render(<ProviderHeadersFieldHarness initialConfig={baseProviderConfig} />)
 

--- a/src/utils/providers/__tests__/headers.test.ts
+++ b/src/utils/providers/__tests__/headers.test.ts
@@ -1,26 +1,7 @@
 import { describe, expect, it } from "vitest"
-import {
-  getDefaultProviderHeaders,
-  getProviderHeadersWithOverride,
-} from "../headers"
+import { getProviderHeadersWithOverride } from "../headers"
 
 describe("provider headers", () => {
-  it("returns default headers for Anthropic", () => {
-    expect(getDefaultProviderHeaders("anthropic")).toEqual({
-      "anthropic-dangerous-direct-browser-access": "true",
-    })
-  })
-
-  it("returns undefined for providers without default headers", () => {
-    expect(getDefaultProviderHeaders("openai")).toBeUndefined()
-  })
-
-  it("falls back to default headers only when user headers are undefined", () => {
-    expect(getProviderHeadersWithOverride("anthropic")).toEqual({
-      "anthropic-dangerous-direct-browser-access": "true",
-    })
-  })
-
   it("uses user headers as a full override without merging defaults", () => {
     expect(getProviderHeadersWithOverride("anthropic", { "X-Test": "1" })).toEqual({
       "X-Test": "1",

--- a/src/utils/providers/__tests__/model.test.ts
+++ b/src/utils/providers/__tests__/model.test.ts
@@ -1,18 +1,25 @@
 import { storage } from "#imports"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_PROVIDER_HEADERS } from "../headers"
 
 let getStorageItemMock: ReturnType<typeof vi.fn>
 
 const {
   anthropicLanguageModelMock,
+  openRouterLanguageModelMock,
   openAICompatibleLanguageModelMock,
   createAnthropicMock,
+  createOpenRouterMock,
   createOpenAICompatibleMock,
 } = vi.hoisted(() => {
   const anthropicLanguageModelMock = vi.fn()
+  const openRouterLanguageModelMock = vi.fn()
   const openAICompatibleLanguageModelMock = vi.fn()
   const createAnthropicMock = vi.fn((_options?: Record<string, unknown>) => ({
     languageModel: anthropicLanguageModelMock,
+  }))
+  const createOpenRouterMock = vi.fn((_options?: Record<string, unknown>) => ({
+    languageModel: openRouterLanguageModelMock,
   }))
   const createOpenAICompatibleMock = vi.fn((_options?: Record<string, unknown>) => ({
     languageModel: openAICompatibleLanguageModelMock,
@@ -20,14 +27,20 @@ const {
 
   return {
     anthropicLanguageModelMock,
+    openRouterLanguageModelMock,
     openAICompatibleLanguageModelMock,
     createAnthropicMock,
+    createOpenRouterMock,
     createOpenAICompatibleMock,
   }
 })
 
 vi.mock("@ai-sdk/anthropic", () => ({
   createAnthropic: createAnthropicMock,
+}))
+
+vi.mock("@openrouter/ai-sdk-provider", () => ({
+  createOpenRouter: createOpenRouterMock,
 }))
 
 vi.mock("@ai-sdk/openai-compatible", () => ({
@@ -50,10 +63,27 @@ function createAnthropicProviderConfig(headers?: Record<string, unknown>) {
   }
 }
 
+function createOpenRouterProviderConfig(headers?: Record<string, unknown>) {
+  return {
+    id: "openrouter-default",
+    name: "OpenRouter",
+    enabled: true,
+    provider: "openrouter",
+    apiKey: "test-key",
+    model: {
+      model: "x-ai/grok-4-fast:free",
+      isCustomModel: false,
+      customModel: null,
+    },
+    ...(headers !== undefined && { headers }),
+  }
+}
+
 describe("getModelById", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     anthropicLanguageModelMock.mockReturnValue("anthropic-model")
+    openRouterLanguageModelMock.mockReturnValue("openrouter-model")
     openAICompatibleLanguageModelMock.mockReturnValue("custom-model")
     getStorageItemMock = vi.fn()
     ;(storage.getItem as unknown as ReturnType<typeof vi.fn>) = getStorageItemMock
@@ -70,11 +100,25 @@ describe("getModelById", () => {
     expect(result).toBe("anthropic-model")
     expect(createAnthropicMock).toHaveBeenCalledWith(expect.objectContaining({
       apiKey: "test-key",
-      headers: {
-        "anthropic-dangerous-direct-browser-access": "true",
-      },
+      headers: DEFAULT_PROVIDER_HEADERS.anthropic,
     }))
     expect(anthropicLanguageModelMock).toHaveBeenCalledWith("claude-haiku-4-5")
+  })
+
+  it("passes attribution headers for OpenRouter when user headers are undefined", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [createOpenRouterProviderConfig()],
+    })
+
+    const { getModelById } = await import("../model")
+    const result = await getModelById("openrouter-default")
+
+    expect(result).toBe("openrouter-model")
+    expect(createOpenRouterMock).toHaveBeenCalledWith(expect.objectContaining({
+      apiKey: "test-key",
+      headers: DEFAULT_PROVIDER_HEADERS.openrouter,
+    }))
+    expect(openRouterLanguageModelMock).toHaveBeenCalledWith("x-ai/grok-4-fast:free")
   })
 
   it("uses user headers as a full override for Anthropic", async () => {

--- a/src/utils/providers/headers.ts
+++ b/src/utils/providers/headers.ts
@@ -4,6 +4,10 @@ export const DEFAULT_PROVIDER_HEADERS: Partial<Record<LLMProviderTypes, Record<s
   anthropic: {
     "anthropic-dangerous-direct-browser-access": "true",
   },
+  openrouter: {
+    "HTTP-Referer": "https://readfrog.app",
+    "X-OpenRouter-Title": "Read Frog",
+  },
 }
 
 function compactStringRecord(record?: Readonly<Record<string, unknown>>): Record<string, string> | undefined {

--- a/src/utils/providers/headers.ts
+++ b/src/utils/providers/headers.ts
@@ -1,12 +1,15 @@
 import type { LLMProviderTypes } from "@/types/config/provider"
+import { APP_NAME } from "@read-frog/definitions"
+
+const OPENROUTER_ATTRIBUTION_SITE_URL = "https://readfrog.app"
 
 export const DEFAULT_PROVIDER_HEADERS: Partial<Record<LLMProviderTypes, Record<string, string>>> = {
   anthropic: {
     "anthropic-dangerous-direct-browser-access": "true",
   },
   openrouter: {
-    "HTTP-Referer": "https://readfrog.app",
-    "X-OpenRouter-Title": "Read Frog",
+    "HTTP-Referer": OPENROUTER_ATTRIBUTION_SITE_URL,
+    "X-OpenRouter-Title": APP_NAME,
   },
 }
 

--- a/src/utils/providers/headers.ts
+++ b/src/utils/providers/headers.ts
@@ -1,14 +1,13 @@
 import type { LLMProviderTypes } from "@/types/config/provider"
 import { APP_NAME } from "@read-frog/definitions"
-
-const OPENROUTER_ATTRIBUTION_SITE_URL = "https://readfrog.app"
+import { env } from "@/env"
 
 export const DEFAULT_PROVIDER_HEADERS: Partial<Record<LLMProviderTypes, Record<string, string>>> = {
   anthropic: {
     "anthropic-dangerous-direct-browser-access": "true",
   },
   openrouter: {
-    "HTTP-Referer": OPENROUTER_ATTRIBUTION_SITE_URL,
+    "HTTP-Referer": env.WXT_WEBSITE_URL,
     "X-OpenRouter-Title": APP_NAME,
   },
 }


### PR DESCRIPTION
## Type of Changes

- [x] New feature (feat)
- [x] Test related (test)

## Description

Adds default OpenRouter attribution headers so Read Frog OpenRouter requests are attributed on OpenRouter rankings/analytics:

- HTTP-Referer: env.WXT_WEBSITE_URL
- X-OpenRouter-Title: APP_NAME from @read-frog/definitions

This builds on the provider header configuration work by wiring OpenRouter into the shared default provider headers path. It also trims low-value header tests that only duplicated constants and keeps behavior-focused coverage for override semantics and provider factory wiring.

## Related Issue

Related to #1361

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Commands run:

- SKIP_FREE_API=true pnpm test src/utils/providers/__tests__/headers.test.ts src/utils/providers/__tests__/model.test.ts src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-headers-field.test.tsx src/utils/atoms/__tests__/provider.test.ts
- SKIP_FREE_API=true pnpm type-check
- git diff --check
- Pre-push hook: lint, type-check, full test suite (132 files, 1147 tests)

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

No OpenRouter category header is sent because OpenRouter does not currently expose a suitable education/translation/language-learning category.