### PR TITLE
feat: add duplicate action for API providers

### DIFF
--- a/.changeset/quick-provider-copy.md
+++ b/.changeset/quick-provider-copy.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+Add a duplicate action for API provider configs so users can quickly copy credentials/settings when adding multiple models for the same provider.

--- a/src/entrypoints/options/pages/api-providers/__tests__/utils.test.ts
+++ b/src/entrypoints/options/pages/api-providers/__tests__/utils.test.ts
@@ -1,0 +1,62 @@
+import type { Config } from "@/types/config/config"
+import type { APIProviderConfig } from "@/types/config/provider"
+import { describe, expect, it, vi } from "vitest"
+import { duplicateProvider } from "../utils"
+
+type AlibabaProviderConfig = Extract<APIProviderConfig, { provider: "alibaba" }>
+
+describe("api provider utils", () => {
+  it("duplicates an existing provider config with a fresh id and unique name", async () => {
+    const sourceProvider: AlibabaProviderConfig = {
+      id: "alibaba-original",
+      name: "Alibaba Cloud",
+      description: "shared credentials",
+      enabled: true,
+      provider: "alibaba",
+      apiKey: "[REDACTED]",
+      baseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+      temperature: 0.3,
+      providerOptions: { extraBody: { enable_thinking: false } },
+      headers: { "x-test": "enabled" },
+      model: {
+        model: "qwen3-max",
+        isCustomModel: true,
+        customModel: "qwen3-max",
+      },
+    }
+    const existingCopy: AlibabaProviderConfig = {
+      ...sourceProvider,
+      id: "alibaba-copy",
+      name: "Alibaba Cloud 1",
+    }
+    const providersConfig = [sourceProvider, existingCopy] as Config["providersConfig"]
+    let updatedProviders: Config["providersConfig"] | undefined
+    const setProvidersConfig = vi.fn(async (config: Partial<Config["providersConfig"]>) => {
+      updatedProviders = config as Config["providersConfig"]
+    })
+    const setSelectedProviderId = vi.fn()
+
+    const newProviderId = await duplicateProvider(
+      sourceProvider,
+      providersConfig,
+      setProvidersConfig,
+      setSelectedProviderId,
+    )
+
+    expect(newProviderId).not.toBe(sourceProvider.id)
+    expect(setProvidersConfig).toHaveBeenCalledOnce()
+    expect(updatedProviders).toHaveLength(3)
+
+    const duplicatedProvider = updatedProviders?.[2] as AlibabaProviderConfig
+    expect(duplicatedProvider).toEqual({
+      ...sourceProvider,
+      id: newProviderId,
+      name: "Alibaba Cloud 2",
+    })
+    expect(duplicatedProvider).not.toBe(sourceProvider)
+    expect(duplicatedProvider.model).not.toBe(sourceProvider.model)
+    expect(duplicatedProvider.providerOptions).not.toBe(sourceProvider.providerOptions)
+    expect(duplicatedProvider.headers).not.toBe(sourceProvider.headers)
+    expect(setSelectedProviderId).toHaveBeenCalledWith(newProviderId)
+  })
+})

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
@@ -179,7 +179,7 @@ export function ProviderConfigForm() {
             </AdvancedOptionsSection>
           )}
         </div>
-        <div className="flex justify-end gap-2 mt-8">
+        <div className="flex justify-between mt-8">
           <Button type="button" variant="outline" onClick={handleDuplicate}>
             {i18n.t("options.apiProviders.form.duplicate")}
           </Button>

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
@@ -29,6 +29,7 @@ import {
 import { buildFeatureProviderPatch } from "@/utils/constants/feature-providers"
 import { cn } from "@/utils/styles/utils"
 import { selectedProviderIdAtom } from "../atoms"
+import { duplicateProvider } from "../utils"
 import { APIKeyField } from "./api-key-field"
 import { BaseURLField } from "./base-url-field"
 import { AdvancedOptionsSection } from "./components/advanced-options-section"
@@ -79,6 +80,10 @@ export function ProviderConfigForm() {
   const chooseNextProviderConfig = (providersConfig: ProvidersConfig) => {
     const firstProvider = providersConfig.find(p => !isNonAPIProvider(p.provider))
     return firstProvider ?? providersConfig[0]
+  }
+
+  const handleDuplicate = async () => {
+    await duplicateProvider(providerConfig, allProvidersConfig, setAllProvidersConfig, setSelectedProviderId)
   }
 
   const handleDelete = async () => {
@@ -174,7 +179,10 @@ export function ProviderConfigForm() {
             </AdvancedOptionsSection>
           )}
         </div>
-        <div className="flex justify-end mt-8">
+        <div className="flex justify-end gap-2 mt-8">
+          <Button type="button" variant="outline" onClick={handleDuplicate}>
+            {i18n.t("options.apiProviders.form.duplicate")}
+          </Button>
           <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
             <AlertDialogTrigger render={<Button type="button" variant="destructive" />}>
               {i18n.t("options.apiProviders.form.delete")}

--- a/src/entrypoints/options/pages/api-providers/utils.ts
+++ b/src/entrypoints/options/pages/api-providers/utils.ts
@@ -28,3 +28,26 @@ export async function addProvider(
 
   return newProvider.id
 }
+
+export async function duplicateProvider(
+  providerConfig: APIProviderConfig,
+  providersConfig: Config["providersConfig"],
+  setProvidersConfig: (config: Partial<Config["providersConfig"]>) => Promise<void>,
+  setSelectedProviderId?: (id: string) => void,
+): Promise<string> {
+  const existingNames = new Set(providersConfig.map(p => p.name))
+  const newProvider: APIProviderConfig = {
+    ...structuredClone(providerConfig),
+    id: getRandomUUID(),
+    name: getUniqueName(providerConfig.name, existingNames),
+  }
+
+  const updatedProviders = [...providersConfig, newProvider]
+  await setProvidersConfig(updatedProviders)
+
+  if (setSelectedProviderId) {
+    setSelectedProviderId(newProvider.id)
+  }
+
+  return newProvider.id
+}

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -109,6 +109,7 @@ options:
         apiKey: API Key
         baseURL: Base URL
         optional: Optional
+      duplicate: Duplicate
       delete: Delete
       deleteDialog:
         title: Delete Provider?

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -109,6 +109,7 @@ options:
         apiKey: Clave API
         baseURL: Base URL
         optional: Opcional
+      duplicate: Duplicar
       delete: Eliminar
       deleteDialog:
         title: ¿Eliminar proveedor?

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -109,6 +109,7 @@ options:
         apiKey: APIキー
         baseURL: ベースURL
         optional: オプション
+      duplicate: 複製
       delete: 削除
       deleteDialog:
         title: プロバイダーを削除しますか？

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -109,6 +109,7 @@ options:
         apiKey: API Key
         baseURL: Base URL
         optional: 선택사항
+      duplicate: 복제
       delete: 삭제
       deleteDialog:
         title: 제공업체를 삭제하시겠습니까?

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -109,6 +109,7 @@ options:
         apiKey: API-ключ
         baseURL: Base URL
         optional: Необязательно
+      duplicate: Дублировать
       delete: Удалить
       deleteDialog:
         title: Удалить провайдера?

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -109,6 +109,7 @@ options:
         apiKey: API Anahtarı
         baseURL: Base URL
         optional: İsteğe Bağlı
+      duplicate: Çoğalt
       delete: Sil
       deleteDialog:
         title: Sağlayıcıyı sil?

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -109,6 +109,7 @@ options:
         apiKey: API Key
         baseURL: Base URL
         optional: Tùy chọn
+      duplicate: Sao chép
       delete: Xóa
       deleteDialog:
         title: Xóa nhà cung cấp?

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -109,6 +109,7 @@ options:
         apiKey: API Key
         baseURL: Base URL
         optional: 可选
+      duplicate: 复制
       delete: 删除
       deleteDialog:
         title: 删除提供商？

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -109,6 +109,7 @@ options:
         apiKey: API Key
         baseURL: Base URL
         optional: 可選
+      duplicate: 複製
       delete: 刪除
       deleteDialog:
         title: 刪除提供商？


### PR DESCRIPTION
## Summary
- Adds a Duplicate action to the API provider config form.
- Duplicates the selected provider config with a fresh ID and a unique copy name, then selects the new provider.
- Adds coverage for duplicate behavior and localizes the new action label.

Closes #1549

## Technical approach
- Reuses the API provider config update path via a new `duplicateProvider` helper in `src/entrypoints/options/pages/api-providers/utils.ts`.
- Uses `structuredClone` to copy nested provider settings, assigns `getRandomUUID()`, and uses `getUniqueName()` to avoid name collisions.
- Adds the action beside the existing Delete button in the API provider form footer.

## Demo video or screenshots
Real screenshots captured from the built Chrome MV3 extension in Microsoft Edge via Playwright. Viewport: `1440x1200`. Route: `options.html#/api-providers`.

### API Providers: provider action footer
| Before | After |
| --- | --- |
| ![Before: API provider footer only has Delete](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog-pr-issue-1549-api-provider-duplicate/before-api-provider-actions.png) | ![After: API provider footer has Duplicate and Delete](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog-pr-issue-1549-api-provider-duplicate/after-api-provider-actions.png) |

### Duplicate action result
After clicking **Duplicate**, the copied provider is appended and selected with a unique name.

![After clicking Duplicate: copied provider is selected](https://f004.backblazeb2.com/file/mengxi-public/hermes/read-frog-pr-issue-1549-api-provider-duplicate/after-duplicate-result.png)

## Test Plan
- [x] `SKIP_FREE_API=true pnpm test src/entrypoints/options/pages/api-providers/__tests__/utils.test.ts`
- [x] `pnpm exec eslint src/entrypoints/options/pages/api-providers/utils.ts src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx src/entrypoints/options/pages/api-providers/__tests__/utils.test.ts`
- [x] `WXT_SKIP_ENV_VALIDATION=true pnpm wxt prepare`
- [x] `pnpm type-check`
- [x] `WXT_SKIP_ENV_VALIDATION=true pnpm build`
- [x] Pre-push hooks: `nx run @read-frog/extension:lint`, `nx run @read-frog/extension:type-check`, `nx run @read-frog/extension:test` (`141` test files, `1220` tests passed)
