### PR TITLE
feat(translate): add Microsoft batch translation for subtitle warmup

### DIFF
--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -11,6 +11,7 @@ import { generateArticleSummary } from "@/utils/content/summary"
 import { cleanText } from "@/utils/content/utils"
 import { db } from "@/utils/db/dexie/db"
 import { Sha256Hex } from "@/utils/hash"
+import { microsoftTranslate } from "@/utils/host/translate/api/microsoft"
 import { executeTranslate } from "@/utils/host/translate/execute-translate"
 import { normalizePromptContextValue } from "@/utils/host/translate/translate-text"
 import { normalizeTranslationOutput } from "@/utils/host/translate/translation-output-normalization"
@@ -345,6 +346,13 @@ export async function setUpSubtitlesTranslationQueue() {
     }
 
     return await getOrGenerateSubtitleSummary(videoTitle, subtitlesContext, providerConfig, requestQueue)
+  })
+
+  onMessage("microsoftBatchTranslate", async (message) => {
+    const { texts, fromLang, toLang } = message.data
+    const hash = Sha256Hex("ms-batch", fromLang, toLang, ...texts)
+    const thunk = () => microsoftTranslate(texts, fromLang, toLang)
+    return requestQueue.enqueue(thunk, Date.now(), hash)
   })
 
   onMessage("setSubtitlesRequestQueueConfig", (message) => {

--- a/src/utils/host/translate/api/microsoft.ts
+++ b/src/utils/host/translate/api/microsoft.ts
@@ -1,10 +1,18 @@
+export async function microsoftTranslate(source: string, fromLang: string, toLang: string): Promise<string>
+export async function microsoftTranslate(source: string[], fromLang: string, toLang: string): Promise<string[]>
 export async function microsoftTranslate(
-  sourceText: string,
+  source: string | string[],
   fromLang: string,
   toLang: string,
-): Promise<string> {
-  const effectiveFromLang = fromLang === "auto" ? "" : fromLang
+): Promise<string | string[]> {
+  const isSingle = typeof source === "string"
+  const texts = isSingle ? [source] : source
 
+  if (texts.length === 0) {
+    return []
+  }
+
+  const effectiveFromLang = fromLang === "auto" ? "" : fromLang
   const token = await refreshMicrosoftToken()
 
   const resp = await fetch(
@@ -16,7 +24,7 @@ export async function microsoftTranslate(
         "Ocp-Apim-Subscription-Key": token,
         "Authorization": `Bearer ${token}`,
       },
-      body: JSON.stringify([{ Text: sourceText }]),
+      body: JSON.stringify(texts.map(text => ({ Text: text }))),
     },
   ).catch((error) => {
     throw new Error(
@@ -38,13 +46,21 @@ export async function microsoftTranslate(
   try {
     const result = await resp.json()
 
-    if (!Array.isArray(result) || !result[0]?.translations?.[0]?.text) {
+    if (!Array.isArray(result) || result.length !== texts.length) {
       throw new Error(
-        "Unexpected response format from Microsoft translation API",
+        `Unexpected response format: expected ${texts.length} results, got ${Array.isArray(result) ? result.length : "non-array"}`,
       )
     }
 
-    return result[0].translations[0].text
+    const translations = result.map((item: { translations?: { text?: string }[] }, index: number) => {
+      const text = item?.translations?.[0]?.text
+      if (text == null) {
+        throw new Error(`Missing translation for item at index ${index}`)
+      }
+      return text
+    })
+
+    return isSingle ? translations[0] : translations
   }
   catch (error) {
     throw new Error(
@@ -53,7 +69,7 @@ export async function microsoftTranslate(
   }
 }
 
-async function refreshMicrosoftToken(): Promise<string> {
+export async function refreshMicrosoftToken(): Promise<string> {
   try {
     const resp = await fetch("https://edge.microsoft.com/translate/auth")
 

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -65,6 +65,8 @@ interface ProtocolMap {
   // Subtitle-specific queue config messages
   setSubtitlesRequestQueueConfig: (data: Partial<RequestQueueConfig>) => void
   setSubtitlesBatchQueueConfig: (data: Partial<BatchQueueConfig>) => void
+  // microsoft batch translation
+  microsoftBatchTranslate: (data: { texts: string[], fromLang: string, toLang: string }) => Promise<string[]>
   // network proxy
   backgroundFetch: (data: ProxyRequest) => Promise<ProxyResponse>
   // cache management

--- a/src/utils/subtitles/__tests__/microsoft-warmup.test.ts
+++ b/src/utils/subtitles/__tests__/microsoft-warmup.test.ts
@@ -1,0 +1,151 @@
+import type { SubtitlesFragment } from "../types"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { sendMessage } from "@/utils/message"
+import { microsoftWarmupTranslate } from "../warmup/microsoft-warmup"
+
+vi.mock("@/utils/message", () => ({
+  sendMessage: vi.fn(),
+}))
+
+vi.mock("@/utils/logger", () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+}))
+
+const mockSendMessage = vi.mocked(sendMessage)
+
+function makeFragment(text: string, start: number, end?: number): SubtitlesFragment {
+  return { text, start, end: end ?? start + 1000 }
+}
+
+describe("microsoftWarmupTranslate", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it("returns empty array for empty input", async () => {
+    const result = await microsoftWarmupTranslate([], "en", "zh")
+    expect(result).toEqual([])
+    expect(mockSendMessage).not.toHaveBeenCalled()
+  })
+
+  it("translates a single fragment", async () => {
+    mockSendMessage.mockResolvedValueOnce(["你好"] as never)
+
+    const fragments = [makeFragment("Hello", 0)]
+    const result = await microsoftWarmupTranslate(fragments, "en", "zh")
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(1)
+    expect(mockSendMessage).toHaveBeenCalledWith("microsoftBatchTranslate", {
+      texts: ["Hello"],
+      fromLang: "en",
+      toLang: "zh",
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].translation).toBe("你好")
+    expect(result[0].text).toBe("Hello")
+    expect(result[0].start).toBe(0)
+  })
+
+  it("translates multiple fragments in one chunk", async () => {
+    mockSendMessage.mockResolvedValueOnce(["你好", "世界", "今天"] as never)
+
+    const fragments = [
+      makeFragment("Hello", 0),
+      makeFragment("World", 1000),
+      makeFragment("Today", 2000),
+    ]
+    const result = await microsoftWarmupTranslate(fragments, "en", "zh")
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(1)
+    expect(result).toHaveLength(3)
+    expect(result[0].translation).toBe("你好")
+    expect(result[1].translation).toBe("世界")
+    expect(result[2].translation).toBe("今天")
+  })
+
+  it("splits fragments into chunks by element count (100 max)", async () => {
+    const fragments = Array.from({ length: 150 }, (_, i) =>
+      makeFragment(`Text ${i}`, i * 1000),
+    )
+
+    mockSendMessage
+      .mockResolvedValueOnce(Array.from({ length: 100 }, (_, i) => `翻译 ${i}`) as never)
+      .mockResolvedValueOnce(Array.from({ length: 50 }, (_, i) => `翻译 ${100 + i}`) as never)
+
+    const result = await microsoftWarmupTranslate(fragments, "en", "zh")
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    expect(result).toHaveLength(150)
+    expect(result[0].translation).toBe("翻译 0")
+    expect(result[99].translation).toBe("翻译 99")
+    expect(result[100].translation).toBe("翻译 100")
+    expect(result[149].translation).toBe("翻译 149")
+  })
+
+  it("splits fragments into chunks by character count (50000 max)", async () => {
+    const longText = "a".repeat(30_000)
+    const fragments = [
+      makeFragment(longText, 0),
+      makeFragment(longText, 1000),
+      makeFragment("short", 2000),
+    ]
+
+    // chunk1: [frag0] (30K chars), chunk2: [frag1, frag2] (30K + 5 < 50K)
+    mockSendMessage
+      .mockResolvedValueOnce(["翻译1"] as never)
+      .mockResolvedValueOnce(["翻译2", "短"] as never)
+
+    const result = await microsoftWarmupTranslate(fragments, "en", "zh")
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(2)
+    expect(result[0].translation).toBe("翻译1")
+    expect(result[1].translation).toBe("翻译2")
+    expect(result[2].translation).toBe("短")
+  })
+
+  it("handles partial chunk failure gracefully", async () => {
+    const fragments = Array.from({ length: 150 }, (_, i) =>
+      makeFragment(`Text ${i}`, i * 1000),
+    )
+
+    // chunk1: 100 fragments succeeds, chunk2: 50 fragments fails
+    mockSendMessage
+      .mockResolvedValueOnce(Array.from({ length: 100 }, (_, i) => `翻译 ${i}`) as never)
+      .mockRejectedValueOnce(new Error("Network error") as never)
+
+    const result = await microsoftWarmupTranslate(fragments, "en", "zh")
+
+    expect(result).toHaveLength(150)
+    expect(result[0].translation).toBe("翻译 0")
+    expect(result[99].translation).toBe("翻译 99")
+    // Second chunk failed — translations remain undefined
+    expect(result[100].translation).toBeUndefined()
+    expect(result[149].translation).toBeUndefined()
+  })
+
+  it("preserves original fragment properties", async () => {
+    mockSendMessage.mockResolvedValueOnce(["你好"] as never)
+
+    const fragments = [{ text: "Hello", start: 500, end: 1500 }]
+    const result = await microsoftWarmupTranslate(fragments, "en", "zh")
+
+    expect(result[0]).toEqual({
+      text: "Hello",
+      start: 500,
+      end: 1500,
+      translation: "你好",
+    })
+  })
+
+  it("does not mutate input fragments", async () => {
+    mockSendMessage.mockResolvedValueOnce(["你好"] as never)
+
+    const original: SubtitlesFragment = { text: "Hello", start: 0, end: 1000 }
+    const fragments = [original]
+    const result = await microsoftWarmupTranslate(fragments, "en", "zh")
+
+    expect(original.translation).toBeUndefined()
+    expect(result[0].translation).toBe("你好")
+  })
+})

--- a/src/utils/subtitles/warmup/microsoft-warmup.ts
+++ b/src/utils/subtitles/warmup/microsoft-warmup.ts
@@ -1,0 +1,79 @@
+import type { SubtitlesFragment } from "../types"
+import { logger } from "@/utils/logger"
+import { sendMessage } from "@/utils/message"
+
+const MS_BATCH_MAX_ELEMENTS = 100
+const MS_BATCH_MAX_CHARACTERS = 50_000
+
+function chunkFragments(fragments: SubtitlesFragment[]): SubtitlesFragment[][] {
+  const chunks: SubtitlesFragment[][] = []
+  let currentChunk: SubtitlesFragment[] = []
+  let currentCharCount = 0
+
+  for (const fragment of fragments) {
+    const textLength = fragment.text.length
+
+    if (currentChunk.length > 0
+      && (currentChunk.length >= MS_BATCH_MAX_ELEMENTS
+        || currentCharCount + textLength > MS_BATCH_MAX_CHARACTERS)) {
+      chunks.push(currentChunk)
+      currentChunk = []
+      currentCharCount = 0
+    }
+
+    currentChunk.push(fragment)
+    currentCharCount += textLength
+  }
+
+  if (currentChunk.length > 0) {
+    chunks.push(currentChunk)
+  }
+
+  return chunks
+}
+
+export async function microsoftWarmupTranslate(
+  fragments: SubtitlesFragment[],
+  fromLang: string,
+  toLang: string,
+): Promise<SubtitlesFragment[]> {
+  if (fragments.length === 0) {
+    return []
+  }
+
+  const chunks = chunkFragments(fragments)
+  const results = await Promise.allSettled(
+    chunks.map(chunk =>
+      sendMessage("microsoftBatchTranslate", {
+        texts: chunk.map(f => f.text),
+        fromLang,
+        toLang,
+      }),
+    ),
+  )
+
+  const translatedFragments = [...fragments]
+  let globalIndex = 0
+
+  for (let i = 0; i < chunks.length; i++) {
+    const result = results[i]
+    const chunk = chunks[i]
+
+    if (result.status === "fulfilled") {
+      const translations = result.value
+      for (let j = 0; j < chunk.length; j++) {
+        translatedFragments[globalIndex + j] = {
+          ...translatedFragments[globalIndex + j],
+          translation: translations[j],
+        }
+      }
+    }
+    else {
+      logger.warn(`Microsoft warmup chunk ${i} failed:`, result.reason)
+    }
+
+    globalIndex += chunk.length
+  }
+
+  return translatedFragments
+}


### PR DESCRIPTION
## Summary
- Refactor `microsoftTranslate` with TypeScript function overloads to support both single string and string array inputs, leveraging the MS Translate v3.0 API's native array format
- Add `microsoftBatchTranslate` message type and background handler reusing existing `RequestQueue` infrastructure for rate limiting and retries  
- Add `microsoftWarmupTranslate` orchestration function with auto-chunking (≤100 elements / ≤50K chars per API request) and best-effort error handling

This PR lays the groundwork for improving subtitle first-screen translation speed by enabling a warmup layer that can pre-translate all subtitles upfront via Microsoft Translate before the reactive LLM translation kicks in.

## Test plan
- [x] Type check passes (`pnpm type-check`)
- [x] All 1214 existing tests pass with no regressions
- [x] 8 new unit tests for warmup module covering: empty input, single/multi fragment, element count chunking, character count chunking, partial failure resilience, property preservation, immutability

🤖 Generated with [Claude Code](https://claude.com/claude-code)