### PR TITLE
fix(extension): speed up node translation hold triggers

### DIFF
--- a/.changeset/quick-hover-triggers.md
+++ b/.changeset/quick-hover-triggers.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+Speed up hover/long-press node translation triggers by shortening the hold delay.

--- a/src/entrypoints/host.content/translation-control/__tests__/node-translation-trigger.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/node-translation-trigger.test.ts
@@ -144,7 +144,7 @@ describe("registerNodeTranslationTriggerListeners", () => {
 
     dispatchMouseEvent("mousedown", { button: 0, clientX: 30, clientY: 40 })
     await Promise.resolve()
-    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(500)
 
     expect(onTrigger).toHaveBeenCalledWith(
       { x: 30, y: 40 },
@@ -154,6 +154,65 @@ describe("registerNodeTranslationTriggerListeners", () => {
         }),
       }),
     )
+  })
+
+  it("triggers held hover hotkeys after the shorter hold delay without firing twice", async () => {
+    vi.useFakeTimers()
+    const onTrigger = vi.fn()
+
+    teardown = registerNodeTranslationTriggerListeners({
+      getConfig: () => Promise.resolve(createConfig("control")),
+      onTrigger,
+    })
+
+    dispatchMouseEvent("mouseover", { clientX: 70, clientY: 80 })
+    dispatchKeyboardEvent("keydown", "Control")
+    await Promise.resolve()
+
+    await vi.advanceTimersByTimeAsync(499)
+    expect(onTrigger).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    await vi.waitFor(() => {
+      expect(onTrigger).toHaveBeenCalledTimes(1)
+    })
+
+    dispatchKeyboardEvent("keyup", "Control")
+    await Promise.resolve()
+
+    expect(onTrigger).toHaveBeenCalledTimes(1)
+    expect(onTrigger).toHaveBeenCalledWith(
+      { x: 70, y: 80 },
+      expect.objectContaining({
+        translate: expect.objectContaining({
+          node: expect.objectContaining({ hotkey: "control" }),
+        }),
+      }),
+    )
+  })
+
+  it("cancels held hover hotkey translation when another key creates a combo", async () => {
+    vi.useFakeTimers()
+    const onTrigger = vi.fn()
+
+    teardown = registerNodeTranslationTriggerListeners({
+      getConfig: () => Promise.resolve(createConfig("control")),
+      onTrigger,
+    })
+
+    dispatchMouseEvent("mouseover", { clientX: 70, clientY: 80 })
+    dispatchKeyboardEvent("keydown", "Control")
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(250)
+
+    dispatchKeyboardEvent("keydown", "a")
+    await Promise.resolve()
+    await vi.advanceTimersByTimeAsync(500)
+    dispatchKeyboardEvent("keyup", "a")
+    dispatchKeyboardEvent("keyup", "Control")
+    await Promise.resolve()
+
+    expect(onTrigger).not.toHaveBeenCalled()
   })
 
   it("does not trigger while the caller says the event should be ignored", async () => {

--- a/src/entrypoints/host.content/translation-control/node-translation-trigger.ts
+++ b/src/entrypoints/host.content/translation-control/node-translation-trigger.ts
@@ -3,8 +3,6 @@ import type { Point } from "@/types/dom"
 import { HOTKEY_EVENT_KEYS } from "@/utils/constants/hotkeys"
 
 const NODE_TRANSLATION_HOLD_TRIGGER_MS = 500
-const CLICK_AND_HOLD_TRIGGER_MS = NODE_TRANSLATION_HOLD_TRIGGER_MS
-const HOVER_HOTKEY_HOLD_TRIGGER_MS = NODE_TRANSLATION_HOLD_TRIGGER_MS
 const CLICK_AND_HOLD_MOVE_TOLERANCE = 6
 const MOUSEMOVE_THROTTLE_MS = 300
 const MOUSEMOVE_DISTANCE_THRESHOLD = 3
@@ -201,7 +199,7 @@ export function registerNodeTranslationTriggerListeners({
           triggerNodeTranslation(mousePressPosition, currentConfig)
           clickAndHoldTriggered = true
         })()
-      }, CLICK_AND_HOLD_TRIGGER_MS)
+      }, NODE_TRANSLATION_HOLD_TRIGGER_MS)
     })()
   }, { signal })
 
@@ -261,7 +259,7 @@ export function registerNodeTranslationTriggerListeners({
               actionTriggered = true
               timerId = null
             })()
-          }, HOVER_HOTKEY_HOLD_TRIGGER_MS)
+          }, NODE_TRANSLATION_HOLD_TRIGGER_MS)
 
           if (!isHotkeySessionPure && timerId) {
             clearTimeout(timerId)

--- a/src/entrypoints/host.content/translation-control/node-translation-trigger.ts
+++ b/src/entrypoints/host.content/translation-control/node-translation-trigger.ts
@@ -2,7 +2,9 @@ import type { Config } from "@/types/config/config"
 import type { Point } from "@/types/dom"
 import { HOTKEY_EVENT_KEYS } from "@/utils/constants/hotkeys"
 
-const CLICK_AND_HOLD_TRIGGER_MS = 1000
+const NODE_TRANSLATION_HOLD_TRIGGER_MS = 500
+const CLICK_AND_HOLD_TRIGGER_MS = NODE_TRANSLATION_HOLD_TRIGGER_MS
+const HOVER_HOTKEY_HOLD_TRIGGER_MS = NODE_TRANSLATION_HOLD_TRIGGER_MS
 const CLICK_AND_HOLD_MOVE_TOLERANCE = 6
 const MOUSEMOVE_THROTTLE_MS = 300
 const MOUSEMOVE_DISTANCE_THRESHOLD = 3
@@ -259,7 +261,7 @@ export function registerNodeTranslationTriggerListeners({
               actionTriggered = true
               timerId = null
             })()
-          }, 1000)
+          }, HOVER_HOTKEY_HOLD_TRIGGER_MS)
 
           if (!isHotkeySessionPure && timerId) {
             clearTimeout(timerId)


### PR DESCRIPTION
## Summary
- Shorten the shared hold delay for node translation triggers from 1000ms to 500ms, covering both hover-hotkey hold and click-and-hold modes.
- Keep the existing combo-key cancellation behavior so shortcuts like Ctrl+A can still cancel before the hold trigger fires.
- Add regression coverage for held hover hotkeys, no double-fire on keyup, and combo-key cancellation.

## Test Plan
- `SKIP_FREE_API=true pnpm exec vitest run src/entrypoints/host.content/translation-control/__tests__`
- `SKIP_FREE_API=true pnpm exec tsc --noEmit`
- Push hook also ran `nx lint`, `nx type-check`, and the full `nx test` suite: 141 test files / 1222 tests passed.

## Screenshots
Not applicable: this changes interaction timing only and has no visual UI change.

Closes #1566
