### PR TITLE
perf(iframe): avoid eager node host injection

### DIFF
--- a/.changeset/quiet-iframes-heal.md
+++ b/.changeset/quiet-iframes-heal.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+perf: avoid eager iframe host injection for node translation

--- a/src/entrypoints/background/__tests__/iframe-injection.test.ts
+++ b/src/entrypoints/background/__tests__/iframe-injection.test.ts
@@ -56,14 +56,20 @@ function createDetails(overrides: Partial<NavigationDetails> = {}): NavigationDe
   }
 }
 
-function createConfig({ nodeTranslationEnabled = false }: { nodeTranslationEnabled?: boolean } = {}): Config {
+function createConfig({
+  nodeTranslationEnabled = false,
+  siteControl,
+}: {
+  nodeTranslationEnabled?: boolean
+  siteControl?: Config["siteControl"]
+} = {}): Config {
   return {
     translate: {
       node: {
         enabled: nodeTranslationEnabled,
       },
     },
-    siteControl: {
+    siteControl: siteControl ?? {
       mode: "blacklist",
       blacklistPatterns: [],
       whitelistPatterns: [],
@@ -126,10 +132,21 @@ describe("setupIframeInjection", () => {
     expect(executeScriptMock).not.toHaveBeenCalled()
   })
 
-  it("injects host content when node translation is enabled without page translation", async () => {
+  it("skips eager iframe injection when only node translation is enabled", async () => {
     const { onCompleted } = await setupSubject()
     storageGetItemMock.mockResolvedValue({ enabled: false })
     getLocalConfigMock.mockResolvedValue(createConfig({ nodeTranslationEnabled: true }))
+
+    await onCompleted(createDetails())
+
+    expect(getAllFramesMock).not.toHaveBeenCalled()
+    expect(executeScriptMock).not.toHaveBeenCalled()
+  })
+
+  it("injects host content when page translation is enabled", async () => {
+    const { onCompleted } = await setupSubject()
+    storageGetItemMock.mockResolvedValue({ enabled: true })
+    getLocalConfigMock.mockResolvedValue(createConfig({ nodeTranslationEnabled: false }))
 
     await onCompleted(createDetails())
 
@@ -239,5 +256,75 @@ describe("setupIframeInjection", () => {
     onRemoved(currentTabId)
     await onCompleted(details)
     expect(executeScriptMock).toHaveBeenCalledTimes(6)
+  })
+
+  it("injects current tab iframes after top-frame node translation even when page translation is disabled", async () => {
+    const { injectHostContentIntoCurrentTabIframesAfterNodeTranslation } = await import("../iframe-injection")
+    storageGetItemMock.mockResolvedValue({ enabled: false })
+    getLocalConfigMock.mockResolvedValue(createConfig({ nodeTranslationEnabled: true }))
+    getAllFramesMock.mockResolvedValue([
+      createFrame(0, "https://example.com/app", -1),
+      createFrame(2, "https://example.com/frame-a"),
+      createFrame(3, "https://example.com/frame-b"),
+    ])
+
+    await injectHostContentIntoCurrentTabIframesAfterNodeTranslation(currentTabId)
+
+    const calls = executeScriptMock.mock.calls.map(([call]) => call)
+    expect(executeScriptMock).toHaveBeenCalledTimes(4)
+    expect(calls).toEqual(expect.arrayContaining([expect.objectContaining({
+      target: { tabId: currentTabId, frameIds: [2] },
+      func: expect.any(Function),
+      args: [SITE_CONTROL_URL_WINDOW_KEY, "https://example.com/frame-a"],
+    })]))
+    expect(calls).toEqual(expect.arrayContaining([expect.objectContaining({
+      target: { tabId: currentTabId, frameIds: [2] },
+      files: ["/content-scripts/host.js"],
+    })]))
+    expect(calls).toEqual(expect.arrayContaining([expect.objectContaining({
+      target: { tabId: currentTabId, frameIds: [3] },
+      func: expect.any(Function),
+      args: [SITE_CONTROL_URL_WINDOW_KEY, "https://example.com/frame-b"],
+    })]))
+    expect(calls).toEqual(expect.arrayContaining([expect.objectContaining({
+      target: { tabId: currentTabId, frameIds: [3] },
+      files: ["/content-scripts/host.js"],
+    })]))
+  })
+
+  it("respects site control during top-frame node activation iframe injection", async () => {
+    const { injectHostContentIntoCurrentTabIframesAfterNodeTranslation } = await import("../iframe-injection")
+    getLocalConfigMock.mockResolvedValue(createConfig({
+      nodeTranslationEnabled: true,
+      siteControl: {
+        mode: "blacklist",
+        blacklistPatterns: ["example.com"],
+        whitelistPatterns: [],
+      },
+    }))
+
+    await injectHostContentIntoCurrentTabIframesAfterNodeTranslation(currentTabId)
+
+    expect(executeScriptMock).not.toHaveBeenCalled()
+  })
+
+  it("does not enable late iframe injection after top-frame node activation", async () => {
+    const { onCompleted } = await setupSubject()
+    const { injectHostContentIntoCurrentTabIframesAfterNodeTranslation } = await import("../iframe-injection")
+    storageGetItemMock.mockResolvedValue({ enabled: false })
+    getLocalConfigMock.mockResolvedValue(createConfig({ nodeTranslationEnabled: true }))
+
+    await injectHostContentIntoCurrentTabIframesAfterNodeTranslation(currentTabId)
+    executeScriptMock.mockClear()
+    getAllFramesMock.mockClear()
+
+    await onCompleted(createDetails({
+      frameId: 4,
+      documentId: "doc-late",
+      url: "https://example.com/late-frame",
+    }))
+
+    expect(getAllFramesMock).not.toHaveBeenCalled()
+    expect(executeScriptMock).not.toHaveBeenCalled()
   })
 })

--- a/src/entrypoints/background/__tests__/translation-signal.test.ts
+++ b/src/entrypoints/background/__tests__/translation-signal.test.ts
@@ -10,6 +10,7 @@ const storageRemoveItemMock = vi.fn()
 const tabsOnRemovedAddListenerMock = vi.fn()
 const webNavigationOnCommittedAddListenerMock = vi.fn()
 const injectHostContentIntoTabIframesMock = vi.fn()
+const injectHostContentIntoCurrentTabIframesAfterNodeTranslationMock = vi.fn()
 const loggerErrorMock = vi.fn()
 const loggerWarnMock = vi.fn()
 const shouldEnableAutoTranslationMock = vi.fn()
@@ -34,6 +35,7 @@ vi.mock("@/utils/logger", () => ({
 
 vi.mock("../iframe-injection", () => ({
   injectHostContentIntoTabIframes: injectHostContentIntoTabIframesMock,
+  injectHostContentIntoCurrentTabIframesAfterNodeTranslation: injectHostContentIntoCurrentTabIframesAfterNodeTranslationMock,
 }))
 
 function getHandler(name: string) {
@@ -136,6 +138,38 @@ describe("translationMessage", () => {
       expect.objectContaining({
         data: {},
         sender: {},
+      }),
+    )
+  })
+
+  it("injects current iframes after successful top-frame node translation", async () => {
+    await setupSubject()
+
+    await getHandler("injectCurrentIframesAfterTopFrameNodeTranslation")({
+      data: undefined,
+      sender: {
+        tab: { id: 42 },
+        frameId: 0,
+      },
+    })
+
+    expect(injectHostContentIntoCurrentTabIframesAfterNodeTranslationMock).toHaveBeenCalledWith(42)
+    expect(injectHostContentIntoTabIframesMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects iframe senders for top-frame node translation iframe injection", async () => {
+    await setupSubject()
+
+    await getHandler("injectCurrentIframesAfterTopFrameNodeTranslation")({
+      data: undefined,
+      sender: { tab: { id: 42 }, frameId: 7 },
+    })
+
+    expect(injectHostContentIntoCurrentTabIframesAfterNodeTranslationMock).not.toHaveBeenCalled()
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      "Invalid sender in injectCurrentIframesAfterTopFrameNodeTranslation",
+      expect.objectContaining({
+        sender: { tab: { id: 42 }, frameId: 7 },
       }),
     )
   })

--- a/src/entrypoints/background/iframe-injection.ts
+++ b/src/entrypoints/background/iframe-injection.ts
@@ -18,6 +18,10 @@ interface FrameInjectionDetails {
   url?: string
 }
 
+interface InjectHostContentIntoTabIframesOptions {
+  requirePageTranslationEnabled?: boolean
+}
+
 function getDocumentInjectionKey(details: FrameInjectionDetails) {
   // documentId is best, but getAllFrames may not expose it. Fall back to URL so
   // explicit per-tab injections still dedupe until the frame navigates.
@@ -86,15 +90,17 @@ async function getFrameSnapshot(tabId: number): Promise<FrameInfoForSiteControl[
 async function getShouldInjectHostContentIntoTabIframes(
   tabId: number,
   existingConfig?: Config | null,
+  options: InjectHostContentIntoTabIframesOptions = {},
 ): Promise<{ config: Config | null, shouldInject: boolean }> {
+  const requirePageTranslationEnabled = options.requirePageTranslationEnabled ?? true
   const [isPageTranslationEnabled, config] = await Promise.all([
-    getPageTranslationEnabled(tabId),
+    requirePageTranslationEnabled ? getPageTranslationEnabled(tabId) : Promise.resolve(true),
     existingConfig === undefined ? getLocalConfig() : Promise.resolve(existingConfig),
   ])
 
   return {
     config,
-    shouldInject: isPageTranslationEnabled || Boolean(config?.translate.node.enabled),
+    shouldInject: isPageTranslationEnabled,
   }
 }
 
@@ -108,8 +114,10 @@ async function injectHostContentIntoFrame(
 
   if (
     pendingDocumentKeys.has(documentKey)
-    || injectedDocumentKeysByFrame.get(frameKey) === documentKey
   ) {
+    return
+  }
+  if (injectedDocumentKeysByFrame.get(frameKey) === documentKey) {
     return
   }
 
@@ -168,11 +176,14 @@ async function injectHostContentIntoFrame(
   }
 }
 
-export async function injectHostContentIntoTabIframes(tabId: number) {
+export async function injectHostContentIntoTabIframes(
+  tabId: number,
+  options: InjectHostContentIntoTabIframesOptions = {},
+) {
   let config: Config | null
   let shouldInject: boolean
   try {
-    ({ config, shouldInject } = await getShouldInjectHostContentIntoTabIframes(tabId))
+    ({ config, shouldInject } = await getShouldInjectHostContentIntoTabIframes(tabId, undefined, options))
   }
   catch (error) {
     logger.warn("[Background][IframeInjection] Failed to resolve iframe injection state", error)
@@ -204,6 +215,10 @@ export async function injectHostContentIntoTabIframes(tabId: number) {
     }, frames, config)))
 }
 
+export async function injectHostContentIntoCurrentTabIframesAfterNodeTranslation(tabId: number) {
+  await injectHostContentIntoTabIframes(tabId, { requirePageTranslationEnabled: false })
+}
+
 export function setupIframeInjection() {
   browser.tabs.onRemoved.addListener(clearTabDocumentState)
   browser.webNavigation.onBeforeNavigate.addListener((details) => {
@@ -215,10 +230,9 @@ export function setupIframeInjection() {
     clearFrameInjectedDocumentState(details.tabId, details.frameId)
   })
 
-  // Only inject into subframes after page translation or hover/node translation
-  // is enabled for the tab.
-  // This keeps iframe-heavy pages and benchmarks from paying content-script cost
-  // before the feature is actually used.
+  // Only page translation eagerly injects host content into newly completed
+  // subframes. Top-frame node translation can separately scan existing iframes
+  // once, but it does not enable late iframe injection.
   browser.webNavigation.onCompleted.addListener(async (details) => {
     // Skip main frame (frameId === 0), only handle iframes
     if (details.frameId === 0)

--- a/src/entrypoints/background/translation-signal.ts
+++ b/src/entrypoints/background/translation-signal.ts
@@ -8,7 +8,7 @@ import { getTranslationStateKey } from "@/utils/constants/storage-keys"
 import { shouldEnableAutoTranslation } from "@/utils/host/translate/auto-translation"
 import { logger } from "@/utils/logger"
 import { onMessage, sendMessage } from "@/utils/message"
-import { injectHostContentIntoTabIframes } from "./iframe-injection"
+import { injectHostContentIntoCurrentTabIframesAfterNodeTranslation, injectHostContentIntoTabIframes } from "./iframe-injection"
 import { getPageTranslationEnabled, setPageTranslationEnabled } from "./page-translation-state"
 
 function notifyPageTranslationStateChanged(tabId: number, enabled: boolean) {
@@ -48,6 +48,18 @@ export function translationMessage() {
     }
 
     logger.error("Invalid tabId in ensureIframeHostContentInjected", msg)
+  })
+
+  onMessage("injectCurrentIframesAfterTopFrameNodeTranslation", async (msg) => {
+    const tabId = msg.sender?.tab?.id
+    const frameId = msg.sender?.frameId
+
+    if (typeof tabId === "number" && frameId === 0) {
+      await injectHostContentIntoCurrentTabIframesAfterNodeTranslation(tabId)
+      return
+    }
+
+    logger.error("Invalid sender in injectCurrentIframesAfterTopFrameNodeTranslation", msg)
   })
 
   onMessage("tryToSetEnablePageTranslationByTabId", async (msg) => {

--- a/src/entrypoints/host.content/runtime.ts
+++ b/src/entrypoints/host.content/runtime.ts
@@ -34,10 +34,6 @@ export async function bootstrapHostContent(ctx: ContentScriptContext, initialCon
 
   const cleanupTranslationShortcut = await bindTranslationShortcutKey(manager)
 
-  if (window === window.top && initialConfig?.translate.node.enabled) {
-    void sendMessage("ensureIframeHostContentInjected", {})
-  }
-
   // For late-loading iframes: check if translation is already enabled for this tab
   let translationEnabled = false
   try {

--- a/src/entrypoints/host.content/translation-control/__tests__/node-translation-trigger.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/node-translation-trigger.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+import type { Config } from "@/types/config/config"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { registerNodeTranslationTriggerListeners } from "../node-translation-trigger"
+
+function createConfig(hotkey: Config["translate"]["node"]["hotkey"]): Config {
+  return {
+    translate: {
+      node: {
+        enabled: true,
+        hotkey,
+      },
+    },
+  } as Config
+}
+
+function dispatchKeyboardEvent(type: "keydown" | "keyup", key: string) {
+  document.dispatchEvent(new KeyboardEvent(type, { key, bubbles: true }))
+}
+
+function dispatchMouseEvent(type: "mousemove" | "mouseover" | "mousedown" | "mouseup", init: MouseEventInit) {
+  document.dispatchEvent(new MouseEvent(type, { bubbles: true, ...init }))
+}
+
+describe("registerNodeTranslationTriggerListeners", () => {
+  let teardown: (() => void) | null = null
+
+  afterEach(() => {
+    teardown?.()
+    teardown = null
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("triggers backtick node translation at the latest mouse position", async () => {
+    const onTrigger = vi.fn()
+    const getConfig = vi.fn(() => Promise.resolve(createConfig("backtick")))
+
+    teardown = registerNodeTranslationTriggerListeners({
+      getConfig,
+      onTrigger,
+    })
+
+    dispatchMouseEvent("mousemove", { clientX: 50, clientY: 60 })
+    dispatchKeyboardEvent("keydown", "`")
+    await vi.waitFor(() => {
+      expect(getConfig).toHaveBeenCalledTimes(1)
+    })
+    dispatchKeyboardEvent("keyup", "`")
+
+    await vi.waitFor(() => {
+      expect(onTrigger).toHaveBeenCalledWith(
+        { x: 50, y: 60 },
+        expect.objectContaining({
+          translate: expect.objectContaining({
+            node: expect.objectContaining({ hotkey: "backtick" }),
+          }),
+        }),
+      )
+    })
+  })
+
+  it("triggers node translation at the latest mouseover position", async () => {
+    const onTrigger = vi.fn()
+
+    teardown = registerNodeTranslationTriggerListeners({
+      getConfig: () => Promise.resolve(createConfig("control")),
+      onTrigger,
+    })
+
+    dispatchMouseEvent("mouseover", { clientX: 70, clientY: 80 })
+    dispatchKeyboardEvent("keydown", "Control")
+    await Promise.resolve()
+    dispatchKeyboardEvent("keyup", "Control")
+
+    await vi.waitFor(() => {
+      expect(onTrigger).toHaveBeenCalledWith(
+        { x: 70, y: 80 },
+        expect.objectContaining({
+          translate: expect.objectContaining({
+            node: expect.objectContaining({ hotkey: "control" }),
+          }),
+        }),
+      )
+    })
+  })
+
+  it("falls back to the hovered element center when no mouse position was recorded", async () => {
+    const onTrigger = vi.fn()
+    const hovered = document.createElement("p")
+    document.body.append(hovered)
+    vi.spyOn(hovered, "getBoundingClientRect").mockReturnValue({
+      left: 20,
+      top: 30,
+      width: 100,
+      height: 40,
+      right: 120,
+      bottom: 70,
+      x: 20,
+      y: 30,
+      toJSON: () => ({}),
+    } as DOMRect)
+    vi.spyOn(document, "querySelectorAll").mockImplementation((selector) => {
+      if (selector === ":hover") {
+        const hoveredElements = [document.documentElement, document.body, hovered]
+        return {
+          length: hoveredElements.length,
+          item: (index: number) => hoveredElements[index] ?? null,
+        } as unknown as NodeListOf<Element>
+      }
+
+      return [] as unknown as NodeListOf<Element>
+    })
+
+    teardown = registerNodeTranslationTriggerListeners({
+      getConfig: () => Promise.resolve(createConfig("backtick")),
+      onTrigger,
+    })
+
+    dispatchKeyboardEvent("keydown", "`")
+    await Promise.resolve()
+    dispatchKeyboardEvent("keyup", "`")
+
+    await vi.waitFor(() => {
+      expect(onTrigger).toHaveBeenCalledWith(
+        { x: 70, y: 50 },
+        expect.objectContaining({
+          translate: expect.objectContaining({
+            node: expect.objectContaining({ hotkey: "backtick" }),
+          }),
+        }),
+      )
+    })
+  })
+
+  it("triggers click-and-hold node translation after the hold delay", async () => {
+    vi.useFakeTimers()
+    const onTrigger = vi.fn()
+
+    teardown = registerNodeTranslationTriggerListeners({
+      getConfig: () => Promise.resolve(createConfig("clickAndHold")),
+      onTrigger,
+    })
+
+    dispatchMouseEvent("mousedown", { button: 0, clientX: 30, clientY: 40 })
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(onTrigger).toHaveBeenCalledWith(
+      { x: 30, y: 40 },
+      expect.objectContaining({
+        translate: expect.objectContaining({
+          node: expect.objectContaining({ hotkey: "clickAndHold" }),
+        }),
+      }),
+    )
+  })
+
+  it("does not trigger while the caller says the event should be ignored", async () => {
+    const onTrigger = vi.fn()
+
+    teardown = registerNodeTranslationTriggerListeners({
+      getConfig: () => Promise.resolve(createConfig("control")),
+      onTrigger,
+      shouldIgnoreEvent: () => true,
+    })
+
+    dispatchMouseEvent("mousemove", { clientX: 50, clientY: 60 })
+    dispatchKeyboardEvent("keydown", "Control")
+    await Promise.resolve()
+    dispatchKeyboardEvent("keyup", "Control")
+    await Promise.resolve()
+
+    expect(onTrigger).not.toHaveBeenCalled()
+  })
+})

--- a/src/entrypoints/host.content/translation-control/__tests__/node-translation.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/node-translation.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import type { Config } from "@/types/config/config"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { registerNodeTranslationTriggers } from "../node-translation"
+
+const mocks = vi.hoisted(() => ({
+  getLocalConfig: vi.fn(),
+  removeOrShowNodeTranslation: vi.fn(),
+  sendMessage: vi.fn(),
+}))
+
+vi.mock("@/utils/config/storage", () => ({
+  getLocalConfig: mocks.getLocalConfig,
+}))
+
+vi.mock("@/utils/host/translate/node-manipulation", () => ({
+  removeOrShowNodeTranslation: mocks.removeOrShowNodeTranslation,
+}))
+
+vi.mock("@/utils/message", () => ({
+  sendMessage: mocks.sendMessage,
+}))
+
+function createConfig(): Config {
+  return {
+    translate: {
+      node: {
+        enabled: true,
+        hotkey: "backtick",
+      },
+    },
+  } as Config
+}
+
+function dispatchKeyboardEvent(type: "keydown" | "keyup", key: string) {
+  document.dispatchEvent(new KeyboardEvent(type, { key, bubbles: true }))
+}
+
+function dispatchMouseEvent(type: "mousemove" | "mouseover", init: MouseEventInit) {
+  document.dispatchEvent(new MouseEvent(type, { bubbles: true, ...init }))
+}
+
+async function triggerBacktickNodeTranslation() {
+  dispatchMouseEvent("mousemove", { clientX: 15, clientY: 25 })
+  dispatchKeyboardEvent("keydown", "`")
+  await Promise.resolve()
+  dispatchKeyboardEvent("keyup", "`")
+}
+
+describe("registerNodeTranslationTriggers", () => {
+  let teardown: (() => void) | null = null
+
+  afterEach(() => {
+    teardown?.()
+    teardown = null
+    vi.clearAllMocks()
+  })
+
+  it("requests current iframe injection after a successful top-frame node translation", async () => {
+    mocks.getLocalConfig.mockResolvedValue(createConfig())
+    mocks.removeOrShowNodeTranslation.mockResolvedValue(true)
+    mocks.sendMessage.mockResolvedValue(undefined)
+    teardown = registerNodeTranslationTriggers()
+
+    await triggerBacktickNodeTranslation()
+
+    await vi.waitFor(() => {
+      expect(mocks.removeOrShowNodeTranslation).toHaveBeenCalledWith(
+        { x: 15, y: 25 },
+        expect.objectContaining({
+          translate: expect.objectContaining({
+            node: expect.objectContaining({ enabled: true }),
+          }),
+        }),
+      )
+      expect(mocks.sendMessage).toHaveBeenCalledWith(
+        "injectCurrentIframesAfterTopFrameNodeTranslation",
+        undefined,
+      )
+    })
+  })
+
+  it("does not request iframe injection when node translation finds no translatable node", async () => {
+    mocks.getLocalConfig.mockResolvedValue(createConfig())
+    mocks.removeOrShowNodeTranslation.mockResolvedValue(false)
+    teardown = registerNodeTranslationTriggers()
+
+    await triggerBacktickNodeTranslation()
+
+    await vi.waitFor(() => {
+      expect(mocks.removeOrShowNodeTranslation).toHaveBeenCalled()
+    })
+    expect(mocks.sendMessage).not.toHaveBeenCalled()
+  })
+
+  it("requests current iframe injection only once for repeated successful node translations", async () => {
+    mocks.getLocalConfig.mockResolvedValue(createConfig())
+    mocks.removeOrShowNodeTranslation.mockResolvedValue(true)
+    mocks.sendMessage.mockResolvedValue(undefined)
+    teardown = registerNodeTranslationTriggers()
+
+    await triggerBacktickNodeTranslation()
+    await vi.waitFor(() => {
+      expect(mocks.sendMessage).toHaveBeenCalledTimes(1)
+    })
+
+    await triggerBacktickNodeTranslation()
+    await vi.waitFor(() => {
+      expect(mocks.removeOrShowNodeTranslation).toHaveBeenCalledTimes(2)
+    })
+    expect(mocks.sendMessage).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/entrypoints/host.content/translation-control/node-translation-trigger.ts
+++ b/src/entrypoints/host.content/translation-control/node-translation-trigger.ts
@@ -1,0 +1,324 @@
+import type { Config } from "@/types/config/config"
+import type { Point } from "@/types/dom"
+import { HOTKEY_EVENT_KEYS } from "@/utils/constants/hotkeys"
+
+const CLICK_AND_HOLD_TRIGGER_MS = 1000
+const CLICK_AND_HOLD_MOVE_TOLERANCE = 6
+const MOUSEMOVE_THROTTLE_MS = 300
+const MOUSEMOVE_DISTANCE_THRESHOLD = 3
+
+export interface NodeTranslationTriggerOptions {
+  getConfig: () => Promise<Config | null>
+  onTrigger: (point: Point, config: Config) => void | Promise<void>
+  shouldIgnoreEvent?: () => boolean
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement))
+    return false
+
+  const tag = target.tagName
+  if (tag === "INPUT" || tag === "TEXTAREA")
+    return true
+  if (target.isContentEditable)
+    return true
+  return false
+}
+
+/**
+ * Registers the shared node-translation interaction state machine.
+ *
+ * The full host content script uses this to translate immediately while keeping
+ * the hotkey and click-and-hold handling in one place.
+ */
+export function registerNodeTranslationTriggerListeners({
+  getConfig,
+  onTrigger,
+  shouldIgnoreEvent = () => false,
+}: NodeTranslationTriggerOptions): () => void {
+  const ac = new AbortController()
+  const { signal } = ac
+
+  const mousePosition: Point = { x: 0, y: 0 }
+  let hasMousePosition = false
+
+  const updateMousePosition = (point: Point) => {
+    mousePosition.x = point.x
+    mousePosition.y = point.y
+    hasMousePosition = true
+  }
+
+  const getDeepestHoveredElement = (): Element | null => {
+    const hoveredElements = document.querySelectorAll(":hover")
+    return hoveredElements.item(hoveredElements.length - 1)
+  }
+
+  const getElementCenterPoint = (element: Element): Point | null => {
+    const rect = element.getBoundingClientRect()
+    if (rect.width <= 0 || rect.height <= 0)
+      return null
+
+    return {
+      x: rect.left + rect.width / 2,
+      y: rect.top + rect.height / 2,
+    }
+  }
+
+  const resolveTriggerPoint = (): Point => {
+    if (hasMousePosition)
+      return { ...mousePosition }
+
+    const hoveredElement = getDeepestHoveredElement()
+    const hoveredPoint = hoveredElement ? getElementCenterPoint(hoveredElement) : null
+    return hoveredPoint ?? { ...mousePosition }
+  }
+
+  // --- Mousemove: throttled + distance threshold ---
+  let lastMoveX = 0
+  let lastMoveY = 0
+  let moveThrottleTimer: ReturnType<typeof setTimeout> | null = null
+
+  // --- Click-and-hold state ---
+  let isMousePressed = false
+  let clickAndHoldTriggered = false
+  let mousePressPosition: Point | null = null
+  let clickAndHoldTimerId: ReturnType<typeof setTimeout> | null = null
+
+  const clearClickAndHoldTimer = () => {
+    if (clickAndHoldTimerId) {
+      clearTimeout(clickAndHoldTimerId)
+      clickAndHoldTimerId = null
+    }
+  }
+
+  const getCurrentConfig = async (): Promise<Config | null> => {
+    const config = await getConfig()
+    if (signal.aborted)
+      return null
+    return config
+  }
+
+  const triggerNodeTranslation = (point: Point, config: Config) => {
+    void onTrigger(point, config)
+  }
+
+  document.addEventListener("mousemove", (event) => {
+    if (shouldIgnoreEvent())
+      return
+
+    // Distance threshold: ignore tiny movements (trackpad tremor, mouse jitter)
+    if (
+      Math.abs(event.clientX - lastMoveX) + Math.abs(event.clientY - lastMoveY)
+      <= MOUSEMOVE_DISTANCE_THRESHOLD
+    ) {
+      return
+    }
+
+    // Click-and-hold move cancellation (always immediate, no throttle)
+    if (isMousePressed && mousePressPosition) {
+      const deltaX = event.clientX - mousePressPosition.x
+      const deltaY = event.clientY - mousePressPosition.y
+      if (Math.hypot(deltaX, deltaY) > CLICK_AND_HOLD_MOVE_TOLERANCE) {
+        isMousePressed = false
+        mousePressPosition = null
+        clearClickAndHoldTimer()
+      }
+    }
+
+    // Throttled position update
+    if (moveThrottleTimer)
+      return
+
+    moveThrottleTimer = setTimeout(() => {
+      moveThrottleTimer = null
+    }, MOUSEMOVE_THROTTLE_MS)
+
+    updateMousePosition({ x: event.clientX, y: event.clientY })
+    lastMoveX = event.clientX
+    lastMoveY = event.clientY
+  }, { signal })
+
+  const updateMousePositionFromEvent = (event: MouseEvent | PointerEvent) => {
+    if (shouldIgnoreEvent())
+      return
+
+    updateMousePosition({ x: event.clientX, y: event.clientY })
+    lastMoveX = event.clientX
+    lastMoveY = event.clientY
+  }
+
+  document.addEventListener("mouseover", updateMousePositionFromEvent, { signal })
+  document.addEventListener("pointerover", updateMousePositionFromEvent, { signal })
+
+  let isHotkeyPressed = false
+  let isHotkeySessionPure = true
+  let timerId: ReturnType<typeof setTimeout> | null = null
+  let actionTriggered = false
+  let activeHotkeyEventKey: string | null = null
+
+  const resetHotkeySession = () => {
+    if (timerId) {
+      clearTimeout(timerId)
+      timerId = null
+    }
+    isHotkeyPressed = false
+    isHotkeySessionPure = true
+    actionTriggered = false
+    activeHotkeyEventKey = null
+  }
+
+  document.addEventListener("mousedown", (event) => {
+    void (async () => {
+      if (shouldIgnoreEvent())
+        return
+      if (event.button !== 0)
+        return
+      if (isEditableTarget(event.target))
+        return
+
+      const config = await getCurrentConfig()
+      if (!config || !config.translate.node.enabled || config.translate.node.hotkey !== "clickAndHold")
+        return
+
+      isMousePressed = true
+      clickAndHoldTriggered = false
+      mousePressPosition = { x: event.clientX, y: event.clientY }
+
+      clearClickAndHoldTimer()
+      clickAndHoldTimerId = setTimeout(() => {
+        void (async () => {
+          if (shouldIgnoreEvent())
+            return
+          if (!isMousePressed || !mousePressPosition || clickAndHoldTriggered)
+            return
+
+          const currentConfig = await getCurrentConfig()
+          if (!currentConfig || !currentConfig.translate.node.enabled || currentConfig.translate.node.hotkey !== "clickAndHold")
+            return
+
+          triggerNodeTranslation(mousePressPosition, currentConfig)
+          clickAndHoldTriggered = true
+        })()
+      }, CLICK_AND_HOLD_TRIGGER_MS)
+    })()
+  }, { signal })
+
+  document.addEventListener("mouseup", (event) => {
+    if (shouldIgnoreEvent())
+      return
+    if (event.button !== 0)
+      return
+    if (!isMousePressed && !clickAndHoldTimerId)
+      return
+
+    isMousePressed = false
+    clickAndHoldTriggered = false
+    mousePressPosition = null
+    clearClickAndHoldTimer()
+  }, { signal })
+
+  document.addEventListener("keydown", (event) => {
+    void (async () => {
+      if (shouldIgnoreEvent())
+        return
+      if (isEditableTarget(event.target))
+        return
+
+      const config = await getCurrentConfig()
+      if (!config || !config.translate.node.enabled || config.translate.node.hotkey === "clickAndHold") {
+        resetHotkeySession()
+        return
+      }
+
+      const hotkeyEventKey = HOTKEY_EVENT_KEYS[config.translate.node.hotkey]
+
+      if (event.key === hotkeyEventKey) {
+        if (!isHotkeyPressed) {
+          isHotkeyPressed = true
+          activeHotkeyEventKey = hotkeyEventKey
+          timerId = setTimeout(() => {
+            void (async () => {
+              if (shouldIgnoreEvent())
+                return
+              if (!isHotkeySessionPure || !isHotkeyPressed) {
+                timerId = null
+                return
+              }
+
+              const currentConfig = await getCurrentConfig()
+              if (!currentConfig || !currentConfig.translate.node.enabled || currentConfig.translate.node.hotkey === "clickAndHold") {
+                timerId = null
+                return
+              }
+              if (HOTKEY_EVENT_KEYS[currentConfig.translate.node.hotkey] !== activeHotkeyEventKey) {
+                timerId = null
+                return
+              }
+
+              triggerNodeTranslation(resolveTriggerPoint(), currentConfig)
+              actionTriggered = true
+              timerId = null
+            })()
+          }, 1000)
+
+          if (!isHotkeySessionPure && timerId) {
+            clearTimeout(timerId)
+            timerId = null
+          }
+        }
+      }
+      else {
+        isHotkeySessionPure = false
+        if (isHotkeyPressed && timerId) {
+          clearTimeout(timerId)
+          timerId = null
+        }
+      }
+    })()
+  }, { signal })
+
+  document.addEventListener("keyup", (event) => {
+    void (async () => {
+      if (shouldIgnoreEvent())
+        return
+      if (isEditableTarget(event.target))
+        return
+
+      const config = await getCurrentConfig()
+      if (!config || !config.translate.node.enabled || config.translate.node.hotkey === "clickAndHold") {
+        if (event.key === activeHotkeyEventKey)
+          resetHotkeySession()
+        return
+      }
+
+      const hotkeyEventKey = HOTKEY_EVENT_KEYS[config.translate.node.hotkey]
+
+      if (event.key === hotkeyEventKey || event.key === activeHotkeyEventKey) {
+        if (isHotkeyPressed && isHotkeySessionPure) {
+          if (timerId) {
+            clearTimeout(timerId)
+            timerId = null
+          }
+          if (!actionTriggered) {
+            const currentConfig = await getCurrentConfig()
+            if (!currentConfig || !currentConfig.translate.node.enabled || currentConfig.translate.node.hotkey === "clickAndHold")
+              return
+
+            triggerNodeTranslation(resolveTriggerPoint(), currentConfig)
+          }
+        }
+        resetHotkeySession()
+      }
+    })()
+  }, { signal })
+
+  return () => {
+    ac.abort()
+    resetHotkeySession()
+    if (moveThrottleTimer) {
+      clearTimeout(moveThrottleTimer)
+      moveThrottleTimer = null
+    }
+    clearClickAndHoldTimer()
+  }
+}

--- a/src/entrypoints/host.content/translation-control/node-translation.ts
+++ b/src/entrypoints/host.content/translation-control/node-translation.ts
@@ -1,15 +1,9 @@
 import type { Config } from "@/types/config/config"
-import type { Point } from "@/types/dom"
 import { getLocalConfig } from "@/utils/config/storage"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
-import { HOTKEY_EVENT_KEYS } from "@/utils/constants/hotkeys"
-import { isEditable } from "@/utils/host/dom/filter"
 import { removeOrShowNodeTranslation } from "@/utils/host/translate/node-manipulation"
-
-const CLICK_AND_HOLD_TRIGGER_MS = 1000
-const CLICK_AND_HOLD_MOVE_TOLERANCE = 6
-const MOUSEMOVE_THROTTLE_MS = 300
-const MOUSEMOVE_DISTANCE_THRESHOLD = 3
+import { sendMessage } from "@/utils/message"
+import { registerNodeTranslationTriggerListeners } from "./node-translation-trigger"
 
 /**
  * Registers node translation triggers based on the current config.
@@ -22,26 +16,6 @@ export function registerNodeTranslationTriggers(): () => void {
   const ac = new AbortController()
   const { signal } = ac
 
-  const mousePosition: Point = { x: 0, y: 0 }
-
-  // --- Mousemove: throttled + distance threshold ---
-  let lastMoveX = 0
-  let lastMoveY = 0
-  let moveThrottleTimer: ReturnType<typeof setTimeout> | null = null
-
-  // --- Click-and-hold state ---
-  let isMousePressed = false
-  let clickAndHoldTriggered = false
-  let mousePressPosition: Point | null = null
-  let clickAndHoldTimerId: ReturnType<typeof setTimeout> | null = null
-
-  const clearClickAndHoldTimer = () => {
-    if (clickAndHoldTimerId) {
-      clearTimeout(clickAndHoldTimerId)
-      clickAndHoldTimerId = null
-    }
-  }
-
   const getCurrentConfig = async (): Promise<Config | null> => {
     const config = await getLocalConfig()
     if (signal.aborted)
@@ -49,199 +23,34 @@ export function registerNodeTranslationTriggers(): () => void {
     return config ?? DEFAULT_CONFIG
   }
 
-  // Mousemove handler with throttle + distance threshold
-  document.addEventListener("mousemove", (event) => {
-    // Distance threshold: ignore tiny movements (trackpad tremor, mouse jitter)
-    if (
-      Math.abs(event.clientX - lastMoveX) + Math.abs(event.clientY - lastMoveY)
-      <= MOUSEMOVE_DISTANCE_THRESHOLD
-    ) {
-      return
-    }
+  let hasRequestedIframeInjection = false
 
-    // Click-and-hold move cancellation (always immediate, no throttle)
-    if (isMousePressed && mousePressPosition) {
-      const deltaX = event.clientX - mousePressPosition.x
-      const deltaY = event.clientY - mousePressPosition.y
-      if (Math.hypot(deltaX, deltaY) > CLICK_AND_HOLD_MOVE_TOLERANCE) {
-        isMousePressed = false
-        mousePressPosition = null
-        clearClickAndHoldTimer()
-      }
-    }
-
-    // Throttled position update
-    if (moveThrottleTimer)
+  const requestIframeInjectionAfterSuccessfulTopFrameNodeTranslation = () => {
+    if (hasRequestedIframeInjection || window !== window.top || signal.aborted)
       return
 
-    moveThrottleTimer = setTimeout(() => {
-      moveThrottleTimer = null
-    }, MOUSEMOVE_THROTTLE_MS)
-
-    mousePosition.x = event.clientX
-    mousePosition.y = event.clientY
-    lastMoveX = event.clientX
-    lastMoveY = event.clientY
-  }, { signal })
-
-  let isHotkeyPressed = false
-  let isHotkeySessionPure = true
-  let timerId: ReturnType<typeof setTimeout> | null = null
-  let actionTriggered = false
-  let activeHotkeyEventKey: string | null = null
-
-  const resetHotkeySession = () => {
-    if (timerId) {
-      clearTimeout(timerId)
-      timerId = null
-    }
-    isHotkeyPressed = false
-    isHotkeySessionPure = true
-    actionTriggered = false
-    activeHotkeyEventKey = null
+    hasRequestedIframeInjection = true
+    void sendMessage("injectCurrentIframesAfterTopFrameNodeTranslation", undefined)
+      .catch(() => undefined)
   }
 
-  document.addEventListener("mousedown", (event) => {
-    void (async () => {
-      if (event.button !== 0)
-        return
-      if (event.target instanceof HTMLElement && isEditable(event.target))
-        return
+  const translateNode = async (point: Parameters<typeof removeOrShowNodeTranslation>[0], config: Config) => {
+    const didTranslate = await removeOrShowNodeTranslation(point, config)
+    if (didTranslate) {
+      requestIframeInjectionAfterSuccessfulTopFrameNodeTranslation()
+    }
+  }
 
-      const config = await getCurrentConfig()
-      if (!config || !config.translate.node.enabled || config.translate.node.hotkey !== "clickAndHold")
-        return
-
-      isMousePressed = true
-      clickAndHoldTriggered = false
-      mousePressPosition = { x: event.clientX, y: event.clientY }
-
-      clearClickAndHoldTimer()
-      clickAndHoldTimerId = setTimeout(() => {
-        void (async () => {
-          if (!isMousePressed || !mousePressPosition || clickAndHoldTriggered)
-            return
-
-          const currentConfig = await getCurrentConfig()
-          if (!currentConfig || !currentConfig.translate.node.enabled || currentConfig.translate.node.hotkey !== "clickAndHold")
-            return
-
-          void removeOrShowNodeTranslation(mousePressPosition, currentConfig)
-          clickAndHoldTriggered = true
-        })()
-      }, CLICK_AND_HOLD_TRIGGER_MS)
-    })()
-  }, { signal })
-
-  document.addEventListener("mouseup", (event) => {
-    if (event.button !== 0)
-      return
-    if (!isMousePressed && !clickAndHoldTimerId)
-      return
-
-    isMousePressed = false
-    clickAndHoldTriggered = false
-    mousePressPosition = null
-    clearClickAndHoldTimer()
-  }, { signal })
-
-  document.addEventListener("keydown", (event) => {
-    void (async () => {
-      if (event.target instanceof HTMLElement && isEditable(event.target))
-        return
-
-      const config = await getCurrentConfig()
-      if (!config || !config.translate.node.enabled || config.translate.node.hotkey === "clickAndHold") {
-        resetHotkeySession()
-        return
-      }
-
-      const hotkeyEventKey = HOTKEY_EVENT_KEYS[config.translate.node.hotkey]
-
-      if (event.key === hotkeyEventKey) {
-        if (!isHotkeyPressed) {
-          isHotkeyPressed = true
-          activeHotkeyEventKey = hotkeyEventKey
-          timerId = setTimeout(() => {
-            void (async () => {
-              if (!isHotkeySessionPure || !isHotkeyPressed) {
-                timerId = null
-                return
-              }
-
-              const currentConfig = await getCurrentConfig()
-              if (!currentConfig || !currentConfig.translate.node.enabled || currentConfig.translate.node.hotkey === "clickAndHold") {
-                timerId = null
-                return
-              }
-              if (HOTKEY_EVENT_KEYS[currentConfig.translate.node.hotkey] !== activeHotkeyEventKey) {
-                timerId = null
-                return
-              }
-
-              void removeOrShowNodeTranslation(mousePosition, currentConfig)
-              actionTriggered = true
-              timerId = null
-            })()
-          }, 1000)
-
-          if (!isHotkeySessionPure && timerId) {
-            clearTimeout(timerId)
-            timerId = null
-          }
-        }
-      }
-      else {
-        isHotkeySessionPure = false
-        if (isHotkeyPressed && timerId) {
-          clearTimeout(timerId)
-          timerId = null
-        }
-      }
-    })()
-  }, { signal })
-
-  document.addEventListener("keyup", (event) => {
-    void (async () => {
-      if (event.target instanceof HTMLElement && isEditable(event.target))
-        return
-
-      const config = await getCurrentConfig()
-      if (!config || !config.translate.node.enabled || config.translate.node.hotkey === "clickAndHold") {
-        if (event.key === activeHotkeyEventKey)
-          resetHotkeySession()
-        return
-      }
-
-      const hotkeyEventKey = HOTKEY_EVENT_KEYS[config.translate.node.hotkey]
-
-      if (event.key === hotkeyEventKey || event.key === activeHotkeyEventKey) {
-        if (isHotkeyPressed && isHotkeySessionPure) {
-          if (timerId) {
-            clearTimeout(timerId)
-            timerId = null
-          }
-          if (!actionTriggered) {
-            const currentConfig = await getCurrentConfig()
-            if (!currentConfig || !currentConfig.translate.node.enabled || currentConfig.translate.node.hotkey === "clickAndHold")
-              return
-
-            void removeOrShowNodeTranslation(mousePosition, currentConfig)
-          }
-        }
-        resetHotkeySession()
-      }
-    })()
-  }, { signal })
+  const teardownTriggerListeners = registerNodeTranslationTriggerListeners({
+    getConfig: getCurrentConfig,
+    onTrigger: (point, config) => {
+      void translateNode(point, config)
+    },
+  })
 
   // Teardown: abort all listeners + cancel pending timers
   return () => {
     ac.abort()
-    resetHotkeySession()
-    if (moveThrottleTimer) {
-      clearTimeout(moveThrottleTimer)
-      moveThrottleTimer = null
-    }
-    clearClickAndHoldTimer()
+    teardownTriggerListeners()
   }
 }

--- a/src/entrypoints/popup/components/node-translation-hotkey-selector.tsx
+++ b/src/entrypoints/popup/components/node-translation-hotkey-selector.tsx
@@ -1,4 +1,4 @@
-import { browser, i18n } from "#imports"
+import { i18n } from "#imports"
 import { deepmerge } from "deepmerge-ts"
 import { useAtom } from "jotai"
 import {
@@ -11,7 +11,6 @@ import {
 import { Switch } from "@/components/ui/base-ui/switch"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { HOTKEY_ICONS, HOTKEYS } from "@/utils/constants/hotkeys"
-import { sendMessage } from "@/utils/message"
 
 function HotkeyDisplay({ hotkey }: { hotkey: typeof HOTKEYS[number] }) {
   const icon = HOTKEY_ICONS[hotkey]
@@ -51,14 +50,6 @@ export default function NodeTranslationHotkeySelector() {
 
   const handleNodeTranslationEnabledChange = async (checked: boolean) => {
     await setTranslateConfig(deepmerge(translateConfig, { node: { enabled: checked } }))
-
-    if (!checked)
-      return
-
-    const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })
-    if (typeof currentTab?.id === "number") {
-      void sendMessage("ensureIframeHostContentInjected", { tabId: currentTab.id })
-    }
   }
 
   return (

--- a/src/utils/host/translate/node-manipulation.ts
+++ b/src/utils/host/translate/node-manipulation.ts
@@ -14,11 +14,11 @@ export { translateWalkedElement } from "./core/translation-walker"
 export { removeAllTranslatedWrapperNodes } from "./dom/translation-cleanup"
 
 // High-level orchestration function
-export async function removeOrShowNodeTranslation(point: Point, config: Config): Promise<void> {
+export async function removeOrShowNodeTranslation(point: Point, config: Config): Promise<boolean> {
   const node = findNearestAncestorBlockNodeAt(point)
 
   if (!node || !isHTMLElement(node))
-    return
+    return false
 
   const detectedCode = await getDetectedCodeFromStorage()
 
@@ -27,10 +27,11 @@ export async function removeOrShowNodeTranslation(point: Point, config: Config):
     translate: config.translate,
     language: config.language,
   }, detectedCode)) {
-    return
+    return false
   }
 
   const id = getRandomUUID()
   walkAndLabelElement(node, id, config)
   await translateWalkedElement(node, id, config, true)
+  return true
 }

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -37,6 +37,7 @@ interface ProtocolMap {
   setAndNotifyPageTranslationStateChangedByManager: (data: { enabled: boolean }) => void
   notifyTranslationStateChanged: (data: { enabled: boolean }) => void
   ensureIframeHostContentInjected: (data: { tabId?: number }) => void
+  injectCurrentIframesAfterTopFrameNodeTranslation: () => void
   // for auto start page translation
   checkAndAskAutoPageTranslation: (data: { url: string, detectedCodeOrUnd: LangCodeISO6393 | "und" }) => void
   // ask host to start page translation


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [x] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

iframe test url: https://practice.expandtesting.com/iframe?utm_source=chatgpt.com

Avoid eager iframe `host.js` injection when only node translation is enabled. Iframe host injection now happens only when page translation is active, or once for currently existing iframes after a successful top-frame node translation.

This removes the previous node-only iframe eager path and keeps the simplified UX tradeoff: iframe-first node shortcut does not translate on the first press, but if an iframe already has `host.js` from page translation or top-frame node activation, iframe node translation still works.

Key changes:

- Gate `webNavigation.onCompleted` iframe host injection on active page translation only.
- Remove popup/runtime node-enabled paths that proactively inject all iframes.
- Add top-frame-only `injectCurrentIframesAfterTopFrameNodeTranslation` message.
- Inject current existing iframes after successful top-frame node translation, while preserving site-control and dedupe behavior.
- Extract node hotkey/click-and-hold trigger handling into a shared helper with focused tests.

## Related Issue

Closes #1093

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

### Automated Validation

| Check | Command / source | Result |
| --- | --- | --- |
| Targeted iframe/node tests | `SKIP_FREE_API=true pnpm exec vitest run src/entrypoints/background/__tests__/iframe-injection.test.ts src/entrypoints/background/__tests__/translation-signal.test.ts src/entrypoints/host.content/translation-control/__tests__/node-translation.test.ts src/entrypoints/host.content/translation-control/__tests__/node-translation-trigger.test.ts` | Passed: 4 files, 27 tests |
| ESLint on changed files | `pnpm exec eslint src/entrypoints/background/iframe-injection.ts src/entrypoints/background/translation-signal.ts src/entrypoints/background/__tests__/iframe-injection.test.ts src/entrypoints/background/__tests__/translation-signal.test.ts src/entrypoints/host.content/translation-control/node-translation.ts src/entrypoints/host.content/translation-control/node-translation-trigger.ts src/entrypoints/host.content/translation-control/__tests__/node-translation.test.ts src/entrypoints/host.content/translation-control/__tests__/node-translation-trigger.test.ts src/utils/host/translate/node-manipulation.ts src/utils/message.ts src/entrypoints/host.content/runtime.ts src/entrypoints/popup/components/node-translation-hotkey-selector.tsx` | Passed |
| TypeScript | `SKIP_FREE_API=true pnpm type-check` | Passed |
| Full unit suite | `SKIP_FREE_API=true pnpm test` | Passed: 133 files passed, 1 skipped; 1157 tests passed, 4 skipped |
| Edge production build | `WXT_SKIP_ENV_VALIDATION=true pnpm build:edge` | Passed |
| Push hook | `git push -u origin codex/simplify-iframe-node-injection` | Passed lint, type-check, and full test suite: 134 files / 1161 tests |

### Real Browser Behavior

| Scenario | Browser / artifact | Setup | Expected | Result |
| --- | --- | --- | --- | --- |
| No eager iframe host injection from node config | Microsoft Edge `147.0.3912.98`, `.output/edge-mv3` production artifact | Page translation disabled, extension loaded, iframe present before node activation | Programmatic `/content-scripts/host.js` iframe injection count stays `0` | Passed: initial eager host calls = `0` |
| Existing iframe injection after top-frame node activation | Same | Triggered the top-frame node activation message after a successful top-frame node translation path | Current existing iframe receives full `host.js` | Passed: host call count became `1`, iframe isolated context had `window.__READ_FROG_HOST_INJECTED__ === true` |
| No late iframe injection after node activation | Same | Added a new iframe after top-frame node activation completed | Late iframe should not receive `host.js` only because node was activated | Passed: host call count remained `1` |

### Speedometer 3.1 Methodology

| Item | Value |
| --- | --- |
| Browser | Microsoft Edge `147.0.3912.98` |
| Benchmark | Speedometer 3.1 |
| Extension artifact | `.output/edge-mv3` from `WXT_SKIP_ENV_VALIDATION=true pnpm build:edge` |
| Isolation | One fresh Edge process and one fresh user profile per sample |
| Tab control | The auto-opened `https://www.readfrog.app/en/guide/step-1` tab was closed before benchmark start; the runner kept only the Speedometer tab during the run |
| Sample policy | Extension groups used all samples; no-extension group had obvious cold-start low outliers removed after manual inspection |
| Outliers removed | No-extension scores `36.5`, `37.4`, `38.3` were removed because they formed a separate low cluster below `40` while retained samples clustered around `46-48` |

### Speedometer 3.1 Results

| Condition | Scores Used | n | Mean | SD | RSD | Range | Delta vs No Extension | Delta vs Node Off |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| No extension | `46.8, 46.5, 46.6, 47.0, 46.3, 46.4, 47.9, 48.3, 47.0, 47.4, 46.2` | 11 | `46.95` | `0.68` | `1.44%` | `46.2-48.3` | baseline | N/A |
| Extension, node off | `46.8, 46.9, 46.9, 47.1, 46.2` | 5 | `46.78` | `0.34` | `0.73%` | `46.2-47.1` | `-0.35%` | baseline |
| Extension, node on | `45.3, 47.1, 46.6, 47.2, 46.3` | 5 | `46.50` | `0.76` | `1.64%` | `45.3-47.2` | `-0.95%` | `-0.60%` |

Interpretation: node translation enabled did not reproduce the previous iframe-heavy Speedometer slowdown. The measured node-on delta is within the observed run-to-run variance and close to the node-off extension baseline.

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The intentionally simplified behavior does not support iframe-first same-shortcut node translation. Users need page translation active, or one successful top-frame node translation, before existing iframes receive the full host content script.
