### PR TITLE
fix(subtitles): skip same-language subtitle translation

### DIFF
--- a/.changeset/subtitles-same-language-skip.md
+++ b/.changeset/subtitles-same-language-skip.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(subtitles): skip same-language subtitle translation

--- a/src/entrypoints/subtitles.content/ui/subtitles-view.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-view.tsx
@@ -4,6 +4,7 @@ import { Activity, useRef } from "react"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { SUBTITLES_VIEW_CLASS } from "@/utils/constants/subtitles"
 import { cn } from "@/utils/styles/utils"
+import { currentSubtitleAtom } from "../atoms"
 import { MainSubtitle, TranslationSubtitle } from "./subtitle-lines"
 import { useSubtitlesUI } from "./subtitles-ui-context"
 import { useControlsInfo } from "./use-controls-visible"
@@ -14,12 +15,15 @@ interface SubtitlesViewProps {
 }
 
 function SubtitlesContent() {
+  const subtitle = useAtomValue(currentSubtitleAtom)
   const { style } = useAtomValue(configFieldsAtomMap.videoSubtitles)
   const { displayMode, translationPosition, container } = style
 
   const translationAbove = translationPosition === "above"
   const showMain = displayMode !== "translationOnly"
+  const isDuplicateTranslation = !!subtitle?.translation && subtitle.translation === subtitle.text
   const showTranslation = displayMode !== "originalOnly"
+    && !(displayMode === "bilingual" && isDuplicateTranslation)
 
   const containerStyle = {
     backgroundColor: `rgba(0, 0, 0, ${container.backgroundOpacity / 100})`,

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -10,6 +10,7 @@ import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
 import { getProviderConfigById } from "@/utils/config/helpers"
 import { getLocalConfig } from "@/utils/config/storage"
 import { HIDE_NATIVE_CAPTIONS_STYLE_ID, NAVIGATION_HANDLER_DELAY, TRANSLATE_BUTTON_CONTAINER_ID } from "@/utils/constants/subtitles"
+import { resolveLanguageCodeFromLocale } from "@/utils/content/page-language"
 import { waitForElement } from "@/utils/dom/wait-for-element"
 import { OverlaySubtitlesError, ToastSubtitlesError } from "@/utils/subtitles/errors"
 import { optimizeSubtitles } from "@/utils/subtitles/processor/optimizer"
@@ -365,16 +366,23 @@ export class UniversalVideoAdapter {
   private async startTranslation(analyticsContext?: FeatureUsageContext) {
     try {
       const currentVideoId = this.config.getVideoId?.() ?? ""
-      const hasCurrentSession = this.translationCoordinator !== null && this.sessionVideoId === currentVideoId
+      const hasCurrentSession = this.sessionProcessedFragments.length > 0 && this.sessionVideoId === currentVideoId
       this.sessionVideoId = currentVideoId
 
       const useSameTrack = await this.subtitlesFetcher.shouldUseSameTrack()
 
       if (useSameTrack && hasCurrentSession) {
-        // Clear failed states to allow retry on resume
-        this.translationCoordinator?.clearFailed()
-        this.segmentationPipeline?.clearFailedStarts()
-        this.translationCoordinator?.start()
+        // Translated sessions create a coordinator; passthrough sessions only cache rendered fragments.
+        if (this.translationCoordinator) {
+          // Clear failed states to allow retry on resume
+          this.translationCoordinator.clearFailed()
+          this.segmentationPipeline?.clearFailedStarts()
+          this.translationCoordinator.start()
+        }
+        else {
+          this.subtitlesScheduler?.supplementSubtitles(this.sessionProcessedFragments)
+          this.subtitlesScheduler?.setState("idle")
+        }
         if (analyticsContext) {
           void trackFeatureUsed({
             ...analyticsContext,
@@ -393,7 +401,12 @@ export class UniversalVideoAdapter {
       await this.getOrLoadSourceSubtitles()
       this.sessionSubtitles = this.sourceSubtitles
 
-      await this.processSubtitles()
+      if (await this.shouldSkipTranslationForCurrentTrack()) {
+        this.processPassthroughSubtitles()
+      }
+      else {
+        await this.processTranslatedSubtitles()
+      }
       if (analyticsContext) {
         void trackFeatureUsed({
           ...analyticsContext,
@@ -419,7 +432,28 @@ export class UniversalVideoAdapter {
     }
   }
 
-  private async processSubtitles() {
+  private async shouldSkipTranslationForCurrentTrack(): Promise<boolean> {
+    const config = await getLocalConfig()
+    const targetLanguage = config?.language.targetCode
+    const sourceLanguage = resolveLanguageCodeFromLocale(this.subtitlesFetcher.getSourceLanguage())
+
+    if (!targetLanguage || !sourceLanguage) {
+      return false
+    }
+
+    return sourceLanguage === targetLanguage
+  }
+
+  private processPassthroughSubtitles() {
+    this.sessionProcessedFragments = this.sourceProcessedSubtitles.map(fragment => ({
+      ...fragment,
+      translation: fragment.text,
+    }))
+    this.subtitlesScheduler?.supplementSubtitles(this.sessionProcessedFragments)
+    this.subtitlesScheduler?.setState("idle")
+  }
+
+  private async processTranslatedSubtitles() {
     const scheduler = this.subtitlesScheduler
     if (!scheduler)
       return


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

- Skip subtitle translation in the shared adapter when the source track language matches the configured target language.
- Reuse the existing subtitle rendering pipeline by copying passthrough source text into `translation` for same-language tracks.
- Avoid rendering duplicate lines in bilingual mode when passthrough subtitles would otherwise show the same text twice.
- Add a patch changeset for `@read-frog/extension`.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #1442

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing
- Ran `pnpm exec eslint src/entrypoints/subtitles.content/universal-adapter.ts src/entrypoints/subtitles.content/ui/subtitles-view.tsx`
- Ran `pnpm exec tsc --noEmit`

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

N/A

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- This branch starts from `main`, so it does not include the separate YouTube caption-track refresh work.
- Same-language skipping now applies at the shared `startTranslation()` entry point for platforms that provide `getSourceLanguage()`.
