### PR TITLE
fix(translate): persist same-origin page translation

### DIFF
--- a/.changeset/same-origin-page-translation.md
+++ b/.changeset/same-origin-page-translation.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix: keep page translation enabled across same-origin navigation

--- a/src/entrypoints/background/__tests__/translation-signal.test.ts
+++ b/src/entrypoints/background/__tests__/translation-signal.test.ts
@@ -46,6 +46,14 @@ function getHandler(name: string) {
   return handler
 }
 
+function getOnCommittedListener() {
+  const listener = webNavigationOnCommittedAddListenerMock.mock.calls.at(-1)?.[0]
+  if (!listener) {
+    throw new Error("Expected webNavigation.onCommitted listener to be registered")
+  }
+  return listener as (details: { tabId: number, frameId: number, url: string }) => Promise<void>
+}
+
 async function setupSubject() {
   const { translationMessage } = await import("../translation-signal")
   translationMessage()
@@ -77,25 +85,43 @@ describe("translationMessage", () => {
     await setupSubject()
 
     await getHandler("setAndNotifyPageTranslationStateChangedByManager")({
-      data: { enabled: true },
+      data: { enabled: true, url: "https://example.com/articles/1" },
       sender: { tab: { id: 42 }, frameId: 0 },
     })
 
-    expect(storageSetItemMock).toHaveBeenCalledWith(getTranslationStateKey(42), { enabled: true })
+    expect(storageSetItemMock).toHaveBeenCalledWith(getTranslationStateKey(42), {
+      enabled: true,
+      origin: "https://example.com",
+    })
     expect(sendMessageMock).toHaveBeenCalledWith("notifyTranslationStateChanged", { enabled: true }, 42)
     expect(injectHostContentIntoTabIframesMock).toHaveBeenCalledWith(42)
   })
 
-  it("does not reinject every iframe when an iframe manager echoes enabled state", async () => {
+  it("does not overwrite tab state or reinject every iframe when an iframe manager echoes enabled state", async () => {
     await setupSubject()
+    storageGetItemMock.mockResolvedValue({ enabled: true, origin: "https://example.com" })
 
     await getHandler("setAndNotifyPageTranslationStateChangedByManager")({
-      data: { enabled: true },
+      data: { enabled: true, url: "https://embed.example.net/frame" },
       sender: { tab: { id: 42 }, frameId: 7 },
     })
 
-    expect(storageSetItemMock).toHaveBeenCalledWith(getTranslationStateKey(42), { enabled: true })
+    expect(storageSetItemMock).not.toHaveBeenCalled()
     expect(sendMessageMock).toHaveBeenCalledWith("notifyTranslationStateChanged", { enabled: true }, 42)
+    expect(injectHostContentIntoTabIframesMock).not.toHaveBeenCalled()
+  })
+
+  it("ignores enabled iframe manager echoes when tab translation is not already active", async () => {
+    await setupSubject()
+    storageGetItemMock.mockResolvedValue(undefined)
+
+    await getHandler("setAndNotifyPageTranslationStateChangedByManager")({
+      data: { enabled: true, url: "https://embed.example.net/frame" },
+      sender: { tab: { id: 42 }, frameId: 7 },
+    })
+
+    expect(storageSetItemMock).not.toHaveBeenCalled()
+    expect(sendMessageMock).not.toHaveBeenCalledWith("notifyTranslationStateChanged", { enabled: true }, 42)
     expect(injectHostContentIntoTabIframesMock).not.toHaveBeenCalled()
   })
 
@@ -187,5 +213,44 @@ describe("translationMessage", () => {
       enabled: true,
       analyticsContext: undefined,
     }, 42)
+  })
+
+  it("keeps enabled translation state on same-origin top-frame navigation", async () => {
+    await setupSubject()
+    storageGetItemMock.mockResolvedValue({ enabled: true, origin: "https://example.com" })
+
+    await getOnCommittedListener()({
+      tabId: 42,
+      frameId: 0,
+      url: "https://example.com/articles/2?from=feed#comments",
+    })
+
+    expect(storageRemoveItemMock).not.toHaveBeenCalled()
+  })
+
+  it("clears enabled translation state on cross-origin top-frame navigation", async () => {
+    await setupSubject()
+    storageGetItemMock.mockResolvedValue({ enabled: true, origin: "https://example.com" })
+
+    await getOnCommittedListener()({
+      tabId: 42,
+      frameId: 0,
+      url: "https://other.example.com/articles/2",
+    })
+
+    expect(storageRemoveItemMock).toHaveBeenCalledWith(getTranslationStateKey(42))
+  })
+
+  it("does not clear translation state for iframe navigations", async () => {
+    await setupSubject()
+
+    await getOnCommittedListener()({
+      tabId: 42,
+      frameId: 3,
+      url: "https://other.example.com/frame",
+    })
+
+    expect(storageGetItemMock).not.toHaveBeenCalled()
+    expect(storageRemoveItemMock).not.toHaveBeenCalled()
   })
 })

--- a/src/entrypoints/background/page-translation-state.ts
+++ b/src/entrypoints/background/page-translation-state.ts
@@ -1,17 +1,31 @@
 import type { TranslationState } from "@/types/translation-state"
 import { storage } from "#imports"
 import { getTranslationStateKey } from "@/utils/constants/storage-keys"
+import { getPageTranslationOriginScope } from "@/utils/url"
 
-export async function getPageTranslationEnabled(tabId: number): Promise<boolean> {
-  const state = await storage.getItem<TranslationState>(
+export async function getPageTranslationState(tabId: number): Promise<TranslationState | null> {
+  return await storage.getItem<TranslationState>(
     getTranslationStateKey(tabId),
   )
+}
+
+export async function getPageTranslationEnabled(tabId: number): Promise<boolean> {
+  const state = await getPageTranslationState(tabId)
   return state?.enabled ?? false
 }
 
-export async function setPageTranslationEnabled(tabId: number, enabled: boolean): Promise<void> {
+export async function setPageTranslationEnabled(tabId: number, enabled: boolean, url?: string): Promise<void> {
+  const origin = enabled && url ? getPageTranslationOriginScope(url) : null
+
   await storage.setItem<TranslationState>(
     getTranslationStateKey(tabId),
-    { enabled },
+    origin ? { enabled, origin } : { enabled },
   )
+}
+
+export function isPageTranslationStateInUrlScope(state: TranslationState | null | undefined, url: string | undefined): boolean {
+  if (!state?.enabled || !state.origin || !url)
+    return false
+
+  return state.origin === getPageTranslationOriginScope(url)
 }

--- a/src/entrypoints/background/translation-signal.ts
+++ b/src/entrypoints/background/translation-signal.ts
@@ -9,7 +9,12 @@ import { shouldEnableAutoTranslation } from "@/utils/host/translate/auto-transla
 import { logger } from "@/utils/logger"
 import { onMessage, sendMessage } from "@/utils/message"
 import { injectHostContentIntoCurrentTabIframesAfterNodeTranslation, injectHostContentIntoTabIframes } from "./iframe-injection"
-import { getPageTranslationEnabled, setPageTranslationEnabled } from "./page-translation-state"
+import {
+  getPageTranslationEnabled,
+  getPageTranslationState,
+  isPageTranslationStateInUrlScope,
+  setPageTranslationEnabled,
+} from "./page-translation-state"
 
 function notifyPageTranslationStateChanged(tabId: number, enabled: boolean) {
   void sendMessage("notifyTranslationStateChanged", { enabled }, tabId)
@@ -23,6 +28,10 @@ function requestManagerToTogglePageTranslation(
 ) {
   void sendMessage("askManagerToTogglePageTranslation", { enabled, analyticsContext }, tabId)
     .catch(error => logger.warn("Failed to ask page translation manager to toggle", error))
+}
+
+function isIframe(frameId: number | undefined): boolean {
+  return frameId !== undefined && frameId !== 0
 }
 
 export function translationMessage() {
@@ -107,13 +116,25 @@ export function translationMessage() {
 
   onMessage("setAndNotifyPageTranslationStateChangedByManager", async (msg) => {
     const tabId = msg.sender?.tab?.id
-    const { enabled } = msg.data
+    const { enabled, url } = msg.data
     if (typeof tabId === "number") {
-      await setPageTranslationEnabled(tabId, enabled)
+      const senderFrameId = msg.sender?.frameId
+
+      if (enabled && isIframe(senderFrameId)) {
+        // Iframe enabled echoes only synchronize UI; they must not write
+        // tab-level state because that state is scoped to the top-frame origin.
+        const currentState = await getPageTranslationState(tabId)
+        if (!currentState?.enabled)
+          return
+
+        notifyPageTranslationStateChanged(tabId, true)
+        return
+      }
+
+      await setPageTranslationEnabled(tabId, enabled, url ?? msg.sender?.tab?.url)
       notifyPageTranslationStateChanged(tabId, enabled)
 
-      const senderFrameId = msg.sender?.frameId
-      if (enabled && (senderFrameId === 0 || senderFrameId === undefined)) {
+      if (enabled && !isIframe(senderFrameId)) {
         void injectHostContentIntoTabIframes(tabId)
       }
     }
@@ -132,10 +153,17 @@ export function translationMessage() {
     await storage.removeItem(getTranslationStateKey(tabId))
   })
 
-  // Clear translation state when navigating to a new page in the same tab
+  // Clear translation state only when the tab leaves the origin where it was enabled.
   browser.webNavigation.onCommitted.addListener(async (details) => {
     // Only handle main frame navigations, not iframes
     if (details.frameId !== 0)
+      return
+
+    const state = await getPageTranslationState(details.tabId)
+    if (!state?.enabled)
+      return
+
+    if (isPageTranslationStateInUrlScope(state, details.url))
       return
 
     await storage.removeItem(getTranslationStateKey(details.tabId))

--- a/src/entrypoints/host.content/__tests__/runtime.test.ts
+++ b/src/entrypoints/host.content/__tests__/runtime.test.ts
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+
+import type { ContentScriptContext } from "#imports"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { bootstrapHostContent } from "../runtime"
+
+const {
+  managerInstances,
+  mockBindTranslationShortcutKey,
+  mockClearEffectiveSiteControlUrl,
+  mockDetectPageLanguageLightweight,
+  mockEnsurePresetStyles,
+  mockMountHostToast,
+  mockOnMessage,
+  mockRegisterNodeTranslationTriggers,
+  mockSendMessage,
+  mockSetupUrlChangeListener,
+  mockStorageSetItem,
+} = vi.hoisted(() => ({
+  managerInstances: [] as Array<{
+    isActive: boolean
+    start: ReturnType<typeof vi.fn>
+    stop: ReturnType<typeof vi.fn>
+    restart: ReturnType<typeof vi.fn>
+    registerPageTranslationTriggers: ReturnType<typeof vi.fn>
+  }>,
+  mockBindTranslationShortcutKey: vi.fn(),
+  mockClearEffectiveSiteControlUrl: vi.fn(),
+  mockDetectPageLanguageLightweight: vi.fn(),
+  mockEnsurePresetStyles: vi.fn(),
+  mockMountHostToast: vi.fn(),
+  mockOnMessage: vi.fn(),
+  mockRegisterNodeTranslationTriggers: vi.fn(),
+  mockSendMessage: vi.fn(),
+  mockSetupUrlChangeListener: vi.fn(),
+  mockStorageSetItem: vi.fn(),
+}))
+
+vi.mock("#imports", () => ({
+  storage: {
+    setItem: mockStorageSetItem,
+  },
+}))
+
+vi.mock("@/utils/content/page-language", () => ({
+  detectPageLanguageLightweight: mockDetectPageLanguageLightweight,
+}))
+
+vi.mock("@/utils/host/translate/ui/style-injector", () => ({
+  ensurePresetStyles: mockEnsurePresetStyles,
+}))
+
+vi.mock("@/utils/logger", () => ({
+  logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}))
+
+vi.mock("@/utils/message", () => ({
+  onMessage: mockOnMessage,
+  sendMessage: mockSendMessage,
+}))
+
+vi.mock("@/utils/site-control", () => ({
+  clearEffectiveSiteControlUrl: mockClearEffectiveSiteControlUrl,
+}))
+
+vi.mock("../listen", () => ({
+  setupUrlChangeListener: mockSetupUrlChangeListener,
+}))
+
+vi.mock("../mount-host-toast", () => ({
+  mountHostToast: mockMountHostToast,
+}))
+
+vi.mock("../translation-control/bind-translation-shortcut", () => ({
+  bindTranslationShortcutKey: mockBindTranslationShortcutKey,
+}))
+
+vi.mock("../translation-control/node-translation", () => ({
+  registerNodeTranslationTriggers: mockRegisterNodeTranslationTriggers,
+}))
+
+vi.mock("../translation-control/page-translation", () => ({
+  PageTranslationManager: class {
+    isActive = false
+    start = vi.fn(async () => {
+      this.isActive = true
+    })
+
+    stop = vi.fn(() => {
+      this.isActive = false
+    })
+
+    restart = vi.fn(async () => {
+      this.isActive = true
+    })
+
+    registerPageTranslationTriggers = vi.fn(() => vi.fn())
+
+    constructor() {
+      managerInstances.push(this)
+    }
+  },
+}))
+
+function createContentScriptContext() {
+  const invalidationCallbacks: Array<() => void> = []
+
+  return {
+    ctx: {
+      onInvalidated: (callback: () => void) => {
+        invalidationCallbacks.push(callback)
+      },
+    } as ContentScriptContext,
+    invalidate: () => {
+      for (const callback of invalidationCallbacks) {
+        callback()
+      }
+    },
+  }
+}
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve()
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await Promise.resolve()
+}
+
+describe("bootstrapHostContent URL changes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    managerInstances.length = 0
+
+    mockSetupUrlChangeListener.mockReturnValue(vi.fn())
+    mockMountHostToast.mockReturnValue(vi.fn())
+    mockRegisterNodeTranslationTriggers.mockReturnValue(vi.fn())
+    mockBindTranslationShortcutKey.mockResolvedValue(vi.fn())
+    mockOnMessage.mockReturnValue(vi.fn())
+    mockStorageSetItem.mockResolvedValue(undefined)
+    mockDetectPageLanguageLightweight.mockResolvedValue({ detectedCodeOrUnd: "fra" })
+    mockSendMessage.mockImplementation((name: string) => {
+      if (name === "getEnablePageTranslationFromContentScript")
+        return Promise.resolve(false)
+
+      return Promise.resolve(undefined)
+    })
+  })
+
+  it("refreshes active page translation on same-origin SPA navigation without disabling the session", async () => {
+    mockSendMessage.mockImplementation((name: string) => {
+      if (name === "getEnablePageTranslationFromContentScript")
+        return Promise.resolve(true)
+
+      return Promise.resolve(undefined)
+    })
+
+    const { ctx, invalidate } = createContentScriptContext()
+    await bootstrapHostContent(ctx, null)
+    const manager = managerInstances[0]
+
+    window.dispatchEvent(new CustomEvent("extension:URLChange", {
+      detail: {
+        from: "https://example.com/articles/1",
+        to: "https://example.com/articles/2?ref=nav#comments",
+      },
+    }))
+    await flushAsyncWork()
+
+    expect(manager.start).toHaveBeenCalledTimes(1)
+    expect(manager.restart).toHaveBeenCalledTimes(1)
+    expect(manager.stop).not.toHaveBeenCalled()
+    expect(mockSendMessage).toHaveBeenCalledWith("checkAndAskAutoPageTranslation", {
+      url: "https://example.com/articles/2?ref=nav#comments",
+      detectedCodeOrUnd: "fra",
+    })
+
+    invalidate()
+  })
+
+  it("keeps inactive page translation inactive and only asks auto-translation on SPA navigation", async () => {
+    const { ctx, invalidate } = createContentScriptContext()
+    await bootstrapHostContent(ctx, null)
+    const manager = managerInstances[0]
+
+    window.dispatchEvent(new CustomEvent("extension:URLChange", {
+      detail: {
+        from: "https://example.com/articles/1",
+        to: "https://example.com/articles/2",
+      },
+    }))
+    await flushAsyncWork()
+
+    expect(manager.start).not.toHaveBeenCalled()
+    expect(manager.restart).not.toHaveBeenCalled()
+    expect(manager.stop).not.toHaveBeenCalled()
+    expect(mockSendMessage).toHaveBeenCalledWith("checkAndAskAutoPageTranslation", {
+      url: "https://example.com/articles/2",
+      detectedCodeOrUnd: "fra",
+    })
+
+    invalidate()
+  })
+})

--- a/src/entrypoints/host.content/runtime.ts
+++ b/src/entrypoints/host.content/runtime.ts
@@ -8,6 +8,7 @@ import { ensurePresetStyles } from "@/utils/host/translate/ui/style-injector"
 import { logger } from "@/utils/logger"
 import { onMessage, sendMessage } from "@/utils/message"
 import { clearEffectiveSiteControlUrl } from "@/utils/site-control"
+import { areSamePageTranslationOrigin } from "@/utils/url"
 import { setupUrlChangeListener } from "./listen"
 import { mountHostToast } from "./mount-host-toast"
 import { bindTranslationShortcutKey } from "./translation-control/bind-translation-shortcut"
@@ -51,7 +52,12 @@ export async function bootstrapHostContent(ctx: ContentScriptContext, initialCon
     if (from !== to) {
       logger.info("URL changed from", from, "to", to)
       if (manager.isActive) {
-        manager.stop()
+        if (areSamePageTranslationOrigin(from, to)) {
+          await manager.restart()
+        }
+        else {
+          manager.stop()
+        }
       }
       // Only the top frame should detect and set language to avoid race conditions from iframes
       if (window === window.top) {

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts
@@ -180,8 +180,14 @@ describe("pageTranslationManager title handling", () => {
     manager.stop()
 
     expect(document.title).toBe("Updated Source Title")
-    expect(mockSendMessage).toHaveBeenCalledWith("setAndNotifyPageTranslationStateChangedByManager", { enabled: true })
-    expect(mockSendMessage).toHaveBeenCalledWith("setAndNotifyPageTranslationStateChangedByManager", { enabled: false })
+    expect(mockSendMessage).toHaveBeenCalledWith("setAndNotifyPageTranslationStateChangedByManager", {
+      enabled: true,
+      url: window.location.href,
+    })
+    expect(mockSendMessage).toHaveBeenCalledWith("setAndNotifyPageTranslationStateChangedByManager", {
+      enabled: false,
+      url: window.location.href,
+    })
   })
 
   it("does not retrigger title translation for its own managed title updates", async () => {

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -40,6 +40,12 @@ interface IPageTranslationManager {
   stop: () => void
 
   /**
+   * Refreshes translation after an in-document route change without disabling
+   * the tab-level page translation session.
+   */
+  restart: () => Promise<void>
+
+  /**
    * Registers page translation triggers
    */
   registerPageTranslationTriggers: () => () => void
@@ -121,6 +127,7 @@ export class PageTranslationManager implements IPageTranslationManager {
 
       await sendMessage("setAndNotifyPageTranslationStateChangedByManager", {
         enabled: true,
+        url: window.location.href,
       })
 
       this.isPageTranslating = true
@@ -176,14 +183,31 @@ export class PageTranslationManager implements IPageTranslationManager {
   }
 
   stop(): void {
+    this.stopInternal({ notify: true })
+  }
+
+  async restart(): Promise<void> {
+    if (!this.isPageTranslating) {
+      await this.start()
+      return
+    }
+
+    this.stopInternal({ notify: false })
+    await this.start()
+  }
+
+  private stopInternal({ notify }: { notify: boolean }): void {
     if (!this.isPageTranslating) {
       console.warn("AutoTranslationManager is already inactive")
       return
     }
 
-    void sendMessage("setAndNotifyPageTranslationStateChangedByManager", {
-      enabled: false,
-    })
+    if (notify) {
+      void sendMessage("setAndNotifyPageTranslationStateChangedByManager", {
+        enabled: false,
+        url: window.location.href,
+      })
+    }
 
     this.isPageTranslating = false
     this.walkId = null

--- a/src/types/translation-state.ts
+++ b/src/types/translation-state.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 
 export const translationStateSchema = z.object({
   enabled: z.boolean(),
+  origin: z.string().optional(),
 })
 
 export type TranslationState = z.infer<typeof translationStateSchema>

--- a/src/utils/__tests__/url.test.ts
+++ b/src/utils/__tests__/url.test.ts
@@ -1,5 +1,34 @@
 import { describe, expect, it } from "vitest"
-import { matchDomainPattern } from "../url"
+import { areSamePageTranslationOrigin, getPageTranslationOriginScope, matchDomainPattern } from "../url"
+
+describe("page translation origin scope", () => {
+  it("uses origin for http and https URLs", () => {
+    expect(getPageTranslationOriginScope("https://example.com/articles/1")).toBe("https://example.com")
+    expect(getPageTranslationOriginScope("http://localhost:3000/path")).toBe("http://localhost:3000")
+  })
+
+  it("keeps query and hash changes in the same origin scope", () => {
+    expect(areSamePageTranslationOrigin(
+      "https://example.com/articles/1?tab=a#top",
+      "https://example.com/articles/2?tab=b#comments",
+    )).toBe(true)
+  })
+
+  it("treats protocol, hostname, and port changes as different sites", () => {
+    expect(areSamePageTranslationOrigin("https://example.com/a", "http://example.com/a")).toBe(false)
+    expect(areSamePageTranslationOrigin("https://example.com/a", "https://www.example.com/a")).toBe(false)
+    expect(areSamePageTranslationOrigin("http://localhost:3000/a", "http://localhost:3001/a")).toBe(false)
+  })
+
+  it("does not create a broad persistent scope for file or invalid URLs", () => {
+    expect(getPageTranslationOriginScope("file:///Users/example/page.html")).toBeNull()
+    expect(getPageTranslationOriginScope("not-a-url")).toBeNull()
+    expect(areSamePageTranslationOrigin(
+      "file:///Users/example/a.html",
+      "file:///Users/example/b.html",
+    )).toBe(false)
+  })
+})
 
 describe("matchDomainPattern", () => {
   describe("exact domain match", () => {

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -34,7 +34,7 @@ interface ProtocolMap {
   getEnablePageTranslationFromContentScript: () => Promise<boolean>
   tryToSetEnablePageTranslationByTabId: (data: { tabId: number, enabled: boolean, analyticsContext?: FeatureUsageContext }) => void
   tryToSetEnablePageTranslationOnContentScript: (data: { enabled: boolean, analyticsContext?: FeatureUsageContext }) => void
-  setAndNotifyPageTranslationStateChangedByManager: (data: { enabled: boolean }) => void
+  setAndNotifyPageTranslationStateChangedByManager: (data: { enabled: boolean, url?: string }) => void
   notifyTranslationStateChanged: (data: { enabled: boolean }) => void
   ensureIframeHostContentInjected: (data: { tabId?: number }) => void
   injectCurrentIframesAfterTopFrameNodeTranslation: () => void

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,5 +1,26 @@
 import { z } from "zod"
 
+export function getPageTranslationOriginScope(url: string): string | null {
+  try {
+    const urlObj = new URL(url)
+
+    if (urlObj.protocol !== "http:" && urlObj.protocol !== "https:")
+      return null
+
+    return urlObj.origin
+  }
+  catch {
+    return null
+  }
+}
+
+export function areSamePageTranslationOrigin(from: string, to: string): boolean {
+  const fromScope = getPageTranslationOriginScope(from)
+  const toScope = getPageTranslationOriginScope(to)
+
+  return fromScope !== null && fromScope === toScope
+}
+
 export function matchDomainPattern(url: string, pattern: string): boolean {
   if (!z.url().safeParse(url).success) {
     return false


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [x] ✅ Test related (test)

## Description

This PR keeps manually enabled page translation active while the same browser tab stays within the same top-frame origin.

- Stores page-translation session state with an optional `URL.origin` scope.
- Preserves enabled page translation across same-origin main-frame navigations.
- Refreshes active page translation on same-origin SPA route changes without writing a disabled tab state.
- Clears carried manual page translation when the tab leaves the origin, while preserving existing configured auto-translation behavior.
- Prevents iframe manager enabled echoes from overwriting the tab-level top-frame origin scope.

Compared with #1501, this uses same-origin scope instead of navigation transition type, and covers SPA route changes as well as committed navigations.

## Related Issue

Closes #1500
Closes #1346
Closes #1501

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Commands run:

- `SKIP_FREE_API=true pnpm vitest run src/utils/__tests__/url.test.ts src/entrypoints/background/__tests__/translation-signal.test.ts src/entrypoints/host.content/__tests__/runtime.test.ts src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts`
- `SKIP_FREE_API=true pnpm type-check`
- `SKIP_FREE_API=true pnpm test`
- `pnpm eslint src/types/translation-state.ts src/utils/url.ts src/entrypoints/background/page-translation-state.ts src/entrypoints/background/translation-signal.ts src/utils/message.ts src/entrypoints/host.content/runtime.ts src/entrypoints/host.content/translation-control/page-translation.ts src/utils/__tests__/url.test.ts src/entrypoints/background/__tests__/translation-signal.test.ts src/entrypoints/host.content/__tests__/runtime.test.ts src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts`
- Pre-push hook: `nx run @read-frog/extension:lint`, `nx run @read-frog/extension:type-check`, `nx run @read-frog/extension:test` (137 test files / 1182 tests passed)

## Screenshots

Not applicable. This is background/content-script state behavior with no visual UI change.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Potential follow-up: close #1501 after this PR is accepted, since it targets the same issue with a narrower transition-type based implementation.