### PR TITLE
refactor(translate): move lineByLine from TranslationMode enum to interleave config

### DIFF
--- a/.changeset/line-by-line-translation.md
+++ b/.changeset/line-by-line-translation.md
@@ -1,0 +1,9 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(translate): add sentence-interleave translation via `interleave` config
+
+Adds `interleave` config field (`"paragraph"` | `"sentence"`) under translate config. When `interleave` is `"sentence"`, bilingual translation interleaves each source sentence with its translation using `Intl.Segmenter` for sentence segmentation and batch translation via `%%` separators.
+
+The popup mode selector no longer shows sentence-interleave as a separate mode — it is configured in the options page.

--- a/.changeset/refactor-linebyline-into-interleave.md
+++ b/.changeset/refactor-linebyline-into-interleave.md
@@ -1,0 +1,7 @@
+---
+"@read-frog/extension": patch
+---
+
+refactor(translate): remove "lineByLine" from TranslationMode enum
+
+Migration v73 maps legacy `mode: "lineByLine"` configs to `mode: "bilingual"` + `interleave: "sentence"`. The line-by-line rendering logic is moved inside `translateNodesBilingualMode`, gated by the `interleave` config field.

--- a/src/entrypoints/popup/components/translation-mode-selector.tsx
+++ b/src/entrypoints/popup/components/translation-mode-selector.tsx
@@ -14,9 +14,16 @@ import {
 import { TRANSLATION_MODES } from "@/types/config/translate"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 
+/** Modes shown in the popup — "lineByLine" is a detail preference configured in the options page. */
+const POPUP_MODES: TranslationModeType[] = [...TRANSLATION_MODES]
+
 export default function TranslationModeSelector() {
   const [translateConfig, setTranslateConfig] = useAtom(configFieldsAtomMap.translate)
   const currentMode = translateConfig.mode
+
+  // Map legacy "lineByLine" → bilingual for display (lineByLine was removed from the enum
+  // but may still exist in stored configs before migration runs).
+  const displayMode: TranslationModeType = (currentMode as string) === "lineByLine" ? "bilingual" : currentMode
 
   const handleModeChange = (mode: TranslationModeType | null) => {
     if (!mode)
@@ -36,17 +43,17 @@ export default function TranslationModeSelector() {
         </HelpTooltip>
       </span>
       <Select
-        value={currentMode}
+        value={displayMode}
         onValueChange={handleModeChange}
       >
         <SelectTrigger className="h-7! w-31">
           <SelectValue>
-            {i18n.t(`options.translation.translationMode.mode.${currentMode}`)}
+            {i18n.t(`options.translation.translationMode.mode.${displayMode}`)}
           </SelectValue>
         </SelectTrigger>
         <SelectContent>
           <SelectGroup>
-            {TRANSLATION_MODES.map(mode => (
+            {POPUP_MODES.map(mode => (
               <SelectItem key={mode} value={mode}>
                 {i18n.t(`options.translation.translationMode.mode.${mode}`)}
               </SelectItem>

--- a/src/types/config/translate.ts
+++ b/src/types/config/translate.ts
@@ -18,6 +18,9 @@ export const batchQueueConfigSchema = z.object({
 export const TRANSLATION_MODES = ["bilingual", "translationOnly"] as const
 export const translationModeSchema = z.enum(TRANSLATION_MODES)
 
+export const INTERLEAVE_MODES = ["paragraph", "sentence"] as const
+export const interleaveSchema = z.enum(INTERLEAVE_MODES)
+
 export const pageTranslateRangeSchema = z.enum(["main", "all"])
 export type PageTranslateRange = z.infer<typeof pageTranslateRangeSchema>
 
@@ -107,9 +110,11 @@ export const translateConfigSchema = z.object({
   requestQueueConfig: requestQueueConfigSchema,
   batchQueueConfig: batchQueueConfigSchema,
   translationNodeStyle: translationNodeStyleConfigSchema,
+  interleave: interleaveSchema,
 })
 
 export type RequestQueueConfig = z.infer<typeof requestQueueConfigSchema>
 export type BatchQueueConfig = z.infer<typeof batchQueueConfigSchema>
 export type TranslateConfig = z.infer<typeof translateConfigSchema>
 export type TranslationMode = z.infer<typeof translationModeSchema>
+export type InterleaveMode = z.infer<typeof interleaveSchema>

--- a/src/utils/config/migration-scripts/v072-to-v073.ts
+++ b/src/utils/config/migration-scripts/v072-to-v073.ts
@@ -1,0 +1,22 @@
+/**
+ * Migration script from v072 to v073
+ * - Removes "lineByLine" from TRANSLATION_MODES, adds interleave field.
+ *   Users with mode "lineByLine" are migrated to mode "bilingual" +
+ *   interleave "sentence".
+ *
+ * IMPORTANT: All values are hardcoded inline. Migration scripts are frozen
+ * snapshots — never import constants or helpers that may change.
+ */
+export function migrate(oldConfig: any): any {
+  const oldMode = oldConfig?.translate?.mode
+  const isLineByLine = oldMode === "lineByLine"
+
+  return {
+    ...oldConfig,
+    translate: {
+      ...oldConfig?.translate,
+      mode: isLineByLine ? "bilingual" : (oldConfig?.translate?.mode ?? "bilingual"),
+      interleave: isLineByLine ? "sentence" : (oldConfig?.translate?.interleave ?? "paragraph"),
+    },
+  }
+}

--- a/src/utils/constants/config.ts
+++ b/src/utils/constants/config.ts
@@ -18,7 +18,7 @@ export const GOOGLE_DRIVE_TOKEN_STORAGE_KEY = "__googleDriveToken"
 
 export const THEME_STORAGE_KEY = "theme"
 export const DEFAULT_DETECTED_CODE = "eng" as const
-export const CONFIG_SCHEMA_VERSION = 72
+export const CONFIG_SCHEMA_VERSION = 73
 
 export const DEFAULT_FLOATING_BUTTON_POSITION = 0.66
 export const DEFAULT_FLOATING_BUTTON_SIDE: FloatingButtonSide = "right"
@@ -86,6 +86,7 @@ export const DEFAULT_CONFIG: Config = {
       isCustom: false,
       customCSS: null,
     },
+    interleave: "paragraph",
   },
   languageDetection: {
     mode: "basic",

--- a/src/utils/host/translate/core/__tests__/line-by-line-utils.test.ts
+++ b/src/utils/host/translate/core/__tests__/line-by-line-utils.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { buildLineByLineBatchText, parseLineByLineBatchResult } from "../line-by-line-utils"
+
+const BATCH_SEPARATOR = "%%"
+
+describe("buildLineByLineBatchText", () => {
+  it("joins two sentences with %% separator and blank lines", () => {
+    const result = buildLineByLineBatchText(["Hello.", "World."])
+    expect(result).toBe(`Hello.\n\n${BATCH_SEPARATOR}\n\nWorld.`)
+  })
+
+  it("returns single sentence as-is (no separator)", () => {
+    const result = buildLineByLineBatchText(["Only one."])
+    expect(result).toBe("Only one.")
+  })
+
+  it("joins three sentences", () => {
+    const result = buildLineByLineBatchText(["A.", "B.", "C."])
+    const parts = result.split(BATCH_SEPARATOR)
+    expect(parts).toHaveLength(3)
+    expect(parts[0].trim()).toBe("A.")
+    expect(parts[1].trim()).toBe("B.")
+    expect(parts[2].trim()).toBe("C.")
+  })
+
+  it("preserves internal spaces within sentences", () => {
+    const result = buildLineByLineBatchText(["The cat sat.", "It rained."])
+    expect(result).toContain("The cat sat.")
+    expect(result).toContain("It rained.")
+  })
+})
+
+describe("parseLineByLineBatchResult", () => {
+  it("splits two sentences by %%", () => {
+    const result = parseLineByLineBatchResult(`Translation A.\n\n${BATCH_SEPARATOR}\n\nTranslation B.`)
+    expect(result).toEqual(["Translation A.", "Translation B."])
+  })
+
+  it("trims whitespace around sentences", () => {
+    const result = parseLineByLineBatchResult(`  Hello.  \n\n${BATCH_SEPARATOR}\n\n  World.  `)
+    expect(result).toEqual(["Hello.", "World."])
+  })
+
+  it("filters empty segments", () => {
+    const result = parseLineByLineBatchResult(`A.\n\n${BATCH_SEPARATOR}\n\n\n\n${BATCH_SEPARATOR}\n\nC.`)
+    expect(result).toEqual(["A.", "C."])
+  })
+
+  it("returns single element for text without separator", () => {
+    const result = parseLineByLineBatchResult("Single translation.")
+    expect(result).toEqual(["Single translation."])
+  })
+
+  it("returns empty array for empty string", () => {
+    expect(parseLineByLineBatchResult("")).toEqual([])
+  })
+
+  it("returns empty array for whitespace-only string", () => {
+    expect(parseLineByLineBatchResult("   \n  ")).toEqual([])
+  })
+})

--- a/src/utils/host/translate/core/__tests__/line-by-line-utils.test.ts
+++ b/src/utils/host/translate/core/__tests__/line-by-line-utils.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest"
 import { buildLineByLineBatchText, parseLineByLineBatchResult } from "../line-by-line-utils"
 
-const BATCH_SEPARATOR = "%%"
+const SENTENCE_SEPARATOR = "@@"
 
 describe("buildLineByLineBatchText", () => {
-  it("joins two sentences with %% separator and blank lines", () => {
+  it("joins two sentences with @@ separator", () => {
     const result = buildLineByLineBatchText(["Hello.", "World."])
-    expect(result).toBe(`Hello.\n\n${BATCH_SEPARATOR}\n\nWorld.`)
+    expect(result).toBe(`Hello.\n${SENTENCE_SEPARATOR}\nWorld.`)
   })
 
   it("returns single sentence as-is (no separator)", () => {
@@ -16,7 +16,7 @@ describe("buildLineByLineBatchText", () => {
 
   it("joins three sentences", () => {
     const result = buildLineByLineBatchText(["A.", "B.", "C."])
-    const parts = result.split(BATCH_SEPARATOR)
+    const parts = result.split(SENTENCE_SEPARATOR)
     expect(parts).toHaveLength(3)
     expect(parts[0].trim()).toBe("A.")
     expect(parts[1].trim()).toBe("B.")
@@ -31,18 +31,18 @@ describe("buildLineByLineBatchText", () => {
 })
 
 describe("parseLineByLineBatchResult", () => {
-  it("splits two sentences by %%", () => {
-    const result = parseLineByLineBatchResult(`Translation A.\n\n${BATCH_SEPARATOR}\n\nTranslation B.`)
+  it("splits two sentences by @@", () => {
+    const result = parseLineByLineBatchResult(`Translation A.\n${SENTENCE_SEPARATOR}\nTranslation B.`)
     expect(result).toEqual(["Translation A.", "Translation B."])
   })
 
   it("trims whitespace around sentences", () => {
-    const result = parseLineByLineBatchResult(`  Hello.  \n\n${BATCH_SEPARATOR}\n\n  World.  `)
+    const result = parseLineByLineBatchResult(`  Hello.  \n${SENTENCE_SEPARATOR}\n  World.  `)
     expect(result).toEqual(["Hello.", "World."])
   })
 
   it("filters empty segments", () => {
-    const result = parseLineByLineBatchResult(`A.\n\n${BATCH_SEPARATOR}\n\n\n\n${BATCH_SEPARATOR}\n\nC.`)
+    const result = parseLineByLineBatchResult(`A.\n${SENTENCE_SEPARATOR}\n\n${SENTENCE_SEPARATOR}\nC.`)
     expect(result).toEqual(["A.", "C."])
   })
 

--- a/src/utils/host/translate/core/__tests__/segment-sentences.test.ts
+++ b/src/utils/host/translate/core/__tests__/segment-sentences.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+import { segmentSentences } from "../segment-sentences"
+
+describe("segmentSentences", () => {
+  it("splits English text into sentences", () => {
+    const result = segmentSentences("The cat sat on the mat. It was a dark night.")
+    expect(result).toEqual([
+      "The cat sat on the mat. ",
+      "It was a dark night.",
+    ])
+  })
+
+  it("preserves inter-sentence whitespace (trailing space on non-last segments)", () => {
+    const result = segmentSentences("Hello. World. Test.")
+    expect(result).toEqual([
+      "Hello. ",
+      "World. ",
+      "Test.",
+    ])
+  })
+
+  it("splits Chinese text into sentences", () => {
+    const result = segmentSentences("猫坐在垫子上。那是一个漆黑的夜晚。")
+    expect(result).toEqual([
+      "猫坐在垫子上。",
+      "那是一个漆黑的夜晚。",
+    ])
+  })
+
+  it("handles question marks and exclamation marks", () => {
+    const result = segmentSentences("Hello! How are you? I am fine.")
+    expect(result).toEqual([
+      "Hello! ",
+      "How are you? ",
+      "I am fine.",
+    ])
+  })
+
+  it("returns single sentence as-is", () => {
+    const result = segmentSentences("This is a single sentence.")
+    expect(result).toEqual(["This is a single sentence."])
+  })
+
+  it("returns empty array for empty string", () => {
+    expect(segmentSentences("")).toEqual([])
+  })
+
+  it("returns empty array for whitespace-only string", () => {
+    expect(segmentSentences("   \n  \t  ")).toEqual([])
+  })
+
+  it("returns [text] when Intl.Segmenter is not available", () => {
+    const originalIntl = globalThis.Intl
+    // @ts-expect-error - intentionally removing Intl for test
+    delete globalThis.Intl
+
+    const result = segmentSentences("Hello world. Test.")
+    expect(result).toEqual(["Hello world. Test."])
+
+    globalThis.Intl = originalIntl
+  })
+
+  it("filters out empty segments (noise between sentences)", () => {
+    // Intl.Segmenter may produce empty segments between sentences
+    const result = segmentSentences("Hello. World.")
+    expect(result.length).toBe(2)
+    expect(result.every(s => s.length > 0)).toBe(true)
+  })
+})

--- a/src/utils/host/translate/core/line-by-line-utils.ts
+++ b/src/utils/host/translate/core/line-by-line-utils.ts
@@ -1,0 +1,20 @@
+import { BATCH_SEPARATOR } from "../../../constants/prompt"
+
+/**
+ * Join sentences into a single batch text using %% separators,
+ * matching the format expected by the batch translation prompt.
+ */
+export function buildLineByLineBatchText(sentences: string[]): string {
+  return sentences.join(`\n\n${BATCH_SEPARATOR}\n\n`)
+}
+
+/**
+ * Parse a batch translation result back into individual sentence translations.
+ * Splits by %% and filters out empty strings.
+ */
+export function parseLineByLineBatchResult(text: string): string[] {
+  return text
+    .split(BATCH_SEPARATOR)
+    .map(s => s.trim())
+    .filter(s => s.length > 0)
+}

--- a/src/utils/host/translate/core/line-by-line-utils.ts
+++ b/src/utils/host/translate/core/line-by-line-utils.ts
@@ -1,20 +1,25 @@
-import { BATCH_SEPARATOR } from "../../../constants/prompt"
+/**
+ * Sentence-level separator — deliberately different from the queue-level
+ * BATCH_SEPARATOR ("%%") so that sentence-batched text can pass through the
+ * background batch queue without delimiter collision.
+ */
+const SENTENCE_SEPARATOR = "@@"
 
 /**
- * Join sentences into a single batch text using %% separators,
- * matching the format expected by the batch translation prompt.
+ * Join sentences into a single batch text using @@ separators.
+ * The LLM naturally replicates the separator pattern in its output.
  */
 export function buildLineByLineBatchText(sentences: string[]): string {
-  return sentences.join(`\n\n${BATCH_SEPARATOR}\n\n`)
+  return sentences.join(`\n${SENTENCE_SEPARATOR}\n`)
 }
 
 /**
  * Parse a batch translation result back into individual sentence translations.
- * Splits by %% and filters out empty strings.
+ * Splits by @@ and filters out empty strings.
  */
 export function parseLineByLineBatchResult(text: string): string[] {
   return text
-    .split(BATCH_SEPARATOR)
+    .split(SENTENCE_SEPARATOR)
     .map(s => s.trim())
     .filter(s => s.length > 0)
 }

--- a/src/utils/host/translate/core/segment-sentences.ts
+++ b/src/utils/host/translate/core/segment-sentences.ts
@@ -1,0 +1,38 @@
+/**
+ * Segment a text into sentences using Intl.Segmenter.
+ * If Intl.Segmenter is unavailable (e.g., Firefox < 125), returns the text as-is.
+ */
+export function segmentSentences(text: string): string[] {
+  if (!text || !text.trim()) {
+    return []
+  }
+
+  if (typeof Intl === "undefined" || !Intl.Segmenter) {
+    return [text]
+  }
+
+  try {
+    const segmenter = new Intl.Segmenter(undefined, { granularity: "sentence" })
+    const rawSegments = [...segmenter.segment(text)].map(s => s.segment)
+
+    // Intl.Segmenter includes boundary whitespace as trailing space on the
+    // preceding segment (e.g. "Hello. " + "World.").  Trimming drops that
+    // space, which makes line-by-line mode render source sentences
+    // concatenated as "Hello.World.".  Preserve a single trailing space on
+    // every non-last segment that originally had one.
+    const segments: string[] = []
+    for (let i = 0; i < rawSegments.length; i++) {
+      const trimmed = rawSegments[i].trim()
+      if (trimmed.length === 0)
+        continue
+      const isLast = i === rawSegments.length - 1
+      const hadTrailingWS = !isLast && rawSegments[i].endsWith(trimmed) === false
+      segments.push(hadTrailingWS ? `${trimmed} ` : trimmed)
+    }
+
+    return segments.length > 0 ? segments : [text]
+  }
+  catch {
+    return [text]
+  }
+}

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -81,39 +81,30 @@ export async function translateNodesBilingualMode(
         ? await unwrapDeepestOnlyHTMLChild(lastNode)
         : lastNode
 
-    // Check for existing translation — wrapper-based for paragraph interleave,
-    // attribute-based for sentence interleave (paragraph rebuilt in-place)
-    if (config.translate.interleave === "sentence") {
-      const paragraphElement = findParagraphElement(targetNode)
-      const alreadyTranslated = paragraphElement
-        && paragraphElement.getAttribute(TRANSLATION_MODE_ATTRIBUTE) === "lineByLine"
-        && paragraphElement.getAttribute(WALKED_ATTRIBUTE) === walkId
+    // Check for existing translation — handle both wrapper-based and
+    // line-by-line paragraph rebuild, regardless of current interleave.
+    // This prevents stale translations from the "other" mode when the
+    // user switches interleave and re-translates.
+    const paragraphElement = findParagraphElement(targetNode)
+    const lineByLineExists = paragraphElement
+      && paragraphElement.getAttribute(TRANSLATION_MODE_ATTRIBUTE) === "lineByLine"
+      && paragraphElement.getAttribute(WALKED_ATTRIBUTE) === walkId
+    const wrapperExists = findPreviousTranslatedWrapperInside(targetNode, walkId)
 
-      if (alreadyTranslated && paragraphElement) {
-        removeLineByLineTranslation(paragraphElement)
-        if (toggle) {
-          return
-        }
-        else {
-          nodes.forEach(node => translatingNodes.delete(node))
-          void translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
-          return
-        }
-      }
+    if (lineByLineExists && paragraphElement) {
+      removeLineByLineTranslation(paragraphElement)
     }
-    else {
-      const existedTranslatedWrapper = findPreviousTranslatedWrapperInside(targetNode, walkId)
-      if (existedTranslatedWrapper) {
-        removeTranslatedWrapperWithRestore(existedTranslatedWrapper)
-        if (toggle) {
-          return
-        }
-        else {
-          nodes.forEach(node => translatingNodes.delete(node))
-          void translateNodesBilingualMode(nodes, walkId, config, toggle)
-          return
-        }
+    if (wrapperExists) {
+      removeTranslatedWrapperWithRestore(wrapperExists)
+    }
+
+    if (lineByLineExists || wrapperExists) {
+      if (toggle) {
+        return
       }
+      nodes.forEach(node => translatingNodes.delete(node))
+      void translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
+      return
     }
 
     const textContent = transNodes.map(node => extractTextContent(node, config)).join("").trim()

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -154,6 +154,9 @@ export async function translateNodesBilingualMode(
         )
 
         if (realTranslatedText === undefined) {
+          // Error UI was injected into spinnerWrapper — remove it so retries
+          // don't accumulate stale error wrappers beside the paragraph.
+          spinnerWrapper.remove()
           return
         }
         spinnerWrapper.remove()

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -2,13 +2,17 @@ import type { Config } from "@/types/config/config"
 import type { TranslationMode } from "@/types/config/translate"
 import type { TransNode } from "@/types/dom"
 import {
+  BLOCK_ATTRIBUTE,
+  BLOCK_CONTENT_CLASS,
   CONTENT_WRAPPER_CLASS,
+  INLINE_CONTENT_CLASS,
   NOTRANSLATE_CLASS,
+  PARAGRAPH_ATTRIBUTE,
   TRANSLATION_MODE_ATTRIBUTE,
   WALKED_ATTRIBUTE,
 } from "../../../constants/dom-labels"
 import { batchDOMOperation } from "../../dom/batch-dom"
-import { isBlockTransNode, isHTMLElement, isTextNode, isTransNode } from "../../dom/filter"
+import { isBlockTransNode, isCustomForceBlockTranslation, isHTMLElement, isInlineTransNode, isTextNode, isTransNode } from "../../dom/filter"
 import { unwrapDeepestOnlyHTMLChild } from "../../dom/find"
 import { getOwnerDocument } from "../../dom/node"
 import { extractTextContent } from "../../dom/traversal"
@@ -18,8 +22,11 @@ import { findPreviousTranslatedWrapperInside } from "../dom/translation-wrapper"
 import { shouldFilterSmallParagraph } from "../filter-small-paragraph"
 import { prepareTranslationText } from "../text-preparation"
 import { setTranslationDirAndLang } from "../translation-attributes"
+import { decorateTranslationNode } from "../ui/decorate-translation"
 import { createSpinnerInside, getTranslatedTextAndRemoveSpinner } from "../ui/spinner"
-import { isNumericContent } from "../ui/translation-utils"
+import { isForceInlineTranslation, isNumericContent } from "../ui/translation-utils"
+import { buildLineByLineBatchText, parseLineByLineBatchResult } from "./line-by-line-utils"
+import { segmentSentences } from "./segment-sentences"
 import { MARK_ATTRIBUTES_REGEX, originalContentMap, translatingNodes } from "./translation-state"
 
 const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g
@@ -74,16 +81,38 @@ export async function translateNodesBilingualMode(
         ? await unwrapDeepestOnlyHTMLChild(lastNode)
         : lastNode
 
-    const existedTranslatedWrapper = findPreviousTranslatedWrapperInside(targetNode, walkId)
-    if (existedTranslatedWrapper) {
-      removeTranslatedWrapperWithRestore(existedTranslatedWrapper)
-      if (toggle) {
-        return
+    // Check for existing translation — wrapper-based for paragraph interleave,
+    // attribute-based for sentence interleave (paragraph rebuilt in-place)
+    if (config.translate.interleave === "sentence") {
+      const paragraphElement = findParagraphElement(targetNode)
+      const alreadyTranslated = paragraphElement
+        && paragraphElement.getAttribute(TRANSLATION_MODE_ATTRIBUTE) === "lineByLine"
+        && paragraphElement.getAttribute(WALKED_ATTRIBUTE) === walkId
+
+      if (alreadyTranslated && paragraphElement) {
+        removeLineByLineTranslation(paragraphElement)
+        if (toggle) {
+          return
+        }
+        else {
+          nodes.forEach(node => translatingNodes.delete(node))
+          void translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
+          return
+        }
       }
-      else {
-        nodes.forEach(node => translatingNodes.delete(node))
-        void translateNodesBilingualMode(nodes, walkId, config, toggle)
-        return
+    }
+    else {
+      const existedTranslatedWrapper = findPreviousTranslatedWrapperInside(targetNode, walkId)
+      if (existedTranslatedWrapper) {
+        removeTranslatedWrapperWithRestore(existedTranslatedWrapper)
+        if (toggle) {
+          return
+        }
+        else {
+          nodes.forEach(node => translatingNodes.delete(node))
+          void translateNodesBilingualMode(nodes, walkId, config, toggle)
+          return
+        }
       }
     }
 
@@ -93,6 +122,109 @@ export async function translateNodesBilingualMode(
 
     if (await shouldFilterSmallParagraph(textContent, config))
       return
+
+    // ── Sentence-interleave path ──────────────────────────────
+    if (config.translate.interleave === "sentence") {
+      const sentences = segmentSentences(textContent)
+
+      // Single sentence — fall through to normal bilingual below
+      if (sentences.length > 1) {
+        const batchText = buildLineByLineBatchText(sentences)
+
+        const ownerDoc = getOwnerDocument(targetNode)
+        const spinnerWrapper = ownerDoc.createElement("span")
+        spinnerWrapper.className = `${NOTRANSLATE_CLASS} ${CONTENT_WRAPPER_CLASS}`
+        spinnerWrapper.setAttribute(TRANSLATION_MODE_ATTRIBUTE, "lineByLine" as TranslationMode)
+        spinnerWrapper.setAttribute(WALKED_ATTRIBUTE, walkId)
+        setTranslationDirAndLang(spinnerWrapper, config)
+        const spinner = createSpinnerInside(spinnerWrapper)
+
+        const insertOperation = () => {
+          if (isTextNode(targetNode) || transNodes.length > 1) {
+            targetNode.parentNode?.insertBefore(spinnerWrapper, targetNode.nextSibling)
+          }
+          else {
+            targetNode.appendChild(spinnerWrapper)
+          }
+        }
+        batchDOMOperation(insertOperation)
+
+        const realTranslatedText = await getTranslatedTextAndRemoveSpinner(
+          nodes, batchText, spinner, spinnerWrapper,
+        )
+
+        if (realTranslatedText === undefined) {
+          return
+        }
+        spinnerWrapper.remove()
+
+        if (realTranslatedText === "") {
+          return
+        }
+
+        const translatedSentences = parseLineByLineBatchResult(realTranslatedText)
+        if (translatedSentences.length !== sentences.length) {
+          // Count mismatch — retry as normal bilingual
+          transNodes.forEach(node => translatingNodes.delete(node))
+          void translateNodesBilingualMode(nodes, walkId, { ...config, translate: { ...config.translate, interleave: "paragraph" } }, toggle, forceBlockTranslation)
+          return
+        }
+
+        const targetParagraph = findParagraphElement(targetNode)
+          ?? (isHTMLElement(targetNode) ? targetNode : targetNode.parentElement)
+        if (targetParagraph?.querySelector(`[${BLOCK_ATTRIBUTE}]`)) {
+          // Block children present — fall back to normal bilingual
+          transNodes.forEach(node => translatingNodes.delete(node))
+          void translateNodesBilingualMode(nodes, walkId, { ...config, translate: { ...config.translate, interleave: "paragraph" } }, toggle, forceBlockTranslation)
+          return
+        }
+
+        if (targetParagraph && !originalContentMap.has(targetParagraph)) {
+          originalContentMap.set(targetParagraph, targetParagraph.innerHTML)
+        }
+        if (targetParagraph) {
+          targetParagraph.setAttribute(TRANSLATION_MODE_ATTRIBUTE, "lineByLine" as TranslationMode)
+          targetParagraph.setAttribute(WALKED_ATTRIBUTE, walkId)
+        }
+
+        const forceInline = isForceInlineTranslation(targetNode)
+        const customForceBlock = isHTMLElement(targetNode) && isCustomForceBlockTranslation(targetNode)
+        let isBlock: boolean
+        if (customForceBlock)
+          isBlock = true
+        else if (forceInline)
+          isBlock = false
+        else if (forceBlockTranslation)
+          isBlock = true
+        else if (isInlineTransNode(targetNode))
+          isBlock = false
+        else if (isBlockTransNode(targetNode))
+          isBlock = true
+        else return
+
+        const fragment = ownerDoc.createDocumentFragment()
+        for (let i = 0; i < sentences.length; i++) {
+          const origSpan = ownerDoc.createElement("span")
+          origSpan.className = NOTRANSLATE_CLASS
+          origSpan.style.display = "contents"
+          origSpan.textContent = sentences[i]
+          fragment.appendChild(origSpan)
+
+          const transSpan = ownerDoc.createElement("span")
+          transSpan.className = `${NOTRANSLATE_CLASS} ${isBlock ? BLOCK_CONTENT_CLASS : INLINE_CONTENT_CLASS}`
+          transSpan.textContent = translatedSentences[i]
+          await decorateTranslationNode(transSpan, config.translate.translationNodeStyle)
+          fragment.appendChild(transSpan)
+        }
+
+        if (targetParagraph) {
+          targetParagraph.innerHTML = ""
+          targetParagraph.appendChild(fragment)
+        }
+        return
+      }
+      // Single sentence: fall through to normal bilingual below
+    }
 
     const ownerDoc = getOwnerDocument(targetNode)
     const translatedWrapperNode = ownerDoc.createElement("span")
@@ -141,6 +273,23 @@ export async function translateNodesBilingualMode(
   finally {
     transNodes.forEach(node => translatingNodes.delete(node))
   }
+}
+
+// ── Line-by-line helpers ────────────────────────────────────────────
+
+function findParagraphElement(node: Node): HTMLElement | null {
+  const element = isHTMLElement(node) ? node : node.parentElement
+  return element?.closest<HTMLElement>(`[${PARAGRAPH_ATTRIBUTE}]`) ?? null
+}
+
+function removeLineByLineTranslation(paragraphElement: HTMLElement): void {
+  const savedHTML = originalContentMap.get(paragraphElement)
+  if (savedHTML !== undefined) {
+    paragraphElement.innerHTML = savedHTML
+    originalContentMap.delete(paragraphElement)
+  }
+  paragraphElement.removeAttribute(TRANSLATION_MODE_ATTRIBUTE)
+  paragraphElement.removeAttribute(WALKED_ATTRIBUTE)
 }
 
 export async function translateNodeTranslationOnlyMode(

--- a/src/utils/host/translate/dom/translation-cleanup.ts
+++ b/src/utils/host/translate/dom/translation-cleanup.ts
@@ -1,4 +1,4 @@
-import { REACT_SHADOW_HOST_CLASS, TRANSLATION_MODE_ATTRIBUTE } from "../../../constants/dom-labels"
+import { REACT_SHADOW_HOST_CLASS, TRANSLATION_MODE_ATTRIBUTE, WALKED_ATTRIBUTE } from "../../../constants/dom-labels"
 import { removeReactShadowHost } from "../../../react-shadow-host/create-shadow-host"
 import { batchDOMOperation } from "../../dom/batch-dom"
 import { isHTMLElement, isTranslatedWrapperNode } from "../../dom/filter"
@@ -57,4 +57,22 @@ export function removeAllTranslatedWrapperNodes(
   translatedNodes.forEach((contentWrapperNode) => {
     removeTranslatedWrapperWithRestore(contentWrapperNode)
   })
+
+  // Also clean up line-by-line translated paragraphs — they don't have
+  // wrapper elements; their innerHTML was replaced in-place.
+  const lineByLineParas = deepQueryTopLevelSelector(
+    root,
+    el => isHTMLElement(el) && el.getAttribute(TRANSLATION_MODE_ATTRIBUTE) === "lineByLine",
+  )
+  for (const para of lineByLineParas) {
+    if (!isHTMLElement(para))
+      continue
+    const saved = originalContentMap.get(para)
+    if (saved !== undefined) {
+      para.innerHTML = saved
+      originalContentMap.delete(para)
+    }
+    para.removeAttribute(TRANSLATION_MODE_ATTRIBUTE)
+    para.removeAttribute(WALKED_ATTRIBUTE)
+  }
 }


### PR DESCRIPTION
## Type of Changes

- [x] ♻️ Code refactoring (refactor)
- [x] ✨ New feature (feat)

## Description

Refactors the line-by-line translation from a third \`TranslationMode\` enum value into an orthogonal \`interleave\` config property, as suggested by mengxi-ream.

### Before

\`\`\`
TRANSLATION_MODES = ["bilingual", "lineByLine", "translationOnly"]
\`\`\`

Three discrete modes with a standalone 160-line function, 3-way branches in dispatch/cleanup/retry.

### After

\`\`\`
TRANSLATION_MODES = ["bilingual", "translationOnly"]
interleave: "paragraph" | "sentence"  // new config field
\`\`\`

\`translateNodesLineByLineMode\` merged into \`translateNodesBilingualMode\` — sentence segmentation and DOM rebuild are gated by \`config.translate.interleave === "sentence"\`. One fewer function, 2-way branches everywhere.

### Key changes

| File | Change |
|---|---|
| \`src/types/config/translate.ts\` | \`TRANSLATION_MODES\` → 2 values; add \`INTERLEAVE_MODES\` + \`interleaveSchema\` |
| \`src/utils/host/translate/core/translation-modes.ts\` | Delete \`translateNodesLineByLineMode\` (160 lines); merge logic into bilingual mode under interleave gate; 2-way dispatch |
| \`src/utils/config/migration-scripts/v072-to-v073.ts\` | **New** — \`mode: "lineByLine"\` → \`mode: "bilingual"\` + \`interleave: "sentence"\` |
| \`src/entrypoints/popup/.../translation-mode-selector.tsx\` | Simplified to 2-option dropdown; legacy \`"lineByLine"\` runtime fallback |
| \`src/components/translation/error/retry-button.tsx\` | 2-way branch (was 3) |
| \`src/utils/host/translate/core/segment-sentences.ts\` | Preserve inter-sentence whitespace for faithful DOM-rebuild rendering |

### Architectural effect

\`\`\`
Before: mode enum → 3 functions → 6+ dispatch sites
After:  mode enum + interleave config → 2 functions → 4 dispatch sites
\`\`\`

Future display variants (e.g., hover word-level, side-by-side columns) can add new \`interleave\` values without touching dispatch/cleanup/retry — they only need rendering logic inside the bilingual function.

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing
- [x] Real Chromium browser + Playwright: popup shows only 2 options, page translation works with interleave=paragraph
- [x] \`pnpm type-check\` ✅
- [x] \`pnpm build\` ✅

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality