### PR TITLE
chore(config): default page translation range to all

### DIFF
--- a/.changeset/default-translate-range-all.md
+++ b/.changeset/default-translate-range-all.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+chore(config): default page translation range to all

--- a/src/utils/constants/config.ts
+++ b/src/utils/constants/config.ts
@@ -58,8 +58,7 @@ export const DEFAULT_CONFIG: Config = {
       hotkey: "control",
     },
     page: {
-      // TODO: change this to "all" for users once our translation algorithm can handle most cases elegantly
-      range: import.meta.env.DEV ? "all" : "main",
+      range: "all",
       autoTranslatePatterns: ["news.ycombinator.com"],
       autoTranslateLanguages: [],
       shortcut: DEFAULT_AUTO_TRANSLATE_SHORTCUT_KEY,


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Default page translation range now uses all content instead of main content for new configs.

Also adds a patch changeset for the default config change.

## Related Issue

N/A

## How Has This Been Tested?

- [ ] Added unit tests
- [ ] Verified through manual testing

Commands run:

- `SKIP_FREE_API=true pnpm test src/utils/atoms/__tests__/config.test.ts`
- `pnpm lint src/utils/constants/config.ts`
- Pre-push hook: `pnpm lint`, `pnpm type-check`, `pnpm test`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

N/A
