### PR TITLE
refactor(page-translation): fix method name typo and comment errors

### DIFF
--- a/.changeset/fix-page-translation-typos.md
+++ b/.changeset/fix-page-translation-typos.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+refactor(page-translation): fix method name typo and comment errors

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -136,7 +136,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       )
       this.startDocumentTitleTracking()
 
-      // Listen to existing elements when they enter the viewpoint
+      // Listen to existing elements when they enter the viewport
       const walkId = getRandomUUID()
       this.walkId = walkId
       this.intersectionObserver = new IntersectionObserver(async (entries, observer) => {
@@ -159,7 +159,7 @@ export class PageTranslationManager implements IPageTranslationManager {
 
       // Initialize walkability state for existing elements
       this.addWalkBlockedElements(document.body, config)
-      await this.observerTopLevelParagraphs(document.body, config)
+      await this.observeTopLevelParagraphs(document.body, config)
 
       // Start observing mutations from document.body and all shadow roots
       this.observeMutations(document.body)
@@ -198,7 +198,7 @@ export class PageTranslationManager implements IPageTranslationManager {
 
   private stopInternal({ notify }: { notify: boolean }): void {
     if (!this.isPageTranslating) {
-      console.warn("AutoTranslationManager is already inactive")
+      console.warn("PageTranslationManager is already inactive")
       return
     }
 
@@ -276,7 +276,7 @@ export class PageTranslationManager implements IPageTranslationManager {
     document.addEventListener("touchend", onEnd, { passive: true })
     document.addEventListener("touchcancel", reset, { passive: true })
 
-    // 供调用方卸载
+    // Teardown: remove all touch listeners
     return () => {
       document.removeEventListener("touchstart", onStart)
       document.removeEventListener("touchmove", onMove)
@@ -408,7 +408,7 @@ export class PageTranslationManager implements IPageTranslationManager {
     }
   }
 
-  private async observerTopLevelParagraphs(container: HTMLElement, existingConfig?: Config): Promise<void> {
+  private async observeTopLevelParagraphs(container: HTMLElement, existingConfig?: Config): Promise<void> {
     const observer = this.intersectionObserver
     if (!this.walkId || !observer)
       return
@@ -542,7 +542,7 @@ export class PageTranslationManager implements IPageTranslationManager {
         rec.addedNodes.forEach((node) => {
           if (isHTMLElement(node)) {
             this.addWalkBlockedElements(node, config)
-            void this.observerTopLevelParagraphs(node, config)
+            void this.observeTopLevelParagraphs(node, config)
             this.observeIsolatedDescendantsMutations(node)
           }
         })
@@ -550,7 +550,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       else if (this.isWalkabilityAttributeMutation(rec)) {
         const el = rec.target
         if (isHTMLElement(el) && this.didChangeToWalkable(el, config)) {
-          void this.observerTopLevelParagraphs(el, config)
+          void this.observeTopLevelParagraphs(el, config)
         }
       }
     }
@@ -566,7 +566,7 @@ export class PageTranslationManager implements IPageTranslationManager {
 
   /**
    * Recursively find and observe shadow roots and iframes in an element and its descendants
-   * These can't be find as top level paragraph elements because isolated shadow roots and iframes are not
+   * These can't be found as top level paragraph elements because isolated shadow roots and iframes are not
    * considered as part of the document.
    */
   private observeIsolatedDescendantsMutations(element: HTMLElement): void {


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [x] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fix naming and comment issues in `PageTranslationManager`:

1. **Method name typo**: Rename `observerTopLevelParagraphs` → `observeTopLevelParagraphs` (`observer` is a noun, `observe` is the correct verb form). Affects 1 declaration + 3 call sites.
2. **Stale class name in log**: `console.warn("AutoTranslationManager is already inactive")` → `"PageTranslationManager is already inactive"` to match the actual class name.
3. **Comment typos**: `viewpoint` → `viewport`, `can't be find` → `can't be found`.
4. **Comment language consistency**: Replace a lone Chinese comment (`// 供调用方卸载`) with English (`// Teardown: remove all touch listeners`) to match the rest of the codebase.

All changes are in a single file: `page-translation.ts`.

## Related Issue

N/A

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

All changes are either renames of a private method (no public API impact) or comment/log text corrections. Existing tests pass without modification.

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

N/A
