### PR TITLE
fix(translation): decode Google Translate HTML entities

### DIFF
--- a/.changeset/google-translate-html-entities.md
+++ b/.changeset/google-translate-html-entities.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): decode Google Translate HTML entities

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "defuddle": "^0.18.1",
     "dequal": "^2.0.3",
     "dexie": "^4.4.2",
+    "entities": "^8.0.0",
     "file-saver": "^2.0.5",
     "franc": "^6.2.0",
     "jotai": "^2.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       dexie:
         specifier: ^4.4.2
         version: 4.4.2
+      entities:
+        specifier: ^8.0.0
+        version: 8.0.0
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
@@ -4242,6 +4245,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -11507,6 +11514,8 @@ snapshots:
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 

--- a/src/entrypoints/background/__tests__/translation-queues.test.ts
+++ b/src/entrypoints/background/__tests__/translation-queues.test.ts
@@ -62,6 +62,20 @@ const llmProvider: ProviderConfig = {
   model: { model: "gpt-5-mini", isCustomModel: false, customModel: null },
 }
 
+const googleProvider: ProviderConfig = {
+  id: "google-translate-default",
+  name: "Google Translate",
+  provider: "google-translate",
+  enabled: true,
+}
+
+const microsoftProvider: ProviderConfig = {
+  id: "microsoft-translate-default",
+  name: "Microsoft Translate",
+  provider: "microsoft-translate",
+  enabled: true,
+}
+
 describe("translation queue helpers", () => {
   beforeEach(() => {
     vi.resetModules()
@@ -191,6 +205,56 @@ describe("translation queue helpers", () => {
         },
       }),
     )
+  })
+
+  it("normalizes cached Google translations before returning them", async () => {
+    translationCacheGetMock.mockResolvedValueOnce({
+      key: "webpage-hash",
+      translation: "L&#39;Iran chiama &quot;Dichiarazione&quot; &lt;span&gt;",
+    })
+
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    const result = await handler({
+      data: {
+        text: "hello",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: googleProvider,
+        scheduleAt: Date.now(),
+        hash: "webpage-hash",
+      },
+    })
+
+    expect(result).toBe("L'Iran chiama \"Dichiarazione\" <span>")
+    expect(executeTranslateMock).not.toHaveBeenCalled()
+    expect(translationCachePutMock).not.toHaveBeenCalled()
+  })
+
+  it("does not normalize cached non-Google translations", async () => {
+    translationCacheGetMock.mockResolvedValueOnce({
+      key: "webpage-hash",
+      translation: "A&amp;B",
+    })
+
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    const result = await handler({
+      data: {
+        text: "hello",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: microsoftProvider,
+        scheduleAt: Date.now(),
+        hash: "webpage-hash",
+      },
+    })
+
+    expect(result).toBe("A&amp;B")
+    expect(executeTranslateMock).not.toHaveBeenCalled()
+    expect(translationCachePutMock).not.toHaveBeenCalled()
   })
 
   it("exposes webpage summary generation as a separate background handler", async () => {

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -13,6 +13,7 @@ import { db } from "@/utils/db/dexie/db"
 import { Sha256Hex } from "@/utils/hash"
 import { executeTranslate } from "@/utils/host/translate/execute-translate"
 import { normalizePromptContextValue } from "@/utils/host/translate/translate-text"
+import { normalizeTranslationOutput } from "@/utils/host/translate/translation-output-normalization"
 import { logger } from "@/utils/logger"
 import { onMessage } from "@/utils/message"
 import { getSubtitlesTranslatePrompt } from "@/utils/prompts/subtitles"
@@ -231,7 +232,7 @@ export async function setUpWebPageTranslationQueue() {
     if (hash) {
       const cached = await db.translationCache.get(hash)
       if (cached) {
-        return cached.translation
+        return normalizeTranslationOutput(providerConfig, cached.translation)
       }
     }
 
@@ -254,6 +255,7 @@ export async function setUpWebPageTranslationQueue() {
 
     // Cache the translation result if successful
     if (result && hash) {
+      result = normalizeTranslationOutput(providerConfig, result)
       await db.translationCache.put({
         key: hash,
         translation: result,
@@ -304,7 +306,7 @@ export async function setUpSubtitlesTranslationQueue() {
     if (hash) {
       const cached = await db.translationCache.get(hash)
       if (cached) {
-        return cached.translation
+        return normalizeTranslationOutput(providerConfig, cached.translation)
       }
     }
 
@@ -324,6 +326,7 @@ export async function setUpSubtitlesTranslationQueue() {
     }
 
     if (result && hash) {
+      result = normalizeTranslationOutput(providerConfig, result)
       await db.translationCache.put({
         key: hash,
         translation: result,

--- a/src/utils/host/__tests__/translate-text.test.tsx
+++ b/src/utils/host/__tests__/translate-text.test.tsx
@@ -19,6 +19,10 @@ vi.mock("@/utils/host/translate/api/microsoft", () => ({
   microsoftTranslate: vi.fn(),
 }))
 
+vi.mock("@/utils/host/translate/api/google", () => ({
+  googleTranslate: vi.fn(),
+}))
+
 vi.mock("@/utils/prompts/translate", () => ({
   getTranslatePrompt: vi.fn(),
 }))
@@ -33,6 +37,7 @@ vi.mock("@/utils/host/translate/webpage-summary", () => ({
 
 let mockSendMessage: any
 let mockMicrosoftTranslate: any
+let mockGoogleTranslate: any
 let mockGetConfigFromStorage: any
 let mockGetTranslatePrompt: any
 let mockGetOrCreateWebPageContext: any
@@ -45,6 +50,7 @@ describe("translate-text", () => {
     document.body.innerHTML = "<main>Body content</main>"
     mockSendMessage = vi.mocked((await import("@/utils/message")).sendMessage)
     mockMicrosoftTranslate = vi.mocked((await import("@/utils/host/translate/api/microsoft")).microsoftTranslate)
+    mockGoogleTranslate = vi.mocked((await import("@/utils/host/translate/api/google")).googleTranslate)
     mockGetConfigFromStorage = vi.mocked((await import("@/utils/config/storage")).getLocalConfig)
     mockGetTranslatePrompt = vi.mocked((await import("@/utils/prompts/translate")).getTranslatePrompt)
     mockGetOrCreateWebPageContext = vi.mocked((await import("@/utils/host/translate/webpage-context")).getOrCreateWebPageContext)
@@ -277,6 +283,21 @@ describe("translate-text", () => {
       const result = await executeTranslate("test input", langConfig, providerConfig, getTranslatePrompt)
 
       expect(result).toBe("测试结果")
+    })
+
+    it("should decode Google translateHtml entities", async () => {
+      const googleProviderConfig = {
+        id: "google-translate-default",
+        enabled: true,
+        name: "Google Translate",
+        provider: "google-translate" as const,
+      }
+      mockGoogleTranslate.mockResolvedValue(" L&#39;Iran chiama &quot;Dichiarazione&quot; AT&amp;T &lt;span&gt; ")
+
+      const result = await executeTranslate("test input", langConfig, googleProviderConfig, getTranslatePrompt)
+
+      expect(result).toBe("L'Iran chiama \"Dichiarazione\" AT&T <span>")
+      expect(mockGoogleTranslate).toHaveBeenCalledWith("test input", "en", "zh")
     })
   })
 })

--- a/src/utils/host/translate/__tests__/translation-output-normalization.test.ts
+++ b/src/utils/host/translate/__tests__/translation-output-normalization.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+import { normalizeTranslationOutput } from "../translation-output-normalization"
+
+describe("normalizeTranslationOutput", () => {
+  const googleProvider = { provider: "google-translate" as const }
+  const microsoftProvider = { provider: "microsoft-translate" as const }
+
+  it("decodes apostrophe and quote entities returned by Google translateHtml", () => {
+    expect(normalizeTranslationOutput(googleProvider, "L&#39;Iran")).toBe("L'Iran")
+    expect(normalizeTranslationOutput(googleProvider, "&quot;Dichiarazione&quot;")).toBe("\"Dichiarazione\"")
+  })
+
+  it("decodes safe text entities for Google Translate", () => {
+    expect(normalizeTranslationOutput(googleProvider, "AT&amp;T&nbsp;")).toBe("AT&T\u00A0")
+  })
+
+  it("decodes escaped tags for Google Translate", () => {
+    expect(normalizeTranslationOutput(googleProvider, "&lt;span&gt;")).toBe("<span>")
+    expect(normalizeTranslationOutput(googleProvider, "&#60;span&#62;")).toBe("<span>")
+  })
+
+  it("keeps real HTML tags while decoding text entities inside them", () => {
+    expect(normalizeTranslationOutput(googleProvider, "<span>L&#39;Iran</span>")).toBe("<span>L'Iran</span>")
+  })
+
+  it("does not normalize non-Google providers", () => {
+    expect(normalizeTranslationOutput(microsoftProvider, "A&amp;B")).toBe("A&amp;B")
+  })
+})

--- a/src/utils/host/translate/execute-translate.ts
+++ b/src/utils/host/translate/execute-translate.ts
@@ -9,6 +9,7 @@ import { deeplxTranslate } from "./api/deeplx"
 import { googleTranslate } from "./api/google"
 import { microsoftTranslate } from "./api/microsoft"
 import { prepareTranslationText } from "./text-preparation"
+import { normalizeTranslationOutput } from "./translation-output-normalization"
 
 export async function executeTranslate<TContext>(
   text: string,
@@ -63,5 +64,5 @@ export async function executeTranslate<TContext>(
     throw new Error(`Unknown provider: ${provider}`)
   }
 
-  return translatedText.trim()
+  return normalizeTranslationOutput(providerConfig, translatedText).trim()
 }

--- a/src/utils/host/translate/translation-output-normalization.ts
+++ b/src/utils/host/translate/translation-output-normalization.ts
@@ -1,0 +1,8 @@
+import type { ProviderConfig } from "@/types/config/provider"
+import { decodeHTML } from "entities"
+
+export function normalizeTranslationOutput(providerConfig: Pick<ProviderConfig, "provider">, text: string): string {
+  return providerConfig.provider === "google-translate"
+    ? decodeHTML(text)
+    : text
+}


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fixes Google Translate results that display raw HTML entities such as `L&#39;Iran` and `&quot;Dichiarazione&quot;` in translated text.

This adds an explicit `entities` runtime dependency and normalizes Google Translate output through a shared translation-output helper. Fresh translation results are decoded before returning from `executeTranslate`, and cached Google translations are decoded when read so users do not need to clear existing translation cache.

Non-Google providers keep their existing output behavior unchanged.

## Related Issue

Closes #1467

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validated with:

- `SKIP_FREE_API=true pnpm test -- src/utils/host/translate/__tests__/translation-output-normalization.test.ts src/utils/host/__tests__/translate-text.test.tsx src/entrypoints/background/__tests__/translation-queues.test.ts`
- `pnpm type-check`
- `WXT_GOOGLE_CLIENT_ID=dummy WXT_POSTHOG_HOST=https://example.com WXT_POSTHOG_API_KEY=dummy pnpm build`
- push hook: `lint`, `type-check`, and full `test`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The production build requires WXT environment variables locally, so placeholder values were used for the build verification command.
