### PR TITLE
fix(translation): remove auto same-language warning

### DIFF
--- a/.changeset/quiet-languages-warn.md
+++ b/.changeset/quiet-languages-warn.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: remove same-language warning for automatic source detection

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -3,7 +3,6 @@ import type { Config } from "@/types/config/config"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { isLLMProviderConfig } from "@/types/config/provider"
 import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
-import { getDetectedCodeFromStorage } from "@/utils/config/languages"
 import { getLocalConfig } from "@/utils/config/storage"
 import { CONTENT_WRAPPER_CLASS } from "@/utils/constants/dom-labels"
 import { resolveProviderConfig } from "@/utils/constants/feature-providers"
@@ -103,13 +102,11 @@ export class PageTranslationManager implements IPageTranslationManager {
       return
     }
 
-    const detectedCode = await getDetectedCodeFromStorage()
-
     if (!validateTranslationConfigAndToast({
       providersConfig: config.providersConfig,
       translate: config.translate,
       language: config.language,
-    }, detectedCode)) {
+    })) {
       if (trackedContext) {
         void trackFeatureUsed({
           ...trackedContext,

--- a/src/utils/host/translate/node-manipulation.ts
+++ b/src/utils/host/translate/node-manipulation.ts
@@ -1,6 +1,5 @@
 import type { Config } from "@/types/config/config"
 import type { Point } from "@/types/dom"
-import { getDetectedCodeFromStorage } from "@/utils/config/languages"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
 import { isHTMLElement } from "../dom/filter"
 import { findNearestAncestorBlockNodeAt } from "../dom/find"
@@ -20,13 +19,11 @@ export async function removeOrShowNodeTranslation(point: Point, config: Config):
   if (!node || !isHTMLElement(node))
     return false
 
-  const detectedCode = await getDetectedCodeFromStorage()
-
   if (!validateTranslationConfigAndToast({
     providersConfig: config.providersConfig,
     translate: config.translate,
     language: config.language,
-  }, detectedCode)) {
+  })) {
     return false
   }
 

--- a/src/utils/host/translate/translate-text.ts
+++ b/src/utils/host/translate/translate-text.ts
@@ -3,7 +3,7 @@ import type { Config } from "@/types/config/config"
 import type { ProviderConfig } from "@/types/config/provider"
 import type { WebPagePromptContext } from "@/types/content"
 import { i18n } from "#imports"
-import { LANG_CODE_TO_EN_NAME, LANG_CODE_TO_LOCALE_NAME } from "@read-frog/definitions"
+import { LANG_CODE_TO_EN_NAME } from "@read-frog/definitions"
 import { toast } from "sonner"
 import { isAPIProviderConfig, isLLMProviderConfig } from "@/types/config/provider"
 import { getProviderConfigById } from "@/utils/config/helpers"
@@ -162,7 +162,6 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
 
 export function validateTranslationConfigAndToast(
   config: Pick<Config, "providersConfig" | "translate" | "language">,
-  detectedCode: LangCodeISO6393,
 ): boolean {
   const { providersConfig, translate: translateConfig, language: languageConfig } = config
   const providerConfig = getProviderConfigById(providersConfig, translateConfig.providerId)
@@ -174,11 +173,6 @@ export function validateTranslationConfigAndToast(
     toast.error(i18n.t("translation.sameLanguage"))
     logger.info("validateTranslationConfig: returning false (same language)")
     return false
-  }
-  else if (languageConfig.sourceCode === "auto" && detectedCode === languageConfig.targetCode) {
-    toast.warning(i18n.t("translation.autoModeSameLanguage", [
-      LANG_CODE_TO_LOCALE_NAME[detectedCode] ?? detectedCode,
-    ]))
   }
 
   // check if the API key is configured


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Removes the warning toast shown when automatic source-language detection reports the same language as the configured target language.

Explicitly configuring the same source and target language still blocks translation and shows the existing error. Since the automatic detection result is no longer needed for this validation path, this PR also removes the storage read and parameter plumbing from page and node translation startup.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

Validation run by git hooks while pushing:

- `pnpm lint:fix`
- `nx run @read-frog/extension:lint`
- `nx run @read-frog/extension:type-check`
- `nx run @read-frog/extension:test`

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

N/A

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

The PR description file is intentionally left uncommitted for copy/paste.