### PR TITLE
i18n(options): replace subtitle survey with Notebase access

### DIFF
--- a/.changeset/notebase-survey-entry.md
+++ b/.changeset/notebase-survey-entry.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+i18n(options): replace subtitle survey entry with Notebase early access survey

--- a/src/entrypoints/options/app-sidebar/product-nav.tsx
+++ b/src/entrypoints/options/app-sidebar/product-nav.tsx
@@ -14,7 +14,7 @@ import { cn } from "@/utils/styles/utils"
 import { getLastViewedSurvey, hasNewSurvey, saveLastViewedSurvey } from "@/utils/survey"
 import { AnimatedIndicator } from "./animated-indicator"
 
-const SURVEY_URL = "https://tally.so/r/kdNN5R"
+const SURVEY_URL = "https://tally.so/r/aQaa4Z"
 
 export function ProductNav() {
   const { open } = useSidebar()

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -944,7 +944,7 @@ options:
   whatsNew:
     title: What's New
   survey:
-    title: Improve Subtitle 🎁
+    title: Notebase Early Access
   rateUs:
     title: Rate Us
 side:

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -944,7 +944,7 @@ options:
   whatsNew:
     title: Novedades
   survey:
-    title: Mejorar subtítulos 🎁
+    title: Acceso anticipado a Notebase
   rateUs:
     title: Calificarnos
 side:

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -829,7 +829,7 @@ options:
   whatsNew:
     title: 新機能
   survey:
-    title: 字幕を改善 🎁
+    title: Notebase 先行体験
   rateUs:
     title: レビューを書く
 side:

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -829,7 +829,7 @@ options:
   whatsNew:
     title: 새로운 기능
   survey:
-    title: 자막 개선하기 🎁
+    title: Notebase 사전 체험
   rateUs:
     title: 리뷰 남기기
 side:

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -829,7 +829,7 @@ options:
   whatsNew:
     title: Что нового
   survey:
-    title: Улучшить субтитры 🎁
+    title: Ранний доступ к Notebase
   rateUs:
     title: Оцените нас
 side:

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -829,7 +829,7 @@ options:
   whatsNew:
     title: Yenilikler
   survey:
-    title: Altyazıyı Geliştir 🎁
+    title: Notebase Erken Erişim
   rateUs:
     title: Bizi Değerlendirin
 side:

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -829,7 +829,7 @@ options:
   whatsNew:
     title: Có gì mới
   survey:
-    title: Cải thiện phụ đề 🎁
+    title: Trải nghiệm sớm Notebase
   rateUs:
     title: Đánh giá chúng tôi
 side:

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -944,7 +944,7 @@ options:
   whatsNew:
     title: 最近更新
   survey:
-    title: 改进字幕 🎁
+    title: 笔记库（生词本）抢先体验
   rateUs:
     title: 好评支持
 side:

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -829,7 +829,7 @@ options:
   whatsNew:
     title: 最近更新
   survey:
-    title: 改進字幕 🎁
+    title: 笔记库（生词本）抢先体验
   rateUs:
     title: 好評支持
 side:


### PR DESCRIPTION
## Type of Changes

- [x] 🌐 Internationalization (i18n)

## Description

Replace the sidebar survey entry from the subtitle feedback survey to the Notebase early access Tally form.

This updates the survey URL to `https://tally.so/r/aQaa4Z`, removes the gift emoji from the survey label, and updates Simplified and Traditional Chinese labels to `笔记库（生词本）抢先体验`.

## Related Issue

N/A

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through local testing

Validation run by the push hook:

- `nx run @read-frog/extension:lint`
- `nx run @read-frog/extension:type-check`
- `nx run @read-frog/extension:test` (145 files, 1236 tests)

Also ran `git diff --check` and confirmed the old survey URL, old subtitle labels, and `🎁` marker are not present in the options survey entry.

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Added a patch changeset for the user-facing survey entry update.