### PR TITLE
fix(translation): force block X/Twitter tweet text via DOM rules

### DIFF
--- a/src/utils/constants/dom-rules.ts
+++ b/src/utils/constants/dom-rules.ts
@@ -168,4 +168,12 @@ export const CUSTOM_FORCE_BLOCK_TRANSLATION_SELECTOR_MAP: Record<string, string[
   "www.youtube.com": [
     "yt-attributed-string > span",
   ],
+  "x.com": [
+    "[data-testid=\"tweetText\"]",
+    "[data-testid=\"tweetText\"] > span:only-child",
+  ],
+  "twitter.com": [
+    "[data-testid=\"tweetText\"]",
+    "[data-testid=\"tweetText\"] > span:only-child",
+  ],
 }


### PR DESCRIPTION
## Problem

X/Twitter tweet text is rendered under `[data-testid="tweetText"]` with nested inline elements. In bilingual translation mode, the translation and original text appear merged without clear paragraph separation.

## Root Cause

`unwrapDeepestOnlyHTMLChild()` (called inside `translateNodesBilingualMode`) unwraps `targetNode` from the `tweetText` container to its inner `<span>` when the container has exactly one HTML child and no text children.

After unwrapping, `isCustomForceBlockTranslation(targetNode)` checks the inner `<span>` against the selector — which does not match `[data-testid="tweetText"]` — so the force-block flag is never set, and `addInlineTranslation` is called instead of `addBlockTranslation`.

## Why `[data-testid="tweetText"] *` broke layout

The `*` descendant selector matched every descendant inside `tweetText`, causing each inline child to be force-blocked individually. This turned every word/phrase into a separate block with its own `<br>`, breaking tweet layout.

## Fix: `:only-child` selector

```typescript
"x.com": [
  "[data-testid=\"tweetText\"]",
  "[data-testid=\"tweetText\"] > span:only-child",
],
"twitter.com": [
  "[data-testid=\"tweetText\"]",
  "[data-testid=\"tweetText\"] > span:only-child",
],
```

- `[data-testid="tweetText"]` — matches the container itself (handles the case where `targetNode` stays as the container)
- `[data-testid="tweetText"] > span:only-child` — matches the inner `<span>` only when it is the sole child of the container (handles the `unwrapDeepestOnlyHTMLChild` case)

The `:only-child` pseudo-class ensures this selector only activates when `unwrapDeepestOnlyHTMLChild` would unwrap to the inner span. For tweets with multiple children (e.g. with images, emojis, or multiple text segments), `:only-child` does not match, and the container is translated as a whole — avoiding the layout breakage from `*`.

## Changed files

- `src/utils/constants/dom-rules.ts` (+8 lines) — add X/Twitter entries to `CUSTOM_FORCE_BLOCK_TRANSLATION_SELECTOR_MAP`

## Verification

- [x] Pre-push checks: lint, type-check, test suite all pass
- [x] Local Chrome MV3 build installed and tested on X/Twitter
- [x] Random blind test on multiple X/Twitter posts — original and translated text correctly separated with `<br>`
- [x] Verified with browser DevTools: translation wrapper uses `read-frog-translated-block-content` (not `inline-content`)
- [x] Only changes DOM rules file — no changes to walker, filter, or translation insertion behavior