### PR TITLE
fix(translation): update preset text color

### DIFF
--- a/.changeset/update-translation-text-color.md
+++ b/.changeset/update-translation-text-color.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): update the preset translation text color

--- a/src/assets/styles/custom-translation-node.css
+++ b/src/assets/styles/custom-translation-node.css
@@ -35,7 +35,7 @@
 }
 
 [data-read-frog-custom-translation-style="textColor"] {
-  color: var(--read-frog-brand) !important;
+  color: oklch(0.693 0.17 162.48) !important;
 }
 
 [data-read-frog-custom-translation-style="background"] {


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [x] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Updates the `textColor` translation style preset to use `oklch(0.693 0.17 162.48)` for translated text.

A patch changeset is included so the next version will ship this preset text color update.

## Related Issue

Closes #1636

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

Commands run:

- `SKIP_FREE_API=true pnpm test src/utils/host/translate/ui/__tests__/style-injector.test.ts`
- `WXT_SKIP_ENV_VALIDATION=true pnpm build`
- pre-push hook with `SKIP_FREE_API=true`: lint, type-check, and 146 test files / 1244 tests passed with `free-api.test.ts` excluded per local agent instructions

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

`pnpm build` without `WXT_SKIP_ENV_VALIDATION=true` stops before bundling in this local environment because production env vars are not set (`WXT_GOOGLE_CLIENT_ID`, `WXT_POSTHOG_HOST`, `WXT_POSTHOG_API_KEY`).