### PR TITLE
feat(translate): integrate Microsoft warmup into subtitle translation flow

### DIFF
--- a/.changeset/subtitle-warmup-integration.md
+++ b/.changeset/subtitle-warmup-integration.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(translate): integrate Microsoft warmup into subtitle translation flow

--- a/src/entrypoints/subtitles.content/subtitles-scheduler.ts
+++ b/src/entrypoints/subtitles.content/subtitles-scheduler.ts
@@ -63,6 +63,11 @@ export class SubtitlesScheduler {
     }
   }
 
+  hasTranslation(start: number): boolean {
+    const sub = this.subtitles.find(s => s.start === start)
+    return !!sub?.translation
+  }
+
   getVideoElement(): HTMLVideoElement {
     return this.videoElement
   }

--- a/src/entrypoints/subtitles.content/subtitles-scheduler.ts
+++ b/src/entrypoints/subtitles.content/subtitles-scheduler.ts
@@ -42,7 +42,7 @@ export class SubtitlesScheduler {
       }
 
       if (newSub.translation) {
-        const updatedSub = { ...existing, translation: newSub.translation }
+        const updatedSub = { ...existing, translation: newSub.translation, isWarmup: newSub.isWarmup ?? false }
         const idx = this.subtitles.findIndex(s => s.start === existing.start)
         if (idx >= 0) {
           this.subtitles[idx] = updatedSub

--- a/src/entrypoints/subtitles.content/subtitles-scheduler.ts
+++ b/src/entrypoints/subtitles.content/subtitles-scheduler.ts
@@ -2,7 +2,6 @@ import type { StateData, SubtitlesFragment, SubtitlesState } from "@/utils/subti
 import { currentSubtitleAtom, currentTimeMsAtom, subtitlesStateAtom, subtitlesStore, subtitlesVisibleAtom } from "./atoms"
 
 const ERROR_STATE_AUTO_HIDE_MS = 5_000
-
 export class SubtitlesScheduler {
   private videoElement: HTMLVideoElement
   private subtitles: SubtitlesFragment[] = []
@@ -41,16 +40,18 @@ export class SubtitlesScheduler {
         continue
       }
 
-      if (newSub.translation) {
-        const updatedSub = { ...existing, translation: newSub.translation, isWarmup: newSub.isWarmup ?? false }
-        const idx = this.subtitles.findIndex(s => s.start === existing.start)
-        if (idx >= 0) {
-          this.subtitles[idx] = updatedSub
-        }
+      if (!newSub.translation) {
+        continue
+      }
 
-        if (currentSubtitle && existing.start === currentSubtitle.start) {
-          currentSubtitleUpdated = true
-        }
+      const updatedSub = { ...existing, translation: newSub.translation, isWarmup: newSub.isWarmup ?? false }
+      const idx = this.subtitles.findIndex(s => s.start === existing.start)
+      if (idx >= 0) {
+        this.subtitles[idx] = updatedSub
+      }
+
+      if (currentSubtitle && existing.start === currentSubtitle.start) {
+        currentSubtitleUpdated = true
       }
     }
 

--- a/src/entrypoints/subtitles.content/translation-coordinator.ts
+++ b/src/entrypoints/subtitles.content/translation-coordinator.ts
@@ -18,6 +18,7 @@ export class TranslationCoordinator {
   private translatingStarts = new Set<number>()
   private translatedStarts = new Set<number>()
   private failedStarts = new Set<number>()
+  private warmupStarts = new Set<number>()
   private isTranslating = false
   private lastEmittedState: SubtitlesState = "idle"
   private videoContext: SubtitlesVideoContext = { videoTitle: "", subtitlesTextContent: "" }
@@ -72,6 +73,7 @@ export class TranslationCoordinator {
     this.translatingStarts.clear()
     this.translatedStarts.clear()
     this.failedStarts.clear()
+    this.warmupStarts.clear()
     this.isTranslating = false
     this.lastEmittedState = "idle"
     this.videoContext = { videoTitle: "", subtitlesTextContent: "" }
@@ -79,6 +81,12 @@ export class TranslationCoordinator {
 
   clearFailed() {
     this.failedStarts.clear()
+  }
+
+  addWarmupStarts(starts: number[]) {
+    for (const start of starts) {
+      this.warmupStarts.add(start)
+    }
   }
 
   private handleTranslationTick = () => {
@@ -172,7 +180,9 @@ export class TranslationCoordinator {
   }
 
   private isCueResolved(startMs: number): boolean {
-    return this.translatedStarts.has(startMs) || this.failedStarts.has(startMs)
+    return this.translatedStarts.has(startMs)
+      || this.failedStarts.has(startMs)
+      || this.warmupStarts.has(startMs)
   }
 
   private updateLoadingStateAt(timeMs: number, fragments: SubtitlesFragment[]) {

--- a/src/entrypoints/subtitles.content/ui/subtitle-lines.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitle-lines.tsx
@@ -1,4 +1,5 @@
 import type { SubtitleTextStyle } from "@/types/config/subtitles"
+import { i18n } from "#imports"
 import { useAtomValue } from "jotai"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { SUBTITLE_FONT_FAMILIES } from "@/utils/constants/subtitles"
@@ -40,6 +41,7 @@ export function TranslationSubtitle({ content, className }: SubtitleLineProps) {
   const { style } = useAtomValue(configFieldsAtomMap.videoSubtitles)
   const language = useAtomValue(configFieldsAtomMap.language)
   const text = content ?? subtitle?.translation ?? ""
+  const isWarmup = subtitle?.isWarmup ?? false
   const { dir, lang } = getLanguageDirectionAndLang(language.targetCode)
 
   return (
@@ -50,6 +52,13 @@ export function TranslationSubtitle({ content, className }: SubtitleLineProps) {
       lang={lang}
     >
       {text}
+      {isWarmup && (
+        <span className="ml-2 text-xs opacity-60">
+          (
+          {i18n.t("subtitles.state.warmup")}
+          )
+        </span>
+      )}
     </div>
   )
 }

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -518,6 +518,17 @@ export class UniversalVideoAdapter {
       this.sessionProcessedFragments = [...this.sourceProcessedSubtitles]
     }
 
+    this.translationCoordinator = new TranslationCoordinator({
+      getFragments: () => this.segmentationPipeline
+        ? this.segmentationPipeline.processedFragments
+        : this.sessionProcessedFragments,
+      getVideoElement: () => scheduler.getVideoElement(),
+      getCurrentState: () => scheduler.getState(),
+      segmentationPipeline: this.segmentationPipeline,
+      onTranslated: fragments => scheduler.supplementSubtitles(fragments),
+      onStateChange: (state, data) => scheduler.setState(state, data),
+    })
+
     const langConfig = config?.language
     if (langConfig && !useAiSegmentation && providerConfig) {
       const fragments = this.segmentationPipeline
@@ -530,21 +541,11 @@ export class UniversalVideoAdapter {
           const untranslated = chunk.filter(f => !scheduler.hasTranslation(f.start))
           if (untranslated.length > 0) {
             scheduler.supplementSubtitles(untranslated)
+            this.translationCoordinator?.addWarmupStarts(untranslated.map(f => f.start))
           }
         },
       ).catch(error => logger.warn("Warmup translation failed:", error))
     }
-
-    this.translationCoordinator = new TranslationCoordinator({
-      getFragments: () => this.segmentationPipeline
-        ? this.segmentationPipeline.processedFragments
-        : this.sessionProcessedFragments,
-      getVideoElement: () => scheduler.getVideoElement(),
-      getCurrentState: () => scheduler.getState(),
-      segmentationPipeline: this.segmentationPipeline,
-      onTranslated: fragments => scheduler.supplementSubtitles(fragments),
-      onStateChange: (state, data) => scheduler.setState(state, data),
-    })
     this.translationCoordinator.start(videoContext)
     const summaryContextHash = buildSubtitlesSummaryContextHash(videoContext, providerConfig)
     this.subtitlesSummaryContextHash = summaryContextHash ?? null

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -47,6 +47,7 @@ export class UniversalVideoAdapter {
   private segmentationPipeline: SegmentationPipeline | null = null
   private translationCoordinator: TranslationCoordinator | null = null
   private subtitlesSummaryContextHash: string | null = null
+  private warmupFragments: SubtitlesFragment[] = []
 
   get embedded() {
     return this.config.embedded
@@ -170,6 +171,8 @@ export class UniversalVideoAdapter {
     this.sourceSubtitles = subtitles
     this.sourceProcessedSubtitles = this.buildSourceProcessedSubtitles(subtitles)
 
+    void this.startWarmup()
+
     return subtitles
   }
 
@@ -180,6 +183,62 @@ export class UniversalVideoAdapter {
     return optimizeSubtitles(rawSubtitles, sourceLanguage)
   }
 
+  private async startWarmup() {
+    this.warmupFragments = []
+    const config = await getLocalConfig()
+    if (!config)
+      return
+
+    const useAiSegmentation = !!config.videoSubtitles?.aiSegmentation
+    const providerConfig = getProviderConfigById(config.providersConfig, config.videoSubtitles.providerId)
+    const langConfig = config.language
+
+    if (useAiSegmentation || !providerConfig)
+      return
+
+    await microsoftWarmup(
+      this.sourceProcessedSubtitles,
+      langConfig.sourceCode,
+      langConfig.targetCode,
+      providerConfig.provider,
+      (chunk) => {
+        this.warmupFragments.push(...chunk)
+      },
+    )
+  }
+
+  private applyWarmupTranslations(
+    scheduler: SubtitlesScheduler,
+    config: Awaited<ReturnType<typeof getLocalConfig>>,
+    providerConfig: ReturnType<typeof getProviderConfigById>,
+  ) {
+    const useAiSegmentation = !!config?.videoSubtitles?.aiSegmentation
+
+    if (useAiSegmentation)
+      return
+
+    if (this.warmupFragments.length > 0) {
+      scheduler.supplementSubtitles(this.warmupFragments)
+      this.translationCoordinator?.addWarmupStarts(this.warmupFragments.map(f => f.start))
+    }
+    else if (config?.language && providerConfig) {
+      const fragments = this.segmentationPipeline
+        ? this.segmentationPipeline.processedFragments
+        : this.sessionProcessedFragments
+      void microsoftWarmup(
+        fragments, config.language.sourceCode, config.language.targetCode,
+        providerConfig.provider,
+        (chunk) => {
+          const untranslated = chunk.filter(f => !scheduler.hasTranslation(f.start))
+          if (untranslated.length > 0) {
+            scheduler.supplementSubtitles(untranslated)
+            this.translationCoordinator?.addWarmupStarts(untranslated.map(f => f.start))
+          }
+        },
+      ).catch(error => logger.warn("Warmup translation failed:", error))
+    }
+  }
+
   private clearSourceProcessedSubtitles() {
     this.sourceProcessedSubtitles = []
   }
@@ -188,6 +247,7 @@ export class UniversalVideoAdapter {
     this.sourceSubtitles = []
     this.clearSourceProcessedSubtitles()
     this.sourceVideoId = null
+    this.warmupFragments = []
   }
 
   private clearRuntimeSession() {
@@ -529,23 +589,8 @@ export class UniversalVideoAdapter {
       onStateChange: (state, data) => scheduler.setState(state, data),
     })
 
-    const langConfig = config?.language
-    if (langConfig && !useAiSegmentation && providerConfig) {
-      const fragments = this.segmentationPipeline
-        ? this.segmentationPipeline.processedFragments
-        : this.sessionProcessedFragments
-      void microsoftWarmup(
-        fragments, langConfig.sourceCode, langConfig.targetCode,
-        providerConfig.provider,
-        (chunk) => {
-          const untranslated = chunk.filter(f => !scheduler.hasTranslation(f.start))
-          if (untranslated.length > 0) {
-            scheduler.supplementSubtitles(untranslated)
-            this.translationCoordinator?.addWarmupStarts(untranslated.map(f => f.start))
-          }
-        },
-      ).catch(error => logger.warn("Warmup translation failed:", error))
-    }
+    this.applyWarmupTranslations(scheduler, config, providerConfig)
+
     this.translationCoordinator.start(videoContext)
     const summaryContextHash = buildSubtitlesSummaryContextHash(videoContext, providerConfig)
     this.subtitlesSummaryContextHash = summaryContextHash ?? null

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -12,10 +12,12 @@ import { getLocalConfig } from "@/utils/config/storage"
 import { HIDE_NATIVE_CAPTIONS_STYLE_ID, NAVIGATION_HANDLER_DELAY, TRANSLATE_BUTTON_CONTAINER_ID } from "@/utils/constants/subtitles"
 import { resolveLanguageCodeFromLocale } from "@/utils/content/page-language"
 import { waitForElement } from "@/utils/dom/wait-for-element"
+import { logger } from "@/utils/logger"
 import { OverlaySubtitlesError, ToastSubtitlesError } from "@/utils/subtitles/errors"
 import { optimizeSubtitles } from "@/utils/subtitles/processor/optimizer"
 import { buildSubtitlesSummaryContextHash, fetchSubtitlesSummary } from "@/utils/subtitles/processor/translator"
 import { downloadSubtitlesAsSrt } from "@/utils/subtitles/srt"
+import { microsoftWarmup } from "@/utils/subtitles/warmup/microsoft-warmup"
 import { subtitlesPositionAtom, subtitlesSettingsPanelOpenAtom, subtitlesSettingsPanelViewAtom, subtitlesStore } from "./atoms"
 import { renderSubtitlesTranslateButton } from "./renderer/render-translate-button"
 import { SegmentationPipeline } from "./segmentation-pipeline"
@@ -514,6 +516,23 @@ export class UniversalVideoAdapter {
     }
     else {
       this.sessionProcessedFragments = [...this.sourceProcessedSubtitles]
+    }
+
+    const langConfig = config?.language
+    if (langConfig && !useAiSegmentation && providerConfig) {
+      const fragments = this.segmentationPipeline
+        ? this.segmentationPipeline.processedFragments
+        : this.sessionProcessedFragments
+      void microsoftWarmup(
+        fragments, langConfig.sourceCode, langConfig.targetCode,
+        providerConfig.provider,
+        (chunk) => {
+          const untranslated = chunk.filter(f => !scheduler.hasTranslation(f.start))
+          if (untranslated.length > 0) {
+            scheduler.supplementSubtitles(untranslated)
+          }
+        },
+      ).catch(error => logger.warn("Warmup translation failed:", error))
     }
 
     this.translationCoordinator = new TranslationCoordinator({

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1003,7 +1003,7 @@ subtitles:
   state:
     loading: Read Frog loading captions
     error: Error occurred
-    warmup: Quick Translate
+    warmup: Microsoft Translate Warmup
   errors:
     http429: 429 Too many requests to youtube subtitle API, please try again later
     http404: 404 Youtube captions not found

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1003,6 +1003,7 @@ subtitles:
   state:
     loading: Read Frog loading captions
     error: Error occurred
+    warmup: Quick Translate
   errors:
     http429: 429 Too many requests to youtube subtitle API, please try again later
     http404: 404 Youtube captions not found

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -1003,6 +1003,7 @@ subtitles:
   state:
     loading: Read Frog está cargando subtítulos
     error: Se produjo un error
+    warmup: Traducción rápida
   errors:
     http429: 429 Demasiadas solicitudes a la API de subtítulos de youtube; inténtalo de nuevo más tarde
     http404: 404 Subtítulos de Youtube no encontrados

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -1003,7 +1003,7 @@ subtitles:
   state:
     loading: Read Frog está cargando subtítulos
     error: Se produjo un error
-    warmup: Traducción rápida
+    warmup: Precalentamiento de Microsoft Translate
   errors:
     http429: 429 Demasiadas solicitudes a la API de subtítulos de youtube; inténtalo de nuevo más tarde
     http404: 404 Subtítulos de Youtube no encontrados

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -888,6 +888,7 @@ subtitles:
   state:
     loading: Read Frog 字幕読み込み中
     error: エラーが発生しました
+    warmup: クイック翻訳
   errors:
     http429: 429 YouTube字幕APIへのリクエストが多すぎます。しばらくしてから再試行してください
     http404: 404 YouTubeの字幕が見つかりません

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -888,7 +888,7 @@ subtitles:
   state:
     loading: Read Frog 字幕読み込み中
     error: エラーが発生しました
-    warmup: クイック翻訳
+    warmup: Microsoft翻訳プレヒート
   errors:
     http429: 429 YouTube字幕APIへのリクエストが多すぎます。しばらくしてから再試行してください
     http404: 404 YouTubeの字幕が見つかりません

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -888,7 +888,7 @@ subtitles:
   state:
     loading: Read Frog 자막 로딩 중
     error: 오류 발생
-    warmup: 빠른 번역
+    warmup: Microsoft 번역 워밍업
   errors:
     http429: 429 유튜브 자막 인터페이스 요청이 너무 많습니다. 잠시 후 다시 시도해 주세요
     http404: 404 유튜브 자막을 찾을 수 없습니다

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -888,6 +888,7 @@ subtitles:
   state:
     loading: Read Frog 자막 로딩 중
     error: 오류 발생
+    warmup: 빠른 번역
   errors:
     http429: 429 유튜브 자막 인터페이스 요청이 너무 많습니다. 잠시 후 다시 시도해 주세요
     http404: 404 유튜브 자막을 찾을 수 없습니다

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -888,6 +888,7 @@ subtitles:
   state:
     loading: Read Frog загрузка субтитров
     error: Произошла ошибка
+    warmup: Быстрый перевод
   errors:
     http429: 429 Слишком много запросов к API YouTube субтитров, пожалуйста, попробуйте снова позже
     http404: 404 Субтитры YouTube не найдены

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -888,7 +888,7 @@ subtitles:
   state:
     loading: Read Frog загрузка субтитров
     error: Произошла ошибка
-    warmup: Быстрый перевод
+    warmup: Прогрев Microsoft Translate
   errors:
     http429: 429 Слишком много запросов к API YouTube субтитров, пожалуйста, попробуйте снова позже
     http404: 404 Субтитры YouTube не найдены

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -888,6 +888,7 @@ subtitles:
   state:
     loading: Read Frog altyazılar yükleniyor
     error: Bir hata oluştu
+    warmup: Hızlı çeviri
   errors:
     http429: 429 YouTube altyazı API'sine çok fazla istek gönderildi. Lütfen biraz bekleyip tekrar deneyin.
     http404: 404 YouTube altyazı bulunamadı.

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -888,7 +888,7 @@ subtitles:
   state:
     loading: Read Frog altyazılar yükleniyor
     error: Bir hata oluştu
-    warmup: Hızlı çeviri
+    warmup: Microsoft Çeviri Ön Isınma
   errors:
     http429: 429 YouTube altyazı API'sine çok fazla istek gönderildi. Lütfen biraz bekleyip tekrar deneyin.
     http404: 404 YouTube altyazı bulunamadı.

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -888,7 +888,7 @@ subtitles:
   state:
     loading: Read Frog đang tải phụ đề
     error: Đã xảy ra lỗi
-    warmup: Dịch nhanh
+    warmup: Khởi động dịch Microsoft
   errors:
     http429: 429 Đã gửi quá nhiều yêu cầu đến API phụ đề Youtube, vui lòng thử lại sau
     http404: 404 Không tìm thấy phụ đề Youtube

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -888,6 +888,7 @@ subtitles:
   state:
     loading: Read Frog đang tải phụ đề
     error: Đã xảy ra lỗi
+    warmup: Dịch nhanh
   errors:
     http429: 429 Đã gửi quá nhiều yêu cầu đến API phụ đề Youtube, vui lòng thử lại sau
     http404: 404 Không tìm thấy phụ đề Youtube

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -1003,7 +1003,7 @@ subtitles:
   state:
     loading: Read Frog 字幕加载中
     error: 发生错误
-    warmup: 快速翻译
+    warmup: 微软翻译预热
   errors:
     http429: 429 youtube 字幕接口请求次数过多，请稍后再试
     http404: 404 未找到 youtube 字幕

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -1003,6 +1003,7 @@ subtitles:
   state:
     loading: Read Frog 字幕加载中
     error: 发生错误
+    warmup: 快速翻译
   errors:
     http429: 429 youtube 字幕接口请求次数过多，请稍后再试
     http404: 404 未找到 youtube 字幕

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -888,7 +888,7 @@ subtitles:
   state:
     loading: Read Frog 字幕載入中
     error: 發生錯誤
-    warmup: 快速翻譯
+    warmup: 微軟翻譯預熱
   errors:
     http429: 429 youtube 字幕介面請求次數過多，請稍後再試
     http404: 404 找不到 youtube 字幕

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -888,6 +888,7 @@ subtitles:
   state:
     loading: Read Frog 字幕載入中
     error: 發生錯誤
+    warmup: 快速翻譯
   errors:
     http429: 429 youtube 字幕介面請求次數過多，請稍後再試
     http404: 404 找不到 youtube 字幕

--- a/src/utils/subtitles/__tests__/microsoft-warmup.test.ts
+++ b/src/utils/subtitles/__tests__/microsoft-warmup.test.ts
@@ -2,7 +2,7 @@ import type { SubtitlesFragment } from "../types"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { sendMessage } from "@/utils/message"
-import { microsoftWarmupTranslate } from "../warmup/microsoft-warmup"
+import { microsoftWarmup } from "../warmup/microsoft-warmup"
 
 vi.mock("@/utils/message", () => ({
   sendMessage: vi.fn(),
@@ -18,53 +18,65 @@ function makeFragment(text: string, start: number, end?: number): SubtitlesFragm
   return { text, start, end: end ?? start + 1000 }
 }
 
-describe("microsoftWarmupTranslate", () => {
+describe("microsoftWarmup", () => {
   beforeEach(() => {
     vi.resetAllMocks()
   })
 
-  it("returns empty array for empty input", async () => {
-    const result = await microsoftWarmupTranslate([], "en", "zh")
-    expect(result).toEqual([])
+  it("does nothing for empty input", async () => {
+    const onChunk = vi.fn()
+    await microsoftWarmup([], "eng", "cmn", "openai", onChunk)
+    expect(onChunk).not.toHaveBeenCalled()
     expect(mockSendMessage).not.toHaveBeenCalled()
   })
 
-  it("translates a single fragment", async () => {
-    mockSendMessage.mockResolvedValueOnce(["你好"] as never)
+  it("skips when provider is non-API (microsoft-translate)", async () => {
+    const onChunk = vi.fn()
+    await microsoftWarmup([makeFragment("Hello", 0)], "eng", "cmn", "microsoft-translate", onChunk)
+    expect(onChunk).not.toHaveBeenCalled()
+    expect(mockSendMessage).not.toHaveBeenCalled()
+  })
 
-    const fragments = [makeFragment("Hello", 0)]
-    const result = await microsoftWarmupTranslate(fragments, "en", "zh")
+  it("skips when provider is non-API (google-translate)", async () => {
+    const onChunk = vi.fn()
+    await microsoftWarmup([makeFragment("Hello", 0)], "eng", "cmn", "google-translate", onChunk)
+    expect(onChunk).not.toHaveBeenCalled()
+    expect(mockSendMessage).not.toHaveBeenCalled()
+  })
 
-    expect(mockSendMessage).toHaveBeenCalledTimes(1)
+  it("translates a single chunk and calls back", async () => {
+    mockSendMessage.mockResolvedValueOnce(["你好", "世界"] as never)
+    const onChunk = vi.fn()
+
+    const fragments = [makeFragment("Hello", 0), makeFragment("World", 1000)]
+    await microsoftWarmup(fragments, "eng", "cmn", "openai", onChunk)
+
+    expect(onChunk).toHaveBeenCalledTimes(1)
+    expect(onChunk).toHaveBeenCalledWith([
+      { text: "Hello", start: 0, end: 1000, translation: "你好" },
+      { text: "World", start: 1000, end: 2000, translation: "世界" },
+    ])
     expect(mockSendMessage).toHaveBeenCalledWith("microsoftBatchTranslate", {
-      texts: ["Hello"],
+      texts: ["Hello", "World"],
       fromLang: "en",
       toLang: "zh",
     })
-    expect(result).toHaveLength(1)
-    expect(result[0].translation).toBe("你好")
-    expect(result[0].text).toBe("Hello")
-    expect(result[0].start).toBe(0)
   })
 
-  it("translates multiple fragments in one chunk", async () => {
-    mockSendMessage.mockResolvedValueOnce(["你好", "世界", "今天"] as never)
+  it("resolves auto source language", async () => {
+    mockSendMessage.mockResolvedValueOnce(["你好"] as never)
+    const onChunk = vi.fn()
 
-    const fragments = [
-      makeFragment("Hello", 0),
-      makeFragment("World", 1000),
-      makeFragment("Today", 2000),
-    ]
-    const result = await microsoftWarmupTranslate(fragments, "en", "zh")
+    await microsoftWarmup([makeFragment("Hello", 0)], "auto", "cmn", "openai", onChunk)
 
-    expect(mockSendMessage).toHaveBeenCalledTimes(1)
-    expect(result).toHaveLength(3)
-    expect(result[0].translation).toBe("你好")
-    expect(result[1].translation).toBe("世界")
-    expect(result[2].translation).toBe("今天")
+    expect(mockSendMessage).toHaveBeenCalledWith("microsoftBatchTranslate", {
+      texts: ["Hello"],
+      fromLang: "auto",
+      toLang: "zh",
+    })
   })
 
-  it("splits fragments into chunks by element count (100 max)", async () => {
+  it("calls back per chunk sequentially", async () => {
     const fragments = Array.from({ length: 150 }, (_, i) =>
       makeFragment(`Text ${i}`, i * 1000),
     )
@@ -73,79 +85,59 @@ describe("microsoftWarmupTranslate", () => {
       .mockResolvedValueOnce(Array.from({ length: 100 }, (_, i) => `翻译 ${i}`) as never)
       .mockResolvedValueOnce(Array.from({ length: 50 }, (_, i) => `翻译 ${100 + i}`) as never)
 
-    const result = await microsoftWarmupTranslate(fragments, "en", "zh")
+    const onChunk = vi.fn()
+    await microsoftWarmup(fragments, "eng", "cmn", "openai", onChunk)
 
-    expect(mockSendMessage).toHaveBeenCalledTimes(2)
-    expect(result).toHaveLength(150)
-    expect(result[0].translation).toBe("翻译 0")
-    expect(result[99].translation).toBe("翻译 99")
-    expect(result[100].translation).toBe("翻译 100")
-    expect(result[149].translation).toBe("翻译 149")
+    expect(onChunk).toHaveBeenCalledTimes(2)
+    expect(onChunk.mock.calls[0][0]).toHaveLength(100)
+    expect(onChunk.mock.calls[0][0][0].translation).toBe("翻译 0")
+    expect(onChunk.mock.calls[1][0]).toHaveLength(50)
+    expect(onChunk.mock.calls[1][0][0].translation).toBe("翻译 100")
   })
 
-  it("splits fragments into chunks by character count (50000 max)", async () => {
-    const longText = "a".repeat(30_000)
-    const fragments = [
-      makeFragment(longText, 0),
-      makeFragment(longText, 1000),
-      makeFragment("short", 2000),
-    ]
-
-    // chunk1: [frag0] (30K chars), chunk2: [frag1, frag2] (30K + 5 < 50K)
-    mockSendMessage
-      .mockResolvedValueOnce(["翻译1"] as never)
-      .mockResolvedValueOnce(["翻译2", "短"] as never)
-
-    const result = await microsoftWarmupTranslate(fragments, "en", "zh")
-
-    expect(mockSendMessage).toHaveBeenCalledTimes(2)
-    expect(result[0].translation).toBe("翻译1")
-    expect(result[1].translation).toBe("翻译2")
-    expect(result[2].translation).toBe("短")
-  })
-
-  it("handles partial chunk failure gracefully", async () => {
+  it("skips failed chunks and continues", async () => {
     const fragments = Array.from({ length: 150 }, (_, i) =>
       makeFragment(`Text ${i}`, i * 1000),
     )
 
-    // chunk1: 100 fragments succeeds, chunk2: 50 fragments fails
     mockSendMessage
-      .mockResolvedValueOnce(Array.from({ length: 100 }, (_, i) => `翻译 ${i}`) as never)
       .mockRejectedValueOnce(new Error("Network error") as never)
+      .mockResolvedValueOnce(Array.from({ length: 50 }, (_, i) => `翻译 ${100 + i}`) as never)
 
-    const result = await microsoftWarmupTranslate(fragments, "en", "zh")
+    const onChunk = vi.fn()
+    await microsoftWarmup(fragments, "eng", "cmn", "openai", onChunk)
 
-    expect(result).toHaveLength(150)
-    expect(result[0].translation).toBe("翻译 0")
-    expect(result[99].translation).toBe("翻译 99")
-    // Second chunk failed — translations remain undefined
-    expect(result[100].translation).toBeUndefined()
-    expect(result[149].translation).toBeUndefined()
-  })
-
-  it("preserves original fragment properties", async () => {
-    mockSendMessage.mockResolvedValueOnce(["你好"] as never)
-
-    const fragments = [{ text: "Hello", start: 500, end: 1500 }]
-    const result = await microsoftWarmupTranslate(fragments, "en", "zh")
-
-    expect(result[0]).toEqual({
-      text: "Hello",
-      start: 500,
-      end: 1500,
-      translation: "你好",
-    })
+    expect(onChunk).toHaveBeenCalledTimes(1)
+    expect(onChunk.mock.calls[0][0]).toHaveLength(50)
+    expect(onChunk.mock.calls[0][0][0].translation).toBe("翻译 100")
   })
 
   it("does not mutate input fragments", async () => {
     mockSendMessage.mockResolvedValueOnce(["你好"] as never)
-
     const original: SubtitlesFragment = { text: "Hello", start: 0, end: 1000 }
-    const fragments = [original]
-    const result = await microsoftWarmupTranslate(fragments, "en", "zh")
+    const onChunk = vi.fn()
+
+    await microsoftWarmup([original], "eng", "cmn", "openai", onChunk)
 
     expect(original.translation).toBeUndefined()
-    expect(result[0].translation).toBe("你好")
+    expect(onChunk.mock.calls[0][0][0].translation).toBe("你好")
+  })
+
+  it("splits by character count", async () => {
+    const longText = "a".repeat(30_000)
+    const fragments = [
+      makeFragment(longText, 0),
+      makeFragment(longText, 1000),
+    ]
+
+    mockSendMessage
+      .mockResolvedValueOnce(["翻译1"] as never)
+      .mockResolvedValueOnce(["翻译2"] as never)
+
+    const onChunk = vi.fn()
+    await microsoftWarmup(fragments, "eng", "cmn", "openai", onChunk)
+
+    expect(onChunk).toHaveBeenCalledTimes(2)
+    expect(mockSendMessage).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/utils/subtitles/__tests__/microsoft-warmup.test.ts
+++ b/src/utils/subtitles/__tests__/microsoft-warmup.test.ts
@@ -53,8 +53,8 @@ describe("microsoftWarmup", () => {
 
     expect(onChunk).toHaveBeenCalledTimes(1)
     expect(onChunk).toHaveBeenCalledWith([
-      { text: "Hello", start: 0, end: 1000, translation: "你好" },
-      { text: "World", start: 1000, end: 2000, translation: "世界" },
+      { text: "Hello", start: 0, end: 1000, translation: "你好", isWarmup: true },
+      { text: "World", start: 1000, end: 2000, translation: "世界", isWarmup: true },
     ])
     expect(mockSendMessage).toHaveBeenCalledWith("microsoftBatchTranslate", {
       texts: ["Hello", "World"],

--- a/src/utils/subtitles/types.ts
+++ b/src/utils/subtitles/types.ts
@@ -10,4 +10,5 @@ export interface SubtitlesFragment {
   start: number
   end: number
   translation?: string
+  isWarmup?: boolean
 }

--- a/src/utils/subtitles/warmup/microsoft-warmup.ts
+++ b/src/utils/subtitles/warmup/microsoft-warmup.ts
@@ -1,11 +1,14 @@
+import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { SubtitlesFragment } from "../types"
+import { ISO6393_TO_6391 } from "@read-frog/definitions"
+import { isNonAPIProvider } from "@/types/config/provider"
 import { logger } from "@/utils/logger"
 import { sendMessage } from "@/utils/message"
 
 const MS_BATCH_MAX_ELEMENTS = 100
 const MS_BATCH_MAX_CHARACTERS = 50_000
 
-function chunkFragments(fragments: SubtitlesFragment[]): SubtitlesFragment[][] {
+export function chunkFragments(fragments: SubtitlesFragment[]): SubtitlesFragment[][] {
   const chunks: SubtitlesFragment[][] = []
   let currentChunk: SubtitlesFragment[] = []
   let currentCharCount = 0
@@ -32,48 +35,46 @@ function chunkFragments(fragments: SubtitlesFragment[]): SubtitlesFragment[][] {
   return chunks
 }
 
-export async function microsoftWarmupTranslate(
+function resolveTranslateLangs(sourceCode: LangCodeISO6393 | "auto", targetCode: LangCodeISO6393) {
+  const sourceLang = sourceCode === "auto" ? "auto" : (ISO6393_TO_6391[sourceCode] ?? "auto")
+  const targetLang = ISO6393_TO_6391[targetCode]
+  return { sourceLang, targetLang }
+}
+
+export async function microsoftWarmup(
   fragments: SubtitlesFragment[],
-  fromLang: string,
-  toLang: string,
-): Promise<SubtitlesFragment[]> {
-  if (fragments.length === 0) {
-    return []
+  sourceCode: LangCodeISO6393 | "auto",
+  targetCode: LangCodeISO6393,
+  provider: string,
+  onChunkTranslated: (translated: SubtitlesFragment[]) => void,
+): Promise<void> {
+  if (fragments.length === 0 || isNonAPIProvider(provider)) {
+    return
+  }
+
+  const { sourceLang, targetLang } = resolveTranslateLangs(sourceCode, targetCode)
+  if (!targetLang) {
+    return
   }
 
   const chunks = chunkFragments(fragments)
-  const results = await Promise.allSettled(
-    chunks.map(chunk =>
-      sendMessage("microsoftBatchTranslate", {
-        texts: chunk.map(f => f.text),
-        fromLang,
-        toLang,
-      }),
-    ),
-  )
-
-  const translatedFragments = [...fragments]
-  let globalIndex = 0
 
   for (let i = 0; i < chunks.length; i++) {
-    const result = results[i]
     const chunk = chunks[i]
-
-    if (result.status === "fulfilled") {
-      const translations = result.value
-      for (let j = 0; j < chunk.length; j++) {
-        translatedFragments[globalIndex + j] = {
-          ...translatedFragments[globalIndex + j],
-          translation: translations[j],
-        }
-      }
+    try {
+      const translations = await sendMessage("microsoftBatchTranslate", {
+        texts: chunk.map(f => f.text),
+        fromLang: sourceLang,
+        toLang: targetLang,
+      })
+      const translated = chunk.map((f, j) => ({
+        ...f,
+        translation: translations[j],
+      }))
+      onChunkTranslated(translated)
     }
-    else {
-      logger.warn(`Microsoft warmup chunk ${i} failed:`, result.reason)
+    catch (error) {
+      logger.warn(`Microsoft warmup chunk ${i} failed:`, error)
     }
-
-    globalIndex += chunk.length
   }
-
-  return translatedFragments
 }

--- a/src/utils/subtitles/warmup/microsoft-warmup.ts
+++ b/src/utils/subtitles/warmup/microsoft-warmup.ts
@@ -70,6 +70,7 @@ export async function microsoftWarmup(
       const translated = chunk.map((f, j) => ({
         ...f,
         translation: translations[j],
+        isWarmup: true,
       }))
       onChunkTranslated(translated)
     }


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)

## Description

Integrate the Microsoft batch translation warmup layer into the subtitle translation flow to improve first-screen translation speed.

**How it works:**
1. When subtitles load, Microsoft Translate pre-fills all subtitles in parallel (fire-and-forget) via batch API (~100 per request)
2. Each chunk streams back immediately — users see translations within 1-2 seconds
3. LLM TranslationCoordinator runs simultaneously, gradually replacing warmup translations with higher quality LLM output
4. Warmup results never overwrite existing LLM translations (`hasTranslation` check)
5. `warmupStarts` Set in coordinator prevents loading indicator flicker after warmup completes

**Skip conditions:**
- Non-API providers (Microsoft/Google Translate) — warmup would duplicate the same translation
- AI segmentation mode — warmup translates pre-segmentation fragments which won't match post-segmentation results

Builds on #1516 (Microsoft batch translation infrastructure).

## Related Issue

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

- 9 unit tests covering: empty input, chunk streaming, sequential callbacks, chunk failure resilience, immutability, character-count splitting, non-API provider skip, auto language resolution
- Manual testing on YouTube videos with LLM provider configured

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Key files:
- `universal-adapter.ts` — warmup integration point in `processTranslatedSubtitles()`
- `translation-coordinator.ts` — `warmupStarts` Set + `addWarmupStarts()` + `isCueResolved()` update
- `microsoft-warmup.ts` — streaming chunk warmup with `isNonAPIProvider` skip + ISO 639-3 → 639-1 language resolution
- `subtitles-scheduler.ts` — `hasTranslation()` method to prevent warmup overwriting LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)