### PR TITLE
feat(background): include target language in feature context

### DIFF
--- a/src/entrypoints/background/__tests__/analytics.test.ts
+++ b/src/entrypoints/background/__tests__/analytics.test.ts
@@ -10,6 +10,7 @@ describe("background analytics", () => {
   let onMessageMock: ReturnType<typeof vi.fn>
   let storageGetItemMock: ReturnType<typeof vi.fn>
   let storageSetItemMock: ReturnType<typeof vi.fn>
+  let getTargetLanguageMock: ReturnType<typeof vi.fn>
   let posthogInitMock: ReturnType<typeof vi.fn>
   let posthogCaptureMock: ReturnType<typeof vi.fn>
   let posthogRegisterMock: ReturnType<typeof vi.fn>
@@ -41,6 +42,7 @@ describe("background analytics", () => {
       distinctIdOverride: overrides?.distinctIdOverride,
       extensionVersion: "1.0.0",
       getStorageItem: storageGetItemMock as (key: string) => Promise<unknown>,
+      getTargetLanguage: getTargetLanguageMock as () => Promise<"cmn" | undefined>,
       onMessage: onMessageMock as (type: "trackFeatureUsedEvent", handler: RegisteredMessageHandler) => unknown,
       posthog: {
         init: posthogInitMock as (token: string, config: Record<string, unknown>) => void,
@@ -56,6 +58,7 @@ describe("background analytics", () => {
     onMessageMock = vi.fn()
     storageGetItemMock = vi.fn()
     storageSetItemMock = vi.fn()
+    getTargetLanguageMock = vi.fn().mockResolvedValue("cmn")
     posthogInitMock = vi.fn()
     posthogCaptureMock = vi.fn()
     posthogRegisterMock = vi.fn()
@@ -109,8 +112,31 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 1_500,
+      target_language: "cmn",
     })
     expect(storageSetItemMock).not.toHaveBeenCalled()
+  })
+
+  it("adds the configured target language to non-translation feature events", async () => {
+    storageGetItemMock
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce("install-123")
+
+    const { captureFeatureUsedEventInBackground } = createAnalytics()
+    await captureFeatureUsedEventInBackground({
+      feature: "text_to_speech",
+      surface: "tts_settings",
+      outcome: "success",
+      latency_ms: 100,
+    })
+
+    expect(posthogCaptureMock).toHaveBeenCalledWith("feature_used", {
+      feature: "text_to_speech",
+      surface: "tts_settings",
+      outcome: "success",
+      latency_ms: 100,
+      target_language: "cmn",
+    })
   })
 
   it("does not initialize PostHog when analytics is disabled", async () => {
@@ -259,6 +285,7 @@ describe("background analytics", () => {
         latency_ms: 250,
         action_id: "dictionary",
         action_name: "Dictionary",
+        target_language: "cmn",
         $browser: "Chrome",
         $browser_version: "145.0.0.0",
         $insert_id: "insert-123",
@@ -282,6 +309,7 @@ describe("background analytics", () => {
       latency_ms: 250,
       action_id: "dictionary",
       action_name: "Dictionary",
+      target_language: "cmn",
       $browser: "Chrome",
       $browser_version: "145.0.0.0",
       $insert_id: "insert-123",

--- a/src/entrypoints/background/analytics.ts
+++ b/src/entrypoints/background/analytics.ts
@@ -1,8 +1,10 @@
+import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { CaptureResult } from "posthog-js/dist/module.no-external"
 import type { FeatureUsedEventProperties } from "@/types/analytics"
 import posthog from "posthog-js/dist/module.no-external"
 import { storage } from "#imports"
 import { env } from "@/env"
+import { getLocalConfig } from "@/utils/config/storage"
 import {
   ANALYTICS_ENABLED_STORAGE_KEY,
   ANALYTICS_FEATURE_USED_EVENT,
@@ -14,8 +16,12 @@ import { getRandomUUID } from "@/utils/crypto-polyfill"
 import { logger } from "@/utils/logger"
 import { onMessage } from "@/utils/message"
 
+type BackgroundFeatureUsedEventProperties = FeatureUsedEventProperties & {
+  target_language?: LangCodeISO6393
+}
+
 interface BackgroundAnalyticsClient {
-  capture: (eventName: string, properties: FeatureUsedEventProperties) => void
+  capture: (eventName: string, properties: BackgroundFeatureUsedEventProperties) => void
   init: (token: string, config: Record<string, unknown>) => void
   register: (properties: { extension_version: string }) => void
 }
@@ -28,6 +34,7 @@ interface BackgroundAnalyticsRuntime {
   distinctIdOverride?: string
   extensionVersion: string
   getStorageItem: (key: string) => Promise<unknown>
+  getTargetLanguage: () => Promise<LangCodeISO6393 | undefined>
   onMessage: (type: "trackFeatureUsedEvent", handler: (message: { data: FeatureUsedEventProperties }) => Promise<void>) => unknown
   posthog: BackgroundAnalyticsClient
   setStorageItem: (key: string, value: unknown) => Promise<void>
@@ -69,6 +76,10 @@ function createDefaultRuntime(): BackgroundAnalyticsRuntime {
     ),
     extensionVersion: EXTENSION_VERSION,
     getStorageItem: key => storage.getItem(key as `local:${string}`),
+    getTargetLanguage: async () => {
+      const config = await getLocalConfig()
+      return config?.language.targetCode
+    },
     onMessage,
     posthog,
     setStorageItem: (key, value) => storage.setItem(key as `local:${string}`, value),
@@ -100,6 +111,7 @@ export function filterAnalyticsCaptureResult(data: CaptureResult): CaptureResult
   setPropertyIfDefined(filteredProperties, "latency_ms", properties.latency_ms)
   setPropertyIfDefined(filteredProperties, "action_id", properties.action_id)
   setPropertyIfDefined(filteredProperties, "action_name", properties.action_name)
+  setPropertyIfDefined(filteredProperties, "target_language", properties.target_language)
   setPropertyIfDefined(filteredProperties, "$browser", properties.$browser)
   setPropertyIfDefined(filteredProperties, "$browser_version", properties.$browser_version)
   setPropertyIfDefined(filteredProperties, "$insert_id", properties.$insert_id)
@@ -200,10 +212,35 @@ export function createBackgroundAnalytics(
         return
       }
 
-      client.capture(ANALYTICS_FEATURE_USED_EVENT, properties)
+      client.capture(ANALYTICS_FEATURE_USED_EVENT, await buildBackgroundFeatureUsedEventProperties(properties))
     }
     catch (error) {
       runtime.warn(`[Analytics] Failed to capture ${ANALYTICS_FEATURE_USED_EVENT} in background`, error)
+    }
+  }
+
+  async function getBackgroundFeatureUsedEventProperties(): Promise<Partial<BackgroundFeatureUsedEventProperties>> {
+    const backgroundProperties: Partial<BackgroundFeatureUsedEventProperties> = {}
+
+    try {
+      const targetLanguage = await runtime.getTargetLanguage()
+      if (targetLanguage) {
+        backgroundProperties.target_language = targetLanguage
+      }
+    }
+    catch (error) {
+      runtime.warn("[Analytics] Failed to read target language for analytics event", error)
+    }
+
+    return backgroundProperties
+  }
+
+  async function buildBackgroundFeatureUsedEventProperties(
+    properties: FeatureUsedEventProperties,
+  ): Promise<BackgroundFeatureUsedEventProperties> {
+    return {
+      ...properties,
+      ...await getBackgroundFeatureUsedEventProperties(),
     }
   }
 


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)

## Description

- Adds the configured target language to background feature context.
- Keeps caller-provided feature data separate from background-derived fields.
- Preserves the allowlist for the new `target_language` field.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through local testing

Commands run:

- `SKIP_FREE_API=true pnpm test src/utils/__tests__/analytics.test.ts src/entrypoints/background/__tests__/analytics.test.ts`
- `SKIP_FREE_API=true pnpm type-check`
- `pnpm exec eslint src/entrypoints/background/analytics.ts src/entrypoints/background/__tests__/analytics.test.ts src/types/analytics.ts`
- Pre-push hook: lint, type-check, full test suite (`140` files, `1219` tests)

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

No release note is included because this is not a user-facing change.