### PR TITLE
i18n(options): localize language labels

### DIFF
--- a/.changeset/localized-language-labels.md
+++ b/.changeset/localized-language-labels.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+i18n(options): localize UI language labels

--- a/src/components/language-combobox-options.ts
+++ b/src/components/language-combobox-options.ts
@@ -1,23 +1,11 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
-import {
-  LANG_CODE_TO_LOCALE_NAME,
-  langCodeISO6393Schema,
-} from "@read-frog/definitions"
-import { camelCase } from "case-anything"
-import { i18n } from "#imports"
+import { langCodeISO6393Schema } from "@read-frog/definitions"
+import { getLanguageLabel, getLanguageName } from "@/utils/language-labels"
 
 export interface LanguageItem<T extends LangCodeISO6393 | "auto" = LangCodeISO6393 | "auto"> {
   value: T
   label: string
   name?: string
-}
-
-export function getLanguageName(code: LangCodeISO6393) {
-  return i18n.t(`languages.${camelCase(code)}` as Parameters<typeof i18n.t>[0])
-}
-
-export function getLanguageLabel(code: LangCodeISO6393) {
-  return `${getLanguageName(code)} (${LANG_CODE_TO_LOCALE_NAME[code]})`
 }
 
 export function getTargetLanguageItems(): LanguageItem<LangCodeISO6393>[] {

--- a/src/components/multi-language-combobox.tsx
+++ b/src/components/multi-language-combobox.tsx
@@ -1,11 +1,8 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
+import type { LanguageItem } from "./language-combobox-options"
 import { Combobox as ComboboxPrimitive } from "@base-ui/react"
 import { Icon } from "@iconify/react"
-import {
-  LANG_CODE_TO_LOCALE_NAME,
-  langCodeISO6393Schema,
-} from "@read-frog/definitions"
-import { camelCase } from "case-anything"
+import { langCodeISO6393Schema } from "@read-frog/definitions"
 import { useMemo } from "react"
 import { i18n } from "#imports"
 import { Button } from "@/components/ui/base-ui/button"
@@ -17,23 +14,14 @@ import {
   ComboboxItem,
   ComboboxList,
 } from "@/components/ui/base-ui/combobox"
+import { getLanguageLabel } from "@/utils/language-labels"
+import { filterLanguage } from "./language-combobox-options"
 
-interface LanguageItem {
-  value: LangCodeISO6393
-  label: string
-}
-
-function getLanguageItems(): LanguageItem[] {
+function getLanguageItems(): LanguageItem<LangCodeISO6393>[] {
   return langCodeISO6393Schema.options.map(code => ({
     value: code,
-    label: `${i18n.t(`languages.${camelCase(code)}` as Parameters<typeof i18n.t>[0])} (${LANG_CODE_TO_LOCALE_NAME[code]})`,
+    label: getLanguageLabel(code),
   }))
-}
-
-function filterLanguage(item: LanguageItem, query: string): boolean {
-  const searchLower = query.toLowerCase()
-  return item.label.toLowerCase().includes(searchLower)
-    || item.value.toLowerCase().includes(searchLower)
 }
 
 interface MultiLanguageComboboxProps {
@@ -58,7 +46,7 @@ export function MultiLanguageCombobox({
     <Combobox
       multiple
       value={selectedItems}
-      onValueChange={(items: LanguageItem[]) => {
+      onValueChange={(items: LanguageItem<LangCodeISO6393>[]) => {
         onLanguagesChange(items.map(item => item.value))
       }}
       items={languageItems}
@@ -71,7 +59,7 @@ export function MultiLanguageCombobox({
       <ComboboxContent align="end" className="w-fit">
         <ComboboxInput showTrigger={false} placeholder={i18n.t("translationHub.searchLanguages")} />
         <ComboboxList>
-          {(item: LanguageItem) => (
+          {(item: LanguageItem<LangCodeISO6393>) => (
             <ComboboxItem key={item.value} value={item}>
               {item.label}
             </ComboboxItem>

--- a/src/entrypoints/options/pages/input-translation/input-translation-languages.tsx
+++ b/src/entrypoints/options/pages/input-translation/input-translation-languages.tsx
@@ -1,11 +1,6 @@
-import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { InputTranslationLang } from "@/types/config/config"
 import { Icon } from "@iconify/react"
-import {
-  LANG_CODE_TO_EN_NAME,
-  LANG_CODE_TO_LOCALE_NAME,
-  langCodeISO6393Schema,
-} from "@read-frog/definitions"
+import { langCodeISO6393Schema } from "@read-frog/definitions"
 import { useAtom } from "jotai"
 import { Activity } from "react"
 import { i18n } from "#imports"
@@ -20,11 +15,8 @@ import {
   SelectValue,
 } from "@/components/ui/base-ui/select"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { getLanguageLabel } from "@/utils/language-labels"
 import { ConfigCard } from "../../components/config-card"
-
-function langCodeLabel(langCode: LangCodeISO6393) {
-  return `${LANG_CODE_TO_EN_NAME[langCode]} (${LANG_CODE_TO_LOCALE_NAME[langCode]})`
-}
 
 interface LangSelectProps {
   value: InputTranslationLang
@@ -50,7 +42,7 @@ function LangSelect({ value, onValueChange, getDisplayLabel }: LangSelectProps) 
           </SelectItem>
           {langCodeISO6393Schema.options.map(code => (
             <SelectItem key={code} value={code}>
-              {langCodeLabel(code)}
+              {getLanguageLabel(code)}
             </SelectItem>
           ))}
         </SelectGroup>
@@ -69,13 +61,13 @@ export function InputTranslationLanguages() {
       if (language.sourceCode === "auto") {
         return `${label} (auto)`
       }
-      return `${label} (${langCodeLabel(language.sourceCode)})`
+      return `${label} (${getLanguageLabel(language.sourceCode)})`
     }
     if (value === "targetCode") {
       const label = i18n.t("options.inputTranslation.languages.targetCode")
-      return `${label} (${langCodeLabel(language.targetCode)})`
+      return `${label} (${getLanguageLabel(language.targetCode)})`
     }
-    return langCodeLabel(value)
+    return getLanguageLabel(value)
   }
 
   const handleFromLangChange = (value: InputTranslationLang) => {

--- a/src/entrypoints/options/pages/translation/auto-translate-languages.tsx
+++ b/src/entrypoints/options/pages/translation/auto-translate-languages.tsx
@@ -1,14 +1,11 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
 import { Icon } from "@iconify/react"
-import {
-  LANG_CODE_TO_EN_NAME,
-  LANG_CODE_TO_LOCALE_NAME,
-} from "@read-frog/definitions"
 import { useAtom } from "jotai"
 import { i18n } from "#imports"
 import { MultiLanguageCombobox } from "@/components/multi-language-combobox"
 import { Button } from "@/components/ui/base-ui/button"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { getLanguageLabel } from "@/utils/language-labels"
 import { ConfigCard } from "../../components/config-card"
 
 export function AutoTranslateLanguages() {
@@ -72,7 +69,7 @@ function SelectedLanguageCells() {
           key={language}
           className="inline-flex items-center gap-1 rounded-md border bg-muted px-2 py-1 text-sm"
         >
-          <span>{`${LANG_CODE_TO_EN_NAME[language]} (${LANG_CODE_TO_LOCALE_NAME[language]})`}</span>
+          <span>{getLanguageLabel(language)}</span>
           <Button
             variant="ghost"
             size="icon"

--- a/src/entrypoints/options/pages/translation/skip-languages.tsx
+++ b/src/entrypoints/options/pages/translation/skip-languages.tsx
@@ -1,9 +1,5 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
 import { Icon } from "@iconify/react"
-import {
-  LANG_CODE_TO_EN_NAME,
-  LANG_CODE_TO_LOCALE_NAME,
-} from "@read-frog/definitions"
 import { useAtom } from "jotai"
 import { i18n } from "#imports"
 import { HelpTooltip } from "@/components/help-tooltip"
@@ -12,6 +8,7 @@ import { Button } from "@/components/ui/base-ui/button"
 import { Field, FieldContent, FieldLabel } from "@/components/ui/base-ui/field"
 import { Switch } from "@/components/ui/base-ui/switch"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { getLanguageLabel } from "@/utils/language-labels"
 import { ConfigCard } from "../../components/config-card"
 
 export function SkipLanguages() {
@@ -105,7 +102,7 @@ function SelectedSkipLanguageCells() {
           key={language}
           className="inline-flex items-center gap-1 rounded-md border bg-muted px-2 py-1 text-sm"
         >
-          <span>{`${LANG_CODE_TO_EN_NAME[language]} (${LANG_CODE_TO_LOCALE_NAME[language]})`}</span>
+          <span>{getLanguageLabel(language)}</span>
           <Button
             variant="ghost"
             size="icon"

--- a/src/entrypoints/popup/components/language-options-selector.tsx
+++ b/src/entrypoints/popup/components/language-options-selector.tsx
@@ -2,11 +2,7 @@ import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { LanguageItem } from "@/components/language-combobox-options"
 import { Combobox as ComboboxPrimitive } from "@base-ui/react"
 import { Icon } from "@iconify/react"
-import {
-  LANG_CODE_TO_EN_NAME,
-  LANG_CODE_TO_LOCALE_NAME,
-  langCodeISO6393Schema,
-} from "@read-frog/definitions"
+import { langCodeISO6393Schema } from "@read-frog/definitions"
 import { IconChevronDown } from "@tabler/icons-react"
 import { useAtom, useAtomValue } from "jotai"
 import { useMemo } from "react"
@@ -23,16 +19,13 @@ import {
 } from "@/components/ui/base-ui/combobox"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { detectedCodeAtom } from "@/utils/atoms/detected-code"
-
-function langCodeLabel(langCode: LangCodeISO6393) {
-  return `${LANG_CODE_TO_EN_NAME[langCode]} (${LANG_CODE_TO_LOCALE_NAME[langCode]})`
-}
+import { getLanguageLabel, getLanguageName } from "@/utils/language-labels"
 
 function createLanguageItem(code: LangCodeISO6393): LanguageItem<LangCodeISO6393> {
   return {
     value: code,
-    label: langCodeLabel(code),
-    name: LANG_CODE_TO_EN_NAME[code],
+    label: getLanguageLabel(code),
+    name: getLanguageName(code),
   }
 }
 
@@ -81,8 +74,8 @@ export default function LanguageOptionsSelector() {
     () => [
       {
         value: "auto",
-        label: langCodeLabel(detectedCode),
-        name: LANG_CODE_TO_EN_NAME[detectedCode],
+        label: getLanguageLabel(detectedCode),
+        name: getLanguageName(detectedCode),
       },
       ...targetLanguageItems,
     ],
@@ -111,10 +104,10 @@ export default function LanguageOptionsSelector() {
 
   const sourceLangLabel
     = language.sourceCode === "auto"
-      ? `${currentSourceItem?.label ?? langCodeLabel(detectedCode)} (auto)`
-      : currentSourceItem?.label ?? langCodeLabel(language.sourceCode)
+      ? `${currentSourceItem?.label ?? getLanguageLabel(detectedCode)} (auto)`
+      : currentSourceItem?.label ?? getLanguageLabel(language.sourceCode)
 
-  const targetLangLabel = currentTargetItem?.label ?? langCodeLabel(language.targetCode)
+  const targetLangLabel = currentTargetItem?.label ?? getLanguageLabel(language.targetCode)
 
   return (
     <div className="flex items-center justify-between">

--- a/src/utils/__tests__/language-labels.test.ts
+++ b/src/utils/__tests__/language-labels.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest"
+import { getLanguageLabel } from "../language-labels"
+
+describe("getLanguageLabel", () => {
+  it("combines the localized language name with the native language name", () => {
+    expect(getLanguageLabel("jpn")).toBe("languages.jpn (日本語)")
+  })
+})

--- a/src/utils/language-labels.ts
+++ b/src/utils/language-labels.ts
@@ -1,0 +1,12 @@
+import type { LangCodeISO6393 } from "@read-frog/definitions"
+import { LANG_CODE_TO_LOCALE_NAME } from "@read-frog/definitions"
+import { camelCase } from "case-anything"
+import { i18n } from "#imports"
+
+export function getLanguageName(code: LangCodeISO6393) {
+  return i18n.t(`languages.${camelCase(code)}` as Parameters<typeof i18n.t>[0])
+}
+
+export function getLanguageLabel(code: LangCodeISO6393) {
+  return `${getLanguageName(code)} (${LANG_CODE_TO_LOCALE_NAME[code]})`
+}


### PR DESCRIPTION
## Type of Changes

- [x] 🌐 Internationalization (i18n)

## Description

Localizes UI language labels that display a browser-locale language name followed by the native/autonym language name in parentheses. Shared formatting now lives in `src/utils/language-labels.ts`, and options/popup selectors reuse it instead of formatting with `LANG_CODE_TO_EN_NAME`.

This keeps user-facing labels localized, for example Chinese UI can show `俄语 (Русский)` and Japanese UI can show `ロシア語 (Русский)`, while prompt/translation internals continue using English language names.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Commands run:

- `SKIP_FREE_API=true pnpm test src/components/__tests__/language-combobox-options.test.ts src/utils/__tests__/language-labels.test.ts`
- `pnpm exec eslint src/utils/language-labels.ts src/utils/__tests__/language-labels.test.ts src/components/language-combobox-options.ts src/components/multi-language-combobox.tsx src/components/__tests__/language-combobox-options.test.ts src/entrypoints/options/pages/translation/auto-translate-languages.tsx src/entrypoints/options/pages/translation/skip-languages.tsx src/entrypoints/popup/components/language-options-selector.tsx src/entrypoints/options/pages/input-translation/input-translation-languages.tsx`
- `pnpm type-check`
- `SKIP_FREE_API=true pnpm test`
- pre-push hook: `nx run @read-frog/extension:lint`, `nx run @read-frog/extension:type-check`, `nx run @read-frog/extension:test`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Includes a patch changeset for `@read-frog/extension`.
