### PR TITLE
fix(translate): scope detected language to tabs

### DIFF
--- a/.changeset/tab-scoped-source-language.md
+++ b/.changeset/tab-scoped-source-language.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): scope detected source language to the active tab

--- a/src/entrypoints/background/__tests__/translation-signal.test.ts
+++ b/src/entrypoints/background/__tests__/translation-signal.test.ts
@@ -1,6 +1,7 @@
 import { browser, storage } from "#imports"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { getTranslationStateKey } from "@/utils/constants/storage-keys"
+import { DEFAULT_DETECTED_CODE } from "@/utils/constants/config"
+import { getDetectedCodeStateKey, getTranslationStateKey } from "@/utils/constants/storage-keys"
 
 const sendMessageMock = vi.fn()
 const onMessageMock = vi.fn()
@@ -8,6 +9,8 @@ const storageGetItemMock = vi.fn()
 const storageSetItemMock = vi.fn()
 const storageRemoveItemMock = vi.fn()
 const tabsOnRemovedAddListenerMock = vi.fn()
+const tabsOnActivatedAddListenerMock = vi.fn()
+const tabsQueryMock = vi.fn()
 const webNavigationOnCommittedAddListenerMock = vi.fn()
 const injectHostContentIntoTabIframesMock = vi.fn()
 const injectHostContentIntoCurrentTabIframesAfterNodeTranslationMock = vi.fn()
@@ -54,6 +57,22 @@ function getOnCommittedListener() {
   return listener as (details: { tabId: number, frameId: number, url: string }) => Promise<void>
 }
 
+function getOnRemovedListener() {
+  const listener = tabsOnRemovedAddListenerMock.mock.calls.at(-1)?.[0]
+  if (!listener) {
+    throw new Error("Expected tabs.onRemoved listener to be registered")
+  }
+  return listener as (tabId: number) => Promise<void>
+}
+
+function getOnActivatedListener() {
+  const listener = tabsOnActivatedAddListenerMock.mock.calls.at(-1)?.[0]
+  if (!listener) {
+    throw new Error("Expected tabs.onActivated listener to be registered")
+  }
+  return listener as (activeInfo: { tabId: number }) => Promise<void>
+}
+
 async function setupSubject() {
   const { translationMessage } = await import("../translation-signal")
   translationMessage()
@@ -65,6 +84,8 @@ describe("translationMessage", () => {
     messageHandlers.clear()
 
     browser.tabs.onRemoved.addListener = tabsOnRemovedAddListenerMock
+    browser.tabs.onActivated.addListener = tabsOnActivatedAddListenerMock
+    browser.tabs.query = tabsQueryMock
     browser.webNavigation.onCommitted.addListener = webNavigationOnCommittedAddListenerMock
     storage.getItem = storageGetItemMock
     storage.setItem = storageSetItemMock
@@ -75,6 +96,7 @@ describe("translationMessage", () => {
       return vi.fn()
     })
     sendMessageMock.mockResolvedValue(undefined)
+    tabsQueryMock.mockResolvedValue([{ id: 42 }])
     storageGetItemMock.mockResolvedValue(undefined)
     storageSetItemMock.mockResolvedValue(undefined)
     storageRemoveItemMock.mockResolvedValue(undefined)
@@ -183,6 +205,76 @@ describe("translationMessage", () => {
     expect(injectHostContentIntoTabIframesMock).not.toHaveBeenCalled()
   })
 
+  it("stores detected language by sender tab and notifies when it is the active tab", async () => {
+    await setupSubject()
+    tabsQueryMock.mockResolvedValue([{ id: 42 }])
+
+    await getHandler("reportDetectedPageLanguage")({
+      data: { detectedCodeOrUnd: "cmn", url: "https://zh.example.test" },
+      sender: { tab: { id: 42 }, frameId: 0 },
+    })
+
+    expect(storageSetItemMock).toHaveBeenCalledWith(getDetectedCodeStateKey(42), "cmn")
+    expect(sendMessageMock).toHaveBeenCalledWith("detectedPageLanguageChanged", { detectedCode: "cmn" })
+  })
+
+  it("does not notify detected language from an inactive tab", async () => {
+    await setupSubject()
+    tabsQueryMock.mockResolvedValue([{ id: 7 }])
+
+    await getHandler("reportDetectedPageLanguage")({
+      data: { detectedCodeOrUnd: "jpn", url: "https://ja.example.test" },
+      sender: { tab: { id: 42 }, frameId: 0 },
+    })
+
+    expect(storageSetItemMock).toHaveBeenCalledWith(getDetectedCodeStateKey(42), "jpn")
+    expect(sendMessageMock).not.toHaveBeenCalledWith("detectedPageLanguageChanged", { detectedCode: "jpn" })
+  })
+
+  it("normalizes undetected page language before caching", async () => {
+    await setupSubject()
+
+    await getHandler("reportDetectedPageLanguage")({
+      data: { detectedCodeOrUnd: "und", url: "https://example.test" },
+      sender: { tab: { id: 42 }, frameId: 0 },
+    })
+
+    expect(storageSetItemMock).toHaveBeenCalledWith(getDetectedCodeStateKey(42), DEFAULT_DETECTED_CODE)
+  })
+
+  it("returns the sender tab detected language to content scripts", async () => {
+    await setupSubject()
+    storageGetItemMock.mockImplementation(async (key: string) => {
+      if (key === getDetectedCodeStateKey(42))
+        return "jpn"
+      return undefined
+    })
+
+    const detectedCode = await getHandler("getDetectedCode")({
+      data: undefined,
+      sender: { tab: { id: 42 }, frameId: 0 },
+    })
+
+    expect(detectedCode).toBe("jpn")
+  })
+
+  it("returns the active tab detected language to extension pages", async () => {
+    await setupSubject()
+    tabsQueryMock.mockResolvedValue([{ id: 8 }])
+    storageGetItemMock.mockImplementation(async (key: string) => {
+      if (key === getDetectedCodeStateKey(8))
+        return "cmn"
+      return undefined
+    })
+
+    const detectedCode = await getHandler("getDetectedCode")({
+      data: undefined,
+      sender: {},
+    })
+
+    expect(detectedCode).toBe("cmn")
+  })
+
   it("rejects iframe senders for top-frame node translation iframe injection", async () => {
     await setupSubject()
 
@@ -213,6 +305,44 @@ describe("translationMessage", () => {
       enabled: true,
       analyticsContext: undefined,
     }, 42)
+  })
+
+  it("publishes cached detected language and requests refresh when tabs are activated", async () => {
+    await setupSubject()
+    storageGetItemMock.mockImplementation(async (key: string) => {
+      if (key === getDetectedCodeStateKey(1))
+        return "cmn"
+      if (key === getDetectedCodeStateKey(2))
+        return "jpn"
+      return undefined
+    })
+
+    const onActivated = getOnActivatedListener()
+    await onActivated({ tabId: 1 })
+    await onActivated({ tabId: 2 })
+
+    expect(sendMessageMock).toHaveBeenCalledWith("detectedPageLanguageChanged", { detectedCode: "cmn" })
+    expect(sendMessageMock).toHaveBeenCalledWith("detectedPageLanguageChanged", { detectedCode: "jpn" })
+    expect(sendMessageMock).toHaveBeenCalledWith("refreshDetectedPageLanguage", undefined, 1)
+    expect(sendMessageMock).toHaveBeenCalledWith("refreshDetectedPageLanguage", undefined, 2)
+  })
+
+  it("publishes default detected language when an activated tab has no cache", async () => {
+    await setupSubject()
+
+    await getOnActivatedListener()({ tabId: 42 })
+
+    expect(sendMessageMock).toHaveBeenCalledWith("detectedPageLanguageChanged", { detectedCode: DEFAULT_DETECTED_CODE })
+    expect(sendMessageMock).toHaveBeenCalledWith("refreshDetectedPageLanguage", undefined, 42)
+  })
+
+  it("clears detected language cache when a tab is removed", async () => {
+    await setupSubject()
+
+    await getOnRemovedListener()(42)
+
+    expect(storageRemoveItemMock).toHaveBeenCalledWith(getTranslationStateKey(42))
+    expect(storageRemoveItemMock).toHaveBeenCalledWith(getDetectedCodeStateKey(42))
   })
 
   it("keeps enabled translation state on same-origin top-frame navigation", async () => {

--- a/src/entrypoints/background/translation-signal.ts
+++ b/src/entrypoints/background/translation-signal.ts
@@ -1,10 +1,11 @@
+import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { FeatureUsageContext } from "@/types/analytics"
 import type { Config } from "@/types/config/config"
 import { browser, storage } from "#imports"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext } from "@/utils/analytics"
-import { CONFIG_STORAGE_KEY } from "@/utils/constants/config"
-import { getTranslationStateKey } from "@/utils/constants/storage-keys"
+import { CONFIG_STORAGE_KEY, DEFAULT_DETECTED_CODE } from "@/utils/constants/config"
+import { getDetectedCodeStateKey, getTranslationStateKey } from "@/utils/constants/storage-keys"
 import { shouldEnableAutoTranslation } from "@/utils/host/translate/auto-translation"
 import { logger } from "@/utils/logger"
 import { onMessage, sendMessage } from "@/utils/message"
@@ -32,6 +33,43 @@ function requestManagerToTogglePageTranslation(
 
 function isIframe(frameId: number | undefined): boolean {
   return frameId !== undefined && frameId !== 0
+}
+
+function normalizeDetectedCode(detectedCodeOrUnd: LangCodeISO6393 | "und"): LangCodeISO6393 {
+  return detectedCodeOrUnd === "und" ? DEFAULT_DETECTED_CODE : detectedCodeOrUnd
+}
+
+async function getCachedDetectedCodeForTab(tabId: number): Promise<LangCodeISO6393 | undefined> {
+  return await storage.getItem<LangCodeISO6393>(getDetectedCodeStateKey(tabId)) ?? undefined
+}
+
+async function getDetectedCodeForTab(tabId: number): Promise<LangCodeISO6393> {
+  return await getCachedDetectedCodeForTab(tabId) ?? DEFAULT_DETECTED_CODE
+}
+
+function notifyDetectedCodeChanged(detectedCode: LangCodeISO6393) {
+  void sendMessage("detectedPageLanguageChanged", { detectedCode })
+    // The popup is often closed, so having no receiver is expected.
+    .catch(() => {})
+}
+
+async function isActiveCurrentWindowTab(tabId: number): Promise<boolean> {
+  const [activeTab] = await browser.tabs.query({ active: true, currentWindow: true })
+  return activeTab?.id === tabId
+}
+
+async function publishCachedDetectedCodeForTab(tabId: number): Promise<void> {
+  notifyDetectedCodeChanged(await getDetectedCodeForTab(tabId))
+}
+
+function requestDetectedPageLanguageRefresh(tabId: number) {
+  void sendMessage("refreshDetectedPageLanguage", undefined, tabId)
+    .catch(error => logger.warn("Failed to refresh detected page language", error))
+}
+
+async function publishAndRefreshActiveTab(tabId: number): Promise<void> {
+  await publishCachedDetectedCodeForTab(tabId)
+  requestDetectedPageLanguageRefresh(tabId)
 }
 
 export function translationMessage() {
@@ -71,6 +109,49 @@ export function translationMessage() {
     logger.error("Invalid sender in injectCurrentIframesAfterTopFrameNodeTranslation", msg)
   })
 
+  onMessage("reportDetectedPageLanguage", async (msg) => {
+    const tabId = msg.sender?.tab?.id
+    const { url, detectedCodeOrUnd } = msg.data
+    if (typeof tabId === "number") {
+      const detectedCode = normalizeDetectedCode(detectedCodeOrUnd)
+      await storage.setItem<LangCodeISO6393>(getDetectedCodeStateKey(tabId), detectedCode)
+
+      if (await isActiveCurrentWindowTab(tabId)) {
+        notifyDetectedCodeChanged(detectedCode)
+      }
+
+      const config = await storage.getItem<Config>(`local:${CONFIG_STORAGE_KEY}`)
+      if (!config)
+        return
+
+      const shouldEnable = await shouldEnableAutoTranslation(url, detectedCodeOrUnd, config)
+      if (shouldEnable) {
+        requestManagerToTogglePageTranslation(
+          tabId,
+          true,
+          createFeatureUsageContext(ANALYTICS_FEATURE.PAGE_TRANSLATION, ANALYTICS_SURFACE.PAGE_AUTO),
+        )
+      }
+      return
+    }
+
+    logger.error("Invalid tabId in reportDetectedPageLanguage", msg)
+  })
+
+  onMessage("getDetectedCode", async (msg) => {
+    const tabId = msg.sender?.tab?.id
+    if (typeof tabId === "number") {
+      return await getDetectedCodeForTab(tabId)
+    }
+
+    const [activeTab] = await browser.tabs.query({ active: true, currentWindow: true })
+    if (typeof activeTab?.id === "number") {
+      return await getDetectedCodeForTab(activeTab.id)
+    }
+
+    return DEFAULT_DETECTED_CODE
+  })
+
   onMessage("tryToSetEnablePageTranslationByTabId", async (msg) => {
     const { tabId, enabled, analyticsContext } = msg.data
     if (!enabled) {
@@ -93,24 +174,6 @@ export function translationMessage() {
     }
     else {
       logger.error("tabId is not a number", msg)
-    }
-  })
-
-  onMessage("checkAndAskAutoPageTranslation", async (msg) => {
-    const tabId = msg.sender?.tab?.id
-    const { url, detectedCodeOrUnd } = msg.data
-    if (typeof tabId === "number") {
-      const config = await storage.getItem<Config>(`local:${CONFIG_STORAGE_KEY}`)
-      if (!config)
-        return
-      const shouldEnable = await shouldEnableAutoTranslation(url, detectedCodeOrUnd, config)
-      if (shouldEnable) {
-        requestManagerToTogglePageTranslation(
-          tabId,
-          true,
-          createFeatureUsageContext(ANALYTICS_FEATURE.PAGE_TRANSLATION, ANALYTICS_SURFACE.PAGE_AUTO),
-        )
-      }
     }
   })
 
@@ -151,6 +214,11 @@ export function translationMessage() {
   // === Cleanup ===
   browser.tabs.onRemoved.addListener(async (tabId) => {
     await storage.removeItem(getTranslationStateKey(tabId))
+    await storage.removeItem(getDetectedCodeStateKey(tabId))
+  })
+
+  browser.tabs.onActivated.addListener(async (activeInfo) => {
+    await publishAndRefreshActiveTab(activeInfo.tabId)
   })
 
   // Clear translation state only when the tab leaves the origin where it was enabled.

--- a/src/entrypoints/host.content/__tests__/runtime.test.ts
+++ b/src/entrypoints/host.content/__tests__/runtime.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { bootstrapHostContent } from "../runtime"
 
 const {
+  messageHandlers,
   managerInstances,
   mockBindTranslationShortcutKey,
   mockClearEffectiveSiteControlUrl,
@@ -15,8 +16,8 @@ const {
   mockRegisterNodeTranslationTriggers,
   mockSendMessage,
   mockSetupUrlChangeListener,
-  mockStorageSetItem,
 } = vi.hoisted(() => ({
+  messageHandlers: new Map<string, (msg?: any) => any>(),
   managerInstances: [] as Array<{
     isActive: boolean
     start: ReturnType<typeof vi.fn>
@@ -33,13 +34,6 @@ const {
   mockRegisterNodeTranslationTriggers: vi.fn(),
   mockSendMessage: vi.fn(),
   mockSetupUrlChangeListener: vi.fn(),
-  mockStorageSetItem: vi.fn(),
-}))
-
-vi.mock("#imports", () => ({
-  storage: {
-    setItem: mockStorageSetItem,
-  },
 }))
 
 vi.mock("@/utils/content/page-language", () => ({
@@ -132,14 +126,17 @@ async function flushAsyncWork(): Promise<void> {
 describe("bootstrapHostContent URL changes", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    messageHandlers.clear()
     managerInstances.length = 0
 
     mockSetupUrlChangeListener.mockReturnValue(vi.fn())
     mockMountHostToast.mockReturnValue(vi.fn())
     mockRegisterNodeTranslationTriggers.mockReturnValue(vi.fn())
     mockBindTranslationShortcutKey.mockResolvedValue(vi.fn())
-    mockOnMessage.mockReturnValue(vi.fn())
-    mockStorageSetItem.mockResolvedValue(undefined)
+    mockOnMessage.mockImplementation((name: string, handler: (msg?: any) => any) => {
+      messageHandlers.set(name, handler)
+      return vi.fn()
+    })
     mockDetectPageLanguageLightweight.mockResolvedValue({ detectedCodeOrUnd: "fra" })
     mockSendMessage.mockImplementation((name: string) => {
       if (name === "getEnablePageTranslationFromContentScript")
@@ -172,7 +169,7 @@ describe("bootstrapHostContent URL changes", () => {
     expect(manager.start).toHaveBeenCalledTimes(1)
     expect(manager.restart).toHaveBeenCalledTimes(1)
     expect(manager.stop).not.toHaveBeenCalled()
-    expect(mockSendMessage).toHaveBeenCalledWith("checkAndAskAutoPageTranslation", {
+    expect(mockSendMessage).toHaveBeenCalledWith("reportDetectedPageLanguage", {
       url: "https://example.com/articles/2?ref=nav#comments",
       detectedCodeOrUnd: "fra",
     })
@@ -196,9 +193,35 @@ describe("bootstrapHostContent URL changes", () => {
     expect(manager.start).not.toHaveBeenCalled()
     expect(manager.restart).not.toHaveBeenCalled()
     expect(manager.stop).not.toHaveBeenCalled()
-    expect(mockSendMessage).toHaveBeenCalledWith("checkAndAskAutoPageTranslation", {
+    expect(mockSendMessage).toHaveBeenCalledWith("reportDetectedPageLanguage", {
       url: "https://example.com/articles/2",
       detectedCodeOrUnd: "fra",
+    })
+
+    invalidate()
+  })
+
+  it("refreshes and reports detected language when background requests active-tab refresh", async () => {
+    const { ctx, invalidate } = createContentScriptContext()
+    await bootstrapHostContent(ctx, null)
+    await flushAsyncWork()
+
+    mockSendMessage.mockClear()
+    mockDetectPageLanguageLightweight.mockClear()
+    mockDetectPageLanguageLightweight.mockResolvedValueOnce({ detectedCodeOrUnd: "jpn" })
+
+    const refreshHandler = messageHandlers.get("refreshDetectedPageLanguage")
+    if (!refreshHandler) {
+      throw new Error("Expected refreshDetectedPageLanguage handler to be registered")
+    }
+
+    refreshHandler()
+    await flushAsyncWork()
+
+    expect(mockDetectPageLanguageLightweight).toHaveBeenCalledOnce()
+    expect(mockSendMessage).toHaveBeenCalledWith("reportDetectedPageLanguage", {
+      url: window.location.href,
+      detectedCodeOrUnd: "jpn",
     })
 
     invalidate()

--- a/src/entrypoints/host.content/runtime.ts
+++ b/src/entrypoints/host.content/runtime.ts
@@ -1,8 +1,6 @@
 import type { ContentScriptContext } from "#imports"
-import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { Config } from "@/types/config/config"
-import { storage } from "#imports"
-import { DEFAULT_CONFIG, DETECTED_CODE_STORAGE_KEY } from "@/utils/constants/config"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { detectPageLanguageLightweight } from "@/utils/content/page-language"
 import { ensurePresetStyles } from "@/utils/host/translate/ui/style-injector"
 import { logger } from "@/utils/logger"
@@ -35,6 +33,11 @@ export async function bootstrapHostContent(ctx: ContentScriptContext, initialCon
 
   const cleanupTranslationShortcut = await bindTranslationShortcutKey(manager)
 
+  const detectAndReportPageLanguage = async (url: string) => {
+    const { detectedCodeOrUnd } = await detectPageLanguageLightweight()
+    void sendMessage("reportDetectedPageLanguage", { url, detectedCodeOrUnd })
+  }
+
   // For late-loading iframes: check if translation is already enabled for this tab
   let translationEnabled = false
   try {
@@ -61,11 +64,7 @@ export async function bootstrapHostContent(ctx: ContentScriptContext, initialCon
       }
       // Only the top frame should detect and set language to avoid race conditions from iframes
       if (window === window.top) {
-        const { detectedCodeOrUnd } = await detectPageLanguageLightweight()
-        const detectedCode: LangCodeISO6393 = detectedCodeOrUnd === "und" ? "eng" : detectedCodeOrUnd
-        await storage.setItem<LangCodeISO6393>(`local:${DETECTED_CODE_STORAGE_KEY}`, detectedCode)
-        // Notify background script that URL has changed, let it decide whether to automatically enable translation
-        void sendMessage("checkAndAskAutoPageTranslation", { url: to, detectedCodeOrUnd })
+        await detectAndReportPageLanguage(to)
       }
     }
   }
@@ -93,6 +92,12 @@ export async function bootstrapHostContent(ctx: ContentScriptContext, initialCon
         enabled ? void manager.start() : manager.stop()
       })
 
+  const cleanupDetectedLanguageRefreshListener = window === window.top
+    ? onMessage("refreshDetectedPageLanguage", () => {
+        void detectAndReportPageLanguage(window.location.href)
+      })
+    : () => {}
+
   ctx.onInvalidated(() => {
     removeHostToast()
     cleanupUrlListener()
@@ -101,6 +106,7 @@ export async function bootstrapHostContent(ctx: ContentScriptContext, initialCon
     cleanupTranslationShortcut()
     cleanupTranslationStateListener()
     cleanupFrameTranslationStateListener()
+    cleanupDetectedLanguageRefreshListener()
     window.removeEventListener("extension:URLChange", handleExtensionUrlChange)
     window.__READ_FROG_HOST_INJECTED__ = false
     clearEffectiveSiteControlUrl()
@@ -108,11 +114,6 @@ export async function bootstrapHostContent(ctx: ContentScriptContext, initialCon
 
   // Only the top frame should detect and set language to avoid race conditions from iframes
   if (window === window.top) {
-    const { detectedCodeOrUnd } = await detectPageLanguageLightweight()
-    const initialDetectedCode: LangCodeISO6393 = detectedCodeOrUnd === "und" ? "eng" : detectedCodeOrUnd
-    await storage.setItem<LangCodeISO6393>(`local:${DETECTED_CODE_STORAGE_KEY}`, initialDetectedCode)
-
-    // Check if auto-translation should be enabled for initial page load
-    void sendMessage("checkAndAskAutoPageTranslation", { url: window.location.href, detectedCodeOrUnd })
+    await detectAndReportPageLanguage(window.location.href)
   }
 }

--- a/src/utils/atoms/detected-code.ts
+++ b/src/utils/atoms/detected-code.ts
@@ -1,44 +1,47 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
-import { langCodeISO6393Schema } from "@read-frog/definitions"
 import { atom } from "jotai"
-import { DEFAULT_DETECTED_CODE, DETECTED_CODE_STORAGE_KEY } from "../constants/config"
+import { DEFAULT_DETECTED_CODE } from "../constants/config"
 import { logger } from "../logger"
-import { storageAdapter } from "./storage-adapter"
+import { onMessage, sendMessage } from "../message"
 
 // Private base atom - not exported to prevent direct writes
 const baseDetectedCodeAtom = atom<LangCodeISO6393>(DEFAULT_DETECTED_CODE)
 
-// Public atom with read/write - write always goes through storageAdapter
+// Public atom with read/write - writes only update the in-memory popup state.
 export const detectedCodeAtom = atom(
   get => get(baseDetectedCodeAtom),
-  async (get, set, newValue: LangCodeISO6393) => {
-    const prev = get(baseDetectedCodeAtom)
+  (_get, set, newValue: LangCodeISO6393) => {
     set(baseDetectedCodeAtom, newValue)
-    try {
-      await storageAdapter.set(DETECTED_CODE_STORAGE_KEY, newValue, langCodeISO6393Schema)
-    }
-    catch (error) {
-      console.error("Failed to set detectedCode to storage:", newValue, error)
-      set(baseDetectedCodeAtom, prev)
-    }
   },
 )
 
 // onMount on base atom - gets triggered when derived atom subscribes
 baseDetectedCodeAtom.onMount = (setAtom: (newValue: LangCodeISO6393) => void) => {
-  void storageAdapter.get<LangCodeISO6393>(DETECTED_CODE_STORAGE_KEY, DEFAULT_DETECTED_CODE, langCodeISO6393Schema).then(setAtom)
-  const unwatch = storageAdapter.watch<LangCodeISO6393>(DETECTED_CODE_STORAGE_KEY, setAtom)
+  const refreshDetectedCode = () => {
+    void sendMessage("getDetectedCode", undefined)
+      .then(setAtom)
+      .catch((error) => {
+        logger.warn("Failed to refresh active tab detected language", error)
+        setAtom(DEFAULT_DETECTED_CODE)
+      })
+  }
+
+  refreshDetectedCode()
+
+  const cleanupDetectedCodeListener = onMessage("detectedPageLanguageChanged", (msg) => {
+    setAtom(msg.data.detectedCode)
+  })
 
   const handleVisibilityChange = () => {
     if (document.visibilityState === "visible") {
       logger.info("detectedCodeAtom onMount handleVisibilityChange when: ", new Date())
-      void storageAdapter.get<LangCodeISO6393>(DETECTED_CODE_STORAGE_KEY, DEFAULT_DETECTED_CODE, langCodeISO6393Schema).then(setAtom)
+      refreshDetectedCode()
     }
   }
   document.addEventListener("visibilitychange", handleVisibilityChange)
 
   return () => {
-    unwatch()
+    cleanupDetectedCodeListener()
     document.removeEventListener("visibilitychange", handleVisibilityChange)
   }
 }

--- a/src/utils/config/languages.ts
+++ b/src/utils/config/languages.ts
@@ -1,11 +1,16 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
-import { storage } from "#imports"
-import { DEFAULT_DETECTED_CODE, DETECTED_CODE_STORAGE_KEY } from "../constants/config"
+import { DEFAULT_DETECTED_CODE } from "../constants/config"
+import { sendMessage } from "../message"
 
 export function getFinalSourceCode(sourceCode: LangCodeISO6393 | "auto", detectedCode: LangCodeISO6393): LangCodeISO6393 {
   return sourceCode === "auto" ? detectedCode : sourceCode
 }
 
 export async function getDetectedCodeFromStorage(): Promise<LangCodeISO6393> {
-  return await storage.getItem<LangCodeISO6393>(`local:${DETECTED_CODE_STORAGE_KEY}`) ?? DEFAULT_DETECTED_CODE
+  try {
+    return await sendMessage("getDetectedCode", undefined)
+  }
+  catch {
+    return DEFAULT_DETECTED_CODE
+  }
 }

--- a/src/utils/constants/config.ts
+++ b/src/utils/constants/config.ts
@@ -17,7 +17,6 @@ export const LAST_SYNCED_CONFIG_STORAGE_KEY = "lastSyncedConfig"
 export const GOOGLE_DRIVE_TOKEN_STORAGE_KEY = "__googleDriveToken"
 
 export const THEME_STORAGE_KEY = "theme"
-export const DETECTED_CODE_STORAGE_KEY = "detectedCode"
 export const DEFAULT_DETECTED_CODE = "eng" as const
 export const CONFIG_SCHEMA_VERSION = 71
 

--- a/src/utils/constants/storage-keys.ts
+++ b/src/utils/constants/storage-keys.ts
@@ -3,3 +3,9 @@ export const TRANSLATION_STATE_KEY_PREFIX = "session:translationState" as const
 export function getTranslationStateKey(tabId: number): `session:translationState.${number}` {
   return `${TRANSLATION_STATE_KEY_PREFIX}.${tabId}` as const
 }
+
+export const DETECTED_CODE_STATE_KEY_PREFIX = "session:detectedCode" as const
+
+export function getDetectedCodeStateKey(tabId: number): `session:detectedCode.${number}` {
+  return `${DETECTED_CODE_STATE_KEY_PREFIX}.${tabId}` as const
+}

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -38,8 +38,10 @@ interface ProtocolMap {
   notifyTranslationStateChanged: (data: { enabled: boolean }) => void
   ensureIframeHostContentInjected: (data: { tabId?: number }) => void
   injectCurrentIframesAfterTopFrameNodeTranslation: () => void
-  // for auto start page translation
-  checkAndAskAutoPageTranslation: (data: { url: string, detectedCodeOrUnd: LangCodeISO6393 | "und" }) => void
+  reportDetectedPageLanguage: (data: { detectedCodeOrUnd: LangCodeISO6393 | "und", url: string }) => void
+  refreshDetectedPageLanguage: () => void
+  getDetectedCode: () => LangCodeISO6393
+  detectedPageLanguageChanged: (data: { detectedCode: LangCodeISO6393 }) => void
   // ask host to start page translation
   askManagerToTogglePageTranslation: (data: { enabled: boolean, analyticsContext?: FeatureUsageContext }) => void
   openSelectionTranslationFromContextMenu: (data: { selectionText: string }) => void


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [x] ✅ Test related (test)

## Description

This fixes source-language detection being shared across tabs. Detected page language is now stored per tab in session storage, the popup listens to active-tab language updates, and content scripts can be asked to refresh detection when their tab becomes active.

Key changes:
- Store detected page language under a tab-scoped session key.
- Have host content scripts report detection results to the background script instead of writing global storage.
- Publish the active tab cached language to popup/UI consumers and refresh detection on tab activation.
- Resolve content translation language lookups through the sender tab context.
- Remove the old global detected-code storage path and the unused auto-page-translation ask message.

## Related Issue

Closes #1281

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Commands run:
- `SKIP_FREE_API=true pnpm vitest run src/entrypoints/background/__tests__/translation-signal.test.ts src/entrypoints/host.content/__tests__/runtime.test.ts`
- `pnpm type-check`
- `pnpm lint`
- `git push -u origin codex/tab-scoped-source-language` pre-push hook, including full `@read-frog/extension:test`, passed

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The LLM source-language detection setting is intentionally not part of this change; the tab-scoping fix applies to the existing lightweight page language detection path.