### PR TITLE
fix(extension): auto-inject Kiwix iframe runtime

### DIFF
--- a/.changeset/kiwix-iframe-runtime.md
+++ b/.changeset/kiwix-iframe-runtime.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(extension): auto-inject iframe runtime on Kiwix viewer pages

--- a/src/entrypoints/background/__tests__/iframe-injection.test.ts
+++ b/src/entrypoints/background/__tests__/iframe-injection.test.ts
@@ -3,6 +3,9 @@ import { browser, storage } from "#imports"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SITE_CONTROL_URL_WINDOW_KEY } from "@/utils/site-control"
 
+const HOST_CONTENT_SCRIPT_FILE = "/content-scripts/host.js"
+const SELECTION_CONTENT_SCRIPT_FILE = "/content-scripts/selection.js"
+
 const tabsOnRemovedAddListenerMock = vi.fn()
 const webNavigationOnBeforeNavigateAddListenerMock = vi.fn()
 const webNavigationOnCompletedAddListenerMock = vi.fn()
@@ -153,7 +156,159 @@ describe("setupIframeInjection", () => {
     expect(executeScriptMock).toHaveBeenCalledTimes(2)
     expect(executeScriptMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
       target: { tabId: currentTabId, documentIds: ["doc-1"] },
-      files: ["/content-scripts/host.js"],
+      files: [HOST_CONTENT_SCRIPT_FILE],
+    }))
+    expect(executeScriptMock).not.toHaveBeenCalledWith(expect.objectContaining({
+      files: [SELECTION_CONTENT_SCRIPT_FILE],
+    }))
+  })
+
+  it("auto-injects host and selection content for allowlisted iframes when page translation is disabled", async () => {
+    const { onCompleted } = await setupSubject()
+    storageGetItemMock.mockResolvedValue({ enabled: false })
+    getLocalConfigMock.mockResolvedValue(createConfig({ nodeTranslationEnabled: false }))
+
+    await onCompleted(createDetails({
+      url: "https://browse.library.kiwix.org/content/wikipedia_en_all_maxi_2026-02/A/Computer_science",
+    }))
+
+    expect(executeScriptMock).toHaveBeenCalledTimes(3)
+    expect(executeScriptMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      target: { tabId: currentTabId, documentIds: ["doc-1"] },
+      func: expect.any(Function),
+      args: [
+        SITE_CONTROL_URL_WINDOW_KEY,
+        "https://browse.library.kiwix.org/content/wikipedia_en_all_maxi_2026-02/A/Computer_science",
+      ],
+    }))
+    expect(executeScriptMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      target: { tabId: currentTabId, documentIds: ["doc-1"] },
+      files: [HOST_CONTENT_SCRIPT_FILE],
+    }))
+    expect(executeScriptMock).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      target: { tabId: currentTabId, documentIds: ["doc-1"] },
+      files: [SELECTION_CONTENT_SCRIPT_FILE],
+    }))
+  })
+
+  it("auto-injects existing and late iframes for allowlisted top pages", async () => {
+    const { onCompleted } = await setupSubject()
+    storageGetItemMock.mockResolvedValue({ enabled: false })
+    getLocalConfigMock.mockResolvedValue(createConfig({ nodeTranslationEnabled: false }))
+    getAllFramesMock.mockResolvedValue([
+      createFrame(0, "https://browse.library.kiwix.org/viewer", -1),
+      createFrame(2, "https://reader.example/frame"),
+    ])
+
+    await onCompleted(createDetails({
+      frameId: 0,
+      documentId: "top-doc",
+      parentFrameId: -1,
+      url: "https://browse.library.kiwix.org/viewer",
+    }))
+
+    expect(executeScriptMock).toHaveBeenCalledTimes(3)
+    expect(executeScriptMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      target: { tabId: currentTabId, frameIds: [2] },
+      args: [SITE_CONTROL_URL_WINDOW_KEY, "https://browse.library.kiwix.org/viewer"],
+    }))
+    expect(executeScriptMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      target: { tabId: currentTabId, frameIds: [2] },
+      files: [HOST_CONTENT_SCRIPT_FILE],
+    }))
+    expect(executeScriptMock).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      target: { tabId: currentTabId, frameIds: [2] },
+      files: [SELECTION_CONTENT_SCRIPT_FILE],
+    }))
+
+    executeScriptMock.mockClear()
+    getAllFramesMock.mockResolvedValue([
+      createFrame(0, "https://browse.library.kiwix.org/viewer", -1),
+      createFrame(4, "https://reader.example/late-frame"),
+    ])
+
+    await onCompleted(createDetails({
+      frameId: 4,
+      documentId: "doc-late",
+      url: "https://reader.example/late-frame",
+    }))
+
+    expect(executeScriptMock).toHaveBeenCalledTimes(3)
+    expect(executeScriptMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      target: { tabId: currentTabId, documentIds: ["doc-late"] },
+      args: [SITE_CONTROL_URL_WINDOW_KEY, "https://browse.library.kiwix.org/viewer"],
+    }))
+    expect(executeScriptMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      target: { tabId: currentTabId, documentIds: ["doc-late"] },
+      files: [HOST_CONTENT_SCRIPT_FILE],
+    }))
+    expect(executeScriptMock).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      target: { tabId: currentTabId, documentIds: ["doc-late"] },
+      files: [SELECTION_CONTENT_SCRIPT_FILE],
+    }))
+  })
+
+  it("respects site control during allowlisted full-runtime iframe injection", async () => {
+    const { onCompleted } = await setupSubject()
+    storageGetItemMock.mockResolvedValue({ enabled: false })
+    getLocalConfigMock.mockResolvedValue(createConfig({
+      nodeTranslationEnabled: false,
+      siteControl: {
+        mode: "blacklist",
+        blacklistPatterns: ["browse.library.kiwix.org"],
+        whitelistPatterns: [],
+      },
+    }))
+    getAllFramesMock.mockResolvedValue([
+      createFrame(0, "https://browse.library.kiwix.org/viewer", -1),
+      createFrame(2, "https://reader.example/frame"),
+    ])
+
+    await onCompleted(createDetails({
+      frameId: 0,
+      documentId: "top-doc",
+      parentFrameId: -1,
+      url: "https://browse.library.kiwix.org/viewer",
+    }))
+
+    expect(executeScriptMock).not.toHaveBeenCalled()
+  })
+
+  it("dedupes host and selection iframe injection independently", async () => {
+    const { injectHostContentIntoTabIframes } = await import("../iframe-injection")
+    storageGetItemMock.mockResolvedValue({ enabled: false })
+    getLocalConfigMock.mockResolvedValue(createConfig({ nodeTranslationEnabled: false }))
+    getAllFramesMock.mockResolvedValue([
+      createFrame(0, "https://browse.library.kiwix.org/viewer", -1),
+      createFrame(2, "https://browse.library.kiwix.org/content/article"),
+    ])
+
+    await injectHostContentIntoTabIframes(currentTabId, { requirePageTranslationEnabled: false })
+
+    expect(executeScriptMock).toHaveBeenCalledTimes(2)
+    expect(executeScriptMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      target: { tabId: currentTabId, frameIds: [2] },
+      files: [HOST_CONTENT_SCRIPT_FILE],
+    }))
+
+    executeScriptMock.mockClear()
+
+    await injectHostContentIntoTabIframes(currentTabId, {
+      requirePageTranslationEnabled: false,
+      includeSelectionContent: true,
+    })
+
+    expect(executeScriptMock).toHaveBeenCalledTimes(2)
+    expect(executeScriptMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      target: { tabId: currentTabId, frameIds: [2] },
+      args: [SITE_CONTROL_URL_WINDOW_KEY, "https://browse.library.kiwix.org/content/article"],
+    }))
+    expect(executeScriptMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      target: { tabId: currentTabId, frameIds: [2] },
+      files: [SELECTION_CONTENT_SCRIPT_FILE],
+    }))
+    expect(executeScriptMock).not.toHaveBeenCalledWith(expect.objectContaining({
+      files: [HOST_CONTENT_SCRIPT_FILE],
     }))
   })
 
@@ -237,7 +392,7 @@ describe("setupIframeInjection", () => {
     expect(executeScriptMock).toHaveBeenCalledTimes(6)
     expect(executeScriptMock).toHaveBeenLastCalledWith(expect.objectContaining({
       target: { tabId: currentTabId, documentIds: ["doc-stale"] },
-      files: ["/content-scripts/host.js"],
+      files: [HOST_CONTENT_SCRIPT_FILE],
     }))
   })
 
@@ -279,7 +434,7 @@ describe("setupIframeInjection", () => {
     })]))
     expect(calls).toEqual(expect.arrayContaining([expect.objectContaining({
       target: { tabId: currentTabId, frameIds: [2] },
-      files: ["/content-scripts/host.js"],
+      files: [HOST_CONTENT_SCRIPT_FILE],
     })]))
     expect(calls).toEqual(expect.arrayContaining([expect.objectContaining({
       target: { tabId: currentTabId, frameIds: [3] },
@@ -288,7 +443,7 @@ describe("setupIframeInjection", () => {
     })]))
     expect(calls).toEqual(expect.arrayContaining([expect.objectContaining({
       target: { tabId: currentTabId, frameIds: [3] },
-      files: ["/content-scripts/host.js"],
+      files: [HOST_CONTENT_SCRIPT_FILE],
     })]))
   })
 

--- a/src/entrypoints/background/iframe-injection.ts
+++ b/src/entrypoints/background/iframe-injection.ts
@@ -4,11 +4,21 @@ import { browser } from "#imports"
 import { getLocalConfig } from "@/utils/config/storage"
 import { logger } from "@/utils/logger"
 import { isSiteEnabled, SITE_CONTROL_URL_WINDOW_KEY } from "@/utils/site-control"
+import { matchDomainPattern } from "@/utils/url"
 import { resolveSiteControlUrl } from "./iframe-injection-utils"
 import { getPageTranslationEnabled } from "./page-translation-state"
 
-const pendingDocumentKeys = new Set<string>()
-const injectedDocumentKeysByFrame = new Map<string, string>()
+const HOST_CONTENT_SCRIPT_FILE = "/content-scripts/host.js" as const
+const SELECTION_CONTENT_SCRIPT_FILE = "/content-scripts/selection.js" as const
+const IFRAME_FULL_RUNTIME_AUTO_INJECT_PATTERNS = ["browse.library.kiwix.org"] as const
+
+type IframeContentScriptFile
+  = | typeof HOST_CONTENT_SCRIPT_FILE
+    | typeof SELECTION_CONTENT_SCRIPT_FILE
+
+const pendingScriptDocumentKeys = new Set<string>()
+const injectedDocumentKeysByFrameAndScript = new Map<string, string>()
+const fullRuntimeAutoInjectUrlByTab = new Map<number, string>()
 
 interface FrameInjectionDetails {
   tabId: number
@@ -20,6 +30,8 @@ interface FrameInjectionDetails {
 
 interface InjectHostContentIntoTabIframesOptions {
   requirePageTranslationEnabled?: boolean
+  includeSelectionContent?: boolean
+  siteControlUrlOverride?: string
 }
 
 function getDocumentInjectionKey(details: FrameInjectionDetails) {
@@ -32,33 +44,48 @@ function getFrameInjectionKey(details: { tabId: number, frameId: number }) {
   return `${details.tabId}:${details.frameId}`
 }
 
+function getScriptDocumentInjectionKey(details: FrameInjectionDetails, file: IframeContentScriptFile) {
+  return `${getDocumentInjectionKey(details)}:${file}`
+}
+
+function getScriptFrameInjectionKey(details: FrameInjectionDetails, file: IframeContentScriptFile) {
+  return `${getFrameInjectionKey(details)}:${file}`
+}
+
 function clearTabDocumentState(tabId: number) {
-  for (const key of pendingDocumentKeys) {
+  for (const key of pendingScriptDocumentKeys) {
     if (key.startsWith(`${tabId}:`)) {
-      pendingDocumentKeys.delete(key)
+      pendingScriptDocumentKeys.delete(key)
     }
   }
 
-  for (const key of injectedDocumentKeysByFrame.keys()) {
+  for (const key of injectedDocumentKeysByFrameAndScript.keys()) {
     if (key.startsWith(`${tabId}:`)) {
-      injectedDocumentKeysByFrame.delete(key)
+      injectedDocumentKeysByFrameAndScript.delete(key)
     }
   }
+
+  fullRuntimeAutoInjectUrlByTab.delete(tabId)
 }
 
 function clearFrameInjectedDocumentState(tabId: number, frameId: number) {
-  injectedDocumentKeysByFrame.delete(getFrameInjectionKey({ tabId, frameId }))
+  const frameKeyPrefix = `${getFrameInjectionKey({ tabId, frameId })}:`
+  for (const key of injectedDocumentKeysByFrameAndScript.keys()) {
+    if (key.startsWith(frameKeyPrefix)) {
+      injectedDocumentKeysByFrameAndScript.delete(key)
+    }
+  }
 }
 
 function pruneInjectedFrames(tabId: number, liveFrameIds: Set<number>) {
-  for (const frameKey of injectedDocumentKeysByFrame.keys()) {
+  for (const frameKey of injectedDocumentKeysByFrameAndScript.keys()) {
     if (!frameKey.startsWith(`${tabId}:`)) {
       continue
     }
 
-    const frameId = Number(frameKey.slice(frameKey.indexOf(":") + 1))
+    const frameId = Number(frameKey.split(":")[1])
     if (!liveFrameIds.has(frameId)) {
-      injectedDocumentKeysByFrame.delete(frameKey)
+      injectedDocumentKeysByFrameAndScript.delete(frameKey)
     }
   }
 }
@@ -87,6 +114,19 @@ async function getFrameSnapshot(tabId: number): Promise<FrameInfoForSiteControl[
   return await browser.webNavigation.getAllFrames({ tabId }) ?? []
 }
 
+function isFullRuntimeAutoInjectUrl(url: string | undefined): url is string {
+  if (!url)
+    return false
+
+  return IFRAME_FULL_RUNTIME_AUTO_INJECT_PATTERNS.some(pattern => matchDomainPattern(url, pattern))
+}
+
+function getIframeContentScriptFiles(options: InjectHostContentIntoTabIframesOptions): IframeContentScriptFile[] {
+  return options.includeSelectionContent
+    ? [HOST_CONTENT_SCRIPT_FILE, SELECTION_CONTENT_SCRIPT_FILE]
+    : [HOST_CONTENT_SCRIPT_FILE]
+}
+
 async function getShouldInjectHostContentIntoTabIframes(
   tabId: number,
   existingConfig?: Config | null,
@@ -108,20 +148,23 @@ async function injectHostContentIntoFrame(
   details: FrameInjectionDetails,
   frames?: FrameInfoForSiteControl[],
   existingConfig?: Config | null,
+  options: InjectHostContentIntoTabIframesOptions = {},
 ) {
-  const frameKey = getFrameInjectionKey(details)
   const documentKey = getDocumentInjectionKey(details)
+  const filesToInject = getIframeContentScriptFiles(options).filter((file) => {
+    const scriptDocumentKey = getScriptDocumentInjectionKey(details, file)
+    const scriptFrameKey = getScriptFrameInjectionKey(details, file)
+    return !pendingScriptDocumentKeys.has(scriptDocumentKey)
+      && injectedDocumentKeysByFrameAndScript.get(scriptFrameKey) !== documentKey
+  })
 
-  if (
-    pendingDocumentKeys.has(documentKey)
-  ) {
+  if (filesToInject.length === 0) {
     return
   }
-  if (injectedDocumentKeysByFrame.get(frameKey) === documentKey) {
-    return
-  }
 
-  pendingDocumentKeys.add(documentKey)
+  for (const file of filesToInject) {
+    pendingScriptDocumentKeys.add(getScriptDocumentInjectionKey(details, file))
+  }
 
   try {
     let siteControlUrl: string | undefined
@@ -135,7 +178,7 @@ async function injectHostContentIntoFrame(
       liveFrameIds.add(details.frameId)
       pruneInjectedFrames(details.tabId, liveFrameIds)
 
-      siteControlUrl = resolveSiteControlUrl(
+      siteControlUrl = options.siteControlUrlOverride ?? resolveSiteControlUrl(
         details.frameId,
         details.url,
         frameSnapshot,
@@ -160,19 +203,26 @@ async function injectHostContentIntoFrame(
         args: [SITE_CONTROL_URL_WINDOW_KEY, siteControlUrl],
       })
 
-      await browser.scripting.executeScript({
-        target,
-        files: ["/content-scripts/host.js"],
-      })
+      for (const file of filesToInject) {
+        await browser.scripting.executeScript({
+          target,
+          files: [file],
+        })
 
-      injectedDocumentKeysByFrame.set(frameKey, documentKey)
+        injectedDocumentKeysByFrameAndScript.set(
+          getScriptFrameInjectionKey(details, file),
+          documentKey,
+        )
+      }
     }
     catch (error) {
       logger.warn("[Background][IframeInjection] Failed to inject iframe content scripts", error)
     }
   }
   finally {
-    pendingDocumentKeys.delete(documentKey)
+    for (const file of filesToInject) {
+      pendingScriptDocumentKeys.delete(getScriptDocumentInjectionKey(details, file))
+    }
   }
 }
 
@@ -212,7 +262,7 @@ export async function injectHostContentIntoTabIframes(
       frameId: frame.frameId,
       parentFrameId: frame.parentFrameId,
       url: frame.url,
-    }, frames, config)))
+    }, frames, config, options)))
 }
 
 export async function injectHostContentIntoCurrentTabIframesAfterNodeTranslation(tabId: number) {
@@ -224,6 +274,9 @@ export function setupIframeInjection() {
   browser.webNavigation.onBeforeNavigate.addListener((details) => {
     if (details.frameId === 0) {
       clearTabDocumentState(details.tabId)
+      if (isFullRuntimeAutoInjectUrl(details.url)) {
+        fullRuntimeAutoInjectUrlByTab.set(details.tabId, details.url)
+      }
       return
     }
 
@@ -234,9 +287,30 @@ export function setupIframeInjection() {
   // subframes. Top-frame node translation can separately scan existing iframes
   // once, but it does not enable late iframe injection.
   browser.webNavigation.onCompleted.addListener(async (details) => {
-    // Skip main frame (frameId === 0), only handle iframes
-    if (details.frameId === 0)
+    if (details.frameId === 0) {
+      if (!isFullRuntimeAutoInjectUrl(details.url)) {
+        fullRuntimeAutoInjectUrlByTab.delete(details.tabId)
+        return
+      }
+
+      fullRuntimeAutoInjectUrlByTab.set(details.tabId, details.url)
+      await injectHostContentIntoTabIframes(details.tabId, {
+        requirePageTranslationEnabled: false,
+        includeSelectionContent: true,
+        siteControlUrlOverride: details.url,
+      })
       return
+    }
+
+    const fullRuntimeAutoInjectUrl = fullRuntimeAutoInjectUrlByTab.get(details.tabId)
+      ?? (isFullRuntimeAutoInjectUrl(details.url) ? details.url : undefined)
+    if (fullRuntimeAutoInjectUrl) {
+      await injectHostContentIntoFrame(details, undefined, undefined, {
+        includeSelectionContent: true,
+        siteControlUrlOverride: fullRuntimeAutoInjectUrl,
+      })
+      return
+    }
 
     let config: Config | null
     let shouldInject: boolean


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fixes iframe-first translation support for Kiwix browser pages without reverting the iframe performance work from #1417 / #1453.

`browse.library.kiwix.org` pages use iframe content as the primary reading surface, so the existing host-only on-demand iframe injection path is not enough for selection toolbar behavior. This adds a narrow built-in full-runtime iframe allowlist for Kiwix viewer pages:

- allowlisted top pages and matching iframe URLs inject both `/content-scripts/host.js` and `/content-scripts/selection.js`
- the allowlist bypasses page-translation-active gating only for the allowlisted site
- user site-control settings still win, so disabling `browse.library.kiwix.org` prevents the iframe runtime injection
- iframe injection dedupe is tracked per content script, so prior host injection does not block selection injection

Non-allowlisted pages keep the existing behavior: late iframe host injection remains tied to active page translation, and node translation still does not expand into selection runtime injection.

## Related Issue

Closes #1461

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Automated validation:

- `SKIP_FREE_API=true pnpm exec vitest run src/entrypoints/background/__tests__/iframe-injection.test.ts`
- `SKIP_FREE_API=true pnpm type-check`
- `WXT_SKIP_ENV_VALIDATION=true pnpm build:firefox`
- Push hook completed `lint`, `type-check`, and full `test`: `134` test files / `1165` tests passed

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The allowlist currently contains only `browse.library.kiwix.org`. This intentionally avoids restoring global iframe selection injection and keeps the performance-sensitive default path unchanged for iframe-heavy benchmarks and ordinary pages.
