### PR TITLE
fix(extension): sync page translation shortcut updates

### DIFF
--- a/.changeset/calm-frogs-rebind.md
+++ b/.changeset/calm-frogs-rebind.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+Keep the page translation shortcut active in already-open tabs after the shortcut is changed in options.

--- a/src/entrypoints/host.content/translation-control/__tests__/bind-translation-shortcut.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/bind-translation-shortcut.test.ts
@@ -1,15 +1,32 @@
 import type { PageTranslationManager } from "../page-translation"
+import type { Config } from "@/types/config/config"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { bindTranslationShortcutKey } from "../bind-translation-shortcut"
 
 const {
   mockGetLocalConfig,
   mockRegister,
+  mockStorageWatch,
   mockUnregister,
+  mockUnwatchConfig,
 } = vi.hoisted(() => ({
   mockGetLocalConfig: vi.fn(),
   mockRegister: vi.fn(),
+  mockStorageWatch: vi.fn(),
   mockUnregister: vi.fn(),
+  mockUnwatchConfig: vi.fn(),
+}))
+
+vi.mock("#imports", () => ({
+  storage: {
+    watch: mockStorageWatch,
+  },
+}))
+
+vi.mock("wxt/utils/storage", () => ({
+  storage: {
+    watch: mockStorageWatch,
+  },
 }))
 
 vi.mock("@tanstack/hotkeys", async (importOriginal) => {
@@ -43,6 +60,7 @@ describe("bindTranslationShortcutKey", () => {
     mockRegister.mockReturnValue({
       unregister: mockUnregister,
     })
+    mockStorageWatch.mockReturnValue(mockUnwatchConfig)
   })
 
   it("registers the page shortcut with the TanStack manager options", async () => {
@@ -69,6 +87,57 @@ describe("bindTranslationShortcutKey", () => {
 
     cleanup()
     expect(mockUnregister).toHaveBeenCalled()
+  })
+
+  it("rebinds the page shortcut when local config changes", async () => {
+    mockGetLocalConfig.mockResolvedValue({
+      translate: {
+        page: {
+          shortcut: "Mod+E",
+        },
+      },
+    })
+
+    let watchConfigChange: ((config: Config) => void) | undefined
+    mockStorageWatch.mockImplementation((_key: string, callback: (config: Config) => void) => {
+      watchConfigChange = callback
+      return mockUnwatchConfig
+    })
+
+    const cleanup = await bindTranslationShortcutKey(createManager(false))
+
+    expect(mockRegister).toHaveBeenCalledTimes(1)
+    expect(mockRegister).toHaveBeenLastCalledWith(
+      "Mod+E",
+      expect.any(Function),
+      expect.objectContaining({
+        preventDefault: true,
+        stopPropagation: true,
+      }),
+    )
+
+    watchConfigChange?.({
+      translate: {
+        page: {
+          shortcut: "Alt+A",
+        },
+      },
+    } as Config)
+
+    expect(mockUnregister).toHaveBeenCalledTimes(1)
+    expect(mockRegister).toHaveBeenCalledTimes(2)
+    expect(mockRegister).toHaveBeenLastCalledWith(
+      "Alt+A",
+      expect.any(Function),
+      expect.objectContaining({
+        preventDefault: true,
+        stopPropagation: true,
+      }),
+    )
+
+    cleanup()
+    expect(mockUnwatchConfig).toHaveBeenCalledTimes(1)
+    expect(mockUnregister).toHaveBeenCalledTimes(2)
   })
 
   it("toggles page translation through the registered callback", async () => {

--- a/src/entrypoints/host.content/translation-control/bind-translation-shortcut.ts
+++ b/src/entrypoints/host.content/translation-control/bind-translation-shortcut.ts
@@ -1,46 +1,77 @@
 import type { Hotkey } from "@tanstack/hotkeys"
 import type { PageTranslationManager } from "./page-translation"
+import type { Config } from "@/types/config/config"
 import { HotkeyManager } from "@tanstack/hotkeys"
+import { storage } from "#imports"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext } from "@/utils/analytics"
 import { getLocalConfig } from "@/utils/config/storage"
+import { CONFIG_STORAGE_KEY } from "@/utils/constants/config"
 import { isPageTranslationShortcutEmpty, isValidConfiguredPageTranslationShortcut } from "@/utils/page-translation-shortcut"
 
 /**
- * Binds page translation shortcut key from the given config.
- * Uses sync cached config inside the hotkey callback to avoid async overhead.
+ * Binds page translation shortcut key from local config and keeps it in sync with
+ * option-page updates so already-open tabs do not need a reload after the user
+ * changes the page translation shortcut.
  */
 export async function bindTranslationShortcutKey(pageTranslationManager: PageTranslationManager) {
+  let activeShortcut: string | null = null
+  let cleanupRegisteredShortcut = () => {}
+
+  const togglePageTranslation = () => {
+    if (pageTranslationManager.isActive) {
+      pageTranslationManager.stop()
+    }
+    else {
+      void pageTranslationManager.start(
+        createFeatureUsageContext(ANALYTICS_FEATURE.PAGE_TRANSLATION, ANALYTICS_SURFACE.SHORTCUT),
+      )
+    }
+  }
+
+  const bindShortcut = (shortcut: string | null | undefined) => {
+    const nextShortcut = shortcut?.trim() ?? ""
+    if (nextShortcut === activeShortcut) {
+      return
+    }
+
+    cleanupRegisteredShortcut()
+    cleanupRegisteredShortcut = () => {}
+    activeShortcut = nextShortcut
+
+    if (isPageTranslationShortcutEmpty(nextShortcut) || !isValidConfiguredPageTranslationShortcut(nextShortcut)) {
+      return
+    }
+
+    const registration = HotkeyManager.getInstance().register(
+      nextShortcut as Hotkey,
+      togglePageTranslation,
+      {
+        ignoreInputs: true,
+        preventDefault: true,
+        stopPropagation: true,
+      },
+    )
+    cleanupRegisteredShortcut = () => registration.unregister()
+  }
+
+  const bindConfigShortcut = (config: Config | null | undefined) => {
+    bindShortcut(config?.translate?.page?.shortcut)
+  }
+
+  let didReceiveStorageUpdate = false
+  const unwatchConfig = storage.watch<Config>(`local:${CONFIG_STORAGE_KEY}`, (config) => {
+    didReceiveStorageUpdate = true
+    bindConfigShortcut(config)
+  })
+
   const config = await getLocalConfig()
-  if (!config || isPageTranslationShortcutEmpty(config.translate.page.shortcut)) {
-    return () => {}
+  if (!didReceiveStorageUpdate) {
+    bindConfigShortcut(config)
   }
-
-  const shortcut = config.translate.page.shortcut
-  if (!isValidConfiguredPageTranslationShortcut(shortcut)) {
-    return () => {}
-  }
-
-  const registration = HotkeyManager.getInstance().register(
-    shortcut as Hotkey,
-    () => {
-      if (pageTranslationManager.isActive) {
-        pageTranslationManager.stop()
-      }
-      else {
-        void pageTranslationManager.start(
-          createFeatureUsageContext(ANALYTICS_FEATURE.PAGE_TRANSLATION, ANALYTICS_SURFACE.SHORTCUT),
-        )
-      }
-    },
-    {
-      ignoreInputs: true,
-      preventDefault: true,
-      stopPropagation: true,
-    },
-  )
 
   return () => {
-    registration.unregister()
+    unwatchConfig()
+    cleanupRegisteredShortcut()
   }
 }


### PR DESCRIPTION
## Summary
- Keep the page-translation hotkey registration in content scripts synced with option-page config changes.
- Re-register the TanStack hotkey when `translate.page.shortcut` changes, and clean up both the storage watcher and active hotkey on teardown.
- Add a regression test for changing the page shortcut from `Mod+E` to `Alt+A` without reloading the already-open page.

## Root cause
The popup/options UI could show the updated shortcut (`Alt+A`), but `bindTranslationShortcutKey` only read local config once when the content script bootstrapped. Already-open pages therefore kept the previous hotkey registration until the page was reloaded.

## Test plan
- `SKIP_FREE_API=true pnpm test src/entrypoints/host.content/translation-control/__tests__/bind-translation-shortcut.test.ts -- --runInBand`
- `pnpm exec eslint src/entrypoints/host.content/translation-control/bind-translation-shortcut.ts src/entrypoints/host.content/translation-control/__tests__/bind-translation-shortcut.test.ts`
- `SKIP_FREE_API=true pnpm type-check`
- `WXT_SKIP_ENV_VALIDATION=true pnpm build`
- Pre-push hook: `nx lint`, `nx type-check`, `nx test` (1220 tests) passed

Closes #1546
