### PR TITLE
fix(input-translation): support Draft.js rich text editors via main world injection

### DIFF
--- a/.changeset/fix-input-translation-draftjs.md
+++ b/.changeset/fix-input-translation-draftjs.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(input-translation): support Draft.js rich text editors via main world injection

--- a/src/entrypoints/input-injector.content/editors/draft-js.ts
+++ b/src/entrypoints/input-injector.content/editors/draft-js.ts
@@ -1,16 +1,5 @@
-interface ReactFiber {
-  memoizedState: ReactHook | null
-  memoizedProps: Record<string, unknown>
-  stateNode: Record<string, unknown> | null
-  return: ReactFiber | null
-  tag: number
-}
-
-interface ReactHook {
-  memoizedState: unknown
-  queue: { lastRenderedState: unknown } | null
-  next: ReactHook | null
-}
+import type { ReactFiber } from "./shared"
+import { findReactFiber } from "./shared"
 
 interface DraftEditorState {
   getCurrentContent: () => DraftContentState
@@ -41,11 +30,7 @@ export function isDraftElement(element: Element): boolean {
 // or manage EditorState in a parent component's React state.
 function findDraftEditor(element: Element): { editorState: DraftEditorState, onChange: (state: DraftEditorState) => void } | null {
   const contentEl = element.closest(".public-DraftEditor-content") ?? element
-  const fiberKey = Object.keys(contentEl).find(key => key.startsWith("__reactFiber$") || key.startsWith("__reactInternalInstance$"))
-  if (!fiberKey)
-    return null
-
-  let fiber: ReactFiber | null = (contentEl as unknown as Record<string, ReactFiber>)[fiberKey]
+  let fiber: ReactFiber | null = findReactFiber(contentEl)
   while (fiber) {
     const props = fiber.memoizedProps
     if (props && isDraftEditorState(props.editorState) && typeof props.onChange === "function") {

--- a/src/entrypoints/input-injector.content/editors/draft-js.ts
+++ b/src/entrypoints/input-injector.content/editors/draft-js.ts
@@ -1,0 +1,108 @@
+interface ReactFiber {
+  memoizedState: ReactHook | null
+  memoizedProps: Record<string, unknown>
+  stateNode: Record<string, unknown> | null
+  return: ReactFiber | null
+  tag: number
+}
+
+interface ReactHook {
+  memoizedState: unknown
+  queue: { lastRenderedState: unknown } | null
+  next: ReactHook | null
+}
+
+interface DraftEditorState {
+  getCurrentContent: () => DraftContentState
+  getSelection: () => DraftSelectionState
+}
+
+interface DraftContentState {
+  getPlainText: () => string
+  getBlockMap: () => unknown
+}
+
+interface DraftSelectionState {
+  getAnchorKey: () => string
+}
+
+function isDraftEditorState(value: unknown): value is DraftEditorState {
+  return !!value
+    && typeof value === "object"
+    && typeof (value as DraftEditorState).getCurrentContent === "function"
+    && typeof (value as DraftEditorState).getSelection === "function"
+}
+
+export function isDraftElement(element: Element): boolean {
+  return !!element.closest(".DraftEditor-root")
+}
+
+// Draft.js editor components store { editorState, onChange } in their props
+// or manage EditorState in a parent component's React state.
+function findDraftEditor(element: Element): { editorState: DraftEditorState, onChange: (state: DraftEditorState) => void } | null {
+  const contentEl = element.closest(".public-DraftEditor-content") ?? element
+  const fiberKey = Object.keys(contentEl).find(key => key.startsWith("__reactFiber$") || key.startsWith("__reactInternalInstance$"))
+  if (!fiberKey)
+    return null
+
+  let fiber: ReactFiber | null = (contentEl as unknown as Record<string, ReactFiber>)[fiberKey]
+  while (fiber) {
+    const props = fiber.memoizedProps
+    if (props && isDraftEditorState(props.editorState) && typeof props.onChange === "function") {
+      return {
+        editorState: props.editorState as DraftEditorState,
+        onChange: props.onChange as (state: DraftEditorState) => void,
+      }
+    }
+
+    // Also check stateNode for class components
+    const stateNode = fiber.stateNode as Record<string, unknown> | null
+    const stateNodeProps = (stateNode?.props ?? {}) as Record<string, unknown>
+    if (isDraftEditorState(stateNodeProps.editorState)) {
+      return {
+        editorState: stateNodeProps.editorState as DraftEditorState,
+        onChange: stateNodeProps.onChange as (state: DraftEditorState) => void,
+      }
+    }
+
+    fiber = fiber.return
+  }
+
+  return null
+}
+
+export function replaceDraft(element: Element, text: string): boolean {
+  const editor = findDraftEditor(element)
+  if (!editor)
+    return false
+
+  const { editorState, onChange } = editor
+  const contentState = editorState.getCurrentContent()
+
+  // Access Draft.js internals through the global module
+  // Draft.js exposes ContentState.createFromText and EditorState.push
+  // We need to find these constructors from the existing instances
+  const EditorStateProto = Object.getPrototypeOf(editorState)
+  const EditorStateConstructor = EditorStateProto.constructor
+
+  // Draft.js's EditorState has a static `push` method and ContentState has `createFromText`
+  const ContentStateProto = Object.getPrototypeOf(contentState)
+  const ContentStateConstructor = ContentStateProto.constructor
+
+  if (typeof ContentStateConstructor.createFromText !== "function" || typeof EditorStateConstructor.push !== "function")
+    return false
+
+  const newContent = ContentStateConstructor.createFromText(text)
+  const newEditorState = EditorStateConstructor.push(editorState, newContent, "insert-characters")
+
+  // Move cursor to end
+  if (typeof EditorStateConstructor.moveSelectionToEnd === "function") {
+    const finalState = EditorStateConstructor.moveSelectionToEnd(newEditorState)
+    onChange(finalState)
+  }
+  else {
+    onChange(newEditorState)
+  }
+
+  return true
+}

--- a/src/entrypoints/input-injector.content/editors/shared.ts
+++ b/src/entrypoints/input-injector.content/editors/shared.ts
@@ -1,0 +1,18 @@
+export interface ReactFiber {
+  memoizedState: ReactHook | null
+  memoizedProps: Record<string, unknown>
+  stateNode: Record<string, unknown> | null
+  return: ReactFiber | null
+  tag: number
+}
+
+export interface ReactHook {
+  memoizedState: unknown
+  queue: { lastRenderedState: unknown } | null
+  next: ReactHook | null
+}
+
+export function findReactFiber(element: Element): ReactFiber | null {
+  const key = Object.keys(element).find(k => k.startsWith("__reactFiber$") || k.startsWith("__reactInternalInstance$"))
+  return key ? (element as unknown as Record<string, ReactFiber>)[key] : null
+}

--- a/src/entrypoints/input-injector.content/editors/slate.ts
+++ b/src/entrypoints/input-injector.content/editors/slate.ts
@@ -1,12 +1,5 @@
-interface ReactFiber {
-  memoizedState: ReactHook | null
-  return: ReactFiber | null
-}
-
-interface ReactHook {
-  memoizedState: unknown
-  next: ReactHook | null
-}
+import type { ReactFiber } from "./shared"
+import { findReactFiber } from "./shared"
 
 interface SlateEditor {
   children: SlateNode[]
@@ -37,10 +30,8 @@ function isSlateEditor(value: unknown): value is SlateEditor {
 }
 
 function getEditorFromElement(element: Element): SlateEditor | null {
-  const fiberKey = Object.keys(element).find(key => key.startsWith("__reactFiber$") || key.startsWith("__reactInternalInstance$"))
-  if (!fiberKey)
-    return null
-  return findSlateEditor((element as unknown as Record<string, ReactFiber>)[fiberKey])
+  const fiber = findReactFiber(element)
+  return fiber ? findSlateEditor(fiber) : null
 }
 
 export function isSlateElement(element: Element): boolean {

--- a/src/entrypoints/input-injector.content/replace-text.ts
+++ b/src/entrypoints/input-injector.content/replace-text.ts
@@ -1,3 +1,4 @@
+import { isDraftElement, replaceDraft } from "./editors/draft-js"
 import { isSlateElement, replaceSlate } from "./editors/slate"
 
 export function replaceText(text: string): boolean {
@@ -7,6 +8,9 @@ export function replaceText(text: string): boolean {
 
   if (isSlateElement(element))
     return replaceSlate(element, text)
+
+  if (isDraftElement(element))
+    return replaceDraft(element, text)
 
   return replaceFallback(element as HTMLElement, text)
 }


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Discord's search input box uses **Draft.js** (not Slate.js like the chat input). The existing `execCommand` fallback in the main world injector modifies the DOM but not Draft.js's internal `EditorState`, causing translated text to get stuck in the input — backspace doesn't work, and only clicking the X button clears it.

### Solution

Add a Draft.js editor handler (`editors/draft-js.ts`) that:

1. Detects Draft.js by checking for `.DraftEditor-root` ancestor
2. Traverses the React Fiber tree to find the component with `{ editorState, onChange }` props
3. Uses Draft.js's own APIs (`ContentState.createFromText()`, `EditorState.push()`) to create a new state
4. Calls `onChange(newState)` to update through React's normal update path

### Files

```
input-injector.content/
├── replace-text.ts       ← Added Draft.js detection before fallback
└── editors/
    ├── slate.ts          ← Existing (Discord chat input)
    └── draft-js.ts       ← New (Discord search input)
```

Follows up on #1535 which added the main world injection architecture and Slate.js support.

## How Has This Been Tested?

- [x] Verified through manual testing

### Test scenarios
- Discord search box: triple-space translation → text replaced correctly, editable afterwards
- Discord chat input (Slate): regression test, still works

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.