### PR TITLE
fix(youtube): refresh overlay subtitles after caption track changes

### DIFF
--- a/.changeset/neat-cats-jog.md
+++ b/.changeset/neat-cats-jog.md
@@ -1,0 +1,4 @@
+"@read-frog/extension": patch
+---
+
+fix(youtube): refresh overlay subtitles after caption track changes

--- a/src/entrypoints/interceptor.content/inject-player-api.ts
+++ b/src/entrypoints/interceptor.content/inject-player-api.ts
@@ -34,6 +34,11 @@ declare global {
   }
 }
 
+interface SelectedTrackSnapshot {
+  languageCode: string | null
+  vssId: string | null
+}
+
 function findYoutubePlayer(): YouTubePlayer | null {
   return document.querySelector(
     ".html5-video-player.playing-mode, .html5-video-player.paused-mode",
@@ -92,6 +97,9 @@ function getPlayerData(request: PlayerDataRequest): PlayerDataResponse {
 
     const playerResponse = player.getPlayerResponse?.()
     const videoId = playerResponse?.videoDetails?.videoId
+    const tracks = playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks ?? []
+    const captionTracks = normalizeTracks(tracks)
+    const selectedTrack = getSelectedTrackSnapshot(player, captionTracks)
 
     if (!videoId || videoId !== expectedVideoId)
       return errorResponse(requestId, "VIDEO_ID_MISMATCH")
@@ -102,14 +110,13 @@ function getPlayerData(request: PlayerDataRequest): PlayerDataResponse {
       success: true,
       data: {
         videoId,
-        captionTracks: normalizeTracks(
-          playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks ?? [],
-        ),
+        captionTracks,
         audioCaptionTracks: parseAudioTracks(player.getAudioTrack?.()?.captionTracks),
         device: window.ytcfg?.get?.("DEVICE") ?? null,
         cver: player.getWebPlayerContextConfig?.()?.innertubeContextClientVersion ?? null,
         playerState: player.getPlayerState?.() ?? -1,
-        selectedTrackLanguageCode: player.getOption?.("captions", "track")?.languageCode ?? null,
+        selectedTrackLanguageCode: selectedTrack.languageCode,
+        selectedTrackVssId: selectedTrack.vssId,
         cachedTimedtextUrl: getCachedTimedtextUrl(videoId),
       },
     }
@@ -135,4 +142,67 @@ function ensureSubtitlesEnabled(): void {
   else {
     button.click()
   }
+}
+
+function getSelectedTrackSnapshot(
+  player: YouTubePlayer,
+  captionTracks: Array<{ languageCode: string, kind?: string, vssId: string }>,
+): SelectedTrackSnapshot {
+  const selectedTrack = player.getOption?.("captions", "track")
+  const languageCode = selectedTrack?.languageCode ?? null
+  const matchedTrack = matchSelectedTrack(captionTracks, selectedTrack)
+  const vssId = getSelectedTrackVssId(selectedTrack) ?? matchedTrack?.vssId ?? null
+
+  return {
+    languageCode,
+    vssId,
+  }
+}
+
+function getSelectedTrackVssId(selectedTrack: any): string | null {
+  const directVssId = selectedTrack?.vssId ?? selectedTrack?.vss_id
+  if (typeof directVssId === "string" && directVssId.length > 0)
+    return directVssId
+
+  const baseUrl = selectedTrack?.baseUrl
+  if (typeof baseUrl !== "string" || baseUrl.length === 0)
+    return null
+
+  try {
+    return new URL(baseUrl, window.location.origin).searchParams.get("vssId")
+      ?? new URL(baseUrl, window.location.origin).searchParams.get("vss_id")
+  }
+  catch {
+    return null
+  }
+}
+
+function matchSelectedTrack(
+  captionTracks: Array<{ languageCode: string, kind?: string, vssId: string }>,
+  selectedTrack: any,
+) {
+  const selectedVssId = getSelectedTrackVssId(selectedTrack)
+  if (selectedVssId) {
+    return captionTracks.find(track => track.vssId === selectedVssId)
+  }
+
+  const selectedLanguageCode = selectedTrack?.languageCode
+  const selectedKind = selectedTrack?.kind ?? selectedTrack?.trackKind ?? null
+
+  if (typeof selectedLanguageCode !== "string" || selectedLanguageCode.length === 0)
+    return undefined
+
+  if (typeof selectedKind === "string" && selectedKind.length > 0) {
+    const exactKindMatch = captionTracks.find(track =>
+      track.languageCode === selectedLanguageCode && (track.kind ?? null) === selectedKind,
+    )
+    if (exactKindMatch)
+      return exactKindMatch
+  }
+
+  const sameLanguageTracks = captionTracks.filter(track => track.languageCode === selectedLanguageCode)
+  if (sameLanguageTracks.length === 1)
+    return sameLanguageTracks[0]
+
+  return undefined
 }

--- a/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
@@ -26,6 +26,17 @@ function createAdapter(fetchResult: Array<{ text: string, start: number, end: nu
   return { adapter, subtitlesFetcher }
 }
 
+function attachScheduler(adapter: UniversalVideoAdapter, active: boolean) {
+  const subtitlesScheduler = {
+    isActive: vi.fn(() => active),
+    reset: vi.fn(),
+    setState: vi.fn(),
+  }
+
+  ;(adapter as any).subtitlesScheduler = subtitlesScheduler
+  return subtitlesScheduler
+}
+
 describe("universalVideoAdapter", () => {
   it("keeps raw source subtitles and rebuilds processed source subtitles", async () => {
     const subtitles = [
@@ -53,7 +64,7 @@ describe("universalVideoAdapter", () => {
       { text: "hello", start: 0, end: 500 },
     ])
 
-    ;(adapter as any).subtitlesEnabled = true
+    const subtitlesScheduler = attachScheduler(adapter, true)
 
     const clearRuntimeSessionSpy = vi.spyOn(adapter as any, "clearRuntimeSession")
     const clearSourceCacheSpy = vi.spyOn(adapter as any, "clearSourceCache")
@@ -65,6 +76,8 @@ describe("universalVideoAdapter", () => {
     expect(clearRuntimeSessionSpy).toHaveBeenCalledTimes(1)
     expect(clearSourceCacheSpy).toHaveBeenCalledTimes(1)
     expect(subtitlesFetcher.cleanup).toHaveBeenCalledTimes(1)
+    expect(subtitlesScheduler.reset).toHaveBeenCalledTimes(1)
+    expect(subtitlesScheduler.setState).toHaveBeenCalledWith("loading")
     expect(startTranslationSpy).toHaveBeenCalledTimes(1)
   })
 
@@ -73,6 +86,7 @@ describe("universalVideoAdapter", () => {
       { text: "hello", start: 0, end: 500 },
     ])
 
+    attachScheduler(adapter, false)
     const startTranslationSpy = vi.spyOn(adapter as any, "startTranslation").mockResolvedValue(undefined)
 
     await adapter.handleSourceTrackChanged()
@@ -86,7 +100,7 @@ describe("universalVideoAdapter", () => {
       { text: "hello", start: 0, end: 500 },
     ])
 
-    ;(adapter as any).subtitlesEnabled = true
+    const subtitlesScheduler = attachScheduler(adapter, true)
     vi.mocked(subtitlesFetcher.shouldUseSameTrack).mockResolvedValue(true)
 
     const startTranslationSpy = vi.spyOn(adapter as any, "startTranslation").mockResolvedValue(undefined)
@@ -95,6 +109,8 @@ describe("universalVideoAdapter", () => {
 
     expect(subtitlesFetcher.shouldUseSameTrack).toHaveBeenCalledTimes(1)
     expect(subtitlesFetcher.cleanup).not.toHaveBeenCalled()
+    expect(subtitlesScheduler.reset).not.toHaveBeenCalled()
+    expect(subtitlesScheduler.setState).not.toHaveBeenCalled()
     expect(startTranslationSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
@@ -2,7 +2,15 @@ import { describe, expect, it, vi } from "vitest"
 import { UniversalVideoAdapter } from "../universal-adapter"
 
 function createAdapter(fetchResult: Array<{ text: string, start: number, end: number }>) {
-  return new UniversalVideoAdapter({
+  const subtitlesFetcher = {
+    fetch: vi.fn().mockResolvedValue(fetchResult),
+    cleanup: vi.fn(),
+    shouldUseSameTrack: vi.fn().mockResolvedValue(false),
+    getSourceLanguage: () => "en",
+    hasAvailableSubtitles: vi.fn().mockResolvedValue(true),
+  }
+
+  const adapter = new UniversalVideoAdapter({
     config: {
       selectors: {
         video: "video",
@@ -12,14 +20,10 @@ function createAdapter(fetchResult: Array<{ text: string, start: number, end: nu
       },
       events: {},
     },
-    subtitlesFetcher: {
-      fetch: vi.fn().mockResolvedValue(fetchResult),
-      cleanup: vi.fn(),
-      shouldUseSameTrack: vi.fn().mockResolvedValue(false),
-      getSourceLanguage: () => "en",
-      hasAvailableSubtitles: vi.fn().mockResolvedValue(true),
-    },
+    subtitlesFetcher,
   })
+
+  return { adapter, subtitlesFetcher }
 }
 
 describe("universalVideoAdapter", () => {
@@ -30,7 +34,7 @@ describe("universalVideoAdapter", () => {
       { text: "We can do this.", start: 1000, end: 1500 },
       { text: "Let's ship now.", start: 1500, end: 2000 },
     ]
-    const adapter = createAdapter(subtitles)
+    const { adapter } = createAdapter(subtitles)
 
     await (adapter as any).getOrLoadSourceSubtitles()
 
@@ -42,5 +46,55 @@ describe("universalVideoAdapter", () => {
         end: 2000,
       },
     ])
+  })
+
+  it("reloads subtitles when the source track changes while translation is enabled", async () => {
+    const { adapter, subtitlesFetcher } = createAdapter([
+      { text: "hello", start: 0, end: 500 },
+    ])
+
+    ;(adapter as any).subtitlesEnabled = true
+
+    const clearRuntimeSessionSpy = vi.spyOn(adapter as any, "clearRuntimeSession")
+    const clearSourceCacheSpy = vi.spyOn(adapter as any, "clearSourceCache")
+    const startTranslationSpy = vi.spyOn(adapter as any, "startTranslation").mockResolvedValue(undefined)
+
+    await adapter.handleSourceTrackChanged()
+
+    expect(subtitlesFetcher.shouldUseSameTrack).toHaveBeenCalledTimes(1)
+    expect(clearRuntimeSessionSpy).toHaveBeenCalledTimes(1)
+    expect(clearSourceCacheSpy).toHaveBeenCalledTimes(1)
+    expect(subtitlesFetcher.cleanup).toHaveBeenCalledTimes(1)
+    expect(startTranslationSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("ignores source track changes when translation is disabled", async () => {
+    const { adapter, subtitlesFetcher } = createAdapter([
+      { text: "hello", start: 0, end: 500 },
+    ])
+
+    const startTranslationSpy = vi.spyOn(adapter as any, "startTranslation").mockResolvedValue(undefined)
+
+    await adapter.handleSourceTrackChanged()
+
+    expect(subtitlesFetcher.shouldUseSameTrack).not.toHaveBeenCalled()
+    expect(startTranslationSpy).not.toHaveBeenCalled()
+  })
+
+  it("does not reload subtitles when the selected track is unchanged", async () => {
+    const { adapter, subtitlesFetcher } = createAdapter([
+      { text: "hello", start: 0, end: 500 },
+    ])
+
+    ;(adapter as any).subtitlesEnabled = true
+    vi.mocked(subtitlesFetcher.shouldUseSameTrack).mockResolvedValue(true)
+
+    const startTranslationSpy = vi.spyOn(adapter as any, "startTranslation").mockResolvedValue(undefined)
+
+    await adapter.handleSourceTrackChanged()
+
+    expect(subtitlesFetcher.shouldUseSameTrack).toHaveBeenCalledTimes(1)
+    expect(subtitlesFetcher.cleanup).not.toHaveBeenCalled()
+    expect(startTranslationSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/entrypoints/subtitles.content/init-youtube-subtitles.ts
+++ b/src/entrypoints/subtitles.content/init-youtube-subtitles.ts
@@ -1,5 +1,6 @@
 import { YOUTUBE_EMBED_PATH_PATTERN, YOUTUBE_NAVIGATE_FINISH_EVENT, YOUTUBE_WATCH_URL_PATTERN } from "@/utils/constants/subtitles"
-import { setupYoutubeSubtitles } from "./platforms/youtube"
+import { createYoutubeSubtitlesAdapter } from "./platforms/youtube"
+import { createYoutubeCaptionTrackListener } from "./platforms/youtube/caption-track-listener"
 import { getYoutubeConfig } from "./platforms/youtube/config"
 import { mountSubtitlesUI } from "./renderer/mount-subtitles-ui"
 
@@ -13,7 +14,7 @@ function isYoutubeEmbed(): boolean {
 
 export function initYoutubeSubtitles() {
   let initialized = false
-  let mountedAdapter: ReturnType<typeof setupYoutubeSubtitles> | null = null
+  let adapter: ReturnType<typeof createYoutubeSubtitlesAdapter> | null = null
 
   const embedded = isYoutubeEmbed()
   const config = getYoutubeConfig({ embedded })
@@ -23,18 +24,29 @@ export function initYoutubeSubtitles() {
       return
     }
 
-    if (!mountedAdapter) {
-      mountedAdapter = setupYoutubeSubtitles(config)
+    if (!adapter) {
+      adapter = createYoutubeSubtitlesAdapter(config)
     }
 
-    await mountSubtitlesUI({ adapter: mountedAdapter, config })
+    if (!adapter) {
+      return
+    }
+
+    await mountSubtitlesUI({ adapter, config })
 
     if (initialized) {
       return
     }
 
     initialized = true
-    void mountedAdapter.initialize()
+    const trackListener = createYoutubeCaptionTrackListener({
+      playerContainerSelector: config.selectors.playerContainer,
+      onTrackChanged: () => {
+        void adapter?.handleSourceTrackChanged()
+      },
+    })
+    trackListener.start()
+    void adapter.initialize()
   }
 
   void tryInit()

--- a/src/entrypoints/subtitles.content/platforms/youtube/__tests__/caption-track-listener.test.ts
+++ b/src/entrypoints/subtitles.content/platforms/youtube/__tests__/caption-track-listener.test.ts
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { YOUTUBE_NAVIGATE_FINISH_EVENT } from "@/utils/constants/subtitles"
+import { createYoutubeCaptionTrackListener } from "../caption-track-listener"
+
+function flushObserver() {
+  return new Promise(resolve => setTimeout(resolve, 0))
+}
+
+function renderSettingsMenu({
+  expanded = true,
+  menuLabel = "字幕",
+  summary,
+}: {
+  expanded?: boolean
+  menuLabel?: string
+  summary: string
+}) {
+  document.body.innerHTML = `
+    <div id="movie_player" class="html5-video-player">
+      <button class="ytp-settings-button" aria-expanded="${expanded ? "true" : "false"}"></button>
+      <div class="ytp-settings-menu">
+        <div class="ytp-panel-menu" role="menu">
+          <div class="ytp-menuitem" role="menuitem" aria-haspopup="true" tabindex="0">
+            <div class="ytp-menuitem-label">
+              <div>
+                <span>${menuLabel}</span>
+                <span class="ytp-menuitem-label-count"> (1)</span>
+              </div>
+            </div>
+            <div class="ytp-menuitem-content">${summary}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  `
+}
+
+function getSummaryNode() {
+  return document.querySelector<HTMLElement>(".ytp-menuitem-content")
+}
+
+function clickSummaryItem() {
+  document.querySelector<HTMLElement>(".ytp-menuitem")
+    ?.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+}
+
+describe("youtube caption track listener", () => {
+  afterEach(() => {
+    document.body.innerHTML = ""
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("treats the current subtitle summary as the baseline when the menu opens", async () => {
+    renderSettingsMenu({
+      summary: "英语 >> 中文",
+    })
+
+    const onTrackChanged = vi.fn()
+    const listener = createYoutubeCaptionTrackListener({
+      playerContainerSelector: "#movie_player",
+      onTrackChanged,
+    })
+
+    listener.start()
+    await flushObserver()
+
+    expect(listener.getCurrentTrackKey()).toBe("top-level-summary::0::英语 >> 中文")
+    expect(onTrackChanged).not.toHaveBeenCalled()
+  })
+
+  it("forwards changes when the subtitle summary text changes", async () => {
+    renderSettingsMenu({
+      summary: "英语 >> 中文",
+    })
+
+    const onTrackChanged = vi.fn()
+    const listener = createYoutubeCaptionTrackListener({
+      playerContainerSelector: "#movie_player",
+      onTrackChanged,
+    })
+
+    listener.start()
+    await flushObserver()
+
+    getSummaryNode()!.textContent = "英语 (自动生成) >> 阿拉伯语"
+    await flushObserver()
+
+    expect(onTrackChanged).toHaveBeenCalledTimes(1)
+    expect(onTrackChanged.mock.calls[0]?.[0]).toEqual({
+      label: "英语 (自动生成) >> 阿拉伯语",
+      menuHeading: "字幕",
+      trackKey: "top-level-summary::0::英语 (自动生成) >> 阿拉伯语",
+    })
+    expect(onTrackChanged.mock.calls[0]?.[1]).toEqual({
+      label: "英语 >> 中文",
+      menuHeading: "字幕",
+      trackKey: "top-level-summary::0::英语 >> 中文",
+    })
+  })
+
+  it("does not depend on the YouTube UI language for the menu label", async () => {
+    renderSettingsMenu({
+      menuLabel: "Subtitles",
+      summary: "English (auto-generated) >> Arabic",
+    })
+
+    const onTrackChanged = vi.fn()
+    const listener = createYoutubeCaptionTrackListener({
+      playerContainerSelector: "#movie_player",
+      onTrackChanged,
+    })
+
+    listener.start()
+    await flushObserver()
+
+    getSummaryNode()!.textContent = "English >> Spanish"
+    await flushObserver()
+
+    expect(onTrackChanged).toHaveBeenCalledTimes(1)
+    expect(onTrackChanged.mock.calls[0]?.[0]).toEqual({
+      label: "English >> Spanish",
+      menuHeading: "Subtitles",
+      trackKey: "top-level-summary::0::English >> Spanish",
+    })
+    expect(onTrackChanged.mock.calls[0]?.[1]).toEqual({
+      label: "English (auto-generated) >> Arabic",
+      menuHeading: "Subtitles",
+      trackKey: "top-level-summary::0::English (auto-generated) >> Arabic",
+    })
+  })
+
+  it("deduplicates repeated summary values", async () => {
+    renderSettingsMenu({
+      summary: "英语 >> 中文",
+    })
+
+    const onTrackChanged = vi.fn()
+    const listener = createYoutubeCaptionTrackListener({
+      playerContainerSelector: "#movie_player",
+      onTrackChanged,
+    })
+
+    listener.start()
+    await flushObserver()
+
+    getSummaryNode()!.textContent = "英语 (自动生成) >> 阿拉伯语"
+    await flushObserver()
+    getSummaryNode()!.textContent = "英语 (自动生成) >> 阿拉伯语"
+    await flushObserver()
+
+    expect(onTrackChanged).toHaveBeenCalledTimes(1)
+  })
+
+  it("falls back to a delayed reread after a menu click", async () => {
+    vi.useFakeTimers()
+
+    renderSettingsMenu({
+      summary: "英语 >> 中文",
+    })
+
+    const onTrackChanged = vi.fn()
+    const listener = createYoutubeCaptionTrackListener({
+      playerContainerSelector: "#movie_player",
+      onTrackChanged,
+    })
+
+    listener.start()
+    await vi.runAllTimersAsync()
+
+    clickSummaryItem()
+    document.querySelector<HTMLElement>(".ytp-settings-button")?.setAttribute("aria-expanded", "false")
+    getSummaryNode()!.textContent = "英语 (自动生成) >> 阿拉伯语"
+    await vi.advanceTimersByTimeAsync(60)
+
+    expect(onTrackChanged).toHaveBeenCalledTimes(1)
+    expect(onTrackChanged.mock.calls[0]?.[0]).toEqual({
+      label: "英语 (自动生成) >> 阿拉伯语",
+      menuHeading: "字幕",
+      trackKey: "top-level-summary::0::英语 (自动生成) >> 阿拉伯语",
+    })
+    expect(onTrackChanged.mock.calls[0]?.[1]).toEqual({
+      label: "英语 >> 中文",
+      menuHeading: "字幕",
+      trackKey: "top-level-summary::0::英语 >> 中文",
+    })
+  })
+
+  it("rebinds after YouTube navigation", async () => {
+    renderSettingsMenu({
+      summary: "英语 >> 中文",
+    })
+
+    const onTrackChanged = vi.fn()
+    const listener = createYoutubeCaptionTrackListener({
+      playerContainerSelector: "#movie_player",
+      onTrackChanged,
+    })
+
+    listener.start()
+    await flushObserver()
+
+    renderSettingsMenu({
+      summary: "德语 >> 中文",
+    })
+
+    window.dispatchEvent(new Event(YOUTUBE_NAVIGATE_FINISH_EVENT))
+    await flushObserver()
+
+    expect(listener.getCurrentTrackKey()).toBe("top-level-summary::0::德语 >> 中文")
+    expect(onTrackChanged).not.toHaveBeenCalled()
+
+    getSummaryNode()!.textContent = "英语 >> 中文"
+    await flushObserver()
+
+    expect(onTrackChanged).toHaveBeenCalledTimes(1)
+    expect(onTrackChanged.mock.calls[0]?.[0]).toEqual({
+      label: "英语 >> 中文",
+      menuHeading: "字幕",
+      trackKey: "top-level-summary::0::英语 >> 中文",
+    })
+    expect(onTrackChanged.mock.calls[0]?.[1]).toEqual({
+      label: "德语 >> 中文",
+      menuHeading: "字幕",
+      trackKey: "top-level-summary::0::德语 >> 中文",
+    })
+  })
+})

--- a/src/entrypoints/subtitles.content/platforms/youtube/caption-track-listener.ts
+++ b/src/entrypoints/subtitles.content/platforms/youtube/caption-track-listener.ts
@@ -1,0 +1,355 @@
+import { YOUTUBE_NAVIGATE_FINISH_EVENT } from "@/utils/constants/subtitles"
+import { waitForElement } from "@/utils/dom/wait-for-element"
+
+const SETTINGS_BUTTON_SELECTOR = ".ytp-settings-button"
+const SETTINGS_MENU_SELECTOR = ".ytp-settings-menu"
+const MENU_ITEM_SELECTOR = ".ytp-menuitem[role='menuitem']"
+const MENU_ITEM_WITH_SUBMENU_SELECTOR = `${MENU_ITEM_SELECTOR}[aria-haspopup='true']`
+const MENU_ITEM_LABEL_SELECTOR = ".ytp-menuitem-label"
+const MENU_ITEM_CONTENT_SELECTOR = ".ytp-menuitem-content"
+const CLICK_SYNC_DELAY_MS = 50
+
+export interface YoutubeCaptionTrackSnapshot {
+  label: string
+  menuHeading: string | null
+  trackKey: string
+}
+
+type YoutubeTrackChangedHandler = (
+  nextTrack: YoutubeCaptionTrackSnapshot,
+  previousTrack: YoutubeCaptionTrackSnapshot | null,
+) => void
+
+interface YoutubeMenuSummarySnapshot extends YoutubeCaptionTrackSnapshot {
+  slotKey: string
+}
+
+interface YoutubeMenuSummaryChange {
+  next: YoutubeMenuSummarySnapshot
+  previous: YoutubeMenuSummarySnapshot
+}
+
+class YoutubeCaptionTrackListener {
+  // Guards repeated start calls and stale async rebind work.
+  private started = false
+
+  // Monotonic token used to ignore outdated waitForElement results.
+  private bindAttempt = 0
+
+  // The active YouTube settings button inside the current player.
+  private observedSettingsButton: HTMLElement | null = null
+
+  // The currently opened settings menu associated with the active button.
+  private observedSettingsMenu: HTMLElement | null = null
+
+  // Watches aria-expanded on the settings button.
+  private buttonObserver: MutationObserver | null = null
+
+  // Watches summary and selection mutations inside the settings menu.
+  private menuObserver: MutationObserver | null = null
+
+  // Delayed sync used as a fallback when menu clicks close the panel quickly.
+  private clickSyncTimeoutId: ReturnType<typeof setTimeout> | null = null
+
+  // Last observed top-level menu summaries, keyed by stable slot position.
+  private lastMenuSummaryMap: Map<string, YoutubeMenuSummarySnapshot> | null = null
+
+  // Last track-like summary snapshot exposed to callers.
+  private lastTrackedSelection: YoutubeCaptionTrackSnapshot | null = null
+
+  private readonly settingsButtonSelector: string
+
+  constructor(
+    private readonly playerContainerSelector: string,
+    private readonly onTrackChanged: YoutubeTrackChangedHandler,
+  ) {
+    this.settingsButtonSelector = `${playerContainerSelector} ${SETTINGS_BUTTON_SELECTOR}`
+  }
+
+  start() {
+    if (this.started) {
+      return
+    }
+
+    this.started = true
+    window.addEventListener(YOUTUBE_NAVIGATE_FINISH_EVENT, this.handleNavigateFinish)
+    void this.initializeObservers()
+  }
+
+  getCurrentTrackKey() {
+    return this.lastTrackedSelection?.trackKey ?? null
+  }
+
+  private async initializeObservers() {
+    const attempt = ++this.bindAttempt
+    const button = await waitForElement(
+      this.settingsButtonSelector,
+      element => !!element.closest(this.playerContainerSelector),
+    )
+
+    if (
+      !this.started
+      || attempt !== this.bindAttempt
+      || !(button instanceof HTMLElement)
+    ) {
+      return
+    }
+
+    this.attachToSettingsButton(button)
+  }
+
+  private attachToSettingsButton(button: HTMLElement) {
+    if (this.observedSettingsButton === button) {
+      this.syncMenuObserver()
+      return
+    }
+
+    this.disconnectButtonObserver()
+    this.disconnectMenuObserver()
+    this.observedSettingsButton = button
+    this.resetTrackedSelection()
+
+    this.buttonObserver = new MutationObserver(() => {
+      this.syncMenuObserver()
+    })
+    this.buttonObserver.observe(button, {
+      attributes: true,
+      attributeFilter: ["aria-expanded"],
+    })
+
+    this.syncMenuObserver()
+  }
+
+  private syncMenuObserver() {
+    const button = this.observedSettingsButton
+    if (!button || !isSettingsMenuOpen(button)) {
+      this.disconnectMenuObserver()
+      return
+    }
+
+    const menu = this.getCurrentSettingsMenu()
+    if (!menu) {
+      return
+    }
+
+    if (this.observedSettingsMenu !== menu) {
+      this.disconnectMenuObserver()
+      this.observedSettingsMenu = menu
+      menu.addEventListener("click", this.handleMenuClick)
+      this.menuObserver = new MutationObserver(() => {
+        this.syncCurrentSelection(true)
+      })
+      this.menuObserver.observe(menu, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+        attributes: true,
+        attributeFilter: ["aria-checked", "aria-selected", "class", "hidden", "aria-hidden", "style"],
+      })
+    }
+
+    this.syncCurrentSelection(false)
+  }
+
+  private syncCurrentSelection(shouldDispatch: boolean) {
+    const menu = this.observedSettingsMenu ?? this.getCurrentSettingsMenu()
+    if (!menu) {
+      return
+    }
+
+    const currentSummaries = getCurrentSelections(menu)
+    if (currentSummaries.length === 0) {
+      return
+    }
+
+    const currentSummaryMap = new Map(
+      currentSummaries.map(summary => [summary.slotKey, summary] as const),
+    )
+
+    if (!this.lastMenuSummaryMap) {
+      this.lastMenuSummaryMap = currentSummaryMap
+      if (currentSummaries.length === 1) {
+        this.lastTrackedSelection = toPublicSnapshot(currentSummaries[0])
+      }
+      return
+    }
+
+    const changedSummaries = currentSummaries
+      .map((summary) => {
+        const previousSummary = this.lastMenuSummaryMap?.get(summary.slotKey) ?? null
+        if (!previousSummary || previousSummary.trackKey === summary.trackKey) {
+          return null
+        }
+
+        return {
+          next: summary,
+          previous: previousSummary,
+        }
+      })
+      .filter((change): change is YoutubeMenuSummaryChange => change !== null)
+
+    this.lastMenuSummaryMap = currentSummaryMap
+
+    const latestChange = changedSummaries.at(-1)
+    if (!latestChange) {
+      return
+    }
+
+    this.lastTrackedSelection = toPublicSnapshot(latestChange.next)
+
+    if (shouldDispatch) {
+      this.onTrackChanged(
+        toPublicSnapshot(latestChange.next),
+        toPublicSnapshot(latestChange.previous),
+      )
+    }
+  }
+
+  private getCurrentSettingsMenu(): HTMLElement | null {
+    const playerContainer = this.observedSettingsButton?.closest<HTMLElement>(
+      this.playerContainerSelector,
+    )
+    return playerContainer?.querySelector<HTMLElement>(SETTINGS_MENU_SELECTOR) ?? null
+  }
+
+  private scheduleDeferredSync() {
+    if (this.clickSyncTimeoutId !== null) {
+      clearTimeout(this.clickSyncTimeoutId)
+    }
+
+    this.clickSyncTimeoutId = setTimeout(() => {
+      this.clickSyncTimeoutId = null
+      this.syncCurrentSelection(true)
+    }, CLICK_SYNC_DELAY_MS)
+  }
+
+  private clearDeferredSync() {
+    if (this.clickSyncTimeoutId !== null) {
+      clearTimeout(this.clickSyncTimeoutId)
+      this.clickSyncTimeoutId = null
+    }
+  }
+
+  private disconnectButtonObserver() {
+    this.buttonObserver?.disconnect()
+    this.buttonObserver = null
+    this.observedSettingsButton = null
+    this.clearDeferredSync()
+  }
+
+  private disconnectMenuObserver() {
+    this.menuObserver?.disconnect()
+    this.menuObserver = null
+    this.observedSettingsMenu?.removeEventListener("click", this.handleMenuClick)
+    this.observedSettingsMenu = null
+  }
+
+  private resetTrackedSelection() {
+    this.lastMenuSummaryMap = null
+    this.lastTrackedSelection = null
+  }
+
+  private handleMenuClick = (event: Event) => {
+    const menu = this.observedSettingsMenu
+    if (!menu) {
+      return
+    }
+
+    const target = event.target
+    if (!(target instanceof HTMLElement)) {
+      return
+    }
+
+    const clickedItem = target.closest<HTMLElement>(MENU_ITEM_SELECTOR)
+    const clickedRadio = target.closest<HTMLElement>("[role='menuitemradio']")
+    if (
+      (!clickedItem || !menu.contains(clickedItem))
+      && (!clickedRadio || !menu.contains(clickedRadio))
+    ) {
+      return
+    }
+
+    this.scheduleDeferredSync()
+  }
+
+  private handleNavigateFinish = () => {
+    this.disconnectButtonObserver()
+    this.disconnectMenuObserver()
+    this.resetTrackedSelection()
+    void this.initializeObservers()
+  }
+}
+
+export function createYoutubeCaptionTrackListener({
+  playerContainerSelector,
+  onTrackChanged,
+}: {
+  playerContainerSelector: string
+  onTrackChanged: YoutubeTrackChangedHandler
+}) {
+  return new YoutubeCaptionTrackListener(playerContainerSelector, onTrackChanged)
+}
+
+function isSettingsMenuOpen(button: HTMLElement): boolean {
+  return button.getAttribute("aria-expanded") === "true"
+}
+
+function getCurrentSelections(settingsMenu: HTMLElement): YoutubeMenuSummarySnapshot[] {
+  return Array.from(
+    settingsMenu.querySelectorAll<HTMLElement>(MENU_ITEM_WITH_SUBMENU_SELECTOR),
+  )
+    .map((item, index) => getSummarySelection(item, index))
+    .filter((summary): summary is YoutubeMenuSummarySnapshot => summary !== null)
+}
+
+function getSummarySelection(
+  item: HTMLElement,
+  index: number,
+): YoutubeMenuSummarySnapshot | null {
+  const summary = normalizeMenuText(
+    item.querySelector<HTMLElement>(MENU_ITEM_CONTENT_SELECTOR)?.textContent ?? "",
+  )
+  if (!summary) {
+    return null
+  }
+
+  const menuHeading = getMenuItemLabel(item) || null
+  const slotKey = `top-level-summary::${index}`
+
+  return {
+    label: summary,
+    menuHeading,
+    slotKey,
+    trackKey: `${slotKey}::${summary}`,
+  }
+}
+
+function getMenuItemLabel(item: HTMLElement): string {
+  const labelContainer = item.querySelector<HTMLElement>(MENU_ITEM_LABEL_SELECTOR)
+  if (!labelContainer) {
+    return ""
+  }
+
+  const labelParts = Array.from(labelContainer.querySelectorAll<HTMLElement>("span"))
+    .filter(part => !part.classList.contains("ytp-menuitem-label-count"))
+    .map(part => normalizeMenuText(part.textContent ?? ""))
+    .filter(Boolean)
+
+  if (labelParts.length > 0) {
+    return labelParts.join(" ")
+  }
+
+  return normalizeMenuText(labelContainer.textContent ?? "")
+}
+
+function toPublicSnapshot(summary: YoutubeMenuSummarySnapshot): YoutubeCaptionTrackSnapshot {
+  return {
+    label: summary.label,
+    menuHeading: summary.menuHeading,
+    trackKey: summary.trackKey,
+  }
+}
+
+function normalizeMenuText(text: string): string {
+  return text.replace(/\s+/g, " ").trim()
+}

--- a/src/entrypoints/subtitles.content/platforms/youtube/index.ts
+++ b/src/entrypoints/subtitles.content/platforms/youtube/index.ts
@@ -2,9 +2,8 @@ import type { PlatformConfig } from "@/entrypoints/subtitles.content/platforms"
 import { YoutubeSubtitlesFetcher } from "@/utils/subtitles/fetchers"
 import { UniversalVideoAdapter } from "../../universal-adapter"
 
-export function setupYoutubeSubtitles(config: PlatformConfig) {
+export function createYoutubeSubtitlesAdapter(config: PlatformConfig) {
   const subtitlesFetcher = new YoutubeSubtitlesFetcher()
-
   return new UniversalVideoAdapter({
     config,
     subtitlesFetcher,

--- a/src/entrypoints/subtitles.content/subtitles-scheduler.ts
+++ b/src/entrypoints/subtitles.content/subtitles-scheduler.ts
@@ -7,7 +7,7 @@ export class SubtitlesScheduler {
   private videoElement: HTMLVideoElement
   private subtitles: SubtitlesFragment[] = []
   private currentIndex = -1
-  private isActive = false
+  private active = false
   private currentState: StateData = {
     state: "idle",
   }
@@ -20,7 +20,7 @@ export class SubtitlesScheduler {
   }
 
   start() {
-    this.isActive = true
+    this.active = true
     this.updateVisibility()
   }
 
@@ -71,19 +71,23 @@ export class SubtitlesScheduler {
     return this.currentState.state ?? "idle"
   }
 
+  isActive(): boolean {
+    return this.active
+  }
+
   stop() {
-    this.isActive = false
+    this.active = false
     this.detachListeners()
     this.updateVisibility()
   }
 
   show() {
-    this.isActive = true
+    this.active = true
     this.updateVisibility()
   }
 
   hide() {
-    this.isActive = false
+    this.active = false
     this.updateVisibility()
   }
 
@@ -122,7 +126,7 @@ export class SubtitlesScheduler {
   }
 
   private handleTimeUpdate = () => {
-    if (!this.isActive)
+    if (!this.active)
       return
 
     const currentTime = this.videoElement.currentTime
@@ -130,7 +134,7 @@ export class SubtitlesScheduler {
   }
 
   private handleSeeking = () => {
-    if (!this.isActive)
+    if (!this.active)
       return
 
     const currentTime = this.videoElement.currentTime
@@ -168,6 +172,6 @@ export class SubtitlesScheduler {
   }
 
   private updateVisibility() {
-    subtitlesStore.set(subtitlesVisibleAtom, this.isActive)
+    subtitlesStore.set(subtitlesVisibleAtom, this.active)
   }
 }

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -31,6 +31,8 @@ export class UniversalVideoAdapter {
   private subtitlesFetcher: SubtitlesFetcher
   private navigationReinitTimeoutId: ReturnType<typeof setTimeout> | null = null
   private hasPendingNavigationReset = false
+  private subtitlesEnabled = false
+  private trackChangeRefreshPromise: Promise<void> | null = null
 
   private sourceSubtitles: SubtitlesFragment[] = []
   private sourceProcessedSubtitles: SubtitlesFragment[] = []
@@ -81,6 +83,17 @@ export class UniversalVideoAdapter {
 
   toggleSubtitlesManually = (enabled: boolean) => {
     this.toggleSubtitlesWithSource(enabled, "manual")
+  }
+
+  async handleSourceTrackChanged(): Promise<void> {
+    if (!this.trackChangeRefreshPromise) {
+      this.trackChangeRefreshPromise = this.refreshSourceTrackIfNeeded()
+        .finally(() => {
+          this.trackChangeRefreshPromise = null
+        })
+    }
+
+    await this.trackChangeRefreshPromise
   }
 
   downloadSourceSubtitles = async () => {
@@ -316,6 +329,8 @@ export class UniversalVideoAdapter {
   }
 
   private handleToggleSubtitles(enabled: boolean, analyticsContext?: FeatureUsageContext) {
+    this.subtitlesEnabled = enabled
+
     if (enabled) {
       this.subtitlesScheduler?.start()
       this.subtitlesScheduler?.show()
@@ -327,6 +342,25 @@ export class UniversalVideoAdapter {
       this.showNativeSubtitles()
       this.translationCoordinator?.stop()
     }
+  }
+
+  private async refreshSourceTrackIfNeeded(): Promise<void> {
+    if (!this.subtitlesEnabled) {
+      return
+    }
+
+    const useSameTrack = await this.subtitlesFetcher.shouldUseSameTrack()
+    if (useSameTrack) {
+      return
+    }
+
+    this.clearRuntimeSession()
+    this.clearSourceCache()
+    this.subtitlesFetcher.cleanup()
+    this.subtitlesScheduler?.reset()
+    this.subtitlesScheduler?.setState("loading")
+
+    await this.startTranslation()
   }
 
   private showNativeSubtitles() {

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -31,7 +31,6 @@ export class UniversalVideoAdapter {
   private subtitlesFetcher: SubtitlesFetcher
   private navigationReinitTimeoutId: ReturnType<typeof setTimeout> | null = null
   private hasPendingNavigationReset = false
-  private subtitlesEnabled = false
   private trackChangeRefreshPromise: Promise<void> | null = null
 
   private sourceSubtitles: SubtitlesFragment[] = []
@@ -329,8 +328,6 @@ export class UniversalVideoAdapter {
   }
 
   private handleToggleSubtitles(enabled: boolean, analyticsContext?: FeatureUsageContext) {
-    this.subtitlesEnabled = enabled
-
     if (enabled) {
       this.subtitlesScheduler?.start()
       this.subtitlesScheduler?.show()
@@ -345,7 +342,8 @@ export class UniversalVideoAdapter {
   }
 
   private async refreshSourceTrackIfNeeded(): Promise<void> {
-    if (!this.subtitlesEnabled) {
+    const scheduler = this.subtitlesScheduler
+    if (!scheduler || !scheduler.isActive()) {
       return
     }
 
@@ -357,8 +355,8 @@ export class UniversalVideoAdapter {
     this.clearRuntimeSession()
     this.clearSourceCache()
     this.subtitlesFetcher.cleanup()
-    this.subtitlesScheduler?.reset()
-    this.subtitlesScheduler?.setState("loading")
+    scheduler.reset()
+    scheduler.setState("loading")
 
     await this.startTranslation()
   }

--- a/src/utils/subtitles/__tests__/youtube-fetcher.test.ts
+++ b/src/utils/subtitles/__tests__/youtube-fetcher.test.ts
@@ -64,6 +64,7 @@ describe("youtube subtitles fetcher", () => {
                 cver: null,
                 playerState: 1,
                 selectedTrackLanguageCode: null,
+                selectedTrackVssId: null,
                 cachedTimedtextUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=en",
               },
             },
@@ -97,6 +98,7 @@ describe("youtube subtitles fetcher", () => {
       cver: null,
       playerState: 0,
       selectedTrackLanguageCode: "en",
+      selectedTrackVssId: ".en",
       cachedTimedtextUrl: null,
     }
 
@@ -138,6 +140,7 @@ describe("youtube subtitles fetcher", () => {
       cver: null,
       playerState: 1,
       selectedTrackLanguageCode: "en",
+      selectedTrackVssId: ".en",
       cachedTimedtextUrl: null,
     }
     const cachedSubtitles = [{ text: "cached", start: 0, end: 1 }]
@@ -177,6 +180,7 @@ describe("youtube subtitles fetcher", () => {
       cver: null,
       playerState: 0,
       selectedTrackLanguageCode: "en",
+      selectedTrackVssId: ".en",
       cachedTimedtextUrl: null,
     }
 
@@ -219,6 +223,7 @@ describe("youtube subtitles fetcher", () => {
       cver: null,
       playerState: 0,
       selectedTrackLanguageCode: "en",
+      selectedTrackVssId: ".en",
       cachedTimedtextUrl: null,
     }
     const refreshedPlayerData = {
@@ -229,6 +234,7 @@ describe("youtube subtitles fetcher", () => {
         vssId: ".fr",
       }],
       selectedTrackLanguageCode: "fr",
+      selectedTrackVssId: ".fr",
     }
 
     vi.spyOn(fetcher as any, "requestPlayerData").mockResolvedValue({
@@ -249,6 +255,52 @@ describe("youtube subtitles fetcher", () => {
     expect(processRawEventsSpy).toHaveBeenCalledTimes(1)
     expect(waitForPlayerStateSpy).toHaveBeenCalledTimes(1)
     expect(getPlayerDataWithPotSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("prefers the selected vssId when multiple tracks share the same language", async () => {
+    const fetcher = new YoutubeSubtitlesFetcher()
+
+    Object.defineProperty(window, "location", {
+      value: { search: "?v=test123", origin: "https://www.youtube.com", pathname: "/watch", hostname: "www.youtube.com" },
+      writable: true,
+    })
+
+    const playerData = {
+      videoId: "test123",
+      captionTracks: [
+        {
+          baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=en&fmt=vtt",
+          languageCode: "en",
+          vssId: ".en",
+        },
+        {
+          baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=en&kind=asr",
+          languageCode: "en",
+          kind: "asr",
+          vssId: "a.en",
+        },
+      ],
+      audioCaptionTracks: [],
+      device: null,
+      cver: null,
+      playerState: 1,
+      selectedTrackLanguageCode: "en",
+      selectedTrackVssId: "a.en",
+      cachedTimedtextUrl: null,
+    }
+
+    vi.spyOn(fetcher as any, "requestPlayerData").mockResolvedValue({
+      success: true,
+      data: playerData,
+    })
+    const fetchWithRetrySpy = vi.spyOn(fetcher as any, "fetchWithRetry").mockResolvedValue([])
+    const processRawEventsSpy = vi.spyOn(fetcher as any, "processRawEvents").mockResolvedValue([])
+
+    await expect(fetcher.fetch()).resolves.toEqual([])
+
+    expect(fetchWithRetrySpy).toHaveBeenCalledTimes(1)
+    expect(fetchWithRetrySpy.mock.calls[0]?.[0]).toContain("kind=asr")
+    expect(processRawEventsSpy).toHaveBeenCalledTimes(1)
   })
 
   it("returns raw parser fragments for non-AI standard subtitles", async () => {

--- a/src/utils/subtitles/fetchers/youtube/index.ts
+++ b/src/utils/subtitles/fetchers/youtube/index.ts
@@ -153,7 +153,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
       return null
     }
 
-    const track = this.selectTrack(response.data.captionTracks, response.data.selectedTrackLanguageCode)
+    const track = this.selectTrack(response.data)
     return this.buildTrackHash(videoId, track)
   }
 
@@ -183,7 +183,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     }
 
     const playerData = response.data
-    const track = this.selectTrack(playerData.captionTracks, playerData.selectedTrackLanguageCode)
+    const track = this.selectTrack(playerData)
     const currentHash = this.buildTrackHash(videoId, track)
 
     if (!track) {
@@ -222,8 +222,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
     await this.waitForPlayerState(videoId)
 
     const playerData = await this.getPlayerDataWithPot(videoId)
-    const track = this.selectTrack(playerData.captionTracks, playerData.selectedTrackLanguageCode)
-      ?? preferredTrack
+    const track = this.selectTrack(playerData) ?? preferredTrack
 
     if (!track) {
       throw new OverlaySubtitlesError(i18n.t("subtitles.errors.noSubtitlesFound"))
@@ -339,13 +338,27 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
    * 4. Auto-generated ASR subtitles (lower quality but better than nothing)
    * 5. First available track as fallback
    */
-  private selectTrack(tracks: CaptionTrack[], selectedLanguageCode: string | null): CaptionTrack | null {
+  private selectTrack(
+    playerData: PlayerData,
+  ): CaptionTrack | null {
+    const {
+      captionTracks: tracks,
+      selectedTrackLanguageCode,
+      selectedTrackVssId,
+    } = playerData
+
     if (tracks.length === 0)
       return null
 
     // Priority 1: User's selected track in YouTube player
-    if (selectedLanguageCode) {
-      const selectedTrack = tracks.find(t => t.languageCode === selectedLanguageCode)
+    if (selectedTrackVssId) {
+      const selectedTrack = tracks.find(t => t.vssId === selectedTrackVssId)
+      if (selectedTrack)
+        return selectedTrack
+    }
+
+    if (selectedTrackLanguageCode) {
+      const selectedTrack = tracks.find(t => t.languageCode === selectedTrackLanguageCode)
       if (selectedTrack)
         return selectedTrack
     }

--- a/src/utils/subtitles/fetchers/youtube/types.ts
+++ b/src/utils/subtitles/fetchers/youtube/types.ts
@@ -24,6 +24,7 @@ export interface PlayerData {
   cver: string | null
   playerState: number
   selectedTrackLanguageCode: string | null
+  selectedTrackVssId: string | null
   cachedTimedtextUrl: string | null
 }
 


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] 🐛 Bug fix (fix)
- [x] ✅ Test related (test)
- [ ] ✨ New feature (feat)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

- refresh overlay subtitles when the selected YouTube caption track changes
- capture the selected caption track `vssId` from the player so the fetcher can distinguish tracks that share the same language code
- add a YouTube settings-menu listener plus regression tests around track switching and fetcher selection

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #1446 

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [x] Added unit tests
- [ ] Verified through manual testing

Executed:
- `SKIP_FREE_API=true pnpm vitest run src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts src/entrypoints/subtitles.content/platforms/youtube/__tests__/caption-track-listener.test.ts src/utils/subtitles/__tests__/youtube-fetcher.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- branch push hooks also passed `nx run @read-frog/extension:lint`, `type-check`, and `test`

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

N/A

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- includes a patch changeset for `@read-frog/extension`
- current listener implementation is scoped to the existing branch contents; follow-up tightening can happen in a separate PR if needed
