### PR TITLE
fix: avoid Defuddle mutating live page DOM during webpage context extraction

### DIFF
--- a/.changeset/defuddle-live-dom-fix.md
+++ b/.changeset/defuddle-live-dom-fix.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: parse webpage context from a detached Defuddle snapshot to avoid mutating the live page DOM

--- a/src/utils/host/translate/webpage-context.ts
+++ b/src/utils/host/translate/webpage-context.ts
@@ -9,10 +9,17 @@ export interface CachedWebPageContext extends WebPageContext {
 
 let cachedWebPageContext: CachedWebPageContext | null = null
 
+function createDefuddleSnapshotDocument() {
+  const clonedDoc = document.implementation.createHTMLDocument(document.title)
+  clonedDoc.documentElement.innerHTML = document.documentElement.outerHTML
+  return clonedDoc
+}
+
 async function extractWebpageContent(): Promise<string> {
   try {
     const { default: Defuddle, createMarkdownContent } = await import("defuddle/full")
-    const result = new Defuddle(document, {
+    const snapshotDoc = createDefuddleSnapshotDocument()
+    const result = new Defuddle(snapshotDoc, {
       separateMarkdown: true,
       url: window.location.href,
       useAsync: false,


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

This fixes webpage context extraction passing the live page `document` into Defuddle.

`Defuddle.parse()` mutates the document it receives before cloning it, which could scramble the current page while extracting translation context. This change creates a detached HTML snapshot document from the current page markup and runs Defuddle against that snapshot instead, while keeping the existing markdown fallback behavior unchanged.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

## Screenshots

### Before 
<img width="2515" height="1400" alt="745e952f55416d59fe0a70575406b521" src="https://github.com/user-attachments/assets/79da1029-4670-4ab2-9552-04a4b326ba3a" />

### After
<img width="1710" height="969" alt="image" src="https://github.com/user-attachments/assets/89a3ccde-1bc5-45e3-aab4-aaed5aa53fd1" />

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This intentionally uses a simple detached HTML snapshot and does not attempt to preserve shadow DOM flattening or iframe inner documents.
