### PR TITLE
fix(popup): prevent recovery on unsupported language codes

### DIFF
--- a/.changeset/fix-popup-language-recovery.md
+++ b/.changeset/fix-popup-language-recovery.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(extension): prevent popup recovery from unsupported detected languages

--- a/src/components/__tests__/language-combobox-options.test.ts
+++ b/src/components/__tests__/language-combobox-options.test.ts
@@ -1,0 +1,17 @@
+import type { LanguageItem } from "../language-combobox-options"
+import { describe, expect, it } from "vitest"
+import { filterLanguage } from "../language-combobox-options"
+
+describe("filterLanguage", () => {
+  it("does not throw when a legacy language item has no name", () => {
+    const item = {
+      value: "eng",
+      label: "English (English)",
+    } as LanguageItem
+
+    expect(() => filterLanguage(item, "eng")).not.toThrow()
+    expect(filterLanguage(item, "eng")).toBe(true)
+    expect(filterLanguage(item, "English")).toBe(true)
+    expect(filterLanguage(item, "zzz")).toBe(false)
+  })
+})

--- a/src/components/language-combobox-options.ts
+++ b/src/components/language-combobox-options.ts
@@ -9,7 +9,7 @@ import { i18n } from "#imports"
 export interface LanguageItem<T extends LangCodeISO6393 | "auto" = LangCodeISO6393 | "auto"> {
   value: T
   label: string
-  name: string
+  name?: string
 }
 
 export function getLanguageName(code: LangCodeISO6393) {
@@ -45,6 +45,6 @@ export function getLanguageItems(detectedLangCode?: LangCodeISO6393): LanguageIt
 export function filterLanguage(item: LanguageItem, query: string): boolean {
   const searchLower = query.toLowerCase()
   return item.label.toLowerCase().includes(searchLower)
-    || item.name.toLowerCase().includes(searchLower)
+    || (item.name?.toLowerCase().includes(searchLower) ?? false)
     || item.value.toLowerCase().includes(searchLower)
 }

--- a/src/entrypoints/background/__tests__/translation-signal.test.ts
+++ b/src/entrypoints/background/__tests__/translation-signal.test.ts
@@ -242,6 +242,19 @@ describe("translationMessage", () => {
     expect(storageSetItemMock).toHaveBeenCalledWith(getDetectedCodeStateKey(42), DEFAULT_DETECTED_CODE)
   })
 
+  it("normalizes unsupported page language before caching and notifying", async () => {
+    await setupSubject()
+    tabsQueryMock.mockResolvedValue([{ id: 42 }])
+
+    await getHandler("reportDetectedPageLanguage")({
+      data: { detectedCodeOrUnd: "vmw", url: "https://example.test" },
+      sender: { tab: { id: 42 }, frameId: 0 },
+    })
+
+    expect(storageSetItemMock).toHaveBeenCalledWith(getDetectedCodeStateKey(42), DEFAULT_DETECTED_CODE)
+    expect(sendMessageMock).toHaveBeenCalledWith("detectedPageLanguageChanged", { detectedCode: DEFAULT_DETECTED_CODE })
+  })
+
   it("returns the sender tab detected language to content scripts", async () => {
     await setupSubject()
     storageGetItemMock.mockImplementation(async (key: string) => {
@@ -256,6 +269,22 @@ describe("translationMessage", () => {
     })
 
     expect(detectedCode).toBe("jpn")
+  })
+
+  it("normalizes unsupported cached detected language for content scripts", async () => {
+    await setupSubject()
+    storageGetItemMock.mockImplementation(async (key: string) => {
+      if (key === getDetectedCodeStateKey(42))
+        return "vmw"
+      return undefined
+    })
+
+    const detectedCode = await getHandler("getDetectedCode")({
+      data: undefined,
+      sender: { tab: { id: 42 }, frameId: 0 },
+    })
+
+    expect(detectedCode).toBe(DEFAULT_DETECTED_CODE)
   })
 
   it("returns the active tab detected language to extension pages", async () => {

--- a/src/entrypoints/background/translation-signal.ts
+++ b/src/entrypoints/background/translation-signal.ts
@@ -4,6 +4,7 @@ import type { Config } from "@/types/config/config"
 import { browser, storage } from "#imports"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext } from "@/utils/analytics"
+import { normalizeDetectedCode } from "@/utils/config/languages"
 import { CONFIG_STORAGE_KEY, DEFAULT_DETECTED_CODE } from "@/utils/constants/config"
 import { getDetectedCodeStateKey, getTranslationStateKey } from "@/utils/constants/storage-keys"
 import { shouldEnableAutoTranslation } from "@/utils/host/translate/auto-translation"
@@ -35,16 +36,9 @@ function isIframe(frameId: number | undefined): boolean {
   return frameId !== undefined && frameId !== 0
 }
 
-function normalizeDetectedCode(detectedCodeOrUnd: LangCodeISO6393 | "und"): LangCodeISO6393 {
-  return detectedCodeOrUnd === "und" ? DEFAULT_DETECTED_CODE : detectedCodeOrUnd
-}
-
-async function getCachedDetectedCodeForTab(tabId: number): Promise<LangCodeISO6393 | undefined> {
-  return await storage.getItem<LangCodeISO6393>(getDetectedCodeStateKey(tabId)) ?? undefined
-}
-
 async function getDetectedCodeForTab(tabId: number): Promise<LangCodeISO6393> {
-  return await getCachedDetectedCodeForTab(tabId) ?? DEFAULT_DETECTED_CODE
+  const storedCode = await storage.getItem<unknown>(getDetectedCodeStateKey(tabId))
+  return normalizeDetectedCode(storedCode)
 }
 
 function notifyDetectedCodeChanged(detectedCode: LangCodeISO6393) {

--- a/src/utils/atoms/__tests__/detected-code.test.ts
+++ b/src/utils/atoms/__tests__/detected-code.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { createStore } from "jotai"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_DETECTED_CODE } from "@/utils/constants/config"
+import { detectedCodeAtom } from "../detected-code"
+
+const { cleanupMock, onMessageMock, sendMessageMock } = vi.hoisted(() => ({
+  cleanupMock: vi.fn(),
+  onMessageMock: vi.fn(),
+  sendMessageMock: vi.fn(),
+}))
+
+const messageHandlers = new Map<string, (msg: any) => void>()
+
+vi.mock("@/utils/message", () => ({
+  onMessage: onMessageMock,
+  sendMessage: sendMessageMock,
+}))
+
+function flushPromises() {
+  return new Promise(resolve => setTimeout(resolve, 0))
+}
+
+describe("detectedCodeAtom", () => {
+  beforeEach(() => {
+    cleanupMock.mockReset()
+    onMessageMock.mockReset()
+    sendMessageMock.mockReset()
+    messageHandlers.clear()
+
+    onMessageMock.mockImplementation((name: string, handler: (msg: any) => void) => {
+      messageHandlers.set(name, handler)
+      return cleanupMock
+    })
+  })
+
+  it("falls back when background returns an unsupported detected code", async () => {
+    sendMessageMock.mockResolvedValue("vmw")
+
+    const store = createStore()
+    const unsubscribe = store.sub(detectedCodeAtom, () => {})
+    await flushPromises()
+
+    expect(sendMessageMock).toHaveBeenCalledWith("getDetectedCode", undefined)
+    expect(store.get(detectedCodeAtom)).toBe(DEFAULT_DETECTED_CODE)
+
+    unsubscribe()
+    expect(cleanupMock).toHaveBeenCalled()
+  })
+
+  it("falls back when detected language change events carry an unsupported code", async () => {
+    sendMessageMock.mockResolvedValue("jpn")
+
+    const store = createStore()
+    const unsubscribe = store.sub(detectedCodeAtom, () => {})
+    await flushPromises()
+
+    expect(store.get(detectedCodeAtom)).toBe("jpn")
+
+    messageHandlers.get("detectedPageLanguageChanged")?.({ data: { detectedCode: "vmw" } })
+    expect(store.get(detectedCodeAtom)).toBe(DEFAULT_DETECTED_CODE)
+
+    messageHandlers.get("detectedPageLanguageChanged")?.({ data: { detectedCode: "cmn" } })
+    expect(store.get(detectedCodeAtom)).toBe("cmn")
+
+    unsubscribe()
+  })
+})

--- a/src/utils/atoms/detected-code.ts
+++ b/src/utils/atoms/detected-code.ts
@@ -1,5 +1,6 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
 import { atom } from "jotai"
+import { normalizeDetectedCode } from "@/utils/config/languages"
 import { DEFAULT_DETECTED_CODE } from "../constants/config"
 import { logger } from "../logger"
 import { onMessage, sendMessage } from "../message"
@@ -19,7 +20,7 @@ export const detectedCodeAtom = atom(
 baseDetectedCodeAtom.onMount = (setAtom: (newValue: LangCodeISO6393) => void) => {
   const refreshDetectedCode = () => {
     void sendMessage("getDetectedCode", undefined)
-      .then(setAtom)
+      .then(detectedCode => setAtom(normalizeDetectedCode(detectedCode)))
       .catch((error) => {
         logger.warn("Failed to refresh active tab detected language", error)
         setAtom(DEFAULT_DETECTED_CODE)
@@ -29,7 +30,7 @@ baseDetectedCodeAtom.onMount = (setAtom: (newValue: LangCodeISO6393) => void) =>
   refreshDetectedCode()
 
   const cleanupDetectedCodeListener = onMessage("detectedPageLanguageChanged", (msg) => {
-    setAtom(msg.data.detectedCode)
+    setAtom(normalizeDetectedCode(msg.data.detectedCode))
   })
 
   const handleVisibilityChange = () => {

--- a/src/utils/config/__tests__/languages.test.ts
+++ b/src/utils/config/__tests__/languages.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_DETECTED_CODE } from "@/utils/constants/config"
+import { getDetectedCodeFromStorage, normalizeDetectedCode } from "../languages"
+
+const { sendMessageMock } = vi.hoisted(() => ({
+  sendMessageMock: vi.fn(),
+}))
+
+vi.mock("@/utils/message", () => ({
+  sendMessage: sendMessageMock,
+}))
+
+describe("getDetectedCodeFromStorage", () => {
+  beforeEach(() => {
+    sendMessageMock.mockReset()
+  })
+
+  it("normalizes detected code values", () => {
+    expect(normalizeDetectedCode("jpn")).toBe("jpn")
+    expect(normalizeDetectedCode("vmw")).toBe(DEFAULT_DETECTED_CODE)
+    expect(normalizeDetectedCode(null)).toBe(DEFAULT_DETECTED_CODE)
+  })
+
+  it("returns a supported detected code from background", async () => {
+    sendMessageMock.mockResolvedValue("jpn")
+
+    await expect(getDetectedCodeFromStorage()).resolves.toBe("jpn")
+    expect(sendMessageMock).toHaveBeenCalledWith("getDetectedCode", undefined)
+  })
+
+  it("falls back when background returns an unsupported detected code", async () => {
+    sendMessageMock.mockResolvedValue("vmw")
+
+    await expect(getDetectedCodeFromStorage()).resolves.toBe(DEFAULT_DETECTED_CODE)
+  })
+
+  it("falls back when background detected code lookup fails", async () => {
+    sendMessageMock.mockRejectedValue(new Error("no receiver"))
+
+    await expect(getDetectedCodeFromStorage()).resolves.toBe(DEFAULT_DETECTED_CODE)
+  })
+})

--- a/src/utils/config/languages.ts
+++ b/src/utils/config/languages.ts
@@ -1,4 +1,5 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
+import { langCodeISO6393Schema } from "@read-frog/definitions"
 import { DEFAULT_DETECTED_CODE } from "../constants/config"
 import { sendMessage } from "../message"
 
@@ -6,9 +7,15 @@ export function getFinalSourceCode(sourceCode: LangCodeISO6393 | "auto", detecte
   return sourceCode === "auto" ? detectedCode : sourceCode
 }
 
+export function normalizeDetectedCode(value: unknown): LangCodeISO6393 {
+  const parsedCode = langCodeISO6393Schema.safeParse(value)
+  return parsedCode.success ? parsedCode.data : DEFAULT_DETECTED_CODE
+}
+
 export async function getDetectedCodeFromStorage(): Promise<LangCodeISO6393> {
   try {
-    return await sendMessage("getDetectedCode", undefined)
+    const detectedCode = await sendMessage("getDetectedCode", undefined)
+    return normalizeDetectedCode(detectedCode)
   }
   catch {
     return DEFAULT_DETECTED_CODE

--- a/src/utils/content/__tests__/language.test.ts
+++ b/src/utils/content/__tests__/language.test.ts
@@ -1,0 +1,33 @@
+import { franc } from "franc"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { detectLanguageWithSource } from "../language"
+
+vi.mock("franc", () => ({
+  franc: vi.fn(),
+}))
+
+const mockFranc = vi.mocked(franc)
+
+describe("detectLanguageWithSource", () => {
+  beforeEach(() => {
+    mockFranc.mockReset()
+  })
+
+  it("returns franc result when it is a supported language code", async () => {
+    mockFranc.mockReturnValue("eng")
+
+    await expect(detectLanguageWithSource("This is enough text to detect language.")).resolves.toEqual({
+      code: "eng",
+      source: "franc",
+    })
+  })
+
+  it("falls back when franc returns an unsupported language code", async () => {
+    mockFranc.mockReturnValue("vmw")
+
+    await expect(detectLanguageWithSource("Eyi je oro ni ede Yoruba fun idanwo wiwa ede.")).resolves.toEqual({
+      code: "und",
+      source: "fallback",
+    })
+  })
+})

--- a/src/utils/content/language.ts
+++ b/src/utils/content/language.ts
@@ -1,6 +1,7 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { BackgroundGenerateTextPayload } from "@/types/background-generate-text"
 import type { LLMProviderConfig } from "@/types/config/provider"
+import { langCodeISO6393Schema } from "@read-frog/definitions"
 import { franc } from "franc"
 import { toast } from "sonner"
 import { i18n } from "#imports"
@@ -80,7 +81,13 @@ export async function detectLanguageWithSource(
   if (francResult === "und") {
     return { code: "und", source: "fallback" }
   }
-  return { code: francResult as LangCodeISO6393, source: "franc" }
+
+  const parsedFrancResult = langCodeISO6393Schema.safeParse(francResult)
+  if (!parsedFrancResult.success) {
+    return { code: "und", source: "fallback" }
+  }
+
+  return { code: parsedFrancResult.data, source: "franc" }
 }
 
 /**


### PR DESCRIPTION
## Type of Changes

- [ ] New feature (feat)
- [x] Bug fix (fix)
- [ ] Documentation change (docs)
- [ ] UI/style change (style)
- [ ] Code refactoring (refactor)
- [ ] Performance improvement (perf)
- [ ] Test related (test)
- [ ] Build or dependencies update (build)
- [ ] CI/CD related (ci)
- [ ] Internationalization (i18n)
- [ ] AI model related (ai)
- [ ] Revert a previous commit (revert)
- [ ] Other changes that do not modify src or test files (chore)

## Description

Fixes a popup recovery crash triggered by unsupported detected language codes.

`franc` can return ISO 639-3 codes that are not supported by `@read-frog/definitions`. Previously those values were cast directly to `LangCodeISO6393`, which allowed unsupported codes into detected-language storage. When the popup built the auto-detected language option, the language name could be `undefined`; language search then called `item.name.toLowerCase()` and crashed into the recovery boundary.

This PR:

- Validates `franc` results with `langCodeISO6393Schema` and falls back to `und` for unsupported codes.
- Adds `normalizeDetectedCode()` in `src/utils/config/languages.ts` and reuses it for background message reads, atom updates, and tab-scoped detected-code cache reads.
- Normalizes legacy or externally written invalid `detectedCode` values before they reach popup/host translation paths.
- Makes language filtering defensive when an item has no `name`, while still supporting `label` and `value` search.
- Adds regression coverage for unsupported `franc` results, invalid detected-code storage values, and incomplete language items.
- Adds a patch changeset for `@read-frog/extension`.

## Related Issue

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Commands run:

```sh
SKIP_FREE_API=true pnpm exec vitest run src/utils/content/__tests__/language.test.ts src/components/__tests__/language-combobox-options.test.ts src/utils/config/__tests__/languages.test.ts src/utils/atoms/__tests__/detected-code.test.ts src/entrypoints/background/__tests__/translation-signal.test.ts
pnpm exec eslint src/utils/content/language.ts src/components/language-combobox-options.ts src/utils/atoms/detected-code.ts src/utils/config/languages.ts src/entrypoints/background/translation-signal.ts src/utils/content/__tests__/language.test.ts src/components/__tests__/language-combobox-options.test.ts src/utils/config/__tests__/languages.test.ts src/utils/atoms/__tests__/detected-code.test.ts src/entrypoints/background/__tests__/translation-signal.test.ts
pnpm type-check
git push --force-with-lease origin leons-doggy/fix-popup-language-recovery
```

The branch was rebased onto the latest `origin/main` and the conflict was resolved against the new tab-scoped detected-language architecture.

## Screenshots

N/A. This fixes a recovery-boundary crash and does not change the visible UI.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Unsupported detected language codes are intentionally normalized to `und` rather than expanding the supported language list.
