### PR TITLE
fix: cache selection AI streams and filter context

### DIFF
--- a/.changeset/clean-frog-context.md
+++ b/.changeset/clean-frog-context.md
@@ -2,4 +2,4 @@
 "@read-frog/extension": patch
 ---
 
-Exclude Read Frog injected translated content from selection context snapshots.
+Exclude Read Frog injected translated content from selection context snapshots, and cache selection-toolbar AI stream results to avoid repeated requests for the same lookup/translation.

--- a/.changeset/clean-frog-context.md
+++ b/.changeset/clean-frog-context.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+Exclude Read Frog injected translated content from selection context snapshots.

--- a/src/entrypoints/background/__tests__/background-stream.test.ts
+++ b/src/entrypoints/background/__tests__/background-stream.test.ts
@@ -5,6 +5,8 @@ const streamTextMock = vi.fn()
 const outputObjectMock = vi.fn((params: Record<string, unknown>) => params)
 const getModelByIdMock = vi.fn()
 const loggerErrorMock = vi.fn()
+const translationCacheGetMock = vi.fn()
+const translationCachePutMock = vi.fn()
 const parsePartialJsonMock = vi.fn(async (text: string | undefined) => {
   if (!text) {
     return { state: "undefined-input", value: undefined }
@@ -45,6 +47,15 @@ vi.mock("@/utils/providers/model", () => ({
 vi.mock("@/utils/logger", () => ({
   logger: {
     error: loggerErrorMock,
+  },
+}))
+
+vi.mock("@/utils/db/dexie/db", () => ({
+  db: {
+    translationCache: {
+      get: translationCacheGetMock,
+      put: translationCachePutMock,
+    },
   },
 }))
 
@@ -101,6 +112,7 @@ describe("background-stream", () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    translationCacheGetMock.mockResolvedValue(undefined)
   })
 
   it("streams structured object output from background", async () => {
@@ -141,6 +153,7 @@ describe("background-stream", () => {
       model: "mock-model",
       prompt: "Analyze selection",
     }))
+    expect(translationCachePutMock).not.toHaveBeenCalled()
     expect(result).toEqual({
       output: {
         score: 97,
@@ -183,6 +196,82 @@ describe("background-stream", () => {
       score: "99",
       summary: "text",
     }).success).toBe(false)
+  })
+
+  it("returns cached structured object streams without calling the model", async () => {
+    translationCacheGetMock.mockResolvedValue({
+      key: "stream-structured-object:custom-action-cache",
+      translation: JSON.stringify({ term: "frog", definition: "a small amphibian" }),
+      createdAt: new Date(),
+    })
+
+    const { runStructuredObjectStreamInBackground } = await import("../background-stream")
+    const result = await runStructuredObjectStreamInBackground({
+      providerId: "openai-default",
+      cacheKey: "custom-action-cache",
+      prompt: "Define frog",
+      outputSchema: [
+        { name: "term", type: "string" },
+        { name: "definition", type: "string" },
+      ],
+    })
+
+    expect(translationCacheGetMock).toHaveBeenCalledWith("stream-structured-object:custom-action-cache")
+    expect(getModelByIdMock).not.toHaveBeenCalled()
+    expect(streamTextMock).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      output: { term: "frog", definition: "a small amphibian" },
+      thinking: { status: "complete", text: "" },
+    })
+  })
+
+  it("caches completed structured object stream results", async () => {
+    getModelByIdMock.mockResolvedValue("mock-model")
+    streamTextMock.mockReturnValue({
+      fullStream: (async function* () {
+        yield { type: "text-delta", text: "{\"term\":\"frog\",\"definition\":\"a small amphibian\"}" }
+      })(),
+    })
+
+    const { runStructuredObjectStreamInBackground } = await import("../background-stream")
+    const result = await runStructuredObjectStreamInBackground({
+      providerId: "openai-default",
+      cacheKey: "custom-action-cache",
+      prompt: "Define frog",
+      outputSchema: [
+        { name: "term", type: "string" },
+        { name: "definition", type: "string" },
+      ],
+    })
+
+    expect(result.output).toEqual({ term: "frog", definition: "a small amphibian" })
+    expect(translationCachePutMock).toHaveBeenCalledWith(expect.objectContaining({
+      key: "stream-structured-object:custom-action-cache",
+      translation: JSON.stringify({ term: "frog", definition: "a small amphibian" }),
+    }))
+  })
+
+  it("returns cached text stream snapshots without calling the model", async () => {
+    translationCacheGetMock.mockResolvedValue({
+      key: "stream-text:selection-translation-cache",
+      translation: "cached translation",
+      createdAt: new Date(),
+    })
+
+    const { runStreamTextInBackground } = await import("../background-stream")
+    const result = await runStreamTextInBackground({
+      providerId: "openai-default",
+      cacheKey: "selection-translation-cache",
+      prompt: "Translate selection",
+    })
+
+    expect(translationCacheGetMock).toHaveBeenCalledWith("stream-text:selection-translation-cache")
+    expect(getModelByIdMock).not.toHaveBeenCalled()
+    expect(streamTextMock).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      output: "cached translation",
+      thinking: { status: "complete", text: "" },
+    })
   })
 
   it("streams text via background stream port handler", async () => {

--- a/src/entrypoints/background/background-stream.ts
+++ b/src/entrypoints/background/background-stream.ts
@@ -17,11 +17,14 @@ import type {
 import { Output, parsePartialJson, streamText } from "ai"
 import { z } from "zod"
 import { BACKGROUND_STREAM_PORTS } from "@/types/background-stream"
+import { db } from "@/utils/db/dexie/db"
 import { extractAISDKErrorMessage } from "@/utils/error/extract-message"
 import { logger } from "@/utils/logger"
 import { getModelById } from "@/utils/providers/model"
 
 const invalidStreamStartPayloadMessage = "Invalid stream start payload"
+const STREAM_TEXT_CACHE_PREFIX = "stream-text"
+const STREAM_STRUCTURED_OBJECT_CACHE_PREFIX = "stream-structured-object"
 
 function createStreamAbortError(message: string) {
   return new DOMException(message, "AbortError")
@@ -40,6 +43,8 @@ const streamPortStartEnvelopeSchema = z.object({
 
 const streamTextPayloadSchema = z.object({
   providerId: z.string().trim().min(1),
+  cacheKey: z.string().trim().min(1).optional(),
+  bypassCache: z.boolean().optional(),
 }).loose()
 
 const structuredObjectFieldSchema = z.object({
@@ -49,6 +54,8 @@ const structuredObjectFieldSchema = z.object({
 
 const structuredObjectPayloadSchema = z.object({
   providerId: z.string().trim().min(1),
+  cacheKey: z.string().trim().min(1).optional(),
+  bypassCache: z.boolean().optional(),
   outputSchema: z.array(structuredObjectFieldSchema).min(1),
 }).loose().superRefine((payload, ctx) => {
   const nameSet = new Set<string>()
@@ -240,15 +247,86 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value)
 }
 
+function createCompletedThinkingSnapshot(): ThinkingSnapshot {
+  return {
+    status: "complete",
+    text: "",
+  }
+}
+
+function createStreamCacheKey(prefix: string, cacheKey: string) {
+  return `${prefix}:${cacheKey}`
+}
+
+async function getCachedTextStreamSnapshot(cacheKey: string): Promise<BackgroundTextStreamSnapshot | null> {
+  const cached = await db.translationCache.get(createStreamCacheKey(STREAM_TEXT_CACHE_PREFIX, cacheKey))
+  if (!cached) {
+    return null
+  }
+
+  return createStreamSnapshot(cached.translation, createCompletedThinkingSnapshot())
+}
+
+async function putCachedTextStreamSnapshot(cacheKey: string, snapshot: BackgroundTextStreamSnapshot) {
+  if (!snapshot.output) {
+    return
+  }
+
+  await db.translationCache.put({
+    key: createStreamCacheKey(STREAM_TEXT_CACHE_PREFIX, cacheKey),
+    translation: snapshot.output,
+    createdAt: new Date(),
+  })
+}
+
+function parseCachedStructuredObject(value: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(value)
+    return isRecord(parsed) ? parsed : null
+  }
+  catch {
+    return null
+  }
+}
+
+async function getCachedStructuredObjectSnapshot(cacheKey: string): Promise<BackgroundStructuredObjectStreamSnapshot | null> {
+  const cached = await db.translationCache.get(createStreamCacheKey(STREAM_STRUCTURED_OBJECT_CACHE_PREFIX, cacheKey))
+  if (!cached) {
+    return null
+  }
+
+  const value = parseCachedStructuredObject(cached.translation)
+  if (!value) {
+    return null
+  }
+
+  return createStreamSnapshot(value, createCompletedThinkingSnapshot())
+}
+
+async function putCachedStructuredObjectSnapshot(cacheKey: string, snapshot: BackgroundStructuredObjectStreamSnapshot) {
+  await db.translationCache.put({
+    key: createStreamCacheKey(STREAM_STRUCTURED_OBJECT_CACHE_PREFIX, cacheKey),
+    translation: JSON.stringify(snapshot.output),
+    createdAt: new Date(),
+  })
+}
+
 export async function runStreamTextInBackground(
   serializablePayload: BackgroundStreamTextSerializablePayload,
   options: StreamRuntimeOptions<BackgroundTextStreamSnapshot> = {},
 ): Promise<BackgroundTextStreamSnapshot> {
-  const { providerId, ...streamTextParams } = serializablePayload
+  const { providerId, cacheKey, bypassCache, ...streamTextParams } = serializablePayload
   const { signal, onChunk, onError } = options
 
   if (signal?.aborted) {
     throw new DOMException("stream aborted", "AbortError")
+  }
+
+  if (cacheKey && !bypassCache) {
+    const cachedSnapshot = await getCachedTextStreamSnapshot(cacheKey)
+    if (cachedSnapshot) {
+      return cachedSnapshot
+    }
   }
 
   const model = await getModelById(providerId)
@@ -305,18 +383,30 @@ export async function runStreamTextInBackground(
     status: "complete",
   }
 
-  return createStreamSnapshot(cumulativeText, thinking)
+  const snapshot = createStreamSnapshot(cumulativeText, thinking)
+  if (cacheKey) {
+    await putCachedTextStreamSnapshot(cacheKey, snapshot)
+  }
+
+  return snapshot
 }
 
 export async function runStructuredObjectStreamInBackground(
   serializablePayload: BackgroundStreamStructuredObjectSerializablePayload,
   options: StreamRuntimeOptions<BackgroundStructuredObjectStreamSnapshot> = {},
 ): Promise<BackgroundStructuredObjectStreamSnapshot> {
-  const { providerId, outputSchema, ...streamParams } = serializablePayload
+  const { providerId, outputSchema, cacheKey, bypassCache, ...streamParams } = serializablePayload
   const { signal, onChunk, onError } = options
 
   if (signal?.aborted) {
     throw new DOMException("stream aborted", "AbortError")
+  }
+
+  if (cacheKey && !bypassCache) {
+    const cachedSnapshot = await getCachedStructuredObjectSnapshot(cacheKey)
+    if (cachedSnapshot) {
+      return cachedSnapshot
+    }
   }
 
   const model = await getModelById(providerId)
@@ -395,7 +485,12 @@ export async function runStructuredObjectStreamInBackground(
     status: "complete",
   }
 
-  return createStreamSnapshot(finalValue, thinking)
+  const snapshot = createStreamSnapshot(finalValue, thinking)
+  if (cacheKey) {
+    await putCachedStructuredObjectSnapshot(cacheKey, snapshot)
+  }
+
+  return snapshot
 }
 
 const parseStreamTextStartMessage = createStartMessageParser<BackgroundStreamTextSerializablePayload>(streamTextPayloadSchema)

--- a/src/entrypoints/selection.content/__tests__/utils.test.ts
+++ b/src/entrypoints/selection.content/__tests__/utils.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from "vitest"
+import { BLOCK_CONTENT_CLASS, CONTENT_WRAPPER_CLASS, NOTRANSLATE_CLASS } from "@/utils/constants/dom-labels"
 import {
   buildContextSnapshot,
   createRangeSnapshot,
@@ -122,6 +123,38 @@ describe("buildContextSnapshot", () => {
     expect(buildContextSnapshot(createSelectionSnapshot(range))).toEqual({
       text: "Alpha Beta gamma",
       paragraphs: ["Alpha Beta gamma"],
+    })
+  })
+
+  it("excludes Read Frog translated content when building paragraph context", () => {
+    document.body.innerHTML = `
+      <article>
+        <p id="paragraph">
+          Original
+          <strong id="selection">word</strong>
+          tail
+          <span class="${NOTRANSLATE_CLASS} ${CONTENT_WRAPPER_CLASS}">
+            <br>
+            <span class="${NOTRANSLATE_CLASS} ${BLOCK_CONTENT_CLASS}">
+              Translated text that should not be sent back to the model
+            </span>
+          </span>
+        </p>
+      </article>
+    `
+
+    const selectionNode = document.getElementById("selection")?.firstChild
+    if (!selectionNode) {
+      throw new Error("Selection node not found")
+    }
+
+    const range = document.createRange()
+    range.setStart(selectionNode, 0)
+    range.setEnd(selectionNode, selectionNode.textContent?.length ?? 0)
+
+    expect(buildContextSnapshot(createSelectionSnapshot(range))).toEqual({
+      text: "Original word tail",
+      paragraphs: ["Original word tail"],
     })
   })
 })

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/use-custom-action-execution.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/use-custom-action-execution.ts
@@ -13,6 +13,7 @@ import { ANALYTICS_FEATURE } from "@/types/analytics"
 import { isLLMProviderConfig } from "@/types/config/provider"
 import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
 import { streamBackgroundStructuredObject } from "@/utils/content-script/background-stream-client"
+import { Sha256Hex } from "@/utils/hash"
 import { getOrCreateWebPageContext } from "@/utils/host/translate/webpage-context"
 import { resolveModelId } from "@/utils/providers/model-id"
 import { getProviderOptionsWithOverride } from "@/utils/providers/options"
@@ -54,6 +55,7 @@ interface CustomActionExecutionRequest {
   }
   key: string
   payload: {
+    cacheKey: string
     outputSchema: Array<{ name: string, type: SelectionToolbarCustomAction["outputSchema"][number]["type"] }>
     prompt: string
     providerId: string
@@ -217,6 +219,17 @@ function buildCustomActionExecutionRequest({
     providerConfig.providerOptions,
   )
   const outputSchema = action.outputSchema.map(({ name, type }) => ({ name, type }))
+  const cacheKey = Sha256Hex(stringifyExecutionRequestKey({
+    model: providerConfig.model,
+    outputSchema: action.outputSchema.map(({ description, name, type }) => ({ description, name, type })),
+    prompt,
+    promptTokens,
+    provider: providerConfig.provider,
+    providerId: providerConfig.id,
+    providerOptions,
+    system: systemPrompt,
+    temperature: providerConfig.temperature,
+  }))
 
   return {
     analytics: {
@@ -241,6 +254,7 @@ function buildCustomActionExecutionRequest({
     }),
     payload: {
       providerId: providerConfig.id,
+      cacheKey,
       system: systemPrompt,
       prompt,
       outputSchema,

--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx
@@ -15,6 +15,7 @@ import { configFieldsAtomMap, writeConfigAtom } from "@/utils/atoms/config"
 import { filterEnabledProvidersConfig } from "@/utils/config/helpers"
 import { buildFeatureProviderPatch } from "@/utils/constants/feature-providers"
 import { streamBackgroundText } from "@/utils/content-script/background-stream-client"
+import { Sha256Hex } from "@/utils/hash"
 import { prepareTranslationText } from "@/utils/host/translate/text-preparation"
 import { translateTextCore } from "@/utils/host/translate/translate-text"
 import { getOrCreateWebPageContext } from "@/utils/host/translate/webpage-context"
@@ -111,10 +112,20 @@ async function translateWithLlm({
         }
       : undefined,
   )
+  const cacheKey = Sha256Hex(
+    "selectionTranslation",
+    preparedText,
+    translateRequest.language.sourceCode,
+    translateRequest.language.targetCode,
+    JSON.stringify(providerConfig),
+    systemPrompt,
+    prompt,
+  )
 
   const translatedText = await streamBackgroundText(
     {
       providerId,
+      cacheKey,
       system: systemPrompt,
       prompt,
       providerOptions,

--- a/src/entrypoints/selection.content/utils.ts
+++ b/src/entrypoints/selection.content/utils.ts
@@ -1,3 +1,9 @@
+import {
+  CONTENT_WRAPPER_CLASS,
+  REACT_SHADOW_HOST_CLASS,
+  TRANSLATION_ERROR_CONTAINER_CLASS,
+} from "@/utils/constants/dom-labels"
+
 export interface SelectionRangeSnapshot {
   startContainer: Node
   startOffset: number
@@ -286,6 +292,36 @@ function isParagraphLikeDisplay(element: Element) {
   return PARAGRAPH_DISPLAY_VALUES.has(window.getComputedStyle(element).display)
 }
 
+function isReadFrogGeneratedElement(element: Element) {
+  return element.classList.contains(CONTENT_WRAPPER_CLASS)
+    || element.classList.contains(TRANSLATION_ERROR_CONTAINER_CLASS)
+    || element.classList.contains(REACT_SHADOW_HOST_CLASS)
+}
+
+function isInsideReadFrogGeneratedContent(node: Node, boundary: Node) {
+  let current: Node | null = node
+
+  while (current) {
+    if (current instanceof Element && isReadFrogGeneratedElement(current)) {
+      return true
+    }
+    if (current === boundary) {
+      return false
+    }
+    current = getParentNodeAcrossShadow(current)
+  }
+
+  return false
+}
+
+function shouldIncludeContextTextNode(node: Node, boundary: Node) {
+  if (normalizeParagraphText(node.textContent ?? "") === "") {
+    return false
+  }
+
+  return !isInsideReadFrogGeneratedContent(node, boundary)
+}
+
 function findParagraphOwner(node: Node | null): ParagraphOwner | null {
   let current = getNearestParentElement(node)
   let semanticFallback: ParagraphOwner | null = null
@@ -320,9 +356,9 @@ function extractOwnerText(owner: ParagraphOwner) {
   const textParts: string[] = []
   const walker = document.createTreeWalker(owner, NodeFilter.SHOW_TEXT, {
     acceptNode(node) {
-      return normalizeParagraphText(node.textContent ?? "") === ""
-        ? NodeFilter.FILTER_REJECT
-        : NodeFilter.FILTER_ACCEPT
+      return shouldIncludeContextTextNode(node, owner)
+        ? NodeFilter.FILTER_ACCEPT
+        : NodeFilter.FILTER_REJECT
     },
   })
 
@@ -368,9 +404,9 @@ function collectParagraphOwners(rangeSnapshots: SelectionRangeSnapshot[]) {
     const traversalRoot = getTraversalRoot(rangeSnapshot)
     const walker = document.createTreeWalker(traversalRoot, NodeFilter.SHOW_TEXT, {
       acceptNode(node) {
-        return normalizeParagraphText(node.textContent ?? "") === ""
-          ? NodeFilter.FILTER_REJECT
-          : NodeFilter.FILTER_ACCEPT
+        return shouldIncludeContextTextNode(node, traversalRoot)
+          ? NodeFilter.FILTER_ACCEPT
+          : NodeFilter.FILTER_REJECT
       },
     })
 

--- a/src/types/background-stream.ts
+++ b/src/types/background-stream.ts
@@ -4,6 +4,8 @@ import type { SelectionToolbarCustomActionOutputType } from "@/types/config/sele
 
 interface BaseBackgroundStreamSerializablePayload {
   providerId: string
+  cacheKey?: string
+  bypassCache?: boolean
   system?: string
   prompt?: string
   messages?: JSONValue[]


### PR DESCRIPTION
## Summary
- 过滤划词上下文里的 Read Frog 注入翻译节点，避免把已翻译内容再次发送给模型
- 为划词翻译（LLM 流式）和自定义动作/词典类结构化输出增加最终结果缓存，重复查询相同输入时不再重复请求模型
- 复用现有 translationCache 的 TTL/清理路径，并增加回归测试覆盖缓存命中与上下文过滤

Refs #1510（先修复其中“上下文包含已翻译内容”和“划词/词典类动作重复请求无缓存”的部分；完整词典本/收藏 UI 仍需后续产品设计）

## Test Plan
- `SKIP_FREE_API=true pnpm test src/entrypoints/background/__tests__/background-stream.test.ts src/entrypoints/selection.content/__tests__/utils.test.ts`
- `pnpm type-check`
- `pnpm lint src/entrypoints/background/background-stream.ts src/entrypoints/background/__tests__/background-stream.test.ts src/entrypoints/selection.content/utils.ts src/entrypoints/selection.content/__tests__/utils.test.ts src/entrypoints/selection.content/selection-toolbar/custom-action-button/use-custom-action-execution.ts src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx src/types/background-stream.ts`
- `WXT_SKIP_ENV_VALIDATION=true pnpm build`
- pre-push hook: `nx run @read-frog/extension:lint`
- pre-push hook: `nx run @read-frog/extension:type-check`
- pre-push hook: `nx run @read-frog/extension:test` (138 files / 1204 tests passed)
