### PR TITLE
i18n: update extension listing name

### DIFF
--- a/.changeset/update-extension-listing-name.md
+++ b/.changeset/update-extension-listing-name.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+i18n: update extension listing name

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1,5 +1,5 @@
 name: Read Frog
-extName: Read Frog - Open Source Immersive Translate
+extName: "Read Frog - Translate & Learn"
 extDescription: Read Frog is an open source browser extension designed to help you learn languages deeply from any website.
 uninstallSurveyUrl: https://tally.so/r/nPK6Ob
 dataTypes:

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -1,5 +1,5 @@
 name: Read Frog
-extName: Read Frog - Traducción inmersiva de código abierto
+extName: Read Frog - Traduce y aprende
 extDescription: Read Frog es una extensión de navegador de código abierto diseñada para ayudarte a aprender idiomas en profundidad desde cualquier sitio web.
 uninstallSurveyUrl: https://tally.so/r/nPK6Ob
 dataTypes:

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -1,5 +1,5 @@
 name: 読書カエル
-extName: 読書カエル - オープンソースインビジブル翻訳
+extName: 読書カエル - 翻訳して学ぶ
 extDescription: 読書カエルは、あらゆるウェブサイトから言語を深く学ぶために設計されたオープンソースのブラウザ拡張機能です。
 uninstallSurveyUrl: https://tally.so/r/nPK6Ob
 dataTypes:

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -1,5 +1,5 @@
 name: Read Frog
-extName: Read Frog - 오픈 소스 몰입형 번역
+extName: Read Frog - 번역하고 배우기
 extDescription: Read Frog는 모든 웹사이트에서 언어를 깊이 있게 학습할 수 있도록 도와주는 오픈 소스 브라우저 확장 프로그램입니다.
 uninstallSurveyUrl: https://tally.so/r/nPK6Ob
 dataTypes:

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -1,5 +1,5 @@
 name: Read Frog
-extName: Read Frog - Иммерсивный переводчик с открытым исходным кодом
+extName: Read Frog - Переводи и учись
 extDescription: Read Frog — расширение браузера с открытым исходным кодом, которое поможет вам глубоко изучать языки на любом веб-сайте.
 uninstallSurveyUrl: https://tally.so/r/nPK6Ob
 dataTypes:

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -1,5 +1,5 @@
 name: Read Frog
-extName: Read Frog - Açık Kaynak Sürükleyici Çeviri
+extName: Read Frog - Çevir ve Öğren
 extDescription: Read Frog, herhangi bir web sitesinden dilleri derinlemesine öğrenmenize yardımcı olmak için tasarlanmış açık kaynaklı bir tarayıcı uzantısıdır.
 uninstallSurveyUrl: https://tally.so/r/nPK6Ob
 dataTypes:

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -1,5 +1,5 @@
 name: Read Frog
-extName: Read Frog - Dịch Nhúng Mã Nguồn Mở
+extName: Read Frog - Dịch và học
 extDescription: Read Frog là tiện ích mở rộng trình duyệt mã nguồn mở được thiết kế để giúp bạn học ngôn ngữ sâu từ bất kỳ trang web nào.
 uninstallSurveyUrl: https://tally.so/r/nPK6Ob
 dataTypes:

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -1,5 +1,5 @@
 name: 陪读蛙
-extName: 陪读蛙 - 开源沉浸式翻译
+extName: 陪读蛙 - 翻译与学习
 extDescription: 陪读蛙是一款开放源代码的浏览器插件，旨在帮助您从任何网站深入学习语言。
 uninstallSurveyUrl: https://tally.so/r/3E9XDL
 dataTypes:

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -1,5 +1,5 @@
 name: 陪讀蛙
-extName: 陪讀蛙 - 開源沉浸式翻譯
+extName: 陪讀蛙 - 翻譯與學習
 extDescription: 陪讀蛙是一款開放源代碼的瀏覽器插件，旨在幫助您從任何網站深入學習語言。
 uninstallSurveyUrl: https://tally.so/r/3E9XDL
 dataTypes:


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [x] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Updates the localized extension listing name across all supported locales.

- Sets English `extName` to `Read Frog - Translate & Learn`
- Updates translated `extName` strings for Chinese Simplified, Chinese Traditional, Spanish, Japanese, Korean, Russian, Turkish, and Vietnamese
- Adds a patch changeset for the extension package

## Related Issue

None

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

Manual validation:

- `WXT_SKIP_ENV_VALIDATION=true pnpm build`
- Pre-push hook passed lint, type-check, and test
- `vitest run`: 140 test files passed, 1218 tests passed

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The manifest continues to reference `__MSG_extName__`, so the Web Store visible name is updated through the generated locale messages.