### PR TITLE
feat(popup): expose Translation Hub as footer action

### DIFF
--- a/.changeset/translation-hub-footer-action.md
+++ b/.changeset/translation-hub-footer-action.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+Expose the Translation Hub as a visible popup footer action.

--- a/src/entrypoints/popup/app.tsx
+++ b/src/entrypoints/popup/app.tsx
@@ -14,7 +14,7 @@ import { SiteControlToggle } from "./components/site-control-toggle"
 import TranslateButton from "./components/translate-button"
 import TranslatePromptSelector from "./components/translate-prompt-selector"
 import TranslateProviderField from "./components/translate-provider-field"
-import { TranslationHubButton } from "./components/translation-hub-button"
+import { TranslationHubButton, TranslationHubFooterButton } from "./components/translation-hub-button"
 import TranslationModeSelector from "./components/translation-mode-selector"
 
 function App() {
@@ -54,10 +54,13 @@ function App() {
             {i18n.t("popup.options")}
           </span>
         </button>
-        <span className="text-sm text-neutral-500 dark:text-neutral-400">
-          {version}
-        </span>
-        <MoreMenu />
+        <div className="flex items-center gap-1">
+          <span className="px-1 text-sm text-neutral-500 dark:text-neutral-400">
+            {version}
+          </span>
+          <TranslationHubFooterButton />
+          <MoreMenu />
+        </div>
       </div>
     </>
   )

--- a/src/entrypoints/popup/components/more-menu.tsx
+++ b/src/entrypoints/popup/components/more-menu.tsx
@@ -1,4 +1,4 @@
-import { browser, i18n } from "#imports"
+import { i18n } from "#imports"
 import { Icon } from "@iconify/react"
 import {
   DropdownMenu,
@@ -53,14 +53,6 @@ export function MoreMenu() {
         >
           <Icon icon="tabler:star" className="size-4" strokeWidth={1.6} />
           {i18n.t("popup.more.rateUs")}
-        </DropdownMenuItem>
-
-        <DropdownMenuItem
-          onClick={() => void browser.tabs.create({ url: browser.runtime.getURL("/translation-hub.html") })}
-          className="cursor-pointer"
-        >
-          <Icon icon="tabler:language-hiragana" className="size-4" strokeWidth={1.6} />
-          {i18n.t("popup.more.translationHub")}
         </DropdownMenuItem>
 
         <DropdownMenuItem

--- a/src/entrypoints/popup/components/translation-hub-button.tsx
+++ b/src/entrypoints/popup/components/translation-hub-button.tsx
@@ -5,9 +5,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/base-ui
 
 export function TranslationHubButton() {
   const handleClick = async () => {
-    await browser.tabs.create({
-      url: browser.runtime.getURL("/translation-hub.html"),
-    })
+    await openTranslationHub()
   }
 
   return (
@@ -20,4 +18,25 @@ export function TranslationHubButton() {
       </TooltipContent>
     </Tooltip>
   )
+}
+
+export function TranslationHubFooterButton() {
+  return (
+    <button
+      type="button"
+      className="flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 hover:bg-neutral-300 dark:hover:bg-neutral-700"
+      onClick={() => {
+        void openTranslationHub()
+      }}
+    >
+      <Icon icon="tabler:language-hiragana" className="size-4" strokeWidth={1.6} />
+      <span className="text-[13px] font-medium">{i18n.t("popup.more.translationHub")}</span>
+    </button>
+  )
+}
+
+async function openTranslationHub() {
+  await browser.tabs.create({
+    url: browser.runtime.getURL("/translation-hub.html"),
+  })
 }


### PR DESCRIPTION
## Summary
- Expose Translation Hub as a direct popup footer action next to the version/More controls.
- Remove the duplicate Translation Hub entry from the secondary More menu.
- Add a patch changeset for the user-visible popup UI update.

Closes #1506

## Demo video or screenshots

Real screenshots captured from the built Chrome MV3 extension in Microsoft Edge. Viewport: `640x720`; popup state: More menu open.

| Before (`main`) | After (this branch) |
| --- | --- |
| ![Before: Translation Hub only appears inside the More menu](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog-issue-1506-before-popup-translation-hub-menu-open.png) | ![After: Translation Hub is visible in the popup footer and removed from More menu](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog-issue-1506-after-popup-translation-hub-menu-open.png) |

## Verification
- `pnpm exec eslint src/entrypoints/popup/app.tsx src/entrypoints/popup/components/more-menu.tsx src/entrypoints/popup/components/translation-hub-button.tsx`
- `pnpm type-check`
- `WXT_SKIP_ENV_VALIDATION=true pnpm build`
- Built `main` separately with `WXT_SKIP_ENV_VALIDATION=true pnpm build` for before-state evidence
- Real browser screenshot capture for before/after popup states
- Pre-push hook: `nx run @read-frog/extension:lint`, `nx run @read-frog/extension:type-check`, `nx run @read-frog/extension:test` (138 files / 1200 tests passed)
