### PR TITLE
fix(page-translation): translate initially visible content

### DIFF
--- a/.changeset/soft-geese-translate.md
+++ b/.changeset/soft-geese-translate.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+Fix page translation so visible content at the top of a page is translated immediately after starting translation.

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -215,6 +215,36 @@ describe("pageTranslationManager mutation re-walk", () => {
     mockSendMessage.mockResolvedValue(undefined)
   })
 
+  it("immediately translates already visible paragraphs when page translation starts", async () => {
+    document.body.innerHTML = `
+      <section>
+        <p id="top-result">Visible search result</p>
+      </section>
+    `
+
+    const manager = new PageTranslationManager()
+    const topResult = document.getElementById("top-result") as HTMLElement
+    vi.spyOn(topResult, "getBoundingClientRect").mockReturnValue({
+      x: 100,
+      y: 100,
+      width: 320,
+      height: 24,
+      top: 100,
+      left: 100,
+      right: 420,
+      bottom: 124,
+      toJSON: () => ({}),
+    } as DOMRect)
+
+    await manager.start()
+    await flushDomUpdates()
+
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(topResult, "walk-id", DEFAULT_CONFIG)
+    expect(intersectionObservers[0].unobserve).toHaveBeenCalledWith(topResult)
+
+    manager.stop()
+  })
+
   it("observes and translates hidden accordion content after it becomes visible", async () => {
     document.body.innerHTML = `
       <section id="accordion" hidden>

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -142,16 +142,13 @@ export class PageTranslationManager implements IPageTranslationManager {
       this.intersectionObserver = new IntersectionObserver(async (entries, observer) => {
         for (const entry of entries) {
           if (entry.isIntersecting) {
-            if (isHTMLElement(entry.target)) {
-              if (!entry.target.closest(`.${CONTENT_WRAPPER_CLASS}`)) {
-                const currentConfig = await getLocalConfig()
-                if (!currentConfig) {
-                  logger.error("Global config is not initialized")
-                  return
-                }
-                void translateWalkedElement(entry.target, walkId, currentConfig)
-              }
+            const currentConfig = await getLocalConfig()
+            if (!currentConfig) {
+              logger.error("Global config is not initialized")
+              return
             }
+
+            this.translateObservedElement(entry.target, walkId, currentConfig)
             observer.unobserve(entry.target)
           }
         }
@@ -410,7 +407,8 @@ export class PageTranslationManager implements IPageTranslationManager {
 
   private async observerTopLevelParagraphs(container: HTMLElement, existingConfig?: Config): Promise<void> {
     const observer = this.intersectionObserver
-    if (!this.walkId || !observer)
+    const walkId = this.walkId
+    if (!walkId || !observer)
       return
 
     const config = existingConfig ?? await getLocalConfig()
@@ -423,14 +421,14 @@ export class PageTranslationManager implements IPageTranslationManager {
     if (hasNoWalkAncestor(container, config))
       return
 
-    walkAndLabelElement(container, this.walkId, config)
+    walkAndLabelElement(container, walkId, config)
     // if container itself has paragraph and the id
-    if (container.hasAttribute("data-read-frog-paragraph") && container.getAttribute("data-read-frog-walked") === this.walkId) {
+    if (container.hasAttribute("data-read-frog-paragraph") && container.getAttribute("data-read-frog-walked") === walkId) {
       observer.observe(container)
       return
     }
 
-    const paragraphs = this.collectParagraphElementsDeep(container, this.walkId)
+    const paragraphs = this.collectParagraphElementsDeep(container, walkId)
     const topLevelParagraphs = paragraphs.filter((el) => {
       const ancestor = el.parentElement?.closest("[data-read-frog-paragraph]")
       // keep it if either:
@@ -438,7 +436,92 @@ export class PageTranslationManager implements IPageTranslationManager {
       //  • the ancestor is *not* inside container
       return !ancestor || !container.contains(ancestor)
     })
-    topLevelParagraphs.forEach(el => observer.observe(el))
+    topLevelParagraphs.forEach((el) => {
+      observer.observe(el)
+      this.translateIfAlreadyWithinPreloadRange(el, walkId, config, observer)
+    })
+  }
+
+  private translateObservedElement(target: Element, walkId: string, config: Config): void {
+    if (!this.isPageTranslating || this.walkId !== walkId || !isHTMLElement(target)) {
+      return
+    }
+
+    if (target.closest(`.${CONTENT_WRAPPER_CLASS}`)) {
+      return
+    }
+
+    void translateWalkedElement(target, walkId, config)
+  }
+
+  private translateIfAlreadyWithinPreloadRange(
+    element: HTMLElement,
+    walkId: string,
+    config: Config,
+    observer: IntersectionObserver,
+  ): void {
+    if (!this.isElementWithinPreloadRange(element)) {
+      return
+    }
+
+    this.translateObservedElement(element, walkId, config)
+    observer.unobserve(element)
+  }
+
+  private isElementWithinPreloadRange(element: HTMLElement): boolean {
+    const elementRect = element.getBoundingClientRect()
+    if (elementRect.width <= 0 || elementRect.height <= 0) {
+      return false
+    }
+
+    const rootRect = this.getExpandedIntersectionRootRect()
+
+    return elementRect.bottom > rootRect.top
+      && elementRect.top < rootRect.bottom
+      && elementRect.right > rootRect.left
+      && elementRect.left < rootRect.right
+  }
+
+  private getExpandedIntersectionRootRect(): DOMRectReadOnly {
+    const root = this.intersectionOptions.root
+    const rootRect = root && "getBoundingClientRect" in root
+      ? root.getBoundingClientRect()
+      : new DOMRectReadOnly(
+          0,
+          0,
+          window.innerWidth || document.documentElement.clientWidth,
+          window.innerHeight || document.documentElement.clientHeight,
+        )
+
+    const [top, right, bottom, left] = this.parseRootMargin(rootRect)
+    return new DOMRectReadOnly(
+      rootRect.left - left,
+      rootRect.top - top,
+      rootRect.width + left + right,
+      rootRect.height + top + bottom,
+    )
+  }
+
+  private parseRootMargin(rootRect: DOMRectReadOnly): [number, number, number, number] {
+    const rootMargin = this.intersectionOptions.rootMargin ?? "0px"
+    const parts = rootMargin.trim().split(/\s+/).filter(Boolean)
+    const [top = "0px", right = top, bottom = top, left = right] = parts
+
+    return [
+      this.parseRootMarginValue(top, rootRect.height),
+      this.parseRootMarginValue(right, rootRect.width),
+      this.parseRootMarginValue(bottom, rootRect.height),
+      this.parseRootMarginValue(left, rootRect.width),
+    ]
+  }
+
+  private parseRootMarginValue(value: string, referenceLength: number): number {
+    const parsed = Number.parseFloat(value)
+    if (!Number.isFinite(parsed)) {
+      return 0
+    }
+
+    return value.endsWith("%") ? referenceLength * parsed / 100 : parsed
   }
 
   /**


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

When page translation starts, existing paragraphs are registered with `IntersectionObserver` and translated once the observer reports them as intersecting. On some search-result pages this initial observer callback may not run until the page is scrolled, so the text already visible at the top can stay untranslated until the user scrolls.

This PR keeps the existing observer-based lazy translation path, but also checks each newly observed top-level paragraph against the current viewport plus the configured preload margin. If it is already in range when page translation starts, it is translated immediately and unobserved to avoid duplicate work.

## Related Issue

Closes #1537

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Commands run:

- `SKIP_FREE_API=true pnpm exec vitest run src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts --testNamePattern 'immediately translates already visible paragraphs'`
- `SKIP_FREE_API=true pnpm exec vitest run src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts`
- `SKIP_FREE_API=true pnpm type-check`
- `SKIP_FREE_API=true pnpm lint src/entrypoints/host.content/translation-control/page-translation.ts src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts`
- `WXT_SKIP_ENV_VALIDATION=true SKIP_FREE_API=true pnpm build:edge`
- Push hook also passed `nx run @read-frog/extension:lint`, `nx run @read-frog/extension:type-check`, and `nx run @read-frog/extension:test` (140 test files / 1219 tests).

## Screenshots

N/A — this is a behavioral content-script trigger fix, not a visual layout/style change. The regression is covered by the new test that confirms an already-visible paragraph is translated immediately when page translation starts.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- Includes a patch changeset for `@read-frog/extension`.
