### PR TITLE
feat(translate): persist page translation for same-tab links

### DIFF
--- a/.changeset/remember-tab-translation.md
+++ b/.changeset/remember-tab-translation.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat: keep page translation enabled across same-tab link navigations

--- a/src/entrypoints/background/__tests__/translation-signal.test.ts
+++ b/src/entrypoints/background/__tests__/translation-signal.test.ts
@@ -188,4 +188,37 @@ describe("translationMessage", () => {
       analyticsContext: undefined,
     }, 42)
   })
+
+  it("keeps page translation enabled across same-tab link navigations", async () => {
+    await setupSubject()
+
+    const navigationHandler = webNavigationOnCommittedAddListenerMock.mock.calls[0]?.[0]
+    expect(navigationHandler).toBeTypeOf("function")
+
+    await navigationHandler({ tabId: 42, frameId: 0, transitionType: "link" })
+
+    expect(storageRemoveItemMock).not.toHaveBeenCalledWith(getTranslationStateKey(42))
+  })
+
+  it("clears page translation state for typed same-tab navigations", async () => {
+    await setupSubject()
+
+    const navigationHandler = webNavigationOnCommittedAddListenerMock.mock.calls[0]?.[0]
+    expect(navigationHandler).toBeTypeOf("function")
+
+    await navigationHandler({ tabId: 42, frameId: 0, transitionType: "typed" })
+
+    expect(storageRemoveItemMock).toHaveBeenCalledWith(getTranslationStateKey(42))
+  })
+
+  it("clears page translation state when the tab is closed", async () => {
+    await setupSubject()
+
+    const tabRemovedHandler = tabsOnRemovedAddListenerMock.mock.calls[0]?.[0]
+    expect(tabRemovedHandler).toBeTypeOf("function")
+
+    await tabRemovedHandler(42)
+
+    expect(storageRemoveItemMock).toHaveBeenCalledWith(getTranslationStateKey(42))
+  })
 })

--- a/src/entrypoints/background/translation-signal.ts
+++ b/src/entrypoints/background/translation-signal.ts
@@ -16,6 +16,17 @@ function notifyPageTranslationStateChanged(tabId: number, enabled: boolean) {
     .catch(error => logger.warn("Failed to notify page translation state change", error))
 }
 
+const PRESERVE_TRANSLATION_STATE_NAVIGATION_TYPES = new Set([
+  "link",
+  "form_submit",
+  "reload",
+])
+
+function shouldPreserveTranslationStateForNavigation(transitionType?: string): boolean {
+  return typeof transitionType === "string"
+    && PRESERVE_TRANSLATION_STATE_NAVIGATION_TYPES.has(transitionType)
+}
+
 function requestManagerToTogglePageTranslation(
   tabId: number,
   enabled: boolean,
@@ -132,10 +143,11 @@ export function translationMessage() {
     await storage.removeItem(getTranslationStateKey(tabId))
   })
 
-  // Clear translation state when navigating to a new page in the same tab
   browser.webNavigation.onCommitted.addListener(async (details) => {
-    // Only handle main frame navigations, not iframes
     if (details.frameId !== 0)
+      return
+
+    if (shouldPreserveTranslationStateForNavigation(details.transitionType))
       return
 
     await storage.removeItem(getTranslationStateKey(details.tabId))


### PR DESCRIPTION
## Summary
- Keeps manual page translation enabled when the current tab performs link/form/reload main-frame navigations.
- Still clears the tab translation state for typed/address-bar navigations and when the tab closes, preserving the intent of #827.
- Adds regression coverage for link navigation persistence, typed navigation reset, and tab-close cleanup.

## Test Plan
- `SKIP_FREE_API=true pnpm exec vitest run src/entrypoints/background/__tests__/translation-signal.test.ts`
- `pnpm exec eslint src/entrypoints/background/translation-signal.ts src/entrypoints/background/__tests__/translation-signal.test.ts`
- `pnpm type-check`
- Pre-push hook: `nx run @read-frog/extension:lint`, `nx run @read-frog/extension:type-check`, `nx run @read-frog/extension:test` (136 test files / 1175 tests passed)

## Screenshots
Not applicable: background navigation-state behavior only; no visual UI change.

Closes #1500
Refs #1346
