### PR TITLE
feat(translate): add line-by-line translation mode

### DIFF
--- a/.changeset/line-by-line-translation.md
+++ b/.changeset/line-by-line-translation.md
@@ -1,0 +1,7 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(translate): add line-by-line translation mode
+
+Adds a third translation mode that interleaves each source sentence with its translation, reducing eye movement for language learners.

--- a/src/components/translation/error/retry-button.tsx
+++ b/src/components/translation/error/retry-button.tsx
@@ -4,7 +4,7 @@ import { use } from "react"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/base-ui/tooltip"
 import { configAtom } from "@/utils/atoms/config"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
-import { translateNodesBilingualMode, translateNodeTranslationOnlyMode } from "@/utils/host/translate/node-manipulation"
+import { translateNodesBilingualMode, translateNodesLineByLineMode, translateNodeTranslationOnlyMode } from "@/utils/host/translate/node-manipulation"
 import { ShadowWrapperContext } from "@/utils/react-shadow-host/create-shadow-host"
 
 export function RetryButton({ nodes }: { nodes: ChildNode[] }) {
@@ -16,6 +16,9 @@ export function RetryButton({ nodes }: { nodes: ChildNode[] }) {
     const walkId = getRandomUUID()
     if (translationMode === "bilingual") {
       await translateNodesBilingualMode(nodes, walkId, config)
+    }
+    else if (translationMode === "lineByLine") {
+      await translateNodesLineByLineMode(nodes, walkId, config)
     }
     else if (translationMode === "translationOnly") {
       await translateNodeTranslationOnlyMode(nodes, walkId, config)

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -667,6 +667,7 @@ options:
       description: "Choose how the translated text is displayed: bilingual or translation only."
       mode:
         bilingual: Bilingual
+        lineByLine: Line by Line
         translationOnly: Translation Only
     translateRange:
       title: Translate Range

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -667,6 +667,7 @@ options:
       description: "Elige cómo se muestra el texto traducido: bilingüe o solo traducción."
       mode:
         bilingual: Bilingüe
+        lineByLine: Línea por línea
         translationOnly: Solo traducción
     translateRange:
       title: Rango de traducción

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -552,6 +552,7 @@ options:
       description: 翻訳テキストの表示方法を選択：バイリンガルまたは翻訳のみ
       mode:
         bilingual: バイリンガル
+        lineByLine: 1行ずつ
         translationOnly: 翻訳のみ
     translateRange:
       title: 翻訳範囲

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -552,6 +552,7 @@ options:
       description: "번역된 텍스트 표시 방법 선택: 이중 언어 또는 번역만"
       mode:
         bilingual: 이중 언어
+        lineByLine: 줄별 번역
         translationOnly: 번역만
     translateRange:
       title: 번역 범위

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -552,6 +552,7 @@ options:
       description: "Выберите способ отображения переведённого текста: двуязычный или только перевод."
       mode:
         bilingual: Двуязычный
+        lineByLine: Построчно
         translationOnly: Только перевод
     translateRange:
       title: Диапазон перевода

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -552,6 +552,7 @@ options:
       description: "Çevrilmiş metnin nasıl görüntüleneceğini seçin: iki dilli veya yalnızca çeviri."
       mode:
         bilingual: İki Dilli
+        lineByLine: Satır Satır
         translationOnly: Yalnızca Çeviri
     translateRange:
       title: Çeviri Kapsamı

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -552,6 +552,7 @@ options:
       description: "Chọn cách hiển thị văn bản đã dịch: song ngữ hoặc chỉ bản dịch."
       mode:
         bilingual: Song ngữ
+        lineByLine: Từng dòng
         translationOnly: Chỉ bản dịch
     translateRange:
       title: Phạm vi dịch

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -667,6 +667,7 @@ options:
       description: 选择翻译文本的显示方式：双语对照或仅显示翻译
       mode:
         bilingual: 双语对照
+        lineByLine: 逐行翻译
         translationOnly: 仅显示翻译
     translateRange:
       title: 翻译范围

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -552,6 +552,7 @@ options:
       description: 選擇翻譯文字的顯示方式：雙語對照或僅顯示翻譯
       mode:
         bilingual: 雙語對照
+        lineByLine: 逐行翻譯
         translationOnly: 僅顯示翻譯
     translateRange:
       title: 翻譯範圍

--- a/src/types/config/translate.ts
+++ b/src/types/config/translate.ts
@@ -15,7 +15,7 @@ export const batchQueueConfigSchema = z.object({
   maxItemsPerBatch: z.number().gte(MIN_BATCH_ITEMS),
 })
 
-export const TRANSLATION_MODES = ["bilingual", "translationOnly"] as const
+export const TRANSLATION_MODES = ["bilingual", "lineByLine", "translationOnly"] as const
 export const translationModeSchema = z.enum(TRANSLATION_MODES)
 
 export const pageTranslateRangeSchema = z.enum(["main", "all"])

--- a/src/utils/host/translate/core/__tests__/line-by-line-utils.test.ts
+++ b/src/utils/host/translate/core/__tests__/line-by-line-utils.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { buildLineByLineBatchText, parseLineByLineBatchResult } from "../line-by-line-utils"
+
+const BATCH_SEPARATOR = "%%"
+
+describe("buildLineByLineBatchText", () => {
+  it("joins two sentences with %% separator and blank lines", () => {
+    const result = buildLineByLineBatchText(["Hello.", "World."])
+    expect(result).toBe(`Hello.\n\n${BATCH_SEPARATOR}\n\nWorld.`)
+  })
+
+  it("returns single sentence as-is (no separator)", () => {
+    const result = buildLineByLineBatchText(["Only one."])
+    expect(result).toBe("Only one.")
+  })
+
+  it("joins three sentences", () => {
+    const result = buildLineByLineBatchText(["A.", "B.", "C."])
+    const parts = result.split(BATCH_SEPARATOR)
+    expect(parts).toHaveLength(3)
+    expect(parts[0].trim()).toBe("A.")
+    expect(parts[1].trim()).toBe("B.")
+    expect(parts[2].trim()).toBe("C.")
+  })
+
+  it("preserves internal spaces within sentences", () => {
+    const result = buildLineByLineBatchText(["The cat sat.", "It rained."])
+    expect(result).toContain("The cat sat.")
+    expect(result).toContain("It rained.")
+  })
+})
+
+describe("parseLineByLineBatchResult", () => {
+  it("splits two sentences by %%", () => {
+    const result = parseLineByLineBatchResult(`Translation A.\n\n${BATCH_SEPARATOR}\n\nTranslation B.`)
+    expect(result).toEqual(["Translation A.", "Translation B."])
+  })
+
+  it("trims whitespace around sentences", () => {
+    const result = parseLineByLineBatchResult(`  Hello.  \n\n${BATCH_SEPARATOR}\n\n  World.  `)
+    expect(result).toEqual(["Hello.", "World."])
+  })
+
+  it("filters empty segments", () => {
+    const result = parseLineByLineBatchResult(`A.\n\n${BATCH_SEPARATOR}\n\n\n\n${BATCH_SEPARATOR}\n\nC.`)
+    expect(result).toEqual(["A.", "C."])
+  })
+
+  it("returns single element for text without separator", () => {
+    const result = parseLineByLineBatchResult("Single translation.")
+    expect(result).toEqual(["Single translation."])
+  })
+
+  it("returns empty array for empty string", () => {
+    expect(parseLineByLineBatchResult("")).toEqual([])
+  })
+
+  it("returns empty array for whitespace-only string", () => {
+    expect(parseLineByLineBatchResult("   \n  ")).toEqual([])
+  })
+})

--- a/src/utils/host/translate/core/__tests__/segment-sentences.test.ts
+++ b/src/utils/host/translate/core/__tests__/segment-sentences.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+import { segmentSentences } from "../segment-sentences"
+
+describe("segmentSentences", () => {
+  it("splits English text into sentences", () => {
+    const result = segmentSentences("The cat sat on the mat. It was a dark night.")
+    expect(result).toEqual([
+      "The cat sat on the mat.",
+      "It was a dark night.",
+    ])
+  })
+
+  it("splits Chinese text into sentences", () => {
+    const result = segmentSentences("猫坐在垫子上。那是一个漆黑的夜晚。")
+    expect(result).toEqual([
+      "猫坐在垫子上。",
+      "那是一个漆黑的夜晚。",
+    ])
+  })
+
+  it("handles question marks and exclamation marks", () => {
+    const result = segmentSentences("Hello! How are you? I am fine.")
+    expect(result).toEqual([
+      "Hello!",
+      "How are you?",
+      "I am fine.",
+    ])
+  })
+
+  it("returns single sentence as-is", () => {
+    const result = segmentSentences("This is a single sentence.")
+    expect(result).toEqual(["This is a single sentence."])
+  })
+
+  it("returns empty array for empty string", () => {
+    expect(segmentSentences("")).toEqual([])
+  })
+
+  it("returns empty array for whitespace-only string", () => {
+    expect(segmentSentences("   \n  \t  ")).toEqual([])
+  })
+
+  it("returns [text] when Intl.Segmenter is not available", () => {
+    const originalIntl = globalThis.Intl
+    // @ts-expect-error - intentionally removing Intl for test
+    delete globalThis.Intl
+
+    const result = segmentSentences("Hello world. Test.")
+    expect(result).toEqual(["Hello world. Test."])
+
+    globalThis.Intl = originalIntl
+  })
+
+  it("filters out empty segments (noise between sentences)", () => {
+    // Intl.Segmenter may produce empty segments between sentences
+    const result = segmentSentences("Hello. World.")
+    expect(result.length).toBe(2)
+    expect(result.every(s => s.length > 0)).toBe(true)
+  })
+})

--- a/src/utils/host/translate/core/line-by-line-utils.ts
+++ b/src/utils/host/translate/core/line-by-line-utils.ts
@@ -1,0 +1,20 @@
+import { BATCH_SEPARATOR } from "../../../constants/prompt"
+
+/**
+ * Join sentences into a single batch text using %% separators,
+ * matching the format expected by the batch translation prompt.
+ */
+export function buildLineByLineBatchText(sentences: string[]): string {
+  return sentences.join(`\n\n${BATCH_SEPARATOR}\n\n`)
+}
+
+/**
+ * Parse a batch translation result back into individual sentence translations.
+ * Splits by %% and filters out empty strings.
+ */
+export function parseLineByLineBatchResult(text: string): string[] {
+  return text
+    .split(BATCH_SEPARATOR)
+    .map(s => s.trim())
+    .filter(s => s.length > 0)
+}

--- a/src/utils/host/translate/core/segment-sentences.ts
+++ b/src/utils/host/translate/core/segment-sentences.ts
@@ -1,0 +1,25 @@
+/**
+ * Segment a text into sentences using Intl.Segmenter.
+ * If Intl.Segmenter is unavailable (e.g., Firefox < 125), returns the text as-is.
+ */
+export function segmentSentences(text: string): string[] {
+  if (!text || !text.trim()) {
+    return []
+  }
+
+  if (typeof Intl === "undefined" || !Intl.Segmenter) {
+    return [text]
+  }
+
+  try {
+    const segmenter = new Intl.Segmenter(undefined, { granularity: "sentence" })
+    const segments = [...segmenter.segment(text)]
+      .map(s => s.segment.trim())
+      .filter(s => s.length > 0)
+
+    return segments.length > 0 ? segments : [text]
+  }
+  catch {
+    return [text]
+  }
+}

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -2,13 +2,16 @@ import type { Config } from "@/types/config/config"
 import type { TranslationMode } from "@/types/config/translate"
 import type { TransNode } from "@/types/dom"
 import {
+  BLOCK_CONTENT_CLASS,
   CONTENT_WRAPPER_CLASS,
+  INLINE_CONTENT_CLASS,
   NOTRANSLATE_CLASS,
+  PARAGRAPH_ATTRIBUTE,
   TRANSLATION_MODE_ATTRIBUTE,
   WALKED_ATTRIBUTE,
 } from "../../../constants/dom-labels"
 import { batchDOMOperation } from "../../dom/batch-dom"
-import { isBlockTransNode, isHTMLElement, isTextNode, isTransNode } from "../../dom/filter"
+import { isBlockTransNode, isCustomForceBlockTranslation, isHTMLElement, isInlineTransNode, isTextNode, isTransNode } from "../../dom/filter"
 import { unwrapDeepestOnlyHTMLChild } from "../../dom/find"
 import { getOwnerDocument } from "../../dom/node"
 import { extractTextContent } from "../../dom/traversal"
@@ -18,8 +21,11 @@ import { findPreviousTranslatedWrapperInside } from "../dom/translation-wrapper"
 import { shouldFilterSmallParagraph } from "../filter-small-paragraph"
 import { prepareTranslationText } from "../text-preparation"
 import { setTranslationDirAndLang } from "../translation-attributes"
+import { decorateTranslationNode } from "../ui/decorate-translation"
 import { createSpinnerInside, getTranslatedTextAndRemoveSpinner } from "../ui/spinner"
-import { isNumericContent } from "../ui/translation-utils"
+import { isForceInlineTranslation, isNumericContent } from "../ui/translation-utils"
+import { buildLineByLineBatchText, parseLineByLineBatchResult } from "./line-by-line-utils"
+import { segmentSentences } from "./segment-sentences"
 import { MARK_ATTRIBUTES_REGEX, originalContentMap, translatingNodes } from "./translation-state"
 
 const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g
@@ -44,6 +50,9 @@ export async function translateNodes(
   const translationMode = config.translate.mode
   if (translationMode === "translationOnly") {
     await translateNodeTranslationOnlyMode(nodes, walkId, config, toggle)
+  }
+  else if (translationMode === "lineByLine") {
+    await translateNodesLineByLineMode(nodes, walkId, config, toggle, forceBlockTranslation)
   }
   else if (translationMode === "bilingual") {
     await translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
@@ -137,6 +146,203 @@ export async function translateNodesBilingualMode(
       config.translate.translationNodeStyle,
       forceBlockTranslation,
     )
+  }
+  finally {
+    transNodes.forEach(node => translatingNodes.delete(node))
+  }
+}
+
+// ── Line-by-line helpers ────────────────────────────────────────────
+
+function findParagraphElement(node: Node): HTMLElement | null {
+  const element = isHTMLElement(node) ? node : node.parentElement
+  return element?.closest<HTMLElement>(`[${PARAGRAPH_ATTRIBUTE}]`) ?? null
+}
+
+function removeLineByLineTranslation(paragraphElement: HTMLElement): void {
+  const savedHTML = originalContentMap.get(paragraphElement)
+  if (savedHTML !== undefined) {
+    paragraphElement.innerHTML = savedHTML
+    originalContentMap.delete(paragraphElement)
+  }
+  paragraphElement.removeAttribute(TRANSLATION_MODE_ATTRIBUTE)
+  paragraphElement.removeAttribute(WALKED_ATTRIBUTE)
+}
+
+// ── Line-by-line mode ──────────────────────────────────────────────
+
+export async function translateNodesLineByLineMode(
+  nodes: ChildNode[],
+  walkId: string,
+  config: Config,
+  toggle: boolean = false,
+  forceBlockTranslation: boolean = false,
+): Promise<void> {
+  const transNodes = nodes.filter(node => isTransNode(node))
+  if (transNodes.length === 0) {
+    return
+  }
+
+  try {
+    // prevent duplicate translation
+    if (transNodes.every(node => translatingNodes.has(node))) {
+      return
+    }
+    transNodes.forEach(node => translatingNodes.add(node))
+
+    const lastNode = transNodes.at(-1)!
+    const targetNode
+      = transNodes.length === 1 && isBlockTransNode(lastNode) && isHTMLElement(lastNode)
+        ? await unwrapDeepestOnlyHTMLChild(lastNode)
+        : lastNode
+
+    // Check for existing line-by-line translation via paragraph attributes
+    const paragraphElement = findParagraphElement(targetNode)
+    const alreadyTranslated = paragraphElement
+      && paragraphElement.getAttribute(TRANSLATION_MODE_ATTRIBUTE) === "lineByLine"
+      && paragraphElement.getAttribute(WALKED_ATTRIBUTE) === walkId
+
+    if (alreadyTranslated && paragraphElement) {
+      removeLineByLineTranslation(paragraphElement)
+      if (toggle) {
+        return
+      }
+      else {
+        nodes.forEach(node => translatingNodes.delete(node))
+        void translateNodesLineByLineMode(nodes, walkId, config, toggle, forceBlockTranslation)
+        return
+      }
+    }
+
+    const textContent = transNodes.map(node => extractTextContent(node, config)).join("").trim()
+    if (!textContent || isNumericContent(textContent))
+      return
+
+    if (await shouldFilterSmallParagraph(textContent, config))
+      return
+
+    // Segment into sentences
+    const sentences = segmentSentences(textContent)
+
+    // Single sentence → delegate to bilingual mode
+    if (sentences.length <= 1) {
+      return translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
+    }
+
+    // Build batch text with %% separators
+    const batchText = buildLineByLineBatchText(sentences)
+
+    // Create temporary spinner wrapper (same placement as bilingual wrapper)
+    const ownerDoc = getOwnerDocument(targetNode)
+    const spinnerWrapper = ownerDoc.createElement("span")
+    spinnerWrapper.className = `${NOTRANSLATE_CLASS} ${CONTENT_WRAPPER_CLASS}`
+    spinnerWrapper.setAttribute(TRANSLATION_MODE_ATTRIBUTE, "lineByLine" satisfies TranslationMode)
+    spinnerWrapper.setAttribute(WALKED_ATTRIBUTE, walkId)
+    setTranslationDirAndLang(spinnerWrapper, config)
+    const spinner = createSpinnerInside(spinnerWrapper)
+
+    // Insert spinner beside paragraph
+    const insertOperation = () => {
+      if (isTextNode(targetNode) || transNodes.length > 1) {
+        targetNode.parentNode?.insertBefore(
+          spinnerWrapper,
+          targetNode.nextSibling,
+        )
+      }
+      else {
+        targetNode.appendChild(spinnerWrapper)
+      }
+    }
+    batchDOMOperation(insertOperation)
+
+    const realTranslatedText = await getTranslatedTextAndRemoveSpinner(
+      nodes,
+      batchText,
+      spinner,
+      spinnerWrapper,
+    )
+
+    // Error: spinner replaced with error component — keep wrapper, abort
+    if (realTranslatedText === undefined) {
+      return
+    }
+
+    // Success: remove the temporary spinner wrapper
+    spinnerWrapper.remove()
+
+    // Empty result — nothing to display
+    if (realTranslatedText === "") {
+      return
+    }
+
+    // Parse translated sentences
+    const translatedSentences = parseLineByLineBatchResult(realTranslatedText)
+
+    // Count mismatch → fallback to bilingual mode
+    if (translatedSentences.length !== sentences.length) {
+      return translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
+    }
+
+    // Save original content snapshot for restore
+    const targetParagraph = paragraphElement ?? (isHTMLElement(targetNode) ? targetNode : targetNode.parentElement)
+    if (targetParagraph && !originalContentMap.has(targetParagraph)) {
+      originalContentMap.set(targetParagraph, targetParagraph.innerHTML)
+    }
+
+    // Mark paragraph as line-by-line translated
+    if (targetParagraph) {
+      targetParagraph.setAttribute(TRANSLATION_MODE_ATTRIBUTE, "lineByLine" satisfies TranslationMode)
+      targetParagraph.setAttribute(WALKED_ATTRIBUTE, walkId)
+    }
+
+    // Determine block vs inline style — same priority chain as bilingual
+    const forceInline = isForceInlineTranslation(targetNode)
+    const customForceBlock = isHTMLElement(targetNode) && isCustomForceBlockTranslation(targetNode)
+
+    let isBlock: boolean
+    if (customForceBlock) {
+      isBlock = true
+    }
+    else if (forceInline) {
+      isBlock = false
+    }
+    else if (forceBlockTranslation) {
+      isBlock = true
+    }
+    else if (isInlineTransNode(targetNode)) {
+      isBlock = false
+    }
+    else if (isBlockTransNode(targetNode)) {
+      isBlock = true
+    }
+    else {
+      // Neither inline nor block — shouldn't happen for trans nodes, but bail
+      return
+    }
+
+    // Rebuild paragraph DOM with interleaved sentences
+    const fragment = ownerDoc.createDocumentFragment()
+
+    for (let i = 0; i < sentences.length; i++) {
+      // Original sentence — display:contents so layout is unchanged
+      const origSpan = ownerDoc.createElement("span")
+      origSpan.style.display = "contents"
+      origSpan.textContent = sentences[i]
+      fragment.appendChild(origSpan)
+
+      // Translation sentence
+      const transSpan = ownerDoc.createElement("span")
+      transSpan.className = `${NOTRANSLATE_CLASS} ${isBlock ? BLOCK_CONTENT_CLASS : INLINE_CONTENT_CLASS}`
+      transSpan.textContent = translatedSentences[i]
+      await decorateTranslationNode(transSpan, config.translate.translationNodeStyle)
+      fragment.appendChild(transSpan)
+    }
+
+    // Replace paragraph content
+    if (targetParagraph) {
+      targetParagraph.innerHTML = ""
+      targetParagraph.appendChild(fragment)
+    }
   }
   finally {
     transNodes.forEach(node => translatingNodes.delete(node))

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -226,6 +226,7 @@ export async function translateNodesLineByLineMode(
 
     // Single sentence → delegate to bilingual mode
     if (sentences.length <= 1) {
+      transNodes.forEach(node => translatingNodes.delete(node))
       return translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
     }
 
@@ -280,6 +281,7 @@ export async function translateNodesLineByLineMode(
 
     // Count mismatch → fallback to bilingual mode
     if (translatedSentences.length !== sentences.length) {
+      transNodes.forEach(node => translatingNodes.delete(node))
       return translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
     }
 

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -2,6 +2,7 @@ import type { Config } from "@/types/config/config"
 import type { TranslationMode } from "@/types/config/translate"
 import type { TransNode } from "@/types/dom"
 import {
+  BLOCK_ATTRIBUTE,
   BLOCK_CONTENT_CLASS,
   CONTENT_WRAPPER_CLASS,
   INLINE_CONTENT_CLASS,
@@ -285,8 +286,17 @@ export async function translateNodesLineByLineMode(
       return translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
     }
 
-    // Save original content snapshot for restore
+    // If the paragraph has block children the walker passes only a subset of
+    // nodes (consecutive inline chunks). Rebuilding the entire paragraph would
+    // destroy the block children and untranslated siblings. Fall back to
+    // bilingual mode which handles partial chunks with wrapper elements.
     const targetParagraph = paragraphElement ?? (isHTMLElement(targetNode) ? targetNode : targetNode.parentElement)
+    if (targetParagraph?.querySelector(`[${BLOCK_ATTRIBUTE}]`)) {
+      transNodes.forEach(node => translatingNodes.delete(node))
+      return translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
+    }
+
+    // Save original content snapshot for restore
     if (targetParagraph && !originalContentMap.has(targetParagraph)) {
       originalContentMap.set(targetParagraph, targetParagraph.innerHTML)
     }

--- a/src/utils/host/translate/dom/translation-cleanup.ts
+++ b/src/utils/host/translate/dom/translation-cleanup.ts
@@ -1,4 +1,4 @@
-import { REACT_SHADOW_HOST_CLASS, TRANSLATION_MODE_ATTRIBUTE } from "../../../constants/dom-labels"
+import { REACT_SHADOW_HOST_CLASS, TRANSLATION_MODE_ATTRIBUTE, WALKED_ATTRIBUTE } from "../../../constants/dom-labels"
 import { removeReactShadowHost } from "../../../react-shadow-host/create-shadow-host"
 import { batchDOMOperation } from "../../dom/batch-dom"
 import { isHTMLElement, isTranslatedWrapperNode } from "../../dom/filter"
@@ -57,4 +57,22 @@ export function removeAllTranslatedWrapperNodes(
   translatedNodes.forEach((contentWrapperNode) => {
     removeTranslatedWrapperWithRestore(contentWrapperNode)
   })
+
+  // Also clean up line-by-line translated paragraphs — they don't have
+  // wrapper elements; their innerHTML was replaced in-place.
+  const lineByLineParas = deepQueryTopLevelSelector(
+    root,
+    el => isHTMLElement(el) && el.getAttribute(TRANSLATION_MODE_ATTRIBUTE) === "lineByLine",
+  )
+  for (const para of lineByLineParas) {
+    if (!isHTMLElement(para))
+      continue
+    const saved = originalContentMap.get(para)
+    if (saved !== undefined) {
+      para.innerHTML = saved
+      originalContentMap.delete(para)
+    }
+    para.removeAttribute(TRANSLATION_MODE_ATTRIBUTE)
+    para.removeAttribute(WALKED_ATTRIBUTE)
+  }
 }

--- a/src/utils/host/translate/node-manipulation.ts
+++ b/src/utils/host/translate/node-manipulation.ts
@@ -8,7 +8,7 @@ import { translateWalkedElement } from "./core/translation-walker"
 import { validateTranslationConfigAndToast } from "./translate-text"
 
 // Re-export public APIs
-export { translateNodes, translateNodesBilingualMode, translateNodeTranslationOnlyMode } from "./core/translation-modes"
+export { translateNodes, translateNodesBilingualMode, translateNodesLineByLineMode, translateNodeTranslationOnlyMode } from "./core/translation-modes"
 export { translateWalkedElement } from "./core/translation-walker"
 export { removeAllTranslatedWrapperNodes } from "./dom/translation-cleanup"
 


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)

## Description

新增第三种翻译模式 **逐行翻译（lineByLine）**，与现有的双语对照和仅翻译并列。

在逐行翻译模式下，客户端使用 `Intl.Segmenter` 将段落按句子切分，通过现有的批量翻译管线（`%%` 分隔符）一次性发送给 AI，拿到逐句译文后交错插入 DOM：

```
原文句子1
译文句子1
原文句子2
译文句子2
...
```

原文句子包裹在 `display: contents` 的 `<span>` 中以保证视觉渲染不变，译文句子继承用户已配置的译文样式。单句段落自动降级为普通双语模式。

### 设计决策

- 客户端句子分割（`Intl.Segmenter`），不依赖 AI 分割
- 纯文本重建策略（丢弃原文富文本标签），简化 DOM 操作
- 复用现有的批量翻译提示词和 `%%` 协议
- 复用双语模式的 block/inline 样式优先级链和 toggle/恢复逻辑
- 无配置迁移负担（现有 mode 值仍然有效）

### 文件变更

| 文件 | 说明 |
|------|------|
| `src/utils/host/translate/core/segment-sentences.ts` | `segmentSentences()` 纯函数，`Intl.Segmenter` 句子分割 |
| `src/utils/host/translate/core/line-by-line-utils.ts` | `buildLineByLineBatchText()` / `parseLineByLineBatchResult()` 批量文本拼接解析 |
| `src/utils/host/translate/core/translation-modes.ts` | 新增 `translateNodesLineByLineMode` 核心逻辑 |
| `src/types/config/translate.ts` | `TRANSLATION_MODES` 扩展 |
| `src/locales/*.yml` | 9 语言 locale 条目 |
| `src/utils/host/translate/core/__tests__/` | 18 个单元测试 |

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

18 个单元测试覆盖句子分割和批量文本解析。真实浏览器（Chromium）端到端验证通过。

## Screenshots

逐行翻译模式（中译）：

```
The cat sat on the mat.
猫坐在垫子上。
It was a dark and stormy night.
那是一个黑暗而暴风雨交加的夜晚。
The wind howled through the trees.
风在树间呼啸。
```

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] pnpm type-check ✅
- [x] pnpm test ✅ (仅 free-api 外部服务超时，与本次无关)
