### PR TITLE
fix(content): 仅在鼠标悬停于文字上时允许触发翻译快捷键

### DIFF
--- a/src/utils/host/__tests__/node-translate.test.tsx
+++ b/src/utils/host/__tests__/node-translate.test.tsx
@@ -35,7 +35,6 @@ vi.mock("@/utils/config/languages", () => ({
 
 describe("node translation", () => {
   const originalGetComputedStyle = window.getComputedStyle
-  const originalCreateRange = document.createRange
   const documentWithCaretPosition = document as Document & {
     caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node, offset: number } | null
   }
@@ -47,21 +46,6 @@ describe("node translation", () => {
       offset: 1,
       getClientRect: () => null,
     }))
-    document.createRange = vi.fn(() => {
-      const range = originalCreateRange.call(document)
-      range.getClientRects = vi.fn(() => [{
-        left: 100,
-        top: 100,
-        right: 200,
-        bottom: 150,
-        width: 100,
-        height: 50,
-        x: 100,
-        y: 100,
-        toJSON: () => ({}),
-      }] as unknown as DOMRectList)
-      return range
-    })
   }
 
   function getFirstTextNode(element: Element): Text {
@@ -92,13 +76,11 @@ describe("node translation", () => {
   })
 
   afterEach(() => {
-    document.createRange = originalCreateRange
     documentWithCaretPosition.caretPositionFromPoint = originalCaretPositionFromPoint
   })
 
   afterAll(() => {
     window.getComputedStyle = originalGetComputedStyle
-    document.createRange = originalCreateRange
     documentWithCaretPosition.caretPositionFromPoint = originalCaretPositionFromPoint
   })
   describe("show translation", () => {

--- a/src/utils/host/__tests__/node-translate.test.tsx
+++ b/src/utils/host/__tests__/node-translate.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import type { Config } from "@/types/config/config"
 import { act, render, screen } from "@testing-library/react"
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { BLOCK_ATTRIBUTE, BLOCK_CONTENT_CLASS, CONTENT_WRAPPER_CLASS, PARAGRAPH_ATTRIBUTE } from "@/utils/constants/dom-labels"
 import { flushBatchedOperations } from "../dom/batch-dom"
@@ -35,6 +35,42 @@ vi.mock("@/utils/config/languages", () => ({
 
 describe("node translation", () => {
   const originalGetComputedStyle = window.getComputedStyle
+  const originalCreateRange = document.createRange
+  const documentWithCaretPosition = document as Document & {
+    caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node, offset: number } | null
+  }
+  const originalCaretPositionFromPoint = documentWithCaretPosition.caretPositionFromPoint
+
+  function mockTextHit(textNode: Text) {
+    documentWithCaretPosition.caretPositionFromPoint = vi.fn(() => ({
+      offsetNode: textNode,
+      offset: 1,
+      getClientRect: () => null,
+    }))
+    document.createRange = vi.fn(() => {
+      const range = originalCreateRange.call(document)
+      range.getClientRects = vi.fn(() => [{
+        left: 100,
+        top: 100,
+        right: 200,
+        bottom: 150,
+        width: 100,
+        height: 50,
+        x: 100,
+        y: 100,
+        toJSON: () => ({}),
+      }] as unknown as DOMRectList)
+      return range
+    })
+  }
+
+  function getFirstTextNode(element: Element): Text {
+    const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+    const textNode = walker.nextNode()
+    if (!textNode)
+      throw new Error("Expected element to contain a text node")
+    return textNode as Text
+  }
 
   beforeAll(async () => {
     // Mock getLocalConfig to return TEST_CONFIG with bilingual mode
@@ -55,8 +91,15 @@ describe("node translation", () => {
     })
   })
 
+  afterEach(() => {
+    document.createRange = originalCreateRange
+    documentWithCaretPosition.caretPositionFromPoint = originalCaretPositionFromPoint
+  })
+
   afterAll(() => {
     window.getComputedStyle = originalGetComputedStyle
+    document.createRange = originalCreateRange
+    documentWithCaretPosition.caretPositionFromPoint = originalCaretPositionFromPoint
   })
   describe("show translation", () => {
     it("should show the translation when point is over the original text", async () => {
@@ -66,6 +109,7 @@ describe("node translation", () => {
         </div>,
       )
       const node = screen.getByTestId("test-node")
+      mockTextHit(node.firstChild as Text)
       const originalElementFromPoint = document.elementFromPoint
       document.elementFromPoint = vi.fn(() => node)
       await act(async () => {
@@ -81,6 +125,29 @@ describe("node translation", () => {
 
       document.elementFromPoint = originalElementFromPoint
     })
+
+    it("should not show the translation when point is not over text", async () => {
+      render(
+        <div data-testid="test-node">
+          {MOCK_ORIGINAL_TEXT}
+        </div>,
+      )
+      const node = screen.getByTestId("test-node")
+      const originalElementFromPoint = document.elementFromPoint
+      document.elementFromPoint = vi.fn(() => node)
+      documentWithCaretPosition.caretPositionFromPoint = vi.fn(() => null)
+
+      let didTranslate = true
+      await act(async () => {
+        didTranslate = await removeOrShowNodeTranslation({ x: 150, y: 125 }, TEST_CONFIG)
+        flushBatchedOperations()
+      })
+
+      expect(didTranslate).toBe(false)
+      expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+
+      document.elementFromPoint = originalElementFromPoint
+    })
   })
   describe("hide translation", () => {
     it("should hide the translation when point is over the translation content node", async () => {
@@ -90,6 +157,7 @@ describe("node translation", () => {
         </div>,
       )
       const node = screen.getByTestId("test-node")
+      mockTextHit(node.firstChild as Text)
 
       const originalElementFromPoint = document.elementFromPoint
       document.elementFromPoint = vi.fn(() => node)
@@ -99,6 +167,7 @@ describe("node translation", () => {
       })
 
       const translatedContent = node.querySelector(`.${BLOCK_CONTENT_CLASS}`)
+      mockTextHit(translatedContent?.firstChild as Text)
       document.elementFromPoint = vi.fn(() => translatedContent as Element)
       await act(async () => {
         await removeOrShowNodeTranslation({ x: 150, y: 125 }, TEST_CONFIG)
@@ -117,6 +186,7 @@ describe("node translation", () => {
         </div>,
       )
       const node = screen.getByTestId("test-node")
+      mockTextHit(node.firstChild as Text)
       const originalElementFromPoint = document.elementFromPoint
       document.elementFromPoint = vi.fn(() => node)
       await act(async () => {
@@ -124,6 +194,7 @@ describe("node translation", () => {
         flushBatchedOperations()
       })
       const wrapper = node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)
+      mockTextHit(getFirstTextNode(wrapper as Element))
       document.elementFromPoint = vi.fn(() => wrapper as Element)
       await act(async () => {
         await removeOrShowNodeTranslation({ x: 150, y: 125 }, TEST_CONFIG)

--- a/src/utils/host/dom/find.ts
+++ b/src/utils/host/dom/find.ts
@@ -64,71 +64,14 @@ function isTextNode(node: Node | null): node is Text {
   return node?.nodeType === Node.TEXT_NODE
 }
 
-function isPointInsideRect(point: Point, rect: DOMRect | DOMRectReadOnly): boolean {
-  return point.x >= rect.left && point.x <= rect.right && point.y >= rect.top && point.y <= rect.bottom
-}
-
-function isPointInsideTextRange(point: Point, node: Text, startOffset: number, endOffset: number): boolean {
-  if (!node.textContent?.slice(startOffset, endOffset).trim())
-    return false
-
-  const range = document.createRange()
-  range.setStart(node, startOffset)
-  range.setEnd(node, endOffset)
-
-  if (typeof range.getClientRects !== "function")
-    return false
-
-  for (const rect of range.getClientRects()) {
-    if (isPointInsideRect(point, rect))
-      return true
-  }
-
-  return false
-}
-
 function findCaretTextNodeAtPoint(point: Point): Text | null {
   const documentWithCaretPosition = document as Document & {
     caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node, offset: number } | null
   }
   const caretPosition = documentWithCaretPosition.caretPositionFromPoint?.(point.x, point.y)
-  if (caretPosition && isTextNode(caretPosition.offsetNode)) {
-    const text = caretPosition.offsetNode.textContent ?? ""
-    const offsets = [
-      caretPosition.offset,
-      caretPosition.offset - 1,
-    ].filter(offset => offset >= 0 && offset < text.length)
-
-    for (const offset of offsets) {
-      if (isPointInsideTextRange(point, caretPosition.offsetNode, offset, offset + 1))
-        return caretPosition.offsetNode
-    }
-  }
-
-  return null
-}
-
-function findTextNodeByRangeRectsAtPoint(point: Point): Text | null {
-  const element = findElementAt(document, point)
-  if (!element)
-    return null
-
-  const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
-  let currentNode = walker.nextNode()
-
-  while (currentNode) {
-    if (isTextNode(currentNode)) {
-      const text = currentNode.textContent ?? ""
-      for (let offset = 0; offset < text.length; offset++) {
-        if (isPointInsideTextRange(point, currentNode, offset, offset + 1))
-          return currentNode
-      }
-    }
-
-    currentNode = walker.nextNode()
-  }
-
-  return null
+  return caretPosition && isTextNode(caretPosition.offsetNode) && caretPosition.offsetNode.textContent?.trim()
+    ? caretPosition.offsetNode
+    : null
 }
 
 /**
@@ -136,11 +79,10 @@ function findTextNodeByRangeRectsAtPoint(point: Point): Text | null {
  *
  * Element-level hit testing is not enough for node translation: blank areas of
  * large containers such as body/main can otherwise resolve to a block node and
- * translate the whole page. Text range rects keep the trigger tied to actual
- * glyph boxes.
+ * translate the whole page.
  */
 export function isPointOverText(point: Point): boolean {
-  return findCaretTextNodeAtPoint(point) !== null || findTextNodeByRangeRectsAtPoint(point) !== null
+  return findCaretTextNodeAtPoint(point) !== null
 }
 
 export function findNearestAncestorBlockNodeFor(element: Element) {

--- a/src/utils/host/dom/find.ts
+++ b/src/utils/host/dom/find.ts
@@ -60,6 +60,89 @@ function findElementAt(root: Document | ShadowRoot, point: Point): Element | nul
   return findDeepestElement(initialElement)
 }
 
+function isTextNode(node: Node | null): node is Text {
+  return node?.nodeType === Node.TEXT_NODE
+}
+
+function isPointInsideRect(point: Point, rect: DOMRect | DOMRectReadOnly): boolean {
+  return point.x >= rect.left && point.x <= rect.right && point.y >= rect.top && point.y <= rect.bottom
+}
+
+function isPointInsideTextRange(point: Point, node: Text, startOffset: number, endOffset: number): boolean {
+  if (!node.textContent?.slice(startOffset, endOffset).trim())
+    return false
+
+  const range = document.createRange()
+  range.setStart(node, startOffset)
+  range.setEnd(node, endOffset)
+
+  if (typeof range.getClientRects !== "function")
+    return false
+
+  for (const rect of range.getClientRects()) {
+    if (isPointInsideRect(point, rect))
+      return true
+  }
+
+  return false
+}
+
+function findCaretTextNodeAtPoint(point: Point): Text | null {
+  const documentWithCaretPosition = document as Document & {
+    caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node, offset: number } | null
+  }
+  const caretPosition = documentWithCaretPosition.caretPositionFromPoint?.(point.x, point.y)
+  if (caretPosition && isTextNode(caretPosition.offsetNode)) {
+    const text = caretPosition.offsetNode.textContent ?? ""
+    const offsets = [
+      caretPosition.offset,
+      caretPosition.offset - 1,
+    ].filter(offset => offset >= 0 && offset < text.length)
+
+    for (const offset of offsets) {
+      if (isPointInsideTextRange(point, caretPosition.offsetNode, offset, offset + 1))
+        return caretPosition.offsetNode
+    }
+  }
+
+  return null
+}
+
+function findTextNodeByRangeRectsAtPoint(point: Point): Text | null {
+  const element = findElementAt(document, point)
+  if (!element)
+    return null
+
+  const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+  let currentNode = walker.nextNode()
+
+  while (currentNode) {
+    if (isTextNode(currentNode)) {
+      const text = currentNode.textContent ?? ""
+      for (let offset = 0; offset < text.length; offset++) {
+        if (isPointInsideTextRange(point, currentNode, offset, offset + 1))
+          return currentNode
+      }
+    }
+
+    currentNode = walker.nextNode()
+  }
+
+  return null
+}
+
+/**
+ * Returns true only when the viewport point is over rendered text.
+ *
+ * Element-level hit testing is not enough for node translation: blank areas of
+ * large containers such as body/main can otherwise resolve to a block node and
+ * translate the whole page. Text range rects keep the trigger tied to actual
+ * glyph boxes.
+ */
+export function isPointOverText(point: Point): boolean {
+  return findCaretTextNodeAtPoint(point) !== null || findTextNodeByRangeRectsAtPoint(point) !== null
+}
+
 export function findNearestAncestorBlockNodeFor(element: Element) {
   const startElement = element.closest(`.${CONTENT_WRAPPER_CLASS}`)?.parentElement || element
   let currentNode = startElement

--- a/src/utils/host/translate/node-manipulation.ts
+++ b/src/utils/host/translate/node-manipulation.ts
@@ -2,7 +2,7 @@ import type { Config } from "@/types/config/config"
 import type { Point } from "@/types/dom"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
 import { isHTMLElement } from "../dom/filter"
-import { findNearestAncestorBlockNodeAt } from "../dom/find"
+import { findNearestAncestorBlockNodeAt, isPointOverText } from "../dom/find"
 import { walkAndLabelElement } from "../dom/traversal"
 import { translateWalkedElement } from "./core/translation-walker"
 import { validateTranslationConfigAndToast } from "./translate-text"
@@ -14,6 +14,9 @@ export { removeAllTranslatedWrapperNodes } from "./dom/translation-cleanup"
 
 // High-level orchestration function
 export async function removeOrShowNodeTranslation(point: Point, config: Config): Promise<boolean> {
+  if (!isPointOverText(point))
+    return false
+
   const node = findNearestAncestorBlockNodeAt(point)
 
   if (!node || !isHTMLElement(node))


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

修复悬停/长按节点翻译在鼠标未悬浮文本时仍可能触发整页翻译的问题.

现在节点翻译会先判断触发坐标是否真正命中了页面上的渲染文本:

- 鼠标悬浮在文本上时, 快捷键/长按仍正常触发节点翻译
- 鼠标位于空白区域, 容器背景或没有文本的位置时, 不再触发翻译

代码修改:

- 新增 `isPointOverText`, 通过文本 range rect 判断坐标是否落在实际文本上
- 在 `removeOrShowNodeTranslation` 入口处加入文本命中检查
- 补充节点翻译测试，覆盖"未悬浮文本时不触发翻译"的行为

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [x] Added unit tests
- [x] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->
