### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/src/assets/providers/litellm-color.svg
+++ b/src/assets/providers/litellm-color.svg
@@ -1,5 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
-  <rect width="120" height="120" rx="24" fill="#1a56db"/>
-  <path d="M35 85V35h10v42h25v8H35z" fill="#fff"/>
-  <path d="M75 85V35h10v50H75z" fill="#fff"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <rect width="120" height="120" rx="24" fill="#1a73e8"/>
+  <text x="60" y="78" text-anchor="middle" font-size="64">🚅</text>
 </svg>

--- a/src/assets/providers/litellm-color.svg
+++ b/src/assets/providers/litellm-color.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" fill="none">
+  <rect width="120" height="120" rx="24" fill="#1a56db"/>
+  <path d="M35 85V35h10v42h25v8H35z" fill="#fff"/>
+  <path d="M75 85V35h10v50H75z" fill="#fff"/>
+</svg>

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -182,6 +182,7 @@ options:
         alibaba: Alibaba Cloud's Qwen model series with advanced reasoning and multilingual capabilities
         moonshotai: Moonshot AI's Kimi model series with strong reasoning and long-context capabilities
         huggingface: Hugging Face Inference API providing access to thousands of open-source models
+        litellm: LiteLLM AI gateway proxy supporting 100+ LLM providers through a unified API
     apiKey:
       showAPIKey: Show API Key
     howToConfigure: How to configure?

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -182,6 +182,7 @@ options:
         alibaba: Serie de modelos Qwen de Alibaba Cloud con razonamiento avanzado y capacidades multilingües
         moonshotai: Serie de modelos Kimi de Moonshot AI con razonamiento sólido y capacidades de contexto largo
         huggingface: API de inferencia de Hugging Face que proporciona acceso a miles de modelos de código abierto
+        litellm: Proxy de gateway de IA LiteLLM compatible con más de 100 proveedores de LLM a través de una API unificada
     apiKey:
       showAPIKey: Mostrar clave API
     howToConfigure: ¿Cómo configurar?

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -181,6 +181,7 @@ options:
         alibaba: アリババクラウドのQwenモデルシリーズ、高度な推論と多言語機能を備える
         moonshotai: Moonshot AIのKimiモデルシリーズ、優れた推論と長コンテキスト能力
         huggingface: Hugging Face推論API、数千のオープンソースモデルへのアクセスを提供
+        litellm: LiteLLM AIゲートウェイプロキシ、統一APIで100以上のLLMプロバイダーをサポート
     apiKey:
       showAPIKey: APIキーを表示
     howToConfigure: 設定方法は?

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -181,6 +181,7 @@ options:
         alibaba: 알리바바 클라우드의 Qwen 모델 시리즈, 고급 추론 및 다국어 기능 제공
         moonshotai: Moonshot AI의 Kimi 모델 시리즈, 강력한 추론 및 긴 컨텍스트 기능 제공
         huggingface: Hugging Face 추론 API, 수천 개의 오픈소스 모델 접근 제공
+        litellm: LiteLLM AI 게이트웨이 프록시, 통합 API를 통해 100개 이상의 LLM 공급자 지원
     apiKey:
       showAPIKey: API Key 표시
     howToConfigure: 구성 방법은?

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -181,6 +181,7 @@ options:
         alibaba: Серия моделей Qwen от Alibaba Cloud с продвинутыми возможностями рассуждения и многоязычности
         moonshotai: Серия моделей Kimi от Moonshot AI с мощными возможностями рассуждения и длинного контекста
         huggingface: API вывода Hugging Face с доступом к тысячам моделей с открытым кодом
+        litellm: Прокси-шлюз LiteLLM AI с поддержкой 100+ провайдеров LLM через единый API
     apiKey:
       showAPIKey: Показать API-ключ
     howToConfigure: Как настроить?

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -181,6 +181,7 @@ options:
         alibaba: Alibaba Cloud'un Qwen model serisi, gelişmiş muhakeme ve çok dilli yeteneklerle
         moonshotai: Moonshot AI'ın güçlü muhakeme ve uzun bağlam yeteneklerine sahip Kimi model serisi
         huggingface: Binlerce açık kaynak modele erişim sağlayan Hugging Face Çıkarım API'si
+        litellm: Birleşik API aracılığıyla 100'den fazla LLM sağlayıcısını destekleyen LiteLLM AI ağ geçidi proxy'si
     apiKey:
       showAPIKey: API Anahtarını Göster
     howToConfigure: Nasıl yapılandırılır?

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -181,6 +181,7 @@ options:
         alibaba: Dòng mô hình Qwen của Alibaba Cloud với khả năng suy luận và đa ngôn ngữ tiên tiến
         moonshotai: Dòng mô hình Kimi của Moonshot AI với khả năng suy luận mạnh mẽ và ngữ cảnh dài
         huggingface: API suy luận Hugging Face cung cấp quyền truy cập hàng nghìn mô hình mã nguồn mở
+        litellm: Proxy cổng AI LiteLLM hỗ trợ hơn 100 nhà cung cấp LLM thông qua API hợp nhất
     apiKey:
       showAPIKey: Hiển thị API Key
     howToConfigure: Cấu hình như thế nào?

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -182,6 +182,7 @@ options:
         alibaba: 阿里云通义千问系列模型，具备先进的推理和多语言能力
         moonshotai: 月之暗面Kimi系列模型，具备强大的推理和长上下文能力
         huggingface: Hugging Face推理API，提供数千种开源模型访问
+        litellm: LiteLLM AI网关代理，通过统一API支持100多个LLM提供商
     apiKey:
       showAPIKey: 显示 API Key
     howToConfigure: 如何配置?

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -181,6 +181,7 @@ options:
         alibaba: 阿里雲通義千問系列模型，具備先進的推理和多語言能力
         moonshotai: 月之暗面Kimi系列模型，具備強大的推理和長上下文能力
         huggingface: Hugging Face推理API，提供數千種開源模型存取
+        litellm: LiteLLM AI閘道代理，透過統一API支援100多個LLM提供商
     apiKey:
       showAPIKey: 顯示 API Key
     howToConfigure: 如何配置?

--- a/src/types/config/provider/constants.ts
+++ b/src/types/config/provider/constants.ts
@@ -8,7 +8,7 @@ export { LLM_PROVIDER_MODELS, NON_API_TRANSLATE_PROVIDERS, NON_API_TRANSLATE_PRO
   ────────────────────────────── */
 
 // translate provider names
-export const TRANSLATE_PROVIDER_TYPES = ["google-translate", "microsoft-translate", "deeplx", "deepl", "openai", "deepseek", "google", "anthropic", "xai", "openai-compatible", "siliconflow", "tensdaq", "ai302", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
+export const TRANSLATE_PROVIDER_TYPES = ["google-translate", "microsoft-translate", "deeplx", "deepl", "openai", "deepseek", "google", "anthropic", "xai", "openai-compatible", "siliconflow", "tensdaq", "ai302", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface", "litellm"] as const satisfies Readonly<
   (keyof typeof LLM_PROVIDER_MODELS | typeof PURE_TRANSLATE_PROVIDERS[number])[]
 >
 export type TranslateProviderTypes = typeof TRANSLATE_PROVIDER_TYPES[number]
@@ -16,7 +16,7 @@ export function isTranslateProvider(provider: string): provider is TranslateProv
   return TRANSLATE_PROVIDER_TYPES.includes(provider)
 }
 
-export const LLM_PROVIDER_TYPES = ["openai", "deepseek", "google", "anthropic", "xai", "openai-compatible", "siliconflow", "tensdaq", "ai302", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
+export const LLM_PROVIDER_TYPES = ["openai", "deepseek", "google", "anthropic", "xai", "openai-compatible", "siliconflow", "tensdaq", "ai302", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface", "litellm"] as const satisfies Readonly<
   (keyof typeof LLM_PROVIDER_MODELS)[]
 >
 export type LLMProviderTypes = typeof LLM_PROVIDER_TYPES[number]
@@ -24,7 +24,7 @@ export function isLLMProvider(provider: string): provider is LLMProviderTypes {
   return LLM_PROVIDER_TYPES.includes(provider)
 }
 
-export const CUSTOM_LLM_PROVIDER_TYPES = ["openai-compatible", "tensdaq", "siliconflow", "ai302", "volcengine"] as const satisfies Readonly<
+export const CUSTOM_LLM_PROVIDER_TYPES = ["openai-compatible", "tensdaq", "siliconflow", "ai302", "volcengine", "litellm"] as const satisfies Readonly<
   (keyof typeof LLM_PROVIDER_MODELS)[]
 >
 export type CustomLLMProviderTypes = typeof CUSTOM_LLM_PROVIDER_TYPES[number]
@@ -33,14 +33,14 @@ export function isCustomLLMProvider(provider: string): provider is CustomLLMProv
 }
 
 export const NON_CUSTOM_LLM_PROVIDER_TYPES = ["openai", "deepseek", "google", "anthropic", "xai", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
-  Exclude<keyof typeof LLM_PROVIDER_MODELS, CustomLLMProviderTypes>[]
+  Exclude<keyof typeof LLM_PROVIDER_MODELS, CustomLLMProviderTypes | "litellm">[]
 >
 export type NonCustomLLMProviderTypes = typeof NON_CUSTOM_LLM_PROVIDER_TYPES[number]
 export function isNonCustomLLMProvider(provider: string): provider is NonCustomLLMProviderTypes {
   return NON_CUSTOM_LLM_PROVIDER_TYPES.includes(provider)
 }
 
-export const API_PROVIDER_TYPES = ["siliconflow", "tensdaq", "ai302", "openai-compatible", "openai", "deepseek", "google", "anthropic", "xai", "deeplx", "deepl", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
+export const API_PROVIDER_TYPES = ["siliconflow", "tensdaq", "ai302", "openai-compatible", "openai", "deepseek", "google", "anthropic", "xai", "deeplx", "deepl", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface", "litellm"] as const satisfies Readonly<
   (keyof typeof LLM_PROVIDER_MODELS | "deeplx" | "deepl")[]
 >
 export type APIProviderTypes = typeof API_PROVIDER_TYPES[number]
@@ -62,7 +62,7 @@ export function isNonAPIProvider(provider: string): provider is NonAPIProviderTy
 }
 
 // all provider names
-export const ALL_PROVIDER_TYPES = ["google-translate", "microsoft-translate", "deeplx", "deepl", "siliconflow", "tensdaq", "ai302", "openai-compatible", "openai", "deepseek", "google", "anthropic", "xai", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
+export const ALL_PROVIDER_TYPES = ["google-translate", "microsoft-translate", "deeplx", "deepl", "siliconflow", "tensdaq", "ai302", "openai-compatible", "openai", "deepseek", "google", "anthropic", "xai", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface", "litellm"] as const satisfies Readonly<
   TranslateProviderTypes[]
 >
 export type AllProviderTypes = typeof ALL_PROVIDER_TYPES[number]

--- a/src/types/config/provider/schemas.ts
+++ b/src/types/config/provider/schemas.ts
@@ -68,6 +68,10 @@ const llmProviderConfigSchemaList = [
     provider: z.literal("openai-compatible"),
     model: createProviderModelSchema<"openai-compatible">("openai-compatible"),
   }),
+  baseCustomLLMProviderConfigSchema.extend({
+    provider: z.literal("litellm"),
+    model: createProviderModelSchema<"litellm">("litellm"),
+  }),
   baseAPIProviderConfigSchema.extend({
     provider: z.literal("openai"),
     model: createProviderModelSchema<"openai">("openai"),

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -46,6 +46,7 @@ export const LLM_PROVIDER_MODELS = {
   "alibaba": ["qwen3-max", "qwen3.5-plus", "qwen3.5-flash", "qwen-plus", "qwen-flash", "qwen-turbo", "qwq-plus", "qwen3-coder-plus", "deepseek-v3.2", "deepseek-v3.1", "deepseek-r1", "deepseek-v3", "kimi-k2.5", "MiniMax-M2.5", "glm-5"],
   "moonshotai": ["moonshot-v1-8k", "moonshot-v1-32k", "moonshot-v1-128k", "kimi-k2", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-thinking-turbo", "kimi-k2-turbo"],
   "huggingface": ["meta-llama/Llama-3.1-8B-Instruct", "meta-llama/Llama-3.1-70B-Instruct", "meta-llama/Llama-3.3-70B-Instruct", "meta-llama/Llama-4-Maverick-17B-128E-Instruct", "deepseek-ai/DeepSeek-V3.1", "deepseek-ai/DeepSeek-V3-0324", "deepseek-ai/DeepSeek-R1", "deepseek-ai/DeepSeek-R1-Distill-Llama-70B", "Qwen/Qwen3-32B", "Qwen/Qwen3-Coder-480B-A35B-Instruct", "Qwen/Qwen2.5-VL-7B-Instruct", "google/gemma-3-27b-it", "moonshotai/Kimi-K2-Instruct"],
+  "litellm": ["use-custom-model"],
 } as const
 
 export const NON_API_TRANSLATE_PROVIDERS = ["google-translate", "microsoft-translate"] as const

--- a/src/utils/constants/providers.ts
+++ b/src/utils/constants/providers.ts
@@ -4,6 +4,7 @@ import { i18n } from "#imports"
 import customProviderLogo from "@/assets/providers/custom-provider.svg?url&no-inline"
 import deeplxLogoDark from "@/assets/providers/deeplx-dark.svg?url&no-inline"
 import deeplxLogoLight from "@/assets/providers/deeplx-light.svg?url&no-inline"
+import litellmLogoColor from "@/assets/providers/litellm-color.svg?url&no-inline"
 import tensdaqLogoColor from "@/assets/providers/tensdaq-color.svg?url&no-inline"
 import { env } from "@/env"
 import { API_PROVIDER_TYPES, CUSTOM_LLM_PROVIDER_TYPES, NON_API_TRANSLATE_PROVIDERS, NON_API_TRANSLATE_PROVIDERS_MAP, NON_CUSTOM_LLM_PROVIDER_TYPES, PURE_API_PROVIDER_TYPES, PURE_TRANSLATE_PROVIDERS, TRANSLATE_PROVIDER_TYPES } from "@/types/config/provider"
@@ -144,6 +145,11 @@ export const DEFAULT_LLM_PROVIDER_MODELS: LLMProviderModels = {
   "huggingface": {
     model: "Qwen/Qwen3-32B",
     isCustomModel: false,
+    customModel: null,
+  },
+  "litellm": {
+    model: "use-custom-model",
+    isCustomModel: true,
     customModel: null,
   },
 }
@@ -304,6 +310,11 @@ export const PROVIDER_ITEMS: Record<AllProviderTypes, { logo: (theme: Theme) => 
       logo: getLobeIconsCDNUrlFn("huggingface-color"),
       name: "Hugging Face",
       website: "https://huggingface.co/",
+    },
+    "litellm": {
+      logo: () => litellmLogoColor,
+      name: "LiteLLM",
+      website: "https://litellm.ai/",
     },
   }
 
@@ -559,6 +570,15 @@ export const DEFAULT_PROVIDER_CONFIG = {
     enabled: true,
     provider: "huggingface",
     model: DEFAULT_LLM_PROVIDER_MODELS.huggingface,
+  },
+  "litellm": {
+    id: "litellm-default",
+    name: PROVIDER_ITEMS.litellm.name,
+    description: i18n.t("options.apiProviders.providers.description.litellm"),
+    enabled: true,
+    provider: "litellm",
+    baseURL: "http://localhost:4000/v1",
+    model: DEFAULT_LLM_PROVIDER_MODELS.litellm,
   },
 } as const satisfies Record<AllProviderTypes, ProviderConfig>
 

--- a/src/utils/providers/__tests__/litellm.test.ts
+++ b/src/utils/providers/__tests__/litellm.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { storage } from "#imports"
+
+let getStorageItemMock: ReturnType<typeof vi.fn>
+
+const {
+  openAICompatibleLanguageModelMock,
+  createOpenAICompatibleMock,
+} = vi.hoisted(() => {
+  const openAICompatibleLanguageModelMock = vi.fn()
+  const createOpenAICompatibleMock = vi.fn((_options?: Record<string, unknown>) => ({
+    languageModel: openAICompatibleLanguageModelMock,
+  }))
+
+  return {
+    openAICompatibleLanguageModelMock,
+    createOpenAICompatibleMock,
+  }
+})
+
+vi.mock("@ai-sdk/openai-compatible", () => ({
+  createOpenAICompatible: createOpenAICompatibleMock,
+}))
+
+function createLiteLLMProviderConfig(overrides?: Partial<{
+  apiKey: string
+  baseURL: string
+  customModel: string | null
+  headers: Record<string, unknown>
+}>) {
+  return {
+    id: "litellm-default",
+    name: "LiteLLM",
+    enabled: true,
+    provider: "litellm",
+    baseURL: overrides?.baseURL ?? "http://localhost:4000/v1",
+    model: {
+      model: "use-custom-model",
+      isCustomModel: true,
+      customModel: overrides?.customModel ?? "anthropic/claude-haiku-4-5",
+    },
+    ...(overrides?.apiKey !== undefined && { apiKey: overrides.apiKey }),
+    ...(overrides?.headers !== undefined && { headers: overrides.headers }),
+  }
+}
+
+describe("litellm provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    openAICompatibleLanguageModelMock.mockReturnValue("litellm-model")
+    getStorageItemMock = vi.fn()
+    ;(storage.getItem as unknown as ReturnType<typeof vi.fn>) = getStorageItemMock
+  })
+
+  it("creates an OpenAI-compatible provider with litellm base URL", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [createLiteLLMProviderConfig()],
+    })
+
+    const { getModelById } = await import("../model")
+    const result = await getModelById("litellm-default")
+
+    expect(result).toBe("litellm-model")
+    expect(createOpenAICompatibleMock).toHaveBeenCalledWith(expect.objectContaining({
+      name: "litellm",
+      baseURL: "http://localhost:4000/v1",
+      supportsStructuredOutputs: true,
+    }))
+  })
+
+  it("resolves custom model name through the proxy", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [createLiteLLMProviderConfig({ customModel: "openai/gpt-4o" })],
+    })
+
+    const { getModelById } = await import("../model")
+    await getModelById("litellm-default")
+
+    expect(openAICompatibleLanguageModelMock).toHaveBeenCalledWith("openai/gpt-4o")
+  })
+
+  it("forwards API key when provided", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [createLiteLLMProviderConfig({ apiKey: "sk-litellm-master-key" })],
+    })
+
+    const { getModelById } = await import("../model")
+    await getModelById("litellm-default")
+
+    expect(createOpenAICompatibleMock).toHaveBeenCalledWith(expect.objectContaining({
+      apiKey: "sk-litellm-master-key",
+    }))
+  })
+
+  it("omits API key when not set", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [createLiteLLMProviderConfig()],
+    })
+
+    const { getModelById } = await import("../model")
+    await getModelById("litellm-default")
+
+    expect(createOpenAICompatibleMock.mock.calls[0]?.[0]).not.toHaveProperty("apiKey")
+  })
+
+  it("supports custom base URL for remote proxy", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [createLiteLLMProviderConfig({ baseURL: "https://my-litellm.example.com/v1" })],
+    })
+
+    const { getModelById } = await import("../model")
+    await getModelById("litellm-default")
+
+    expect(createOpenAICompatibleMock).toHaveBeenCalledWith(expect.objectContaining({
+      baseURL: "https://my-litellm.example.com/v1",
+    }))
+  })
+
+  it("passes custom headers when provided", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [createLiteLLMProviderConfig({
+        headers: { "X-Custom-Header": "test-value" },
+      })],
+    })
+
+    const { getModelById } = await import("../model")
+    await getModelById("litellm-default")
+
+    expect(createOpenAICompatibleMock).toHaveBeenCalledWith(expect.objectContaining({
+      headers: { "X-Custom-Header": "test-value" },
+    }))
+  })
+})

--- a/src/utils/providers/model.ts
+++ b/src/utils/providers/model.ts
@@ -58,6 +58,7 @@ const CREATE_AI_MAPPER = {
   "alibaba": createAlibaba,
   "moonshotai": createMoonshotAI,
   "huggingface": createHuggingFace,
+  "litellm": createOpenAICompatible,
 } as const
 
 async function getLanguageModelById(providerId: string) {


### PR DESCRIPTION
[## Type of Changes

- [x] ✨ New feature (feat)

## Description

Adds [LiteLLM](https://litellm.ai/) as a first-class AI gateway provider. LiteLLM is an OpenAI-compatible proxy that gives users access to 100+ LLM providers (OpenAI, Anthropic, Azure, Bedrock, Vertex AI, Groq, Ollama, etc.) through a single unified API.

This PR adds LiteLLM as a dedicated custom provider (like SiliconFlow/Tensdaq) so users don't have to manually configure a generic "Custom Provider" -- they get a branded LiteLLM option with the correct default base URL (`http://localhost:4000/v1`).

**No new dependencies** -- reuses the existing `@ai-sdk/openai-compatible` package.

**Files changed:**
- `src/utils/constants/models.ts` -- added `litellm` model entry
- `src/types/config/provider/constants.ts` -- added `litellm` to all provider type arrays
- `src/types/config/provider/schemas.ts` -- added Zod schema
- `src/utils/providers/model.ts` -- mapped `litellm` to `createOpenAICompatible`
- `src/utils/constants/providers.ts` -- added provider metadata, default config with `baseURL: http://localhost:4000/v1`
- `src/assets/providers/litellm-color.svg` -- logo
- `src/locales/*.yml` (9 files) -- localized descriptions

## Related Issue

N/A

## How Has This Been Tested?

- [x] Verified through manual testing

**Live E2E against LiteLLM proxy (Azure Foundry -> Claude Sonnet 4.6):**

Started a LiteLLM proxy, then called it using the exact `createOpenAICompatible` factory this PR wires up:

```js
const provider = createOpenAICompatible({ name: 'litellm', baseURL: 'http://localhost:4000/v1' });
const result = await generateText({ model: provider.languageModel('claude-sonnet'), prompt: 'Translate to Spanish: Good morning' });
// Response: "Buenos días, ¿cómo estás?"
// Model: claude-sonnet-4-6, Finish reason: stop
```

**All existing checks pass:**
```
Type check:  tsc --noEmit  ✅
Lint:        eslint        ✅
Tests:       145 files, 1236 tests passed
```

## Screenshots

N/A -- no UI changes beyond the new provider entry appearing in the OpenAI-compatible providers section of the options page.

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality

## Additional Information

**Example usage:**
1. Start a LiteLLM proxy: `litellm --model anthropic/claude-haiku-4-5`
2. In Read Frog options, add the **LiteLLM** provider
3. Set your proxy URL (default: `http://localhost:4000/v1`) and API key
4. Enter your model name and select LiteLLM as your translation provider
](https://github.com/RheagalFire/read-frog/pull/new/feat/add-litellm-provider)