### PR TITLE
fix(translation): split batches on standalone separator lines

### DIFF
--- a/.changeset/clean-batch-separators.md
+++ b/.changeset/clean-batch-separators.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): only split batch translations on standalone separator lines

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -6,7 +6,7 @@ import type { PromptResolver } from "@/utils/host/translate/api/ai"
 import { isLLMProviderConfig } from "@/types/config/provider"
 import { putBatchRequestRecord } from "@/utils/batch-request-record"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
-import { BATCH_SEPARATOR } from "@/utils/constants/prompt"
+import { BATCH_SEPARATOR, BATCH_SEPARATOR_LINE_PATTERN } from "@/utils/constants/prompt"
 import { generateArticleSummary } from "@/utils/content/summary"
 import { cleanText } from "@/utils/content/utils"
 import { db } from "@/utils/db/dexie/db"
@@ -24,7 +24,7 @@ import { RequestQueue } from "@/utils/request/request-queue"
 import { ensureInitializedConfig } from "./config"
 
 export function parseBatchResult(result: string): string[] {
-  return result.split(BATCH_SEPARATOR).map(t => t.trim())
+  return result.trim().split(BATCH_SEPARATOR_LINE_PATTERN).map(t => t.trim())
 }
 
 export function shouldUseBatchQueue(providerConfig: ProviderConfig): boolean {

--- a/src/utils/constants/prompt.ts
+++ b/src/utils/constants/prompt.ts
@@ -7,6 +7,7 @@ export const TOKENS = WEB_PAGE_PROMPT_TOKENS
  * It is used to differentiate different text paragraphs when merging multiple translation tasks into a single request.
  */
 export const BATCH_SEPARATOR = "%%"
+export const BATCH_SEPARATOR_LINE_PATTERN = /\r?\n[ \t]*%%[ \t]*\r?\n/
 
 export const TARGET_LANGUAGE = WEB_PAGE_PROMPT_TOKENS[0]
 export const INPUT = WEB_PAGE_PROMPT_TOKENS[1]
@@ -48,12 +49,12 @@ export const DEFAULT_TRANSLATE_PROMPT = `Translate to ${getTokenCellText(TARGET_
 ${getTokenCellText(INPUT)}`
 
 export const DEFAULT_BATCH_TRANSLATE_PROMPT = `## Multi-paragraph Translation Rules
-1. If input contains ${BATCH_SEPARATOR}, use ${BATCH_SEPARATOR} in your output, if input has no ${BATCH_SEPARATOR}, don't use ${BATCH_SEPARATOR} in your output
-2. **CRITICAL**: Preserve exact formatting around ${BATCH_SEPARATOR} - use exactly one empty line before and after, with no extra spaces, tabs, or whitespace
+1. If input contains a standalone line containing only ${BATCH_SEPARATOR}, use a standalone ${BATCH_SEPARATOR} line in your output. If input has no standalone ${BATCH_SEPARATOR} line, don't use ${BATCH_SEPARATOR} in your output.
+2. **CRITICAL**: Treat ${BATCH_SEPARATOR} as a separator only when it appears on its own line. Do not treat ${BATCH_SEPARATOR} as a separator when it appears inside normal text, code, quotes, or punctuation.
 
 ## OUTPUT FORMAT:
 - **Single paragraph input** → Output translation directly (no separators, no extra text)
-- **Multi-paragraph input (input uses ${BATCH_SEPARATOR} separators)** → Use ${BATCH_SEPARATOR} as paragraph separator between translations
+- **Multi-paragraph input (input uses standalone ${BATCH_SEPARATOR} separator lines)** → Put ${BATCH_SEPARATOR} on its own line between translations
 
 ## Examples
 

--- a/src/utils/request/__tests__/batch-separator-parsing.test.ts
+++ b/src/utils/request/__tests__/batch-separator-parsing.test.ts
@@ -75,10 +75,32 @@ describe("batch separator parsing edge cases", () => {
     expect(parsed).toEqual(["Translation A", "", "Translation C"])
   })
 
-  it("should handle separator without any surrounding newlines", () => {
+  it("should not split separator without any surrounding newlines", () => {
     const result = `Translation A${BATCH_SEPARATOR}Translation B`
     const parsed = parseBatchResult(result)
-    expect(parsed).toEqual(["Translation A", "Translation B"])
+    expect(parsed).toEqual([`Translation A${BATCH_SEPARATOR}Translation B`])
+  })
+
+  it("should not split separator inside normal text", () => {
+    const result = `User typed ${BATCH_SEPARATOR} by mistake.`
+    const parsed = parseBatchResult(result)
+    expect(parsed).toEqual([`User typed ${BATCH_SEPARATOR} by mistake.`])
+  })
+
+  it("should not split separator inside code", () => {
+    const result = `Use const separator = "${BATCH_SEPARATOR}" in this example.`
+    const parsed = parseBatchResult(result)
+    expect(parsed).toEqual([`Use const separator = "${BATCH_SEPARATOR}" in this example.`])
+  })
+
+  it("should only split standalone separator lines when content also contains inline separators", () => {
+    const result = `Translation A mentions ${BATCH_SEPARATOR} inline.\n\n${BATCH_SEPARATOR}\n\nTranslation B has code: const separator = "${BATCH_SEPARATOR}"\n${BATCH_SEPARATOR}\nTranslation C`
+    const parsed = parseBatchResult(result)
+    expect(parsed).toEqual([
+      `Translation A mentions ${BATCH_SEPARATOR} inline.`,
+      `Translation B has code: const separator = "${BATCH_SEPARATOR}"`,
+      "Translation C",
+    ])
   })
 
   it("should handle LLM adding extra formatting", () => {


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Batch translation previously parsed model output with a raw split on `%%`, which incorrectly treated inline `%%` inside translated text or code as a segment boundary.

This PR keeps the existing `BATCH_SEPARATOR = "%%"` value but only splits batch output on standalone separator lines. It also tightens the default batch prompt to tell models that inline `%%` in normal text, code, quotes, or punctuation is not a separator.

## Related Issue

Closes #918

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation run locally and during push hooks:

- `pnpm test -- src/utils/request/__tests__/batch-separator-parsing.test.ts` (project ran full Vitest suite: 141 files / 1225 tests passed)
- `pnpm type-check`
- push hook: lint, type-check, full test suite

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This is intentionally a low-risk parser/prompt change. It does not introduce JSON/YAML parsing and does not change how batch input is joined.
