### PR TITLE
chore(config): switch default translation provider from Google to Microsoft

### DIFF
--- a/.changeset/default-provider-microsoft.md
+++ b/.changeset/default-provider-microsoft.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+chore(config): switch default translation provider from Google to Microsoft

--- a/src/types/config/__tests__/config-provider-enabled.test.ts
+++ b/src/types/config/__tests__/config-provider-enabled.test.ts
@@ -14,7 +14,7 @@ function getIssuePaths(input: unknown) {
 describe("config provider enabled validation", () => {
   it("fails when a built-in feature uses a disabled provider", () => {
     const providersConfig = DEFAULT_CONFIG.providersConfig.map((provider) => {
-      if (provider.id === "google-translate-default") {
+      if (provider.id === "microsoft-translate-default") {
         return { ...provider, enabled: false }
       }
       return provider

--- a/src/utils/constants/config.ts
+++ b/src/utils/constants/config.ts
@@ -51,7 +51,7 @@ export const DEFAULT_CONFIG: Config = {
   },
   providersConfig: DEFAULT_PROVIDER_CONFIG_LIST,
   translate: {
-    providerId: "google-translate-default",
+    providerId: "microsoft-translate-default",
     mode: "bilingual",
     node: {
       enabled: false,
@@ -107,7 +107,7 @@ export const DEFAULT_CONFIG: Config = {
     features: {
       translate: {
         enabled: true,
-        providerId: "google-translate-default",
+        providerId: "microsoft-translate-default",
       },
       speak: {
         enabled: true,
@@ -126,7 +126,7 @@ export const DEFAULT_CONFIG: Config = {
   },
   inputTranslation: {
     enabled: true,
-    providerId: "google-translate-default",
+    providerId: "microsoft-translate-default",
     fromLang: "targetCode",
     toLang: "sourceCode",
     enableCycle: false,
@@ -135,7 +135,7 @@ export const DEFAULT_CONFIG: Config = {
   videoSubtitles: {
     enabled: true,
     autoStart: false,
-    providerId: "google-translate-default",
+    providerId: "microsoft-translate-default",
     style: {
       displayMode: DEFAULT_DISPLAY_MODE,
       translationPosition: DEFAULT_TRANSLATION_POSITION,


### PR DESCRIPTION
## Type of Changes

- [x] 📦 Other changes that do not modify src or test files (chore)

## Description

Switch the default translation provider from Google Translate to Microsoft Translate for all built-in features:
- Page translation
- Selection toolbar translation
- Input translation
- Video subtitles

## Related Issue

N/A

## How Has This Been Tested?

- [x] Verified through manual testing
- [x] All existing tests pass (updated provider-enabled validation test to match new default)

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality