### PR TITLE
fix(subtitles): preserve video title context

### DIFF
--- a/.changeset/calm-subtitles-carry-title.md
+++ b/.changeset/calm-subtitles-carry-title.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+Keep subtitle video title context available when AI content-aware translation is disabled.

--- a/src/utils/subtitles/processor/__tests__/translator.test.ts
+++ b/src/utils/subtitles/processor/__tests__/translator.test.ts
@@ -151,6 +151,39 @@ describe("subtitles translator", () => {
     expect(request.summary).toBeNull()
   })
 
+  it("keeps subtitle video title context when AI content awareness is disabled", async () => {
+    getLocalConfigMock.mockResolvedValueOnce({
+      ...DEFAULT_CONFIG,
+      translate: {
+        ...DEFAULT_CONFIG.translate,
+        enableAIContentAware: false,
+      },
+      videoSubtitles: {
+        ...DEFAULT_CONFIG.videoSubtitles,
+        providerId: "openai-default",
+      },
+    })
+
+    const { translateSubtitles } = await import("../translator")
+
+    await translateSubtitles([{ text: "hello", start: 0, end: 1_000 }], {
+      videoTitle: "Video title",
+      subtitlesTextContent: "subtitle transcript",
+      summary: "Ignored summary",
+    })
+
+    const request = sendMessageMock.mock.calls[0][1]
+    expect(request.videoTitle).toBe("Video title")
+    expect(request.summary).toBeUndefined()
+    expect(getSubtitlesTranslatePromptMock).toHaveBeenCalledWith(expect.any(String), "hello", expect.objectContaining({
+      isBatch: true,
+      context: {
+        videoTitle: "Video title",
+        videoSummary: undefined,
+      },
+    }))
+  })
+
   it("builds subtitle summary context hashes from subtitles text and provider config", async () => {
     const { buildSubtitlesSummaryContextHash } = await import("../translator")
 

--- a/src/utils/subtitles/processor/translator.ts
+++ b/src/utils/subtitles/processor/translator.ts
@@ -89,7 +89,7 @@ async function buildSubtitleHashComponents(
   const targetLangName = LANG_CODE_TO_EN_NAME[partialLangConfig.targetCode]
   const { systemPrompt, prompt } = await getSubtitlesTranslatePrompt(targetLangName, preparedText, {
     isBatch: true,
-    context: enableAIContentAware ? subtitlePromptContext : undefined,
+    context: subtitlePromptContext,
   })
   hashComponents.push(systemPrompt, prompt)
   hashComponents.push(enableAIContentAware ? "enableAIContentAware=true" : "enableAIContentAware=false")
@@ -117,17 +117,21 @@ async function translateSingleSubtitle(
   videoContext: SubtitlesVideoContext,
 ): Promise<string> {
   const subtitlePromptContext = normalizeSubtitlePromptContext(videoContext)
+  const promptContext: SubtitlePromptContext = {
+    videoTitle: subtitlePromptContext.videoTitle,
+    videoSummary: enableAIContentAware ? subtitlePromptContext.videoSummary : undefined,
+  }
   const hashComponents = await buildSubtitleHashComponents(
     text,
     providerConfig,
     { sourceCode: langConfig.sourceCode, targetCode: langConfig.targetCode },
     enableAIContentAware,
-    subtitlePromptContext,
+    promptContext,
     videoContext.subtitlesTextContent,
   )
 
   if (enableAIContentAware) {
-    const summary = subtitlePromptContext.videoSummary
+    const summary = promptContext.videoSummary
     hashComponents.push(summary ? "subtitleSummary=ready" : "subtitleSummary=missing")
   }
 
@@ -137,8 +141,8 @@ async function translateSingleSubtitle(
     providerConfig,
     scheduleAt: Date.now(),
     hash: Sha256Hex(...hashComponents),
-    videoTitle: enableAIContentAware ? subtitlePromptContext.videoTitle : undefined,
-    summary: enableAIContentAware ? subtitlePromptContext.videoSummary : undefined,
+    videoTitle: promptContext.videoTitle,
+    summary: enableAIContentAware ? promptContext.videoSummary : undefined,
   })
 }
 


### PR DESCRIPTION
## Summary
- Keep the subtitle video title in prompt/request context even when AI content-aware translation is disabled
- Continue gating subtitle summaries behind `translate.enableAIContentAware`
- Add a regression test covering the disabled-content-awareness subtitle path

## Test Plan
- [x] `SKIP_FREE_API=true pnpm exec vitest run src/utils/subtitles/processor/__tests__/translator.test.ts -t "keeps subtitle video title context"`
- [x] `SKIP_FREE_API=true pnpm exec vitest run src/utils/subtitles/processor/__tests__/translator.test.ts src/entrypoints/background/__tests__/translation-queues.test.ts`
- [x] `pnpm exec eslint src/utils/subtitles/processor/translator.ts src/utils/subtitles/processor/__tests__/translator.test.ts`
- [x] `pnpm type-check`
- [x] `SKIP_FREE_API=true pnpm test` (also passed during push hook)

Closes #1483
