### PR TITLE
fix(translate): split bilingual translations inside inline wrappers

### DIFF
--- a/.changeset/fiery-yaks-happen.md
+++ b/.changeset/fiery-yaks-happen.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): split bilingual translations inside inline wrappers with block sections

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -1090,6 +1090,57 @@ describe("translate", () => {
         expect(node.textContent).toBe(`${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}`)
       })
     })
+    describe("inline node has multiple block node children", () => {
+      it("bilingual mode: should promote the inline wrapper to block and translate nested sections separately", async () => {
+        render(
+          <article data-testid="test-node">
+            <div className="item-selector-wrap">{MOCK_ORIGINAL_TEXT}</div>
+            <div className="docsum-wrap" style={{ display: "inline-block" }}>
+              <div className="docsum-content">
+                <a className="docsum-title">
+                  {MOCK_ORIGINAL_TEXT}
+                  <b>{MOCK_ORIGINAL_TEXT}</b>
+                </a>
+                <div className="docsum-citation">{MOCK_ORIGINAL_TEXT}</div>
+                <div className="docsum-snippet">{MOCK_ORIGINAL_TEXT}</div>
+              </div>
+              <div className="result-actions-bar bottom-bar">
+                <button>{MOCK_ORIGINAL_TEXT}</button>
+              </div>
+            </div>
+          </article>,
+        )
+        const node = screen.getByTestId("test-node")
+        const docsumWrap = node.querySelector(".docsum-wrap") as HTMLElement
+        const docsumContent = node.querySelector(".docsum-content") as HTMLElement
+        const docsumTitle = node.querySelector(".docsum-title") as HTMLElement
+        const docsumCitation = node.querySelector(".docsum-citation") as HTMLElement
+        const docsumSnippet = node.querySelector(".docsum-snippet") as HTMLElement
+
+        await removeOrShowPageTranslation("bilingual", true)
+
+        expectNodeLabels(docsumWrap, [BLOCK_ATTRIBUTE])
+        expect(docsumWrap).not.toHaveAttribute(INLINE_ATTRIBUTE)
+        expectNodeLabels(docsumContent, [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
+        expect(node.lastElementChild).toBe(docsumWrap)
+        expect(Array.from(docsumWrap.children).some(child => child.classList.contains(CONTENT_WRAPPER_CLASS))).toBe(false)
+
+        const titleWrapper = expectTranslationWrapper(docsumTitle, "bilingual")
+        expect(titleWrapper).toBe(docsumTitle.lastChild)
+        expectTranslatedContent(titleWrapper, INLINE_CONTENT_CLASS)
+
+        const citationWrapper = expectTranslationWrapper(docsumCitation, "bilingual")
+        expect(citationWrapper).toBe(docsumCitation.lastChild)
+        expectTranslatedContent(citationWrapper, BLOCK_CONTENT_CLASS)
+
+        const snippetWrapper = expectTranslationWrapper(docsumSnippet, "bilingual")
+        expect(snippetWrapper).toBe(docsumSnippet.lastChild)
+        expectTranslatedContent(snippetWrapper, BLOCK_CONTENT_CLASS)
+
+        await removeOrShowPageTranslation("bilingual", true)
+        expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+      })
+    })
     describe("force inline tags inside paragraphs", () => {
       it("bilingual mode: should not split paragraph when inline tag has only decorative block child", async () => {
         render(

--- a/src/utils/host/dom/traversal.ts
+++ b/src/utils/host/dom/traversal.ts
@@ -19,6 +19,25 @@ import {
 
 const NON_NEWLINE_WHITESPACE_RE = /[^\S\n]/
 
+// Some sites wrap multiple block sections in an inline-like shell; promote those
+// containers back to block so bilingual translation can recurse into each section.
+function hasMultipleMeaningfulDirectBlockChildren(validChildNodes: ChildNode[]): boolean {
+  let blockChildCount = 0
+
+  for (const child of validChildNodes) {
+    if (!isHTMLElement(child) || !child.hasAttribute(BLOCK_ATTRIBUTE))
+      continue
+
+    blockChildCount += 1
+    // Keep the existing single-block-child behavior, and only promote wrappers that
+    // clearly act as structural containers for multiple block sections.
+    if (blockChildCount >= 2)
+      return true
+  }
+
+  return false
+}
+
 export function extractTextContent(node: TransNode, config: Config): string {
   if (isTextNode(node)) {
     const text = node.textContent ?? ""
@@ -127,16 +146,18 @@ export function walkAndLabelElement(
   }
 
   const isInlineNode = isShallowInlineHTMLElement(element)
+  const shouldPromoteInlineToBlock = isInlineNode && hasMultipleMeaningfulDirectBlockChildren(validChildNodes)
+  const isEffectivelyInlineNode = isInlineNode && !shouldPromoteInlineToBlock
 
-  if (isShallowBlockHTMLElement(element) || forceBlock || isCustomForceBlockTranslation(element)) {
+  if (isShallowBlockHTMLElement(element) || forceBlock || isCustomForceBlockTranslation(element) || shouldPromoteInlineToBlock) {
     element.setAttribute(BLOCK_ATTRIBUTE, "")
   }
-  else if (isInlineNode) {
+  else if (isEffectivelyInlineNode) {
     element.setAttribute(INLINE_ATTRIBUTE, "")
   }
 
   return {
     forceBlock,
-    isInlineNode,
+    isInlineNode: isEffectivelyInlineNode,
   }
 }


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

- Promote inline-like wrappers with multiple direct block sections to block during host traversal so bilingual translation can recurse into nested sections.
- Preserve the existing single-block-child inline behavior to avoid regressions in previously supported wrapper layouts.
- Add a PubMed-like regression test that verifies title, citation, and snippet translations render in place in bilingual mode.
- Add a patch changeset for the translation fix.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

- The branch has been rebased onto `main`, so the PR only contains the translation fix and its changeset.
