### PR TITLE
feat(translation): customizable batch translation system prompt

### DIFF
--- a/.changeset/modern-dragons-strive.md
+++ b/.changeset/modern-dragons-strive.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(translation): make the batch translation system prompt customizable per personalized prompt, add a toggle to disable appending it on batch requests, and stop appending it when a batch only contains a single paragraph

--- a/src/components/prompt-configurator/configure-prompt.tsx
+++ b/src/components/prompt-configurator/configure-prompt.tsx
@@ -15,8 +15,9 @@ import {
   SheetTitle,
   SheetTrigger,
 } from "@/components/ui/base-ui/sheet"
+import { Switch } from "@/components/ui/base-ui/switch"
 import { QuickInsertableTextarea } from "@/components/ui/insertable-textarea"
-import { DEFAULT_TRANSLATE_PROMPT_ID } from "@/utils/constants/prompt"
+import { DEFAULT_BATCH_TRANSLATE_PROMPT, DEFAULT_TRANSLATE_PROMPT_ID } from "@/utils/constants/prompt"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
 import { cn } from "@/utils/styles/utils"
 import { usePromptAtoms, usePromptInsertCells } from "./context"
@@ -37,7 +38,14 @@ export function ConfigurePrompt({
   const inEdit = !!originPrompt
   const isDefault = originPrompt?.id === DEFAULT_TRANSLATE_PROMPT_ID
 
-  const defaultPrompt = { id: getRandomUUID(), name: "", systemPrompt: "", prompt: "" }
+  const defaultPrompt: TranslatePromptObj = {
+    id: getRandomUUID(),
+    name: "",
+    systemPrompt: "",
+    prompt: "",
+    batchSystemPrompt: DEFAULT_BATCH_TRANSLATE_PROMPT,
+    appendBatchSystemPrompt: true,
+  }
   const initialPrompt = originPrompt ?? defaultPrompt
 
   const [prompt, setPrompt] = useState<TranslatePromptObj>(initialPrompt)
@@ -58,6 +66,8 @@ export function ConfigurePrompt({
       name: "",
       systemPrompt: "",
       prompt: "",
+      batchSystemPrompt: DEFAULT_BATCH_TRANSLATE_PROMPT,
+      appendBatchSystemPrompt: true,
     })
   }
 
@@ -129,6 +139,29 @@ export function ConfigurePrompt({
               className="max-h-60"
               disabled={isDefault}
               onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setPrompt({ ...prompt, prompt: e.target.value })}
+              insertCells={insertCells}
+            />
+          </Field>
+          <Field orientation="horizontal">
+            <FieldLabel htmlFor="append-batch-system-prompt">
+              {i18n.t("options.translation.personalizedPrompts.editPrompt.appendBatchSystemPrompt")}
+            </FieldLabel>
+            <Switch
+              id="append-batch-system-prompt"
+              checked={prompt.appendBatchSystemPrompt}
+              disabled={isDefault}
+              onCheckedChange={(checked) => {
+                setPrompt({ ...prompt, appendBatchSystemPrompt: checked })
+              }}
+            />
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="batch-system-prompt">{i18n.t("options.translation.personalizedPrompts.editPrompt.batchSystemPrompt")}</FieldLabel>
+            <QuickInsertableTextarea
+              value={prompt.batchSystemPrompt}
+              className="min-h-40 max-h-80"
+              disabled={isDefault || !prompt.appendBatchSystemPrompt}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setPrompt({ ...prompt, batchSystemPrompt: e.target.value })}
               insertCells={insertCells}
             />
           </Field>

--- a/src/components/prompt-configurator/import-prompts.tsx
+++ b/src/components/prompt-configurator/import-prompts.tsx
@@ -7,6 +7,7 @@ import { i18n } from "#imports"
 import { Button } from "@/components/ui/base-ui/button"
 import { Input } from "@/components/ui/base-ui/input"
 import { Label } from "@/components/ui/base-ui/label"
+import { DEFAULT_BATCH_TRANSLATE_PROMPT } from "@/utils/constants/prompt"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
 import { usePromptAtoms } from "./context"
 import { analysisJSONFile } from "./utils/prompt-file"
@@ -21,8 +22,10 @@ export function ImportPrompts() {
     const patterns = list.map(item => ({
       ...item,
       id: getRandomUUID(),
-      // Backwards compatibility: add systemPrompt if missing from imported file
+      // Backwards compatibility: fill defaults for fields missing from older imports
       systemPrompt: item.systemPrompt ?? "",
+      batchSystemPrompt: item.batchSystemPrompt ?? DEFAULT_BATCH_TRANSLATE_PROMPT,
+      appendBatchSystemPrompt: item.appendBatchSystemPrompt ?? true,
     }))
 
     setConfig({

--- a/src/components/prompt-configurator/prompt-grid.tsx
+++ b/src/components/prompt-configurator/prompt-grid.tsx
@@ -14,7 +14,7 @@ import {
 import { Checkbox } from "@/components/ui/base-ui/checkbox"
 import { Label } from "@/components/ui/base-ui/label"
 import { Separator } from "@/components/ui/base-ui/separator"
-import { DEFAULT_TRANSLATE_PROMPT, DEFAULT_TRANSLATE_PROMPT_ID, DEFAULT_TRANSLATE_SYSTEM_PROMPT } from "@/utils/constants/prompt"
+import { DEFAULT_BATCH_TRANSLATE_PROMPT, DEFAULT_TRANSLATE_PROMPT, DEFAULT_TRANSLATE_PROMPT_ID, DEFAULT_TRANSLATE_SYSTEM_PROMPT } from "@/utils/constants/prompt"
 import { cn } from "@/utils/styles/utils"
 import { ConfigurePrompt } from "./configure-prompt"
 import { usePromptAtoms } from "./context"
@@ -41,6 +41,8 @@ export function PromptGrid({
     name: i18n.t("options.translation.personalizedPrompts.default"),
     systemPrompt: DEFAULT_TRANSLATE_SYSTEM_PROMPT,
     prompt: DEFAULT_TRANSLATE_PROMPT,
+    batchSystemPrompt: DEFAULT_BATCH_TRANSLATE_PROMPT,
+    appendBatchSystemPrompt: true,
   }
 
   // Prepend default to patterns list

--- a/src/entrypoints/background/__tests__/translation-queues.test.ts
+++ b/src/entrypoints/background/__tests__/translation-queues.test.ts
@@ -163,7 +163,7 @@ describe("translation queue helpers", () => {
       llmProvider,
       expect.any(Function),
       expect.objectContaining({
-        isBatch: true,
+        isBatch: false,
         context: {
           videoTitle: "Video title",
           videoSummary: "Ready summary",

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -39,7 +39,7 @@ export async function executeBatchTranslation<TContext>(
   const texts = dataList.map(d => d.text)
 
   const batchText = texts.join(`\n\n${BATCH_SEPARATOR}\n\n`)
-  const result = await executeTranslate(batchText, langConfig, providerConfig, promptResolver, { isBatch: true, context })
+  const result = await executeTranslate(batchText, langConfig, providerConfig, promptResolver, { isBatch: dataList.length > 1, context })
   return parseBatchResult(result)
 }
 

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -608,6 +608,8 @@ options:
         name: Name
         systemPrompt: System Prompt
         prompt: Prompt
+        batchSystemPrompt: Batch System Prompt
+        appendBatchSystemPrompt: Append on batch requests
         promptCellInput:
           input: Text content to translate
           targetLanguage: Target language

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -493,6 +493,8 @@ options:
         name: 名前
         systemPrompt: システムプロンプト
         prompt: プロンプト
+        batchSystemPrompt: バッチ追記用システムプロンプト
+        appendBatchSystemPrompt: バッチ翻訳時に追記する
         promptCellInput:
           input: 翻訳するテキスト内容
           targetLanguage: 目標言語

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -493,6 +493,8 @@ options:
         name: 이름
         systemPrompt: 시스템 프롬프트
         prompt: 프롬프트
+        batchSystemPrompt: 배치 추가 시스템 프롬프트
+        appendBatchSystemPrompt: 배치 번역 시 이 프롬프트 추가
         promptCellInput:
           input: 번역할 텍스트 내용
           targetLanguage: 목표 언어

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -608,6 +608,8 @@ options:
         name: 标题
         systemPrompt: 系统提示词
         prompt: 提示词
+        batchSystemPrompt: 批量追加的系统提示词
+        appendBatchSystemPrompt: 批量翻译时追加此提示词
         promptCellInput:
           input: 需要翻译的文本内容
           targetLanguage: 目标语言

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -493,6 +493,8 @@ options:
         name: 標題
         systemPrompt: 系統提示詞
         prompt: 提示詞
+        batchSystemPrompt: 批次追加的系統提示詞
+        appendBatchSystemPrompt: 批次翻譯時追加此提示詞
         promptCellInput:
           input: 需要翻譯的文字內容
           targetLanguage: 目標語言

--- a/src/types/config/translate.ts
+++ b/src/types/config/translate.ts
@@ -49,6 +49,8 @@ export const translatePromptObjSchema = z.object({
   id: z.string(),
   systemPrompt: z.string(),
   prompt: z.string(),
+  batchSystemPrompt: z.string(),
+  appendBatchSystemPrompt: z.boolean(),
 })
 export type TranslatePromptObj = z.infer<typeof translatePromptObjSchema>
 

--- a/src/utils/config/__tests__/example/v073.ts
+++ b/src/utils/config/__tests__/example/v073.ts
@@ -1,0 +1,442 @@
+import type { TestSeriesObject } from "./types"
+
+const DEFAULT_BATCH_TRANSLATE_PROMPT = `## Multi-paragraph Translation Rules
+1. If input contains %%, use %% in your output, if input has no %%, don't use %% in your output
+2. **CRITICAL**: Preserve exact formatting around %% - use exactly one empty line before and after, with no extra spaces, tabs, or whitespace
+
+## OUTPUT FORMAT:
+- **Single paragraph input** → Output translation directly (no separators, no extra text)
+- **Multi-paragraph input (input uses %% separators)** → Use %% as paragraph separator between translations
+
+## Examples
+
+### Multi-paragraph Input:
+Paragraph A
+
+%%
+
+Paragraph B
+
+%%
+
+Paragraph C
+
+### Multi-paragraph Output:
+Translation A
+
+%%
+
+Translation B
+
+%%
+
+Translation C
+
+### Single paragraph Input:
+Single paragraph content
+
+### Single paragraph Output:
+Direct translation without separators
+`
+
+export const testSeries: TestSeriesObject = {
+  "prompt-token-migration-coverage": {
+    description: "Covers legacy prompt token migration for translate, custom actions, and video subtitles",
+    config: {
+      language: {
+        sourceCode: "eng",
+        targetCode: "cmn",
+        level: "intermediate",
+      },
+      providersConfig: [
+        {
+          id: "google-default",
+          enabled: true,
+          name: "Gemini",
+          provider: "google",
+          apiKey: "goog-key",
+          model: {
+            model: "gemini-2.5-pro",
+            isCustomModel: false,
+            customModel: "",
+          },
+        },
+      ],
+      translate: {
+        providerId: "google-default",
+        mode: "translationOnly",
+        enableAIContentAware: false,
+        node: {
+          enabled: true,
+          hotkey: "alt",
+        },
+        page: {
+          range: "all",
+          autoTranslatePatterns: [],
+          autoTranslateLanguages: [],
+          shortcut: "Alt+B",
+          preload: {
+            margin: 1000,
+            threshold: 0,
+          },
+          minCharactersPerNode: 0,
+          minWordsPerNode: 0,
+          enableTargetLanguageSkip: true,
+          skipLanguages: [],
+        },
+        customPromptsConfig: {
+          promptId: "legacy-translate-prompt",
+          patterns: [
+            {
+              id: "legacy-translate-prompt",
+              name: "Legacy Translate Prompt",
+              systemPrompt: "Translate into {{targetLanguage}} with title {{webTitle}} and summary {{webSummary}}.",
+              prompt: "Title: {{webTitle}}\nSummary: {{webSummary}}\nTranslate to {{targetLanguage}}:\n{{input}}",
+              batchSystemPrompt: DEFAULT_BATCH_TRANSLATE_PROMPT,
+              appendBatchSystemPrompt: true,
+            },
+          ],
+        },
+        requestQueueConfig: {
+          capacity: 200,
+          rate: 2,
+        },
+        batchQueueConfig: {
+          maxCharactersPerBatch: 1000,
+          maxItemsPerBatch: 4,
+        },
+        translationNodeStyle: {
+          preset: "default",
+          isCustom: false,
+          customCSS: null,
+        },
+      },
+      tts: {
+        defaultVoice: "en-US-GuyNeural",
+        languageVoices: {
+          "eng": "en-US-GuyNeural",
+          "cmn": "zh-CN-YunxiNeural",
+          "cmn-Hant": "zh-TW-YunJheNeural",
+          "yue": "zh-CN-YunxiNeural",
+          "spa": "es-ES-AlvaroNeural",
+          "rus": "ru-RU-DmitryNeural",
+          "arb": "ar-SA-HamedNeural",
+          "ben": "bn-BD-NabanitaNeural",
+          "hin": "hi-IN-MadhurNeural",
+          "por": "pt-BR-AntonioNeural",
+          "ind": "id-ID-ArdiNeural",
+          "jpn": "ja-JP-KeitaNeural",
+          "fra": "fr-FR-HenriNeural",
+          "deu": "de-DE-ConradNeural",
+          "jav": "jv-ID-DimasNeural",
+          "kor": "ko-KR-InJoonNeural",
+          "tel": "te-IN-MohanNeural",
+          "vie": "vi-VN-NamMinhNeural",
+          "mar": "mr-IN-ManoharNeural",
+          "ita": "it-IT-DiegoNeural",
+          "tam": "ta-IN-ValluvarNeural",
+          "tur": "tr-TR-AhmetNeural",
+          "urd": "ur-PK-AsadNeural",
+          "guj": "gu-IN-NiranjanNeural",
+          "pol": "pl-PL-MarekNeural",
+          "ukr": "uk-UA-OstapNeural",
+          "kan": "kn-IN-GaganNeural",
+          "mai": "en-US-GuyNeural",
+          "mal": "ml-IN-MidhunNeural",
+          "pes": "fa-IR-FaridNeural",
+          "mya": "my-MM-ThihaNeural",
+          "swh": "sw-KE-RafikiNeural",
+          "sun": "su-ID-JajangNeural",
+          "ron": "ro-RO-EmilNeural",
+          "pan": "pa-IN-OjasNeural",
+          "bho": "en-US-GuyNeural",
+          "amh": "am-ET-AmehaNeural",
+          "hau": "ha-NG-AbubakarNeural",
+          "fuv": "ff-Latn-SN-SambaNeural",
+          "bos": "bs-BA-GoranNeural",
+          "hrv": "hr-HR-SreckoNeural",
+          "nld": "nl-NL-MaartenNeural",
+          "srp": "sr-RS-NicholasNeural",
+          "tha": "th-TH-NiwatNeural",
+          "ckb": "en-US-GuyNeural",
+          "yor": "yo-NG-AbeoNeural",
+          "uzn": "uz-UZ-SardorNeural",
+          "zlm": "ms-MY-OsmanNeural",
+          "ibo": "ig-NG-EzinneNeural",
+          "npi": "ne-NP-SagarNeural",
+          "ceb": "en-US-GuyNeural",
+          "skr": "en-US-GuyNeural",
+          "tgl": "fil-PH-AngeloNeural",
+          "hun": "hu-HU-TamasNeural",
+          "azj": "az-AZ-BabekNeural",
+          "sin": "si-LK-SameeraNeural",
+          "koi": "en-US-GuyNeural",
+          "ell": "el-GR-NestorasNeural",
+          "ces": "cs-CZ-AntoninNeural",
+          "mag": "en-US-GuyNeural",
+          "run": "en-US-GuyNeural",
+          "bel": "be-BY-YauheniNeural",
+          "plt": "en-US-GuyNeural",
+          "qug": "en-US-GuyNeural",
+          "mad": "en-US-GuyNeural",
+          "nya": "en-US-GuyNeural",
+          "zyb": "en-US-GuyNeural",
+          "pbu": "en-US-GuyNeural",
+          "kin": "rw-RW-JeanNeural",
+          "zul": "zu-ZA-ThembaNeural",
+          "bul": "bg-BG-BorislavNeural",
+          "swe": "sv-SE-MattiasNeural",
+          "lin": "ln-CD-BaudouinNeural",
+          "som": "so-SO-MuuseNeural",
+          "hms": "en-US-GuyNeural",
+          "hnj": "en-US-GuyNeural",
+          "ilo": "en-US-GuyNeural",
+          "kaz": "kk-KZ-DauletNeural",
+          "heb": "he-IL-AvriNeural",
+          "nob": "nb-NO-FinnNeural",
+          "nno": "nn-NO-FinnNeural",
+          "afr": "af-ZA-AdriNeural",
+          "sqi": "sq-AL-IlirNeural",
+          "asm": "as-IN-BiswajitNeural",
+          "eus": "eu-ES-AnderNeural",
+          "bre": "fr-FR-HenriNeural",
+          "cat": "ca-ES-EnricNeural",
+          "cos": "fr-FR-HenriNeural",
+          "cym": "cy-GB-AledNeural",
+          "dan": "da-DK-JeppeNeural",
+          "div": "si-LK-SameeraNeural",
+          "epo": "en-US-GuyNeural",
+          "ekk": "et-EE-KertNeural",
+          "fao": "fo-FO-PoulNeural",
+          "fij": "en-US-GuyNeural",
+          "fin": "fi-FI-HarriNeural",
+          "fry": "nl-NL-MaartenNeural",
+          "gla": "en-GB-RyanNeural",
+          "gle": "ga-IE-ColmNeural",
+          "glg": "gl-ES-RoiNeural",
+          "grn": "es-ES-AlvaroNeural",
+          "hat": "fr-FR-HenriNeural",
+          "haw": "en-US-GuyNeural",
+          "hye": "hy-AM-HaykNeural",
+          "ido": "en-US-GuyNeural",
+          "ina": "en-US-GuyNeural",
+          "isl": "is-IS-GunnarNeural",
+          "kat": "ka-GE-GiorgiNeural",
+          "khm": "km-KH-PisethNeural",
+          "kir": "kk-KZ-DauletNeural",
+          "lao": "lo-LA-ChanthavongNeural",
+          "lat": "it-IT-DiegoNeural",
+          "lvs": "lv-LV-NilsNeural",
+          "lit": "lt-LT-LeonasNeural",
+          "ltz": "fr-FR-HenriNeural",
+          "mkd": "mk-MK-AleksandarNeural",
+          "mlt": "mt-MT-JosephNeural",
+          "mon": "mn-MN-BataaNeural",
+          "mri": "en-NZ-MitchellNeural",
+          "nso": "en-US-GuyNeural",
+          "oci": "fr-FR-HenriNeural",
+          "ori": "or-IN-DineshNeural",
+          "orm": "en-US-GuyNeural",
+          "prs": "en-US-GuyNeural",
+          "san": "hi-IN-MadhurNeural",
+          "slk": "sk-SK-LukasNeural",
+          "slv": "sl-SI-RokNeural",
+          "smo": "en-US-GuyNeural",
+          "sna": "en-US-GuyNeural",
+          "snd": "sd-PK-SalmanNeural",
+          "sot": "en-US-GuyNeural",
+          "tah": "fr-FR-HenriNeural",
+          "tat": "tt-RU-AidarNeural",
+          "tgk": "tg-TJ-SharifNeural",
+          "tir": "am-ET-AmehaNeural",
+          "ton": "en-US-GuyNeural",
+          "tsn": "en-US-GuyNeural",
+          "tuk": "tk-TM-AmanNeural",
+          "uig": "ug-CN-KashgarNeural",
+          "vol": "en-US-GuyNeural",
+          "wol": "en-US-GuyNeural",
+          "xho": "xh-ZA-ThembaNeural",
+          "ydd": "he-IL-AvriNeural",
+          "aka": "en-US-GuyNeural",
+          "bam": "fr-FR-HenriNeural",
+          "bis": "en-US-GuyNeural",
+          "bod": "zh-CN-YunxiNeural",
+          "che": "ru-RU-DmitryNeural",
+          "chv": "ru-RU-DmitryNeural",
+          "dzo": "zh-CN-YunxiNeural",
+          "ewe": "en-US-GuyNeural",
+          "kab": "en-US-GuyNeural",
+          "lug": "en-US-GuyNeural",
+          "oss": "ru-RU-DmitryNeural",
+          "ssw": "en-US-GuyNeural",
+          "ven": "en-US-GuyNeural",
+          "war": "en-US-GuyNeural",
+          "nde": "en-US-GuyNeural",
+          "nbl": "en-US-GuyNeural",
+          "pam": "en-US-GuyNeural",
+          "hil": "en-US-GuyNeural",
+          "bcl": "en-US-GuyNeural",
+          "min": "en-US-GuyNeural",
+          "ace": "en-US-GuyNeural",
+          "bug": "en-US-GuyNeural",
+          "ban": "en-US-GuyNeural",
+          "bjn": "en-US-GuyNeural",
+          "mak": "en-US-GuyNeural",
+          "sas": "en-US-GuyNeural",
+          "tet": "en-US-GuyNeural",
+          "cha": "en-US-GuyNeural",
+          "niu": "en-US-GuyNeural",
+          "tvl": "en-US-GuyNeural",
+          "gil": "en-US-GuyNeural",
+          "mah": "en-US-GuyNeural",
+          "pau": "en-US-GuyNeural",
+          "wls": "en-US-GuyNeural",
+          "rar": "en-US-GuyNeural",
+          "hif": "en-US-GuyNeural",
+        },
+        rate: 0,
+        pitch: 0,
+        volume: 0,
+      },
+      floatingButton: {
+        enabled: true,
+        position: 0.5,
+        disabledFloatingButtonPatterns: [],
+        clickAction: "panel",
+        locked: false,
+        side: "right",
+      },
+      sideContent: {
+        width: 420,
+      },
+      selectionToolbar: {
+        enabled: true,
+        disabledSelectionToolbarPatterns: [],
+        opacity: 100,
+        customActions: [
+          {
+            id: "coverage-action",
+            name: "Coverage Action",
+            enabled: true,
+            icon: "tabler:book-2",
+            providerId: "google-default",
+            systemPrompt: "Answer in {{targetLanguage}} and use {{webTitle}} as metadata.",
+            prompt: "Selection: {{selection}}\nContext: {{paragraphs}}\nTitle: {{webTitle}}\nTarget language: {{targetLanguage}}",
+            outputSchema: [
+              {
+                id: "coverage-term",
+                name: "Term",
+                type: "string",
+                description: "Focus on {{selection}}.",
+                speaking: true,
+              },
+              {
+                id: "coverage-definition",
+                name: "Definition",
+                type: "string",
+                description: "Explain it in {{targetLanguage}}.",
+                speaking: false,
+              },
+              {
+                id: "coverage-context",
+                name: "Context",
+                type: "string",
+                description: "Reuse {{paragraphs}} exactly.",
+                speaking: true,
+              },
+              {
+                id: "coverage-notes",
+                name: "Notes",
+                type: "string",
+                description: "Mention {{webTitle}} when relevant.",
+                speaking: false,
+              },
+            ],
+          },
+        ],
+        features: {
+          translate: {
+            enabled: true,
+            providerId: "google-default",
+          },
+          speak: {
+            enabled: true,
+          },
+        },
+      },
+      betaExperience: {
+        enabled: false,
+      },
+      contextMenu: {
+        enabled: true,
+      },
+      videoSubtitles: {
+        enabled: false,
+        autoStart: false,
+        providerId: "google-default",
+        style: {
+          displayMode: "bilingual",
+          translationPosition: "above",
+          main: {
+            fontFamily: "system",
+            fontScale: 100,
+            color: "#FFFFFF",
+            fontWeight: 400,
+          },
+          translation: {
+            fontFamily: "system",
+            fontScale: 100,
+            color: "#FFFFFF",
+            fontWeight: 400,
+          },
+          container: {
+            backgroundOpacity: 75,
+          },
+        },
+        aiSegmentation: false,
+        requestQueueConfig: {
+          capacity: 200,
+          rate: 2,
+        },
+        batchQueueConfig: {
+          maxCharactersPerBatch: 1000,
+          maxItemsPerBatch: 4,
+        },
+        customPromptsConfig: {
+          promptId: "legacy-subtitles-prompt",
+          patterns: [
+            {
+              id: "legacy-subtitles-prompt",
+              name: "Legacy Subtitles Prompt",
+              systemPrompt: "Translate subtitles into {{targetLanguage}} with {{videoTitle}} and {{videoSummary}} as context.",
+              prompt: "Title: {{videoTitle}}\nSummary: {{videoSummary}}\nTranslate to {{targetLanguage}}:\n{{input}}",
+              batchSystemPrompt: DEFAULT_BATCH_TRANSLATE_PROMPT,
+              appendBatchSystemPrompt: true,
+            },
+          ],
+        },
+        position: {
+          percent: 10,
+          anchor: "bottom",
+        },
+      },
+      inputTranslation: {
+        enabled: true,
+        providerId: "google-default",
+        fromLang: "targetCode",
+        toLang: "sourceCode",
+        enableCycle: false,
+        timeThreshold: 300,
+      },
+      siteControl: {
+        mode: "blacklist",
+        blacklistPatterns: [],
+        whitelistPatterns: [],
+      },
+      languageDetection: {
+        mode: "basic",
+        providerId: "google-default",
+      },
+    },
+  },
+}

--- a/src/utils/config/__tests__/migration-scripts/v072-to-v073.test.ts
+++ b/src/utils/config/__tests__/migration-scripts/v072-to-v073.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { migrate } from "../../migration-scripts/v072-to-v073"
+
+describe("v072-to-v073 migration", () => {
+  it("adds batchSystemPrompt and appendBatchSystemPrompt to every translate pattern", () => {
+    const migrated = migrate({
+      translate: {
+        customPromptsConfig: {
+          promptId: "p1",
+          patterns: [
+            { id: "p1", name: "P1", systemPrompt: "s1", prompt: "u1" },
+            { id: "p2", name: "P2", systemPrompt: "s2", prompt: "u2" },
+          ],
+        },
+      },
+    })
+
+    expect(migrated.translate.customPromptsConfig.promptId).toBe("p1")
+    expect(migrated.translate.customPromptsConfig.patterns).toHaveLength(2)
+    for (const pattern of migrated.translate.customPromptsConfig.patterns) {
+      expect(typeof pattern.batchSystemPrompt).toBe("string")
+      expect(pattern.batchSystemPrompt).toContain("Multi-paragraph Translation Rules")
+      expect(pattern.appendBatchSystemPrompt).toBe(true)
+    }
+  })
+
+  it("adds the same fields to every videoSubtitles pattern", () => {
+    const migrated = migrate({
+      videoSubtitles: {
+        customPromptsConfig: {
+          promptId: "s1",
+          patterns: [{ id: "s1", name: "S1", systemPrompt: "ss", prompt: "uu" }],
+        },
+      },
+    })
+
+    expect(migrated.videoSubtitles.customPromptsConfig.patterns[0].appendBatchSystemPrompt).toBe(true)
+    expect(migrated.videoSubtitles.customPromptsConfig.patterns[0].batchSystemPrompt).toContain("Multi-paragraph Translation Rules")
+  })
+
+  it("handles missing customPromptsConfig gracefully", () => {
+    const migrated = migrate({})
+    expect(migrated.translate.customPromptsConfig.patterns).toEqual([])
+    expect(migrated.videoSubtitles.customPromptsConfig.patterns).toEqual([])
+  })
+})

--- a/src/utils/config/migration-scripts/v072-to-v073.ts
+++ b/src/utils/config/migration-scripts/v072-to-v073.ts
@@ -1,0 +1,80 @@
+/**
+ * Migration script from v072 to v073
+ * - Adds batchSystemPrompt and appendBatchSystemPrompt to every existing
+ *   personalized prompt pattern under translate.customPromptsConfig and
+ *   videoSubtitles.customPromptsConfig.
+ *
+ * IMPORTANT: All values are hardcoded inline. Migration scripts are frozen
+ * snapshots — never import constants or helpers that may change.
+ */
+
+const BATCH_SEPARATOR = "%%"
+
+const DEFAULT_BATCH_TRANSLATE_PROMPT = `## Multi-paragraph Translation Rules
+1. If input contains ${BATCH_SEPARATOR}, use ${BATCH_SEPARATOR} in your output, if input has no ${BATCH_SEPARATOR}, don't use ${BATCH_SEPARATOR} in your output
+2. **CRITICAL**: Preserve exact formatting around ${BATCH_SEPARATOR} - use exactly one empty line before and after, with no extra spaces, tabs, or whitespace
+
+## OUTPUT FORMAT:
+- **Single paragraph input** → Output translation directly (no separators, no extra text)
+- **Multi-paragraph input (input uses ${BATCH_SEPARATOR} separators)** → Use ${BATCH_SEPARATOR} as paragraph separator between translations
+
+## Examples
+
+### Multi-paragraph Input:
+Paragraph A
+
+${BATCH_SEPARATOR}
+
+Paragraph B
+
+${BATCH_SEPARATOR}
+
+Paragraph C
+
+### Multi-paragraph Output:
+Translation A
+
+${BATCH_SEPARATOR}
+
+Translation B
+
+${BATCH_SEPARATOR}
+
+Translation C
+
+### Single paragraph Input:
+Single paragraph content
+
+### Single paragraph Output:
+Direct translation without separators
+`
+
+function addBatchFields(patterns: any[] | undefined): any[] {
+  if (!Array.isArray(patterns))
+    return []
+  return patterns.map(p => ({
+    ...p,
+    batchSystemPrompt: DEFAULT_BATCH_TRANSLATE_PROMPT,
+    appendBatchSystemPrompt: true,
+  }))
+}
+
+export function migrate(oldConfig: any): any {
+  return {
+    ...oldConfig,
+    translate: {
+      ...oldConfig?.translate,
+      customPromptsConfig: {
+        ...oldConfig?.translate?.customPromptsConfig,
+        patterns: addBatchFields(oldConfig?.translate?.customPromptsConfig?.patterns),
+      },
+    },
+    videoSubtitles: {
+      ...oldConfig?.videoSubtitles,
+      customPromptsConfig: {
+        ...oldConfig?.videoSubtitles?.customPromptsConfig,
+        patterns: addBatchFields(oldConfig?.videoSubtitles?.customPromptsConfig?.patterns),
+      },
+    },
+  }
+}

--- a/src/utils/constants/config.ts
+++ b/src/utils/constants/config.ts
@@ -18,7 +18,7 @@ export const GOOGLE_DRIVE_TOKEN_STORAGE_KEY = "__googleDriveToken"
 
 export const THEME_STORAGE_KEY = "theme"
 export const DEFAULT_DETECTED_CODE = "eng" as const
-export const CONFIG_SCHEMA_VERSION = 72
+export const CONFIG_SCHEMA_VERSION = 73
 
 export const DEFAULT_FLOATING_BUTTON_POSITION = 0.66
 export const DEFAULT_FLOATING_BUTTON_SIDE: FloatingButtonSide = "right"

--- a/src/utils/prompts/__tests__/translate.test.ts
+++ b/src/utils/prompts/__tests__/translate.test.ts
@@ -26,6 +26,8 @@ describe("translate prompt tokens", () => {
             name: "Custom",
             systemPrompt: "Target {{targetLanguage}} | Title {{webTitle}} | Content {{webContent}} | Summary {{webSummary}}",
             prompt: "Translate {{input}} for {{targetLanguage}} with {{webTitle}} / {{webContent}} / {{webSummary}}",
+            batchSystemPrompt: "",
+            appendBatchSystemPrompt: true,
           },
         ],
       },
@@ -53,6 +55,8 @@ describe("translate prompt tokens", () => {
             name: "Legacy",
             systemPrompt: "Legacy {{targetLang}} {{title}} {{summary}}",
             prompt: "Translate {{input}} to {{targetLang}}",
+            batchSystemPrompt: "",
+            appendBatchSystemPrompt: true,
           },
         ],
       },
@@ -97,6 +101,51 @@ describe("translate prompt tokens", () => {
 
     expect(result.systemPrompt).toBe("Use Japanese with Video Title and Video Summary")
     expect(result.prompt).toBe("Hello world => Japanese / Video Title / Video Summary")
+  })
+
+  it("uses custom batchSystemPrompt only when isBatch and append flag are true", () => {
+    const config: Pick<Config["translate"], "customPromptsConfig"> = {
+      customPromptsConfig: {
+        promptId: "p1",
+        patterns: [
+          {
+            id: "p1",
+            name: "P1",
+            systemPrompt: "BASE",
+            prompt: "PROMPT {{input}}",
+            batchSystemPrompt: "MY-BATCH-RULES",
+            appendBatchSystemPrompt: true,
+          },
+        ],
+      },
+    }
+
+    const off = getTranslatePromptFromConfig(config, "English", "x", { isBatch: false })
+    expect(off.systemPrompt).toBe("BASE")
+
+    const on = getTranslatePromptFromConfig(config, "English", "x", { isBatch: true })
+    expect(on.systemPrompt).toBe("BASE\n\nMY-BATCH-RULES")
+  })
+
+  it("skips batch prompt when appendBatchSystemPrompt is false", () => {
+    const config: Pick<Config["translate"], "customPromptsConfig"> = {
+      customPromptsConfig: {
+        promptId: "p1",
+        patterns: [
+          {
+            id: "p1",
+            name: "P1",
+            systemPrompt: "BASE",
+            prompt: "PROMPT {{input}}",
+            batchSystemPrompt: "MY-BATCH-RULES",
+            appendBatchSystemPrompt: false,
+          },
+        ],
+      },
+    }
+
+    const result = getTranslatePromptFromConfig(config, "English", "x", { isBatch: true })
+    expect(result.systemPrompt).toBe("BASE")
   })
 
   it("falls back when subtitle prompt context is null or undefined", async () => {

--- a/src/utils/prompts/subtitles.ts
+++ b/src/utils/prompts/subtitles.ts
@@ -26,6 +26,8 @@ export async function getSubtitlesTranslatePrompt(
   // Resolve system prompt and user prompt
   let systemPrompt: string
   let prompt: string
+  let batchSystemPrompt = DEFAULT_BATCH_TRANSLATE_PROMPT
+  let appendBatchSystemPrompt = true
 
   if (!promptId) {
     // Use default prompts from constants
@@ -37,13 +39,17 @@ export async function getSubtitlesTranslatePrompt(
     const customPrompt = patterns.find(pattern => pattern.id === promptId)
     systemPrompt = customPrompt?.systemPrompt ?? DEFAULT_SUBTITLE_TRANSLATE_SYSTEM_PROMPT
     prompt = customPrompt?.prompt ?? DEFAULT_TRANSLATE_PROMPT
+    if (customPrompt) {
+      batchSystemPrompt = customPrompt.batchSystemPrompt
+      appendBatchSystemPrompt = customPrompt.appendBatchSystemPrompt
+    }
   }
 
   // For batch mode, append batch rules to system prompt
-  if (options?.isBatch) {
+  if (options?.isBatch && appendBatchSystemPrompt && batchSystemPrompt.trim() !== "") {
     systemPrompt = `${systemPrompt}
 
-${DEFAULT_BATCH_TRANSLATE_PROMPT}`
+${batchSystemPrompt}`
   }
 
   // Build title and summary replacement values

--- a/src/utils/prompts/translate.ts
+++ b/src/utils/prompts/translate.ts
@@ -40,6 +40,8 @@ export function getTranslatePromptFromConfig(
   // Resolve system prompt and user prompt
   let systemPrompt: string
   let prompt: string
+  let batchSystemPrompt = DEFAULT_BATCH_TRANSLATE_PROMPT
+  let appendBatchSystemPrompt = true
 
   if (!promptId) {
     // Use default prompts from constants
@@ -51,13 +53,17 @@ export function getTranslatePromptFromConfig(
     const customPrompt = patterns.find(pattern => pattern.id === promptId)
     systemPrompt = customPrompt?.systemPrompt ?? DEFAULT_TRANSLATE_SYSTEM_PROMPT
     prompt = customPrompt?.prompt ?? DEFAULT_TRANSLATE_PROMPT
+    if (customPrompt) {
+      batchSystemPrompt = customPrompt.batchSystemPrompt
+      appendBatchSystemPrompt = customPrompt.appendBatchSystemPrompt
+    }
   }
 
   // For batch mode, append batch rules to system prompt
-  if (options?.isBatch) {
+  if (options?.isBatch && appendBatchSystemPrompt && batchSystemPrompt.trim() !== "") {
     systemPrompt = `${systemPrompt}
 
-${DEFAULT_BATCH_TRANSLATE_PROMPT}`
+${batchSystemPrompt}`
   }
 
   // Build title and summary replacement values


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [x] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

1. Do not append the multi-paragraph translation rules prompt when a batch request contains only a single paragraph.
2. Make the multi-paragraph translation rules prompt customizable through a personalized prompt setting.
3. Add a toggle to disable appending the multi-paragraph translation rules prompt for batch requests.

### Implementation notes

- Introduces a config schema **v73 migration** (`v072-to-v073`) that backfills the two new fields (`batchSystemPrompt`, `appendBatchSystemPrompt`) on existing personalized prompts under both `translate.customPromptsConfig` and `videoSubtitles.customPromptsConfig`. The migration is transparent to existing users.
- The personalized prompts JSON importer was updated to fall back to defaults when older exports are imported (older exports lack the two new fields), so existing prompt JSON files remain compatible.
- Added unit tests for the new prompt-builder behavior and for the v072→v073 migration.
- i18n keys for the new controls were added to all five locales (en, zh-CN, zh-TW, ja, ko).
- The v073 migration example (`__tests__/example/v073.ts`) keeps only the one test series that exercises both translate and videoSubtitles prompt patterns, to avoid bloating the diff.

## Related Issue

#1124

## How Has This Been Tested?

- [x] Verified through manual testing
- [x] `pnpm test` — 1229/1229 passing (including new tests)
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean

## Screenshots

<img width="399" height="746" alt="image" src="https://github.com/user-attachments/assets/8de96449-e7c4-436e-9202-fc1c69938236" />

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

**Most of the code was generated by Claude Opus 4.7.**
