### PR TITLE
fix(options): defer autosave during IME composition

### DIFF
--- a/.changeset/calm-otters-compose.md
+++ b/.changeset/calm-otters-compose.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+Fix autosaved option inputs so Chinese IME composition is saved only after composition ends.

--- a/src/components/form/__tests__/input-field-auto-save.test.tsx
+++ b/src/components/form/__tests__/input-field-auto-save.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+import { createFormHook } from "@tanstack/react-form"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { fieldContext, formContext } from "../form-context"
+import { InputFieldAutoSave } from "../input-field-auto-save"
+
+const { useAppForm } = createFormHook({
+  fieldComponents: {
+    InputFieldAutoSave,
+  },
+  formComponents: {},
+  fieldContext,
+  formContext,
+})
+
+function InputFieldAutoSaveHarness({ onSubmit }: { onSubmit: (value: string | undefined) => void }) {
+  const form = useAppForm({
+    defaultValues: {
+      name: "",
+    },
+    onSubmit: async ({ value }) => {
+      onSubmit(value.name)
+    },
+  })
+
+  return (
+    <form.AppForm>
+      <form.AppField name="name">
+        {field => <field.InputFieldAutoSave formForSubmit={form} label="Name" />}
+      </form.AppField>
+    </form.AppForm>
+  )
+}
+
+describe("inputFieldAutoSave", () => {
+  it("submits ordinary input changes immediately", async () => {
+    const handleSubmit = vi.fn()
+    render(<InputFieldAutoSaveHarness onSubmit={handleSubmit} />)
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Read Frog" } })
+
+    expect(screen.getByRole("textbox")).toHaveValue("Read Frog")
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledTimes(1)
+      expect(handleSubmit).toHaveBeenLastCalledWith("Read Frog")
+    })
+  })
+
+  it("waits until IME composition ends before autosaving", async () => {
+    const handleSubmit = vi.fn()
+    render(<InputFieldAutoSaveHarness onSubmit={handleSubmit} />)
+    const input = screen.getByRole("textbox")
+
+    fireEvent.compositionStart(input)
+    fireEvent.change(input, { target: { value: "ni" } })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(input).toHaveValue("ni")
+    expect(handleSubmit).not.toHaveBeenCalled()
+
+    fireEvent.compositionEnd(input, { target: { value: "你" } })
+
+    expect(input).toHaveValue("你")
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledTimes(1)
+      expect(handleSubmit).toHaveBeenLastCalledWith("你")
+    })
+  })
+})

--- a/src/components/form/input-field-auto-save.tsx
+++ b/src/components/form/input-field-auto-save.tsx
@@ -1,19 +1,28 @@
 import { useStore } from "@tanstack/react-form"
+import { useRef } from "react"
 import { Field, FieldError, FieldLabel } from "@/components/ui/base-ui/field"
 import { Input } from "@/components/ui/base-ui/input"
 import { useFieldContext } from "./form-context"
 
 export function InputFieldAutoSave(
-  { formForSubmit, label, labelExtra, type, ...props }:
+  {
+    formForSubmit,
+    label,
+    labelExtra,
+    type,
+    onChange,
+    onCompositionEnd,
+    onCompositionStart,
+    ...props
+  }:
   { formForSubmit: { handleSubmit: () => void }, label: React.ReactNode, labelExtra?: React.ReactNode } & React.InputHTMLAttributes<HTMLInputElement>,
 ) {
   const field = useFieldContext<string | number | undefined>()
   const errors = useStore(field.store, state => state.meta.errors)
   const hasError = errors.length > 0
+  const isComposingRef = useRef(false)
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value
-
+  const updateFieldValue = (value: string) => {
     if (type === "number") {
       if (value === "") {
         field.handleChange(undefined)
@@ -28,7 +37,27 @@ export function InputFieldAutoSave(
     else {
       field.handleChange(value)
     }
+  }
 
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    updateFieldValue(e.target.value)
+    onChange?.(e)
+
+    if (isComposingRef.current)
+      return
+
+    void formForSubmit.handleSubmit()
+  }
+
+  const handleCompositionStart = (e: React.CompositionEvent<HTMLInputElement>) => {
+    isComposingRef.current = true
+    onCompositionStart?.(e)
+  }
+
+  const handleCompositionEnd = (e: React.CompositionEvent<HTMLInputElement>) => {
+    isComposingRef.current = false
+    updateFieldValue(e.currentTarget.value)
+    onCompositionEnd?.(e)
     void formForSubmit.handleSubmit()
   }
 
@@ -46,6 +75,8 @@ export function InputFieldAutoSave(
         value={field.state.value ?? ""}
         onBlur={field.handleBlur}
         onChange={handleChange}
+        onCompositionEnd={handleCompositionEnd}
+        onCompositionStart={handleCompositionStart}
         aria-invalid={hasError}
         {...props}
       />


### PR DESCRIPTION
## Summary
- Defer autosave submissions while an input is in IME composition.
- Save the final committed value on `compositionend` so CustomProvider name/description fields keep Chinese input instead of persisting pinyin.
- Add a regression test for autosaved inputs during IME composition.

## Root cause
`InputFieldAutoSave` submitted every `change` event immediately. During Chinese IME composition, browsers emit interim values such as pinyin before the composition is committed; the options form then autosaved/reset against that interim value, which can make the input appear to refresh and fight deletion/composition.

## Screenshots
N/A — no visual/layout change; this is input behavior covered by the regression test.

## Test Plan
- [x] `SKIP_FREE_API=true pnpm exec vitest run src/components/form/__tests__/input-field-auto-save.test.tsx src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-specific-settings-field.test.tsx --reporter=verbose`
- [x] `pnpm type-check`
- [x] pre-push hooks: `nx run @read-frog/extension:lint`, `nx run @read-frog/extension:type-check`, `nx run @read-frog/extension:test` (141 files / 1220 tests passed)

Closes #1540
