### PR TITLE
fix(selection-toolbar): hide Firefox speech actions

### DIFF
--- a/.changeset/firefox-selection-popup-tts.md
+++ b/.changeset/firefox-selection-popup-tts.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection-toolbar): hide unsupported Firefox speech actions in translation and custom action popovers

--- a/src/entrypoints/selection.content/components/selection-source-content.tsx
+++ b/src/entrypoints/selection.content/components/selection-source-content.tsx
@@ -20,6 +20,7 @@ export function SelectionSourceContent({
   emptyPlaceholder,
   separatorClassName,
 }: SelectionSourceContentProps) {
+  const isFirefox = import.meta.env.BROWSER === "firefox"
   const [actionsExpanded, setActionsExpanded] = useState(defaultExpanded)
   const displayText = text || emptyPlaceholder || ""
 
@@ -49,7 +50,7 @@ export function SelectionSourceContent({
         <Activity mode={actionsExpanded ? "visible" : "hidden"}>
           <div className="flex items-center gap-1">
             <CopyButton text={text ?? undefined} />
-            <SpeakButton text={text ?? undefined} />
+            {!isFirefox && <SpeakButton text={text ?? undefined} />}
           </div>
         </Activity>
       </div>

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/firefox-tts-gating.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/firefox-tts-gating.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { CustomActionContent } from "../custom-action-button/custom-action-content"
+import { TranslationContent } from "../translate-button/translation-content"
+
+vi.mock("../../components/copy-button", () => ({
+  CopyButton: () => <button type="button">Copy</button>,
+}))
+
+vi.mock("../../components/speak-button", () => ({
+  SpeakButton: ({ text }: { text: string | undefined }) => (
+    <button
+      type="button"
+      data-testid={text === "translated text" ? "translation-result-speak-button" : "selection-source-speak-button"}
+    >
+      Speak
+    </button>
+  ),
+}))
+
+vi.mock("../custom-action-button/field-speak-button", () => ({
+  FieldSpeakButton: () => (
+    <button type="button" data-testid="custom-action-field-speak-button">
+      Field speak
+    </button>
+  ),
+}))
+
+describe("selection toolbar Firefox TTS gating", () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it("renders translation popup speak buttons on supported browsers", () => {
+    vi.stubEnv("BROWSER", "chrome")
+
+    render(
+      <TranslationContent
+        selectionContent="selected text"
+        translatedText="translated text"
+        isTranslating={false}
+        thinking={null}
+      />,
+    )
+
+    expect(screen.getByTestId("selection-source-speak-button")).toBeInTheDocument()
+    expect(screen.getByTestId("translation-result-speak-button")).toBeInTheDocument()
+  })
+
+  it("hides translation popup speak buttons on Firefox", () => {
+    vi.stubEnv("BROWSER", "firefox")
+
+    render(
+      <TranslationContent
+        selectionContent="selected text"
+        translatedText="translated text"
+        isTranslating={false}
+        thinking={null}
+      />,
+    )
+
+    expect(screen.queryByTestId("selection-source-speak-button")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("translation-result-speak-button")).not.toBeInTheDocument()
+  })
+
+  it("renders custom action popup speak buttons on supported browsers", () => {
+    vi.stubEnv("BROWSER", "chrome")
+
+    render(
+      <CustomActionContent
+        isRunning={false}
+        outputSchema={[
+          {
+            id: "dictionary-term",
+            name: "Term",
+            type: "string",
+            description: "",
+            speaking: true,
+          },
+        ]}
+        selectionContent="selected text"
+        value={{ Term: "definition text" }}
+        thinking={null}
+      />,
+    )
+
+    expect(screen.getByTestId("selection-source-speak-button")).toBeInTheDocument()
+    expect(screen.getByTestId("custom-action-field-speak-button")).toBeInTheDocument()
+  })
+
+  it("hides custom action popup speak buttons on Firefox", () => {
+    vi.stubEnv("BROWSER", "firefox")
+
+    render(
+      <CustomActionContent
+        isRunning={false}
+        outputSchema={[
+          {
+            id: "dictionary-term",
+            name: "Term",
+            type: "string",
+            description: "",
+            speaking: true,
+          },
+        ]}
+        selectionContent="selected text"
+        value={{ Term: "definition text" }}
+        thinking={null}
+      />,
+    )
+
+    expect(screen.queryByTestId("selection-source-speak-button")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("custom-action-field-speak-button")).not.toBeInTheDocument()
+  })
+})

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/structured-object-renderer.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/structured-object-renderer.tsx
@@ -112,6 +112,7 @@ const { registry: STRUCTURED_OBJECT_REGISTRY } = defineRegistry(structuredObject
   components: {
     ObjectContainer: ({ children }) => <div className="space-y-3">{children}</div>,
     FieldRow: ({ props }) => {
+      const isFirefox = import.meta.env.BROWSER === "firefox"
       const { label, type, value, pending, speakingEnabled } = props
       const speakButtonDisabled = pending || value.length === 0
 
@@ -122,7 +123,7 @@ const { registry: STRUCTURED_OBJECT_REGISTRY } = defineRegistry(structuredObject
               {getFieldTypeIcon(type)}
               <span className="truncate">{label}</span>
             </div>
-            {speakingEnabled && (
+            {speakingEnabled && !isFirefox && (
               <FieldSpeakButton text={value} disabled={speakButtonDisabled} />
             )}
           </div>

--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/translation-content.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/translation-content.tsx
@@ -19,6 +19,7 @@ export function TranslationContent({
   isTranslating,
   thinking,
 }: TranslationContentProps) {
+  const isFirefox = import.meta.env.BROWSER === "firefox"
   const showLoadingIndicator = isTranslating && !thinking && !translatedText
   const showStreamingIndicator = isTranslating && !thinking && translatedText
   return (
@@ -36,7 +37,7 @@ export function TranslationContent({
         <Activity mode={translatedText ? "visible" : "hidden"}>
           <div className="flex items-center gap-1">
             <CopyButton text={translatedText} />
-            <SpeakButton text={translatedText} />
+            {!isFirefox && <SpeakButton text={translatedText} />}
           </div>
         </Activity>
       </div>


### PR DESCRIPTION
## Summary
- Hide selection-source and translated-result speech controls in Firefox selection toolbar translation popovers.
- Hide structured custom-action field speech controls in Firefox, including dictionary-style popovers.
- Add regression coverage for supported-browser vs Firefox speech-control rendering.

## Why
Firefox builds do not support the Chrome offscreen document playback path used by the current TTS action. The UI could still expose those speech buttons in selection popovers, letting Firefox users trigger the unsupported `OFFSCREEN_DOCUMENT` path and see the reported speech generation error.

## Test Plan
- `SKIP_FREE_API=true pnpm vitest run src/entrypoints/selection.content/selection-toolbar/__tests__/firefox-tts-gating.test.tsx`
- `SKIP_FREE_API=true pnpm eslint src/entrypoints/selection.content/components/selection-source-content.tsx src/entrypoints/selection.content/selection-toolbar/translate-button/translation-content.tsx src/entrypoints/selection.content/selection-toolbar/custom-action-button/structured-object-renderer.tsx src/entrypoints/selection.content/selection-toolbar/__tests__/firefox-tts-gating.test.tsx`
- `SKIP_FREE_API=true pnpm type-check`
- `WXT_SKIP_ENV_VALIDATION=true SKIP_FREE_API=true pnpm build:firefox`
- `SKIP_FREE_API=true pnpm test`

Fixes #1577
