### PR TITLE
fix: distinguish Traditional Chinese before language skip

### DIFF
--- a/.changeset/fix-chinese-variant-detection.md
+++ b/.changeset/fix-chinese-variant-detection.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+Fix Traditional Chinese text being mistaken as already Simplified Chinese during page translation.

--- a/src/utils/content/__tests__/language.test.ts
+++ b/src/utils/content/__tests__/language.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+import { detectLanguageWithSource } from "../language"
+
+const TRADITIONAL_CHINESE_SAMPLE = "鳥哥的 Linux 私房菜提供基礎學習篇、伺服器架設篇與各種實務文件，適合想要學習繁體中文技術文章的使用者閱讀。"
+const SIMPLIFIED_CHINESE_SAMPLE = "鸟哥的 Linux 私房菜提供基础学习篇、服务器架设篇与各种实务文件，适合想要学习简体中文技术文章的使用者阅读。"
+
+describe("detectLanguageWithSource", () => {
+  it("detects clear Traditional Chinese text as cmn-Hant instead of Simplified Mandarin", async () => {
+    await expect(detectLanguageWithSource(TRADITIONAL_CHINESE_SAMPLE)).resolves.toEqual({
+      code: "cmn-Hant",
+      source: "franc",
+    })
+  })
+
+  it("keeps clear Simplified Chinese text as cmn", async () => {
+    await expect(detectLanguageWithSource(SIMPLIFIED_CHINESE_SAMPLE)).resolves.toEqual({
+      code: "cmn",
+      source: "franc",
+    })
+  })
+})

--- a/src/utils/content/language.ts
+++ b/src/utils/content/language.ts
@@ -17,6 +17,19 @@ import { cleanText } from "./utils"
 const DEFAULT_MIN_LENGTH = 10
 const DEFAULT_MAX_LENGTH_FOR_LLM = 500
 const LLM_DETECTION_FALLBACK_TOAST_ID = "llm-detection-fallback"
+const CHINESE_VARIANT_MIN_HITS = 2
+
+const TRADITIONAL_CHINESE_VARIANT_CHARS = new Set([
+  "個", "們", "這", "為", "鳥", "書", "與", "學", "習", "體", "範", "氣", "設", "種", "實", "務", "適",
+  "簡", "術", "閱", "讀", "網", "頁", "標", "題", "內", "廣", "東", "關", "係", "長", "萬", "轉", "換",
+  "測", "試", "請", "輸", "譯", "擴", "瀏", "覽", "錯", "誤", "應", "該", "發", "現", "業", "號",
+])
+
+const SIMPLIFIED_CHINESE_VARIANT_CHARS = new Set([
+  "个", "们", "这", "为", "鸟", "书", "与", "学", "习", "体", "范", "气", "设", "种", "实", "务", "适",
+  "简", "术", "阅", "读", "网", "页", "标", "题", "内", "广", "东", "关", "系", "长", "万", "转", "换",
+  "测", "试", "请", "输", "译", "扩", "浏", "览", "器", "错", "误", "应", "该", "发", "现", "业", "号",
+])
 
 export type DetectionSource = "llm" | "franc" | "fallback"
 
@@ -34,6 +47,34 @@ export interface DetectLanguageOptions {
 export interface DetectLanguageResult {
   code: LangCodeISO6393 | "und"
   source: DetectionSource
+}
+
+function countChineseVariantChars(text: string, variantChars: Set<string>): number {
+  let count = 0
+  for (const char of text) {
+    if (variantChars.has(char)) {
+      count += 1
+    }
+  }
+  return count
+}
+
+function refineMandarinChineseVariant(text: string, detectedCode: LangCodeISO6393): LangCodeISO6393 {
+  if (detectedCode !== "cmn") {
+    return detectedCode
+  }
+
+  const traditionalHits = countChineseVariantChars(text, TRADITIONAL_CHINESE_VARIANT_CHARS)
+  const simplifiedHits = countChineseVariantChars(text, SIMPLIFIED_CHINESE_VARIANT_CHARS)
+
+  if (
+    traditionalHits >= CHINESE_VARIANT_MIN_HITS
+    && traditionalHits >= simplifiedHits + CHINESE_VARIANT_MIN_HITS
+  ) {
+    return "cmn-Hant"
+  }
+
+  return "cmn"
 }
 
 /**
@@ -64,7 +105,7 @@ export async function detectLanguageWithSource(
         options?.providerConfig,
       )
       if (llmResult && llmResult !== "und") {
-        return { code: llmResult, source: "llm" }
+        return { code: refineMandarinChineseVariant(trimmedText, llmResult), source: "llm" }
       }
     }
     catch (error) {
@@ -80,7 +121,10 @@ export async function detectLanguageWithSource(
   if (francResult === "und") {
     return { code: "und", source: "fallback" }
   }
-  return { code: francResult as LangCodeISO6393, source: "franc" }
+  return {
+    code: refineMandarinChineseVariant(trimmedText, francResult as LangCodeISO6393),
+    source: "franc",
+  }
 }
 
 /**

--- a/src/utils/host/__tests__/translate-text.test.tsx
+++ b/src/utils/host/__tests__/translate-text.test.tsx
@@ -91,6 +91,21 @@ describe("translate-text", () => {
       expect(mockGetOrCreateWebPageContext).not.toHaveBeenCalled()
       expect(mockGetOrGenerateWebPageSummary).not.toHaveBeenCalled()
     })
+
+    it("translates Traditional Chinese text when the target language is Simplified Chinese", async () => {
+      mockSendMessage.mockResolvedValue("鸟哥的 Linux 私房菜提供基础学习篇、服务器架设篇与各种实务文件。")
+      const traditionalText = "鳥哥的 Linux 私房菜提供基礎學習篇、伺服器架設篇與各種實務文件，適合想要學習繁體中文技術文章的使用者閱讀。"
+
+      const result = await translateTextForPage(traditionalText)
+
+      expect(result).toBe("鸟哥的 Linux 私房菜提供基础学习篇、服务器架设篇与各种实务文件。")
+      expect(mockSendMessage).toHaveBeenCalledWith("enqueueTranslateRequest", expect.objectContaining({
+        text: traditionalText,
+        langConfig: expect.objectContaining({
+          targetCode: "cmn",
+        }),
+      }))
+    })
   })
 
   describe("translateTextForPageTitle", () => {

--- a/src/utils/prompts/__tests__/language-detection.test.ts
+++ b/src/utils/prompts/__tests__/language-detection.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest"
+import { parseDetectedLanguageCode } from "../language-detection"
+
+describe("parseDetectedLanguageCode", () => {
+  it("canonicalizes mixed-case language codes after normalization", () => {
+    expect(parseDetectedLanguageCode("cmn-Hant")).toBe("cmn-Hant")
+    expect(parseDetectedLanguageCode("cmn-hant")).toBe("cmn-Hant")
+    expect(parseDetectedLanguageCode(" `cmn-Hant`, ")).toBe("cmn-Hant")
+  })
+})

--- a/src/utils/prompts/language-detection.ts
+++ b/src/utils/prompts/language-detection.ts
@@ -1,8 +1,11 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
-import { LANG_CODE_TO_EN_NAME, langCodeISO6393Schema } from "@read-frog/definitions"
+import { LANG_CODE_ISO6393_OPTIONS, LANG_CODE_TO_EN_NAME, langCodeISO6393Schema } from "@read-frog/definitions"
 import z from "zod"
 
 const PUNCTUATION_AND_WHITESPACE_PATTERN = /['"`,.\s]/g
+const ISO6393_BY_NORMALIZED_CODE = new Map(
+  LANG_CODE_ISO6393_OPTIONS.map(code => [normalizeLanguageDetectionOutput(code), code] as const),
+)
 
 const supportedLanguageList = Object.entries(LANG_CODE_TO_EN_NAME)
   .map(([code, name]) => `- ${code}: ${name}`)
@@ -26,6 +29,14 @@ export function normalizeLanguageDetectionOutput(rawOutput: string): string {
 
 export function parseDetectedLanguageCode(rawOutput: string): LangCodeISO6393 | "und" | null {
   const cleanedCode = normalizeLanguageDetectionOutput(rawOutput)
-  const parseResult = langCodeISO6393Schema.or(z.literal("und")).safeParse(cleanedCode)
+  const canonicalCode = cleanedCode === "und"
+    ? "und"
+    : ISO6393_BY_NORMALIZED_CODE.get(cleanedCode)
+
+  if (!canonicalCode) {
+    return null
+  }
+
+  const parseResult = langCodeISO6393Schema.or(z.literal("und")).safeParse(canonicalCode)
   return parseResult.success ? parseResult.data : null
 }


### PR DESCRIPTION
## Summary
- refine generic Mandarin (`cmn`) detection to `cmn-Hant` when the source text has clear Traditional Chinese variant markers
- canonicalize normalized LLM language-detection outputs like `cmn-hant` back to supported ISO code casing
- add regression coverage for Traditional Chinese → Simplified Chinese page translation so it no longer skips as already-target-language

Fixes #1489

## Test Plan
- [x] `SKIP_FREE_API=true pnpm test src/utils/content/__tests__/language.test.ts src/utils/prompts/__tests__/language-detection.test.ts src/utils/host/__tests__/translate-text.test.tsx`
- [x] `pnpm exec eslint src/utils/content/language.ts src/utils/content/__tests__/language.test.ts src/utils/prompts/language-detection.ts src/utils/prompts/__tests__/language-detection.test.ts src/utils/host/__tests__/translate-text.test.tsx`
- [x] `pnpm type-check`
- [x] `SKIP_FREE_API=true pnpm test`
- [x] pre-push hook: `nx run @read-frog/extension:lint`, `nx run @read-frog/extension:type-check`, `nx run @read-frog/extension:test`

## Notes
- Existing open PR #1354 is related to redundant skip-language LLM detection, but it does not cover this Traditional-vs-Simplified Chinese variant misclassification path.
