### PR TITLE
fix(providers): disable thinking for Doubao Seed

### DIFF
--- a/.changeset/volcengine-doubao-thinking-defaults.md
+++ b/.changeset/volcengine-doubao-thinking-defaults.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(providers): disable thinking by default for Doubao Seed models

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -194,6 +194,31 @@ describe("getProviderOptions", () => {
       expect(cerebrasOptions.cerebras?.reasoningEffort).toBe("none")
     })
 
+    it("should apply Volcengine Doubao Seed thinking defaults with optional version suffixes", () => {
+      const twoLiteVersionedOptions = getProviderOptions("doubao-seed-2-0-lite-260428", "volcengine")
+      expect(twoLiteVersionedOptions.volcengine?.thinking).toEqual({ type: "disabled" })
+
+      const oneFlashVersionedOptions = getProviderOptions("doubao-seed-1-6-flash-250828", "volcengine")
+      expect(oneFlashVersionedOptions.volcengine?.thinking).toEqual({ type: "disabled" })
+
+      const codePreviewVersionedOptions = getProviderOptions("doubao-seed-code-preview-251028", "volcengine")
+      expect(codePreviewVersionedOptions.volcengine?.thinking).toEqual({ type: "disabled" })
+
+      const twoLiteOptions = getProviderOptions("doubao-seed-2-0-lite", "volcengine")
+      expect(twoLiteOptions.volcengine?.thinking).toEqual({ type: "disabled" })
+
+      const oneSixOptions = getProviderOptions("doubao-seed-1-6", "volcengine")
+      expect(oneSixOptions.volcengine?.thinking).toEqual({ type: "disabled" })
+
+      const prefixedOptions = getProviderOptions("volcengine/doubao-seed-1-8", "openai-compatible")
+      expect(prefixedOptions["openai-compatible"]?.thinking).toEqual({ type: "disabled" })
+    })
+
+    it("should not apply Doubao Seed thinking defaults to unrelated Doubao models", () => {
+      expect(getProviderOptions("doubao-seedance-2-0-pro", "volcengine")).toEqual({})
+      expect(getProviderOptions("doubao-seed-1-6-thinking-250715", "volcengine")).toEqual({})
+    })
+
     it("should apply broadened Qwen defaults to provider-prefixed model ids", () => {
       const groqOptions = getProviderOptions("qwen/qwen3-32b", "groq")
       expect(groqOptions.groq?.enableThinking).toBe(false)

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -169,6 +169,13 @@ export const LLM_MODEL_OPTIONS: Array<{
     options: { reasoningEffort: "none" } satisfies GroqProviderOptions as Record<string, JSONValue>,
   },
 
+  // Volcengine Doubao Seed models - disable thinking by default.
+  // Keep the version suffix optional because non-Volcengine providers may expose the same model family without it.
+  {
+    pattern: /(?:^|\/)doubao-seed-(?:code-preview|1-(?:6(?:-(?:flash|vision))?|8)|2-0-(?:lite|mini|pro|code-preview))(?:-\d{6})?$/i,
+    options: { thinking: { type: "disabled" } } satisfies Record<string, JSONValue>,
+  },
+
   // DeepSeek reasoning models - disable thinking by default
   {
     pattern: /^deepseek-(?:reasoner|v4-(?:flash|pro))$/,


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Adds a provider-agnostic Doubao Seed model-name rule that recommends `thinking: { type: "disabled" }` for supported Volcengine Ark Doubao Seed chat models.

The matcher keeps the six-digit version suffix optional so third-party provider model IDs without the date suffix still receive the same default, while excluding unrelated Doubao families such as Seedance and explicit thinking-only variants.

Also adds unit coverage for versioned, unversioned, provider-prefixed, cross-provider, and negative model IDs.

## Related Issue

No linked issue.

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Focused test:

```bash
SKIP_FREE_API=true pnpm test src/utils/constants/__tests__/model.test.ts
```

Pre-push also passed lint, type-check, and the full test suite.

## Screenshots

Not applicable.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Changeset included as a patch release note.