### PR TITLE
fix: skip Grok 4.1 Fast reasoning defaults

### DIFF
--- a/.changeset/funny-badgers-argue.md
+++ b/.changeset/funny-badgers-argue.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: stop auto-applying xAI reasoningEffort to Grok 4.1 Fast models

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -115,6 +115,9 @@ describe("getProviderOptions", () => {
       const grokOptions = getProviderOptions("grok-4-fast-reasoning", "xai")
       expect(grokOptions.xai?.reasoningEffort).toBe("low")
 
+      const grok41FastOptions = getProviderOptions("grok-4-1-fast-reasoning", "xai")
+      expect(grok41FastOptions).toEqual({})
+
       const deepseekReasonerOptions = getProviderOptions("deepseek-reasoner", "deepseek")
       expect(deepseekReasonerOptions.deepseek?.thinking).toEqual({ type: "disabled" })
 

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -156,9 +156,10 @@ export const LLM_MODEL_OPTIONS: Array<{
   // GPT-5 chat-latest variants are intentionally omitted because their docs do not advertise reasoning.effort.
   ...OPENAI_GPT5_RECOMMENDED_MODEL_OPTIONS,
 
-  // xAI Grok reasoning-capable text models - keep effort at the lowest supported level
+  // xAI Grok reasoning-capable text models - keep effort at the lowest supported level.
+  // Exclude Grok 4.1 Fast because xAI documents that it reasons automatically and errors if reasoning_effort is specified.
   {
-    pattern: /^grok-(?:4(?:-1)?(?:-fast-reasoning)?|4(?:-latest|-0709)?|3(?:-mini)?(?:-latest)?)$/,
+    pattern: /^grok-(?:4(?:-fast-reasoning|-latest|-0709)?|4-1|3(?:-mini)?(?:-latest)?)$/,
     options: { reasoningEffort: "low" } satisfies XaiProviderOptions as Record<string, JSONValue>,
   },
 


### PR DESCRIPTION
## Summary
- stop auto-recommending `reasoningEffort` for `grok-4-1-fast-reasoning`
- keep the existing xAI low-effort defaults for the other Grok models already covered by this rule
- add a regression test proving `grok-4-1-fast-reasoning` now resolves to no recommended provider options

## Root cause
The xAI Grok recommendation regex was matching `grok-4-1-fast-reasoning`, so Read Frog auto-injected:

```json
{ "reasoningEffort": "low" }
```

But xAI's current docs say Grok 4.1 Fast reasons automatically and returns an error if `reasoning_effort` is specified.

## Test plan
- `SKIP_FREE_API=true pnpm exec vitest run src/utils/constants/__tests__/model.test.ts src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-options-field.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/components/__tests__/provider-options-recommendation-trigger.test.tsx`
- `pnpm exec eslint src/utils/constants/models.ts src/utils/constants/__tests__/model.test.ts`
- `pnpm type-check`
- `git push -u origin HEAD` pre-push hook:
  - `nx run @read-frog/extension:lint`
  - `nx run @read-frog/extension:type-check`
  - `nx run @read-frog/extension:test` ✅ `134` files / `1161` tests passed

## Real screenshots
Grok provider options page with translate model set to `grok-4-1-fast-reasoning`.

| Before | After |
| --- | --- |
| ![Before: Grok 4.1 Fast still shows a recommendation and `reasoningEffort` placeholder](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog-issue-1456-before-grok-provider-options.png) | ![After: Grok 4.1 Fast no longer shows a recommendation and falls back to generic provider options placeholder](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog-issue-1456-after-grok-provider-options.png) |

- Before: the Grok 4.1 Fast form shows the recommendation trigger and `{"reasoningEffort":"low"}` as the Provider Options example.
- After: the recommendation trigger is gone for this model and the Provider Options example falls back to the generic placeholder.

Fixes #1456
