### PR TITLE
fix(content): verify page language metadata

### DIFF
--- a/.changeset/weak-metadata-language.md
+++ b/.changeset/weak-metadata-language.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(content): verify page language metadata against visible text

--- a/src/utils/content/__tests__/page-language.test.ts
+++ b/src/utils/content/__tests__/page-language.test.ts
@@ -22,7 +22,7 @@ describe("detectPageLanguageLightweight", () => {
     document.body.innerHTML = ""
   })
 
-  it("uses html lang metadata without invoking text language detection", async () => {
+  it("uses html lang metadata without invoking text language detection when text is short", async () => {
     document.documentElement.lang = "ja-JP"
     document.body.textContent = "This body should not be needed."
 
@@ -35,7 +35,7 @@ describe("detectPageLanguageLightweight", () => {
     expect(mockDetectLanguageWithSource).not.toHaveBeenCalled()
   })
 
-  it("uses page language meta tags before sampling body text", async () => {
+  it("uses page language meta tags without invoking text language detection when text is short", async () => {
     document.head.innerHTML = `<meta property="og:locale" content="zh_TW">`
     document.body.textContent = "This body should not be needed."
 
@@ -46,6 +46,63 @@ describe("detectPageLanguageLightweight", () => {
       detectionSource: "metadata",
     })
     expect(mockDetectLanguageWithSource).not.toHaveBeenCalled()
+  })
+
+  it("prefers Chinese text detection over conflicting English metadata", async () => {
+    mockDetectLanguageWithSource.mockResolvedValueOnce({ code: "cmn", source: "franc" })
+    document.documentElement.lang = "en"
+    document.title = "阅读 - 源仓库"
+    document.body.textContent = "源仓库 资源中心 文章列表 地址发布页 首页 阅读 登录 阅读 书源 书源合集 订阅源 订阅源合集 其他 新建".repeat(2)
+
+    const result = await detectPageLanguageLightweight()
+
+    expect(result).toEqual({
+      detectedCodeOrUnd: "cmn",
+      detectionSource: "franc",
+    })
+    expect(mockDetectLanguageWithSource).toHaveBeenCalledWith(
+      expect.stringContaining("阅读 - 源仓库"),
+      { enableLLM: false },
+    )
+  })
+
+  it("prefers text detection over conflicting non-English metadata", async () => {
+    mockDetectLanguageWithSource.mockResolvedValueOnce({ code: "eng", source: "franc" })
+    document.documentElement.lang = "ja-JP"
+    document.body.textContent = "English body text with enough visible content to verify incorrect page metadata. ".repeat(2)
+
+    const result = await detectPageLanguageLightweight()
+
+    expect(result).toEqual({
+      detectedCodeOrUnd: "eng",
+      detectionSource: "franc",
+    })
+  })
+
+  it("keeps English metadata when text detection agrees", async () => {
+    mockDetectLanguageWithSource.mockResolvedValueOnce({ code: "eng", source: "franc" })
+    document.documentElement.lang = "en"
+    document.body.textContent = "English body text with enough visible content to verify matching page metadata. ".repeat(2)
+
+    const result = await detectPageLanguageLightweight()
+
+    expect(result).toEqual({
+      detectedCodeOrUnd: "eng",
+      detectionSource: "metadata",
+    })
+  })
+
+  it("keeps traditional Chinese metadata when text detection returns generic Chinese", async () => {
+    mockDetectLanguageWithSource.mockResolvedValueOnce({ code: "cmn", source: "franc" })
+    document.head.innerHTML = `<meta property="og:locale" content="zh_TW">`
+    document.body.textContent = "繁體中文內容用來驗證頁面語言中繼資料，這段文字需要足夠長，避免短文本時跳過正文偵測。".repeat(2)
+
+    const result = await detectPageLanguageLightweight()
+
+    expect(result).toEqual({
+      detectedCodeOrUnd: "cmn-Hant",
+      detectionSource: "metadata",
+    })
   })
 
   it("falls back to local text detection with a bounded title and body sample", async () => {

--- a/src/utils/content/page-language.ts
+++ b/src/utils/content/page-language.ts
@@ -8,6 +8,7 @@ import {
 import { detectLanguageWithSource } from "./language"
 
 export const PAGE_LANGUAGE_TEXT_SAMPLE_LIMIT = 3000
+const MIN_TEXT_LENGTH_FOR_METADATA_VERIFICATION = 80
 
 const SHOW_TEXT = 4
 const FILTER_ACCEPT = 1
@@ -183,14 +184,18 @@ function collectPageTextSample(root: Node | null | undefined, maxLength = PAGE_L
   return sample
 }
 
+function areCompatibleDetectedCodes(metadataCode: LangCodeISO6393, textCode: LangCodeISO6393 | "und"): boolean {
+  return textCode === metadataCode || (metadataCode === "cmn-Hant" && textCode === "cmn")
+}
+
 export async function detectPageLanguageLightweight(doc: Document = document): Promise<PageLanguageDetectionResult> {
+  let metadataCode: LangCodeISO6393 | null = null
+
   for (const candidate of getMetaLanguageCandidates(doc)) {
     const code = resolveLanguageCodeFromLocale(candidate)
     if (code) {
-      return {
-        detectedCodeOrUnd: code,
-        detectionSource: "metadata",
-      }
+      metadataCode = code
+      break
     }
   }
 
@@ -199,9 +204,23 @@ export async function detectPageLanguageLightweight(doc: Document = document): P
     collectPageTextSample(doc.body),
   ].filter(Boolean).join("\n\n")
 
+  if (metadataCode && textForDetection.trim().length < MIN_TEXT_LENGTH_FOR_METADATA_VERIFICATION) {
+    return {
+      detectedCodeOrUnd: metadataCode,
+      detectionSource: "metadata",
+    }
+  }
+
   const { code, source } = await detectLanguageWithSource(textForDetection, {
     enableLLM: false,
   })
+
+  if (metadataCode && (code === "und" || areCompatibleDetectedCodes(metadataCode, code))) {
+    return {
+      detectedCodeOrUnd: metadataCode,
+      detectionSource: "metadata",
+    }
+  }
 
   return {
     detectedCodeOrUnd: code,


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Treat page language metadata as a hint when enough visible text is available. This prevents pages with stale or template-level language metadata, such as localized Chinese pages declaring `lang="en"`, from being detected as the wrong source language.

The detector now keeps metadata for short samples, undetected text, matching detections, and `cmn-Hant` metadata when text detection returns generic `cmn`; otherwise it prefers the concrete visible-text detection result.

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Commands run:

```bash
SKIP_FREE_API=true pnpm test -- src/utils/content/__tests__/page-language.test.ts
git push -u origin leons-doggy/fix-page-language-metadata
```

The push hook also passed lint, type-check, and the full test suite.

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Includes a patch changeset for the user-visible bug fix.