### PR TITLE
feat: add translation memory knowledge base

### DIFF
--- a/.changeset/long-frogs-remember.md
+++ b/.changeset/long-frogs-remember.md
@@ -1,0 +1,7 @@
+---
+"@read-frog/extension": minor
+---
+
+feat: add translation memory knowledge base
+
+Persist successful translations to a long-term local knowledge base, add optional webhook sync with retry queue, and expose a Knowledge Base settings page for capture controls, sync testing, export, stats, and clearing data.

--- a/src/entrypoints/background/__tests__/translation-queues.test.ts
+++ b/src/entrypoints/background/__tests__/translation-queues.test.ts
@@ -11,6 +11,7 @@ const articleSummaryCacheGetMock = vi.fn()
 const articleSummaryCachePutMock = vi.fn()
 const translationCacheGetMock = vi.fn()
 const translationCachePutMock = vi.fn()
+const recordTranslationMemoryMock = vi.fn()
 
 vi.mock("@/utils/message", () => ({
   onMessage: onMessageMock,
@@ -43,6 +44,10 @@ vi.mock("@/utils/db/dexie/db", () => ({
       put: translationCachePutMock,
     },
   },
+}))
+
+vi.mock("@/utils/knowledge-base/translation-memory", () => ({
+  recordTranslationMemory: recordTranslationMemoryMock,
 }))
 
 function getRegisteredMessageHandler(name: string) {
@@ -108,6 +113,7 @@ describe("translation queue helpers", () => {
     articleSummaryCachePutMock.mockResolvedValue(undefined)
     translationCacheGetMock.mockResolvedValue(undefined)
     translationCachePutMock.mockResolvedValue(undefined)
+    recordTranslationMemoryMock.mockResolvedValue(undefined)
   })
 
   it(
@@ -230,6 +236,14 @@ describe("translation queue helpers", () => {
     expect(result).toBe("L'Iran chiama \"Dichiarazione\" <span>")
     expect(executeTranslateMock).not.toHaveBeenCalled()
     expect(translationCachePutMock).not.toHaveBeenCalled()
+    expect(recordTranslationMemoryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceText: "hello",
+        translatedText: "L'Iran chiama \"Dichiarazione\" <span>",
+        surface: "page",
+      }),
+      expect.any(Object),
+    )
   })
 
   it("does not normalize cached non-Google translations", async () => {
@@ -255,6 +269,75 @@ describe("translation queue helpers", () => {
     expect(result).toBe("A&amp;B")
     expect(executeTranslateMock).not.toHaveBeenCalled()
     expect(translationCachePutMock).not.toHaveBeenCalled()
+  })
+
+  it("records successful webpage translations in translation memory", async () => {
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    await handler({
+      data: {
+        text: "hello",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: microsoftProvider,
+        scheduleAt: Date.now(),
+        hash: "webpage-hash",
+        surface: "node",
+        url: "https://example.com",
+        title: "Example",
+        contextText: "hello context",
+      },
+    })
+
+    expect(recordTranslationMemoryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceText: "hello",
+        translatedText: "translated subtitle",
+        sourceLang: DEFAULT_CONFIG.language.sourceCode,
+        targetLang: DEFAULT_CONFIG.language.targetCode,
+        providerConfig: microsoftProvider,
+        surface: "node",
+        url: "https://example.com",
+        title: "Example",
+        contextText: "hello context",
+      }),
+      expect.any(Object),
+    )
+  })
+
+  it("records successful subtitle translations in translation memory", async () => {
+    const { setUpSubtitlesTranslationQueue } = await import("../translation-queues")
+    await setUpSubtitlesTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueSubtitlesTranslateRequest")
+    await handler({
+      data: {
+        text: "subtitle",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: microsoftProvider,
+        scheduleAt: Date.now(),
+        hash: "subtitle-hash",
+        videoTitle: "Video title",
+        url: "https://youtube.com/watch?v=test",
+        contextText: "full transcript",
+      },
+    })
+
+    expect(recordTranslationMemoryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceText: "subtitle",
+        translatedText: "translated subtitle",
+        sourceLang: DEFAULT_CONFIG.language.sourceCode,
+        targetLang: DEFAULT_CONFIG.language.targetCode,
+        providerConfig: microsoftProvider,
+        surface: "subtitles",
+        url: "https://youtube.com/watch?v=test",
+        title: "Video title",
+        contextText: "full transcript",
+      }),
+      expect.any(Object),
+    )
   })
 
   it("exposes webpage summary generation as a separate background handler", async () => {

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -14,6 +14,7 @@ import { initializeContextMenu, registerContextMenuListeners } from "./context-m
 import { cleanupAllAiSegmentationCache, cleanupAllSummaryCache, cleanupAllTranslationCache, setUpDatabaseCleanup } from "./db-cleanup"
 import { setupEdgeTTSMessageHandlers } from "./edge-tts"
 import { setupIframeInjection } from "./iframe-injection"
+import { setupKnowledgeBaseMessageHandlers, setupKnowledgeBaseSyncRetry } from "./knowledge-base"
 import { setupLLMGenerateTextMessageHandlers } from "./llm-generate-text"
 import { initMockData } from "./mock-data"
 import { newUserGuide } from "./new-user-guide"
@@ -62,6 +63,7 @@ export default defineBackground({
       logger,
       registerMessageHandler: onMessage,
     })
+    setupKnowledgeBaseMessageHandlers()
 
     onMessage("aiSegmentSubtitles", async (message) => {
       try {
@@ -100,6 +102,7 @@ export default defineBackground({
     void setUpWebPageTranslationQueue()
     void setUpSubtitlesTranslationQueue()
     void setUpDatabaseCleanup()
+    void setupKnowledgeBaseSyncRetry()
     setUpConfigBackup()
     void setupUninstallSurvey()
 

--- a/src/entrypoints/background/knowledge-base.ts
+++ b/src/entrypoints/background/knowledge-base.ts
@@ -1,0 +1,59 @@
+import { browser } from "#imports"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { logger } from "@/utils/logger"
+import { onMessage } from "@/utils/message"
+import {
+  clearTranslationMemory,
+  exportTranslationMemory,
+  getTranslationMemoryStats,
+  recordTranslationMemory,
+  retryKnowledgeSyncQueue,
+  testKnowledgeBaseSync,
+} from "@/utils/knowledge-base/translation-memory"
+import { ensureInitializedConfig } from "./config"
+
+export const KNOWLEDGE_SYNC_RETRY_ALARM = "knowledge-sync-retry"
+const KNOWLEDGE_SYNC_RETRY_INTERVAL_MINUTES = 15
+
+export function setupKnowledgeBaseMessageHandlers() {
+  onMessage("recordTranslationMemory", async (message) => {
+    const config = await ensureInitializedConfig() ?? DEFAULT_CONFIG
+    await recordTranslationMemory(message.data, config)
+  })
+
+  onMessage("exportTranslationMemory", async (message) => {
+    return await exportTranslationMemory(message.data?.format)
+  })
+
+  onMessage("clearTranslationMemory", async () => {
+    await clearTranslationMemory()
+  })
+
+  onMessage("getTranslationMemoryStats", async () => {
+    return await getTranslationMemoryStats()
+  })
+
+  onMessage("testKnowledgeBaseSync", async (message) => {
+    return await testKnowledgeBaseSync(message.data)
+  })
+}
+
+export async function setupKnowledgeBaseSyncRetry() {
+  const existingAlarm = await browser.alarms.get(KNOWLEDGE_SYNC_RETRY_ALARM)
+  if (!existingAlarm) {
+    void browser.alarms.create(KNOWLEDGE_SYNC_RETRY_ALARM, {
+      delayInMinutes: KNOWLEDGE_SYNC_RETRY_INTERVAL_MINUTES,
+      periodInMinutes: KNOWLEDGE_SYNC_RETRY_INTERVAL_MINUTES,
+    })
+  }
+
+  browser.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name !== KNOWLEDGE_SYNC_RETRY_ALARM) {
+      return
+    }
+
+    void ensureInitializedConfig()
+      .then(config => retryKnowledgeSyncQueue(config ?? DEFAULT_CONFIG))
+      .catch(error => logger.warn("Failed to retry knowledge base sync", error))
+  })
+}

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -15,6 +15,7 @@ import { microsoftTranslate } from "@/utils/host/translate/api/microsoft"
 import { executeTranslate } from "@/utils/host/translate/execute-translate"
 import { normalizePromptContextValue } from "@/utils/host/translate/translate-text"
 import { normalizeTranslationOutput } from "@/utils/host/translate/translation-output-normalization"
+import { recordTranslationMemory } from "@/utils/knowledge-base/translation-memory"
 import { logger } from "@/utils/logger"
 import { onMessage } from "@/utils/message"
 import { getSubtitlesTranslatePrompt } from "@/utils/prompts/subtitles"
@@ -216,7 +217,7 @@ async function createTranslationQueues<TContext>(config: TranslationQueueSetupCo
 }
 
 export async function setUpWebPageTranslationQueue() {
-  const config = await ensureInitializedConfig()
+  const config = await ensureInitializedConfig() ?? DEFAULT_CONFIG
 
   const { translate: { requestQueueConfig, batchQueueConfig } } = config ?? DEFAULT_CONFIG
 
@@ -227,13 +228,25 @@ export async function setUpWebPageTranslationQueue() {
   })
 
   onMessage("enqueueTranslateRequest", async (message) => {
-    const { data: { text, langConfig, providerConfig, scheduleAt, hash, webTitle, webContent, webSummary } } = message
+    const { data: { text, langConfig, providerConfig, scheduleAt, hash, webTitle, webContent, webSummary, surface = "page", url, title, contextText } } = message
 
     // Check cache first
     if (hash) {
       const cached = await db.translationCache.get(hash)
       if (cached) {
-        return normalizeTranslationOutput(providerConfig, cached.translation)
+        const cachedTranslation = normalizeTranslationOutput(providerConfig, cached.translation)
+        await recordTranslationMemory({
+          sourceText: text,
+          translatedText: cachedTranslation,
+          sourceLang: langConfig.sourceCode,
+          targetLang: langConfig.targetCode,
+          providerConfig,
+          surface,
+          url,
+          title: title ?? webTitle,
+          contextText: contextText ?? webContent,
+        }, config)
+        return cachedTranslation
       }
     }
 
@@ -262,6 +275,18 @@ export async function setUpWebPageTranslationQueue() {
         translation: result,
         createdAt: new Date(),
       })
+
+      await recordTranslationMemory({
+        sourceText: text,
+        translatedText: result,
+        sourceLang: langConfig.sourceCode,
+        targetLang: langConfig.targetCode,
+        providerConfig,
+        surface,
+        url,
+        title: title ?? webTitle,
+        contextText: contextText ?? webContent,
+      }, config)
     }
 
     return result
@@ -292,7 +317,7 @@ export async function setUpWebPageTranslationQueue() {
  * Set up subtitles translation queue and message handlers
  */
 export async function setUpSubtitlesTranslationQueue() {
-  const config = await ensureInitializedConfig()
+  const config = await ensureInitializedConfig() ?? DEFAULT_CONFIG
   const { videoSubtitles: { requestQueueConfig, batchQueueConfig } } = config ?? DEFAULT_CONFIG
 
   const { requestQueue, batchQueue } = await createTranslationQueues({
@@ -302,12 +327,24 @@ export async function setUpSubtitlesTranslationQueue() {
   })
 
   onMessage("enqueueSubtitlesTranslateRequest", async (message) => {
-    const { data: { text, langConfig, providerConfig, scheduleAt, hash, videoTitle, summary } } = message
+    const { data: { text, langConfig, providerConfig, scheduleAt, hash, videoTitle, summary, url, contextText } } = message
 
     if (hash) {
       const cached = await db.translationCache.get(hash)
       if (cached) {
-        return normalizeTranslationOutput(providerConfig, cached.translation)
+        const cachedTranslation = normalizeTranslationOutput(providerConfig, cached.translation)
+        await recordTranslationMemory({
+          sourceText: text,
+          translatedText: cachedTranslation,
+          sourceLang: langConfig.sourceCode,
+          targetLang: langConfig.targetCode,
+          providerConfig,
+          surface: "subtitles",
+          url,
+          title: videoTitle,
+          contextText: contextText ?? summary,
+        }, config)
+        return cachedTranslation
       }
     }
 
@@ -333,6 +370,18 @@ export async function setUpSubtitlesTranslationQueue() {
         translation: result,
         createdAt: new Date(),
       })
+
+      await recordTranslationMemory({
+        sourceText: text,
+        translatedText: result,
+        sourceLang: langConfig.sourceCode,
+        targetLang: langConfig.targetCode,
+        providerConfig,
+        surface: "subtitles",
+        url,
+        title: videoTitle,
+        contextText: contextText ?? summary,
+      }, config)
     }
 
     return result

--- a/src/entrypoints/options/app-sidebar/nav-items.ts
+++ b/src/entrypoints/options/app-sidebar/nav-items.ts
@@ -8,6 +8,7 @@ export const ROUTE_DEFS = [
   { path: "/selection-toolbar" },
   { path: "/context-menu" },
   { path: "/input-translation" },
+  { path: "/knowledge-base" },
   ...(import.meta.env.BROWSER === "firefox" ? [] : [{ path: "/tts" }]),
   { path: "/statistics" },
   { path: "/config" },

--- a/src/entrypoints/options/app-sidebar/settings-nav.tsx
+++ b/src/entrypoints/options/app-sidebar/settings-nav.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/base-ui/sidebar"
 
 const OVERLAY_TOOLS_PATHS = ["/floating-button", "/selection-toolbar", "/context-menu"] as const
+const KNOWLEDGE_BASE_TITLE_KEY = "options.knowledgeBase.title" as Parameters<typeof i18n.t>[0]
 
 export function SettingsNav() {
   const { pathname } = useLocation()
@@ -69,6 +70,13 @@ export function SettingsNav() {
             <SidebarMenuButton render={<Link to="/input-translation" />} isActive={pathname === "/input-translation"}>
               <Icon icon="tabler:keyboard" />
               <span>{i18n.t("options.overlayTools.inputTranslation.title")}</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+
+          <SidebarMenuItem>
+            <SidebarMenuButton render={<Link to="/knowledge-base" />} isActive={pathname === "/knowledge-base"}>
+              <Icon icon="tabler:database-heart" />
+              <span>{i18n.t(KNOWLEDGE_BASE_TITLE_KEY)}</span>
             </SidebarMenuButton>
           </SidebarMenuItem>
 

--- a/src/entrypoints/options/app.tsx
+++ b/src/entrypoints/options/app.tsx
@@ -14,6 +14,7 @@ const FloatingButtonPage = lazy(() => import("./pages/floating-button").then(mod
 const SelectionToolbarPage = lazy(() => import("./pages/selection-toolbar").then(module => ({ default: module.SelectionToolbarPage })))
 const ContextMenuPage = lazy(() => import("./pages/context-menu").then(module => ({ default: module.ContextMenuPage })))
 const InputTranslationPage = lazy(() => import("./pages/input-translation").then(module => ({ default: module.InputTranslationPage })))
+const KnowledgeBasePage = lazy(() => import("./pages/knowledge-base").then(module => ({ default: module.KnowledgeBasePage })))
 const TextToSpeechPage = lazy(() => import("./pages/text-to-speech").then(module => ({ default: module.TextToSpeechPage })))
 const StatisticsPage = lazy(() => import("./pages/statistics").then(module => ({ default: module.StatisticsPage })))
 const ConfigPage = lazy(() => import("./pages/config").then(module => ({ default: module.ConfigPage })))
@@ -28,6 +29,7 @@ const ROUTE_COMPONENTS: Record<RoutePath, ComponentType> = {
   "/selection-toolbar": SelectionToolbarPage,
   "/context-menu": ContextMenuPage,
   "/input-translation": InputTranslationPage,
+  "/knowledge-base": KnowledgeBasePage,
   "/tts": TextToSpeechPage,
   "/statistics": StatisticsPage,
   "/config": ConfigPage,

--- a/src/entrypoints/options/pages/knowledge-base/index.tsx
+++ b/src/entrypoints/options/pages/knowledge-base/index.tsx
@@ -1,0 +1,330 @@
+import type { KnowledgeBaseSurface } from "@/types/knowledge-base"
+import { Icon } from "@iconify/react"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import { saveAs } from "file-saver"
+import { useAtom } from "jotai"
+import { toast } from "sonner"
+import { i18n } from "#imports"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/base-ui/alert-dialog"
+import { Button } from "@/components/ui/base-ui/button"
+import { Checkbox } from "@/components/ui/base-ui/checkbox"
+import { Input } from "@/components/ui/base-ui/input"
+import { Label } from "@/components/ui/base-ui/label"
+import { Switch } from "@/components/ui/base-ui/switch"
+import { KNOWLEDGE_BASE_SURFACES } from "@/types/knowledge-base"
+import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { sendMessage } from "@/utils/message"
+import { queryClient } from "@/utils/tanstack-query"
+import { ConfigCard } from "../../components/config-card"
+import { PageLayout } from "../../components/page-layout"
+
+type KnowledgeBaseI18nKey =
+  | "title"
+  | "toggle.title"
+  | "toggle.description"
+  | "surfaces.title"
+  | "surfaces.description"
+  | `surfaces.${KnowledgeBaseSurface}`
+  | "remote.title"
+  | "remote.description"
+  | "remote.enabled"
+  | "remote.endpoint"
+  | "remote.token"
+  | "remote.test"
+  | "remote.testSuccess"
+  | "remote.testFailed"
+  | "data.title"
+  | "data.description"
+  | "data.items"
+  | "data.events"
+  | "data.queue"
+  | "data.exportJsonl"
+  | "data.exportJson"
+  | "data.exportSuccess"
+  | "data.clear"
+  | "data.clearSuccess"
+  | "data.clearDialogTitle"
+  | "data.clearDialogDescription"
+  | "data.cancel"
+  | "data.confirmClear"
+
+function t(key: KnowledgeBaseI18nKey) {
+  return i18n.t(`options.knowledgeBase.${key}` as any)
+}
+
+const SURFACE_ICON: Record<KnowledgeBaseSurface, string> = {
+  page: "tabler:file-text",
+  node: "tabler:cursor-text",
+  selection: "tabler:select",
+  input: "tabler:keyboard",
+  subtitles: "tabler:subtitles",
+  translationHub: "tabler:language",
+}
+
+export function KnowledgeBasePage() {
+  return (
+    <PageLayout title={t("title")} innerClassName="*:border-b [&>*:last-child]:border-b-0">
+      <KnowledgeBaseToggle />
+      <CaptureSurfaces />
+      <RemoteSyncConfig />
+      <KnowledgeBaseData />
+    </PageLayout>
+  )
+}
+
+function KnowledgeBaseToggle() {
+  const [knowledgeBase, setKnowledgeBase] = useAtom(configFieldsAtomMap.knowledgeBase)
+
+  return (
+    <ConfigCard
+      id="knowledge-base-toggle"
+      title={t("toggle.title")}
+      description={t("toggle.description")}
+    >
+      <div className="flex justify-end">
+        <Switch
+          checked={knowledgeBase.enabled}
+          onCheckedChange={(enabled) => {
+            void setKnowledgeBase({ ...knowledgeBase, enabled })
+          }}
+        />
+      </div>
+    </ConfigCard>
+  )
+}
+
+function CaptureSurfaces() {
+  const [knowledgeBase, setKnowledgeBase] = useAtom(configFieldsAtomMap.knowledgeBase)
+
+  const toggleSurface = (surface: KnowledgeBaseSurface, checked: boolean) => {
+    const captureSurfaces = checked
+      ? Array.from(new Set([...knowledgeBase.captureSurfaces, surface]))
+      : knowledgeBase.captureSurfaces.filter(item => item !== surface)
+
+    void setKnowledgeBase({
+      ...knowledgeBase,
+      captureSurfaces,
+    })
+  }
+
+  return (
+    <ConfigCard
+      id="knowledge-base-surfaces"
+      title={t("surfaces.title")}
+      description={t("surfaces.description")}
+    >
+      <div className="grid gap-2 sm:grid-cols-2">
+        {KNOWLEDGE_BASE_SURFACES.map(surface => (
+          <label
+            key={surface}
+            className="flex min-w-0 cursor-pointer items-center gap-3 rounded-md border bg-card px-3 py-2 text-sm transition-colors hover:bg-accent/50"
+          >
+            <Checkbox
+              checked={knowledgeBase.captureSurfaces.includes(surface)}
+              onCheckedChange={checked => toggleSurface(surface, checked)}
+            />
+            <Icon icon={SURFACE_ICON[surface]} className="size-4 shrink-0 text-muted-foreground" />
+            <span className="min-w-0 truncate">{t(`surfaces.${surface}`)}</span>
+          </label>
+        ))}
+      </div>
+    </ConfigCard>
+  )
+}
+
+function RemoteSyncConfig() {
+  const [knowledgeBase, setKnowledgeBase] = useAtom(configFieldsAtomMap.knowledgeBase)
+  const remoteSync = knowledgeBase.remoteSync
+
+  const testMutation = useMutation({
+    mutationFn: async () => await sendMessage("testKnowledgeBaseSync", {
+      endpoint: remoteSync.endpoint,
+      token: remoteSync.token,
+    }),
+    onSuccess: (result) => {
+      if (result.ok) {
+        toast.success(t("remote.testSuccess"))
+      }
+      else {
+        toast.error(result.message ?? t("remote.testFailed"))
+      }
+    },
+  })
+
+  const updateRemoteSync = (patch: Partial<typeof remoteSync>) => {
+    void setKnowledgeBase({
+      ...knowledgeBase,
+      remoteSync: {
+        ...remoteSync,
+        ...patch,
+      },
+    })
+  }
+
+  return (
+    <ConfigCard
+      id="knowledge-base-remote-sync"
+      title={t("remote.title")}
+      description={t("remote.description")}
+    >
+      <div className="space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <Label htmlFor="knowledge-base-remote-enabled" className="text-sm font-medium">
+            {t("remote.enabled")}
+          </Label>
+          <Switch
+            id="knowledge-base-remote-enabled"
+            checked={remoteSync.enabled}
+            onCheckedChange={enabled => updateRemoteSync({ enabled })}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="knowledge-base-endpoint" className="text-sm font-medium">
+            {t("remote.endpoint")}
+          </Label>
+          <Input
+            id="knowledge-base-endpoint"
+            value={remoteSync.endpoint}
+            placeholder="https://example.com/api/readfrog-memory"
+            onChange={event => updateRemoteSync({ endpoint: event.target.value })}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="knowledge-base-token" className="text-sm font-medium">
+            {t("remote.token")}
+          </Label>
+          <Input
+            id="knowledge-base-token"
+            type="password"
+            value={remoteSync.token}
+            placeholder="Bearer token"
+            onChange={event => updateRemoteSync({ token: event.target.value })}
+          />
+        </div>
+
+        <div className="flex justify-end">
+          <Button
+            variant="outline"
+            disabled={!remoteSync.endpoint.trim() || testMutation.isPending}
+            onClick={() => testMutation.mutate()}
+          >
+            <Icon icon={testMutation.isPending ? "tabler:loader-2" : "tabler:plug-connected"} className={testMutation.isPending ? "animate-spin" : ""} />
+            {t("remote.test")}
+          </Button>
+        </div>
+      </div>
+    </ConfigCard>
+  )
+}
+
+function KnowledgeBaseData() {
+  const { data: stats, isPending } = useQuery({
+    queryKey: ["translation-memory-stats"],
+    queryFn: async () => await sendMessage("getTranslationMemoryStats"),
+  })
+
+  const exportMutation = useMutation({
+    mutationFn: async (format: "jsonl" | "json") => {
+      const content = await sendMessage("exportTranslationMemory", { format })
+      const extension = format === "json" ? "json" : "jsonl"
+      const blob = new Blob([content], { type: format === "json" ? "application/json;charset=utf-8" : "application/x-ndjson;charset=utf-8" })
+      saveAs(blob, `read-frog-translation-memory.${extension}`)
+    },
+    onSuccess: () => {
+      toast.success(t("data.exportSuccess"))
+    },
+  })
+
+  const clearMutation = useMutation({
+    mutationFn: () => sendMessage("clearTranslationMemory"),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["translation-memory-stats"] })
+      toast.success(t("data.clearSuccess"))
+    },
+  })
+
+  return (
+    <ConfigCard
+      id="knowledge-base-data"
+      title={t("data.title")}
+      description={t("data.description")}
+    >
+      <div className="space-y-4">
+        <div className="grid gap-2 sm:grid-cols-3">
+          <Metric label={t("data.items")} value={isPending ? "..." : String(stats?.itemCount ?? 0)} />
+          <Metric label={t("data.events")} value={isPending ? "..." : String(stats?.eventCount ?? 0)} />
+          <Metric label={t("data.queue")} value={isPending ? "..." : String(stats?.queuedSyncCount ?? 0)} />
+        </div>
+
+        <div className="flex flex-wrap justify-end gap-2">
+          <Button
+            variant="outline"
+            disabled={exportMutation.isPending}
+            onClick={() => exportMutation.mutate("jsonl")}
+          >
+            <Icon icon="tabler:file-type-json" />
+            {t("data.exportJsonl")}
+          </Button>
+          <Button
+            variant="outline"
+            disabled={exportMutation.isPending}
+            onClick={() => exportMutation.mutate("json")}
+          >
+            <Icon icon="tabler:braces" />
+            {t("data.exportJson")}
+          </Button>
+          <ClearKnowledgeBaseButton
+            disabled={clearMutation.isPending}
+            onConfirm={() => clearMutation.mutate()}
+          />
+        </div>
+      </div>
+    </ConfigCard>
+  )
+}
+
+function Metric({ label, value }: { label: string, value: string }) {
+  return (
+    <div className="rounded-md border bg-card px-3 py-2">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="mt-1 text-lg font-semibold tabular-nums">{value}</div>
+    </div>
+  )
+}
+
+function ClearKnowledgeBaseButton({ disabled, onConfirm }: { disabled: boolean, onConfirm: () => void }) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger render={<Button variant="destructive" disabled={disabled} />}>
+        <Icon icon="tabler:trash" />
+        {t("data.clear")}
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{t("data.clearDialogTitle")}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("data.clearDialogDescription")}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t("data.cancel")}</AlertDialogCancel>
+          <AlertDialogAction variant="destructive" onClick={onConfirm}>
+            {t("data.confirmClear")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx
@@ -19,7 +19,7 @@ import { prepareTranslationText } from "@/utils/host/translate/text-preparation"
 import { translateTextCore } from "@/utils/host/translate/translate-text"
 import { getOrCreateWebPageContext } from "@/utils/host/translate/webpage-context"
 import { getOrGenerateWebPageSummary } from "@/utils/host/translate/webpage-summary"
-import { onMessage } from "@/utils/message"
+import { onMessage, sendMessage } from "@/utils/message"
 import { getTranslatePromptFromConfig } from "@/utils/prompts/translate"
 import { resolveModelId } from "@/utils/providers/model-id"
 import { getProviderOptionsWithOverride } from "@/utils/providers/options"
@@ -146,6 +146,10 @@ async function translateWithStandardProvider({
     enableAIContentAware: translateRequest.enableAIContentAware,
     extraHashTags: ["selectionTranslation"],
     webPageContext,
+    surface: "selection",
+    url: window.location.href,
+    title: document.title,
+    contextText: text,
   })
 
   return translatedText
@@ -334,6 +338,20 @@ export function SelectionTranslationProvider({
 
       if (runIdRef.current === runId) {
         setTranslatedText(nextTranslatedText)
+      }
+
+      if (nextTranslatedText && isLLMProviderConfig(providerConfig)) {
+        await sendMessage("recordTranslationMemory", {
+          sourceText: preparedText,
+          translatedText: nextTranslatedText,
+          sourceLang: translateRequest.language.sourceCode,
+          targetLang: translateRequest.language.targetCode,
+          providerConfig,
+          surface: "selection",
+          url: window.location.href,
+          title: document.title,
+          contextText: paragraphsText,
+        })
       }
 
       void trackFeatureUsed({

--- a/src/entrypoints/translation-hub/components/translation-card.tsx
+++ b/src/entrypoints/translation-hub/components/translation-card.tsx
@@ -13,6 +13,7 @@ import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { getProviderConfigById } from "@/utils/config/helpers"
 import { PROVIDER_ITEMS } from "@/utils/constants/providers"
 import { executeTranslate } from "@/utils/host/translate/execute-translate"
+import { sendMessage } from "@/utils/message"
 import { getTranslatePrompt } from "@/utils/prompts/translate"
 import { cn } from "@/utils/styles/utils"
 import { selectedProviderIdsAtom, translateRequestAtom, translationCardExpandedStateAtom } from "../atoms"
@@ -61,6 +62,18 @@ export function TranslationCard({ providerId, isExpanded, onExpandedChange }: Tr
           if (requestIdRef.current !== myRequestId) {
             return undefined
           }
+
+          await sendMessage("recordTranslationMemory", {
+            sourceText: req.inputText,
+            translatedText: result,
+            sourceLang: req.sourceLanguage,
+            targetLang: req.targetLanguage,
+            providerConfig: provider,
+            surface: "translationHub",
+            url: null,
+            title: document.title,
+            contextText: null,
+          })
 
           return result
         },

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -267,6 +267,44 @@ options:
       label: Threshold (ms)
       hint: Time in milliseconds between consecutive space presses (100-1000ms)
       error: Value must be between $1 and $2
+  knowledgeBase:
+    title: Knowledge Base
+    toggle:
+      title: Save Translation Memory
+      description: Keep successful translations as long-term learning data, separate from the short-lived translation cache.
+    surfaces:
+      title: Capture Sources
+      description: Choose which translation surfaces should write into the learning knowledge base.
+      page: Page translation
+      node: Paragraph hover translation
+      selection: Selection translation
+      input: Input translation
+      subtitles: Video subtitles
+      translationHub: Translation Hub
+    remote:
+      title: External Sync API
+      description: Optionally POST each learning record to your own API endpoint for other learning apps.
+      enabled: Enable remote sync
+      endpoint: Endpoint
+      token: Bearer Token
+      test: Test Connection
+      testSuccess: Knowledge base endpoint is reachable
+      testFailed: Knowledge base endpoint test failed
+    data:
+      title: Knowledge Data
+      description: Inspect, export, or clear the long-term learning database stored in this browser.
+      items: Translation pairs
+      events: Learning events
+      queue: Pending sync
+      exportJsonl: Export JSONL
+      exportJson: Export JSON
+      exportSuccess: Knowledge base exported
+      clear: Clear
+      clearSuccess: Knowledge base cleared
+      clearDialogTitle: Clear knowledge base?
+      clearDialogDescription: This will permanently delete saved translation memory, learning events, and pending sync records from this browser.
+      cancel: Cancel
+      confirmClear: Clear
   floatingButtonAndToolbar:
     title: Floating Button & Toolbar
     floatingButtonDemoImageAlt: Floating Button Demo

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -267,6 +267,44 @@ options:
       label: 阈值 (毫秒)
       hint: 连续空格按键之间的时间间隔 (100-1000毫秒)
       error: 数值必须在 $1 到 $2 之间
+  knowledgeBase:
+    title: 英语学习知识库
+    toggle:
+      title: 保存翻译记忆
+      description: 将成功翻译长期保存为学习数据，和短期翻译缓存分开管理。
+    surfaces:
+      title: 保存来源
+      description: 选择哪些翻译场景会写入学习知识库。
+      page: 网页翻译
+      node: 段落悬停翻译
+      selection: 划词翻译
+      input: 输入翻译
+      subtitles: 视频字幕
+      translationHub: 翻译中心
+    remote:
+      title: 外部同步 API
+      description: 可选：把每条学习记录 POST 到你自己的 API，方便其他学习类应用复用。
+      enabled: 启用远程同步
+      endpoint: 接口地址
+      token: Bearer Token
+      test: 测试连接
+      testSuccess: 知识库接口可用
+      testFailed: 知识库接口测试失败
+    data:
+      title: 知识库数据
+      description: 查看、导出或清空当前浏览器中长期保存的学习数据库。
+      items: 翻译对
+      events: 学习事件
+      queue: 待同步
+      exportJsonl: 导出 JSONL
+      exportJson: 导出 JSON
+      exportSuccess: 知识库已导出
+      clear: 清空
+      clearSuccess: 知识库已清空
+      clearDialogTitle: 清空知识库？
+      clearDialogDescription: 这会永久删除此浏览器中保存的翻译记忆、学习事件和待同步记录。
+      cancel: 取消
+      confirmClear: 清空
   floatingButtonAndToolbar:
     title: 悬浮按钮和工具栏
     floatingButtonDemoImageAlt: 悬浮按钮演示

--- a/src/types/config/config.ts
+++ b/src/types/config/config.ts
@@ -8,6 +8,7 @@ import {
 } from "@/utils/constants/selection"
 import { MIN_SIDE_CONTENT_WIDTH } from "@/utils/constants/side"
 import { floatingButtonSchema } from "./floating-button"
+import { knowledgeBaseConfigSchema } from "./knowledge-base"
 import { languageDetectionConfigSchema } from "./language-detection"
 import { isLLMProvider, NON_API_TRANSLATE_PROVIDERS_MAP, providersConfigSchema } from "./provider"
 import { selectionToolbarCustomActionsSchema } from "./selection-toolbar"
@@ -101,6 +102,7 @@ export const configSchema = z.object({
   inputTranslation: inputTranslationSchema,
   videoSubtitles: videoSubtitlesSchema,
   siteControl: siteControlSchema,
+  knowledgeBase: knowledgeBaseConfigSchema,
 }).superRefine((data, ctx) => {
   const providerIdsSet = new Set(data.providersConfig.map(p => p.id))
 

--- a/src/types/config/knowledge-base.ts
+++ b/src/types/config/knowledge-base.ts
@@ -1,0 +1,14 @@
+import { z } from "zod"
+import { KNOWLEDGE_BASE_SURFACES } from "@/types/knowledge-base"
+
+export const knowledgeBaseSurfaceSchema = z.enum(KNOWLEDGE_BASE_SURFACES)
+
+export const knowledgeBaseConfigSchema = z.object({
+  enabled: z.boolean(),
+  captureSurfaces: z.array(knowledgeBaseSurfaceSchema),
+  remoteSync: z.object({
+    enabled: z.boolean(),
+    endpoint: z.string(),
+    token: z.string(),
+  }),
+})

--- a/src/types/knowledge-base.ts
+++ b/src/types/knowledge-base.ts
@@ -1,0 +1,76 @@
+import type { LangCodeISO6393 } from "@read-frog/definitions"
+import type { ProviderConfig } from "./config/provider"
+
+export const KNOWLEDGE_BASE_SURFACES = [
+  "page",
+  "node",
+  "selection",
+  "input",
+  "subtitles",
+  "translationHub",
+] as const
+
+export type KnowledgeBaseSurface = (typeof KNOWLEDGE_BASE_SURFACES)[number]
+
+export interface KnowledgeBaseRemoteSyncConfig {
+  enabled: boolean
+  endpoint: string
+  token: string
+}
+
+export interface KnowledgeBaseConfig {
+  enabled: boolean
+  captureSurfaces: KnowledgeBaseSurface[]
+  remoteSync: KnowledgeBaseRemoteSyncConfig
+}
+
+export interface TranslationMemoryRecordInput {
+  sourceText: string
+  translatedText: string
+  sourceLang: LangCodeISO6393 | "auto"
+  targetLang: LangCodeISO6393
+  providerConfig: ProviderConfig
+  surface: KnowledgeBaseSurface
+  url?: string | null
+  title?: string | null
+  contextText?: string | null
+}
+
+export interface TranslationMemoryItemDTO {
+  id: string
+  sourceText: string
+  translatedText: string
+  sourceLang: LangCodeISO6393 | "auto"
+  targetLang: LangCodeISO6393
+  normalizedSourceHash: string
+  providerId: string
+  provider: string
+  model?: string | null
+  createdAt: string
+  updatedAt: string
+  lastUsedAt: string
+  useCount: number
+}
+
+export interface TranslationMemoryEventDTO {
+  id: string
+  itemId: string
+  surface: KnowledgeBaseSurface
+  url?: string | null
+  title?: string | null
+  contextText?: string | null
+  createdAt: string
+}
+
+export interface TranslationMemorySyncPayload {
+  schemaVersion: 1
+  sourceApp: "readfrog"
+  item: TranslationMemoryItemDTO
+  event: TranslationMemoryEventDTO
+}
+
+export interface TranslationMemoryStats {
+  itemCount: number
+  eventCount: number
+  queuedSyncCount: number
+}

--- a/src/utils/config/__tests__/example/v074.ts
+++ b/src/utils/config/__tests__/example/v074.ts
@@ -1,0 +1,32 @@
+import type { TestSeriesObject } from "./types"
+import { testSeries as previousTestSeries } from "./v073"
+
+const knowledgeBase = {
+  enabled: true,
+  captureSurfaces: [
+    "page",
+    "node",
+    "selection",
+    "input",
+    "subtitles",
+    "translationHub",
+  ],
+  remoteSync: {
+    enabled: false,
+    endpoint: "",
+    token: "",
+  },
+}
+
+export const testSeries: TestSeriesObject = Object.fromEntries(
+  Object.entries(previousTestSeries).map(([seriesId, seriesData]) => [
+    seriesId,
+    {
+      ...seriesData,
+      config: {
+        ...seriesData.config,
+        knowledgeBase,
+      },
+    },
+  ]),
+)

--- a/src/utils/config/__tests__/migration.test.ts
+++ b/src/utils/config/__tests__/migration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { CONFIG_SCHEMA_VERSION } from "@/utils/constants/config"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { ConfigVersionTooNewError } from "../errors"
 import { migrateConfig } from "../migration"
 
@@ -11,5 +12,28 @@ describe("migrateConfig", () => {
     await expect(migrateConfig(config, futureVersion))
       .rejects
       .toThrow(ConfigVersionTooNewError)
+  })
+
+  it("adds knowledge base config when migrating from v073", async () => {
+    const { knowledgeBase: _knowledgeBase, ...v073Config } = DEFAULT_CONFIG
+
+    const migrated = await migrateConfig(v073Config, 73)
+
+    expect(migrated.knowledgeBase).toEqual({
+      enabled: true,
+      captureSurfaces: [
+        "page",
+        "node",
+        "selection",
+        "input",
+        "subtitles",
+        "translationHub",
+      ],
+      remoteSync: {
+        enabled: false,
+        endpoint: "",
+        token: "",
+      },
+    })
   })
 })

--- a/src/utils/config/migration-scripts/v073-to-v074.ts
+++ b/src/utils/config/migration-scripts/v073-to-v074.ts
@@ -1,0 +1,43 @@
+/**
+ * Migration script from v073 to v074
+ * - Adds knowledgeBase settings for long-term translation memory.
+ *
+ * IMPORTANT: All values are hardcoded inline. Migration scripts are frozen
+ * snapshots - never import constants or helpers that may change.
+ */
+
+const DEFAULT_KNOWLEDGE_BASE = {
+  enabled: true,
+  captureSurfaces: [
+    "page",
+    "node",
+    "selection",
+    "input",
+    "subtitles",
+    "translationHub",
+  ],
+  remoteSync: {
+    enabled: false,
+    endpoint: "",
+    token: "",
+  },
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function migrate(oldConfig: any): any {
+  if (!isRecord(oldConfig)) {
+    return oldConfig
+  }
+
+  if (isRecord(oldConfig.knowledgeBase)) {
+    return oldConfig
+  }
+
+  return {
+    ...oldConfig,
+    knowledgeBase: DEFAULT_KNOWLEDGE_BASE,
+  }
+}

--- a/src/utils/constants/config.ts
+++ b/src/utils/constants/config.ts
@@ -5,6 +5,7 @@ import type { PageTranslateRange } from "@/types/config/translate"
 import { CUSTOM_ACTION_TEMPLATES } from "./custom-action-templates"
 import { DEFAULT_TRANSLATE_PROMPTS_CONFIG } from "./prompt"
 import { DEFAULT_PROVIDER_CONFIG_LIST } from "./providers"
+import { DEFAULT_KNOWLEDGE_BASE_CONFIG } from "./knowledge-base"
 import { DEFAULT_SELECTION_OVERLAY_OPACITY } from "./selection"
 import { DEFAULT_SIDE_CONTENT_WIDTH } from "./side"
 import { DEFAULT_BACKGROUND_OPACITY, DEFAULT_DISPLAY_MODE, DEFAULT_FONT_FAMILY, DEFAULT_FONT_SCALE, DEFAULT_FONT_WEIGHT, DEFAULT_SUBTITLE_COLOR, DEFAULT_SUBTITLE_POSITION, DEFAULT_TRANSLATION_POSITION } from "./subtitles"
@@ -18,7 +19,7 @@ export const GOOGLE_DRIVE_TOKEN_STORAGE_KEY = "__googleDriveToken"
 
 export const THEME_STORAGE_KEY = "theme"
 export const DEFAULT_DETECTED_CODE = "eng" as const
-export const CONFIG_SCHEMA_VERSION = 73
+export const CONFIG_SCHEMA_VERSION = 74
 
 export const DEFAULT_FLOATING_BUTTON_POSITION = 0.66
 export const DEFAULT_FLOATING_BUTTON_SIDE: FloatingButtonSide = "right"
@@ -171,6 +172,7 @@ export const DEFAULT_CONFIG: Config = {
     blacklistPatterns: [],
     whitelistPatterns: [],
   },
+  knowledgeBase: DEFAULT_KNOWLEDGE_BASE_CONFIG,
 }
 
 export const PAGE_TRANSLATE_RANGE_ITEMS: Record<

--- a/src/utils/constants/knowledge-base.ts
+++ b/src/utils/constants/knowledge-base.ts
@@ -1,0 +1,18 @@
+import type { KnowledgeBaseConfig } from "@/types/knowledge-base"
+
+export const DEFAULT_KNOWLEDGE_BASE_CONFIG: KnowledgeBaseConfig = {
+  enabled: true,
+  captureSurfaces: [
+    "page",
+    "node",
+    "selection",
+    "input",
+    "subtitles",
+    "translationHub",
+  ],
+  remoteSync: {
+    enabled: false,
+    endpoint: "",
+    token: "",
+  },
+}

--- a/src/utils/db/dexie/app-db.ts
+++ b/src/utils/db/dexie/app-db.ts
@@ -5,6 +5,9 @@ import { APP_NAME } from "@/utils/constants/app"
 import AiSegmentationCache from "./tables/ai-segmentation-cache"
 import ArticleSummaryCache from "./tables/article-summary-cache"
 import BatchRequestRecord from "./tables/batch-request-record"
+import KnowledgeSyncQueue from "./tables/knowledge-sync-queue"
+import TranslationMemoryEvent from "./tables/translation-memory-event"
+import TranslationMemoryItem from "./tables/translation-memory-item"
 import TranslationCache from "./tables/translation-cache"
 
 export default class AppDB extends Dexie {
@@ -26,6 +29,21 @@ export default class AppDB extends Dexie {
   aiSegmentationCache!: EntityTable<
     AiSegmentationCache,
     "key"
+  >
+
+  translationMemoryItems!: EntityTable<
+    TranslationMemoryItem,
+    "id"
+  >
+
+  translationMemoryEvents!: EntityTable<
+    TranslationMemoryEvent,
+    "id"
+  >
+
+  knowledgeSyncQueue!: EntityTable<
+    KnowledgeSyncQueue,
+    "id"
   >
 
   constructor() {
@@ -81,9 +99,52 @@ export default class AppDB extends Dexie {
         key,
         createdAt`,
     })
+    this.version(5).stores({
+      translationCache: `
+        key,
+        translation,
+        createdAt`,
+      batchRequestRecord: `
+        key,
+        createdAt,
+        originalRequestCount,
+        provider,
+        model`,
+      articleSummaryCache: `
+        key,
+        createdAt`,
+      aiSegmentationCache: `
+        key,
+        createdAt`,
+      translationMemoryItems: `
+        id,
+        dedupeKey,
+        normalizedSourceHash,
+        sourceLang,
+        targetLang,
+        providerId,
+        provider,
+        createdAt,
+        updatedAt,
+        lastUsedAt`,
+      translationMemoryEvents: `
+        id,
+        itemId,
+        surface,
+        url,
+        createdAt`,
+      knowledgeSyncQueue: `
+        id,
+        createdAt,
+        updatedAt,
+        attempts`,
+    })
     this.translationCache.mapToClass(TranslationCache)
     this.batchRequestRecord.mapToClass(BatchRequestRecord)
     this.articleSummaryCache.mapToClass(ArticleSummaryCache)
     this.aiSegmentationCache.mapToClass(AiSegmentationCache)
+    this.translationMemoryItems.mapToClass(TranslationMemoryItem)
+    this.translationMemoryEvents.mapToClass(TranslationMemoryEvent)
+    this.knowledgeSyncQueue.mapToClass(KnowledgeSyncQueue)
   }
 }

--- a/src/utils/db/dexie/tables/knowledge-sync-queue.ts
+++ b/src/utils/db/dexie/tables/knowledge-sync-queue.ts
@@ -1,0 +1,11 @@
+import type { TranslationMemorySyncPayload } from "@/types/knowledge-base"
+import { Entity } from "dexie"
+
+export default class KnowledgeSyncQueue extends Entity {
+  id!: string
+  payload!: TranslationMemorySyncPayload
+  createdAt!: Date
+  updatedAt!: Date
+  attempts!: number
+  lastError?: string | null
+}

--- a/src/utils/db/dexie/tables/translation-memory-event.ts
+++ b/src/utils/db/dexie/tables/translation-memory-event.ts
@@ -1,0 +1,12 @@
+import type { KnowledgeBaseSurface } from "@/types/knowledge-base"
+import { Entity } from "dexie"
+
+export default class TranslationMemoryEvent extends Entity {
+  id!: string
+  itemId!: string
+  surface!: KnowledgeBaseSurface
+  url?: string | null
+  title?: string | null
+  contextText?: string | null
+  createdAt!: Date
+}

--- a/src/utils/db/dexie/tables/translation-memory-item.ts
+++ b/src/utils/db/dexie/tables/translation-memory-item.ts
@@ -1,0 +1,21 @@
+import type { KnowledgeBaseSurface } from "@/types/knowledge-base"
+import type { LangCodeISO6393 } from "@read-frog/definitions"
+import { Entity } from "dexie"
+
+export default class TranslationMemoryItem extends Entity {
+  id!: string
+  sourceText!: string
+  translatedText!: string
+  sourceLang!: LangCodeISO6393 | "auto"
+  targetLang!: LangCodeISO6393
+  normalizedSourceHash!: string
+  dedupeKey!: string
+  providerId!: string
+  provider!: string
+  model?: string | null
+  createdAt!: Date
+  updatedAt!: Date
+  lastUsedAt!: Date
+  useCount!: number
+  surfaces!: KnowledgeBaseSurface[]
+}

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -1759,7 +1759,7 @@ describe("translate", () => {
         await removeOrShowPageTranslation("bilingual", true)
 
         // Whitespace-only nodes return single space for word separation
-        expect(translateTextForPage).toHaveBeenCalledWith(`${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`)
+        expect(translateTextForPage).toHaveBeenCalledWith(`${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`, "node")
       })
     })
 
@@ -1774,7 +1774,7 @@ describe("translate", () => {
         )
         await removeOrShowPageTranslation("bilingual", true)
 
-        expect(translateTextForPage).toHaveBeenCalledWith(`${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`)
+        expect(translateTextForPage).toHaveBeenCalledWith(`${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`, "node")
       })
     })
 
@@ -1790,7 +1790,7 @@ describe("translate", () => {
         )
         await removeOrShowPageTranslation("bilingual", true)
 
-        expect(translateTextForPage).toHaveBeenCalledWith(MOCK_ORIGINAL_TEXT)
+        expect(translateTextForPage).toHaveBeenCalledWith(MOCK_ORIGINAL_TEXT, "node")
       })
 
       it("bilingual mode: space leading/trailing is trimmed before translation", async () => {
@@ -1804,7 +1804,7 @@ describe("translate", () => {
         await removeOrShowPageTranslation("bilingual", true)
 
         // Final text is trimmed before translation
-        expect(translateTextForPage).toHaveBeenCalledWith(MOCK_ORIGINAL_TEXT)
+        expect(translateTextForPage).toHaveBeenCalledWith(MOCK_ORIGINAL_TEXT, "node")
       })
     })
 
@@ -1821,7 +1821,7 @@ describe("translate", () => {
         await removeOrShowPageTranslation("bilingual", true)
 
         // Whitespace-only node returns single space to preserve word separation
-        expect(translateTextForPage).toHaveBeenCalledWith(`${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`)
+        expect(translateTextForPage).toHaveBeenCalledWith(`${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`, "node")
       })
 
       it("bilingual mode: space-separated inline elements", async () => {
@@ -1835,7 +1835,7 @@ describe("translate", () => {
         )
         await removeOrShowPageTranslation("bilingual", true)
 
-        expect(translateTextForPage).toHaveBeenCalledWith(`${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`)
+        expect(translateTextForPage).toHaveBeenCalledWith(`${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`, "node")
       })
     })
 
@@ -1853,8 +1853,8 @@ describe("translate", () => {
 
         // BR elements are handled as paragraph separators, each paragraph translated separately
         expect(translateTextForPage).toHaveBeenCalledTimes(2)
-        expect(translateTextForPage).toHaveBeenNthCalledWith(1, MOCK_ORIGINAL_TEXT)
-        expect(translateTextForPage).toHaveBeenNthCalledWith(2, MOCK_ORIGINAL_TEXT)
+        expect(translateTextForPage).toHaveBeenNthCalledWith(1, MOCK_ORIGINAL_TEXT, "node")
+        expect(translateTextForPage).toHaveBeenNthCalledWith(2, MOCK_ORIGINAL_TEXT, "node")
       })
 
       it("translationOnly mode: should handle BR elements as paragraph separators", async () => {
@@ -1869,8 +1869,8 @@ describe("translate", () => {
         await removeOrShowPageTranslation("translationOnly", true)
 
         expect(translateTextForPage).toHaveBeenCalledTimes(2)
-        expect(translateTextForPage).toHaveBeenNthCalledWith(1, MOCK_ORIGINAL_TEXT)
-        expect(translateTextForPage).toHaveBeenNthCalledWith(2, MOCK_ORIGINAL_TEXT)
+        expect(translateTextForPage).toHaveBeenNthCalledWith(1, MOCK_ORIGINAL_TEXT, "node")
+        expect(translateTextForPage).toHaveBeenNthCalledWith(2, MOCK_ORIGINAL_TEXT, "node")
       })
     })
   })

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -1,4 +1,5 @@
 import type { Config } from "@/types/config/config"
+import type { KnowledgeBaseSurface } from "@/types/knowledge-base"
 import type { TranslationMode } from "@/types/config/translate"
 import type { TransNode } from "@/types/dom"
 import {
@@ -40,13 +41,14 @@ export async function translateNodes(
   toggle: boolean = false,
   config: Config,
   forceBlockTranslation: boolean = false,
+  surface: KnowledgeBaseSurface = "page",
 ): Promise<void> {
   const translationMode = config.translate.mode
   if (translationMode === "translationOnly") {
-    await translateNodeTranslationOnlyMode(nodes, walkId, config, toggle)
+    await translateNodeTranslationOnlyMode(nodes, walkId, config, toggle, surface)
   }
   else if (translationMode === "bilingual") {
-    await translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
+    await translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation, surface)
   }
 }
 
@@ -56,6 +58,7 @@ export async function translateNodesBilingualMode(
   config: Config,
   toggle: boolean = false,
   forceBlockTranslation: boolean = false,
+  surface: KnowledgeBaseSurface = "page",
 ): Promise<void> {
   const transNodes = nodes.filter(node => isTransNode(node))
   if (transNodes.length === 0) {
@@ -82,7 +85,7 @@ export async function translateNodesBilingualMode(
       }
       else {
         nodes.forEach(node => translatingNodes.delete(node))
-        void translateNodesBilingualMode(nodes, walkId, config, toggle)
+        void translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation, surface)
         return
       }
     }
@@ -116,7 +119,7 @@ export async function translateNodesBilingualMode(
     }
     batchDOMOperation(insertOperation)
 
-    const realTranslatedText = await getTranslatedTextAndRemoveSpinner(nodes, textContent, spinner, translatedWrapperNode)
+    const realTranslatedText = await getTranslatedTextAndRemoveSpinner(nodes, textContent, spinner, translatedWrapperNode, surface)
 
     const translatedText = getDisplayTranslation(textContent, realTranslatedText)
 
@@ -148,6 +151,7 @@ export async function translateNodeTranslationOnlyMode(
   walkId: string,
   config: Config,
   toggle: boolean = false,
+  surface: KnowledgeBaseSurface = "page",
 ): Promise<void> {
   const isTransNodeAndNotTranslatedWrapper = (node: Node): node is TransNode => {
     if (isHTMLElement(node) && node.classList.contains(CONTENT_WRAPPER_CLASS))
@@ -224,7 +228,7 @@ export async function translateNodeTranslationOnlyMode(
         // same nodes array, we ensure the translation uses the newly created DOM elements since the
         // function will re-query and find the correct parent and child nodes from the restored DOM.
         nodes.forEach(node => translatingNodes.delete(node))
-        void translateNodeTranslationOnlyMode(nodes, walkId, config, toggle)
+        void translateNodeTranslationOnlyMode(nodes, walkId, config, toggle, surface)
         return
       }
     }
@@ -286,7 +290,7 @@ export async function translateNodeTranslationOnlyMode(
     }
     batchDOMOperation(insertOperation)
 
-    const realTranslatedText = await getTranslatedTextAndRemoveSpinner(nodes, textContent, spinner, translatedWrapperNode)
+    const realTranslatedText = await getTranslatedTextAndRemoveSpinner(nodes, textContent, spinner, translatedWrapperNode, surface)
     const translatedText = realTranslatedText ? getDisplayTranslation(textContent, realTranslatedText) : realTranslatedText
 
     if (!translatedText) {

--- a/src/utils/host/translate/core/translation-walker.ts
+++ b/src/utils/host/translate/core/translation-walker.ts
@@ -1,4 +1,5 @@
 import type { Config } from "@/types/config/config"
+import type { KnowledgeBaseSurface } from "@/types/knowledge-base"
 import {
   BLOCK_ATTRIBUTE,
   CONTENT_WRAPPER_CLASS,
@@ -22,6 +23,7 @@ export async function translateWalkedElement(
     return
 
   const promises: Promise<void>[] = []
+  const surface: KnowledgeBaseSurface = toggle ? "node" : "page"
 
   if (element.hasAttribute(PARAGRAPH_ATTRIBUTE)) {
     let hasBlockNodeChild = false
@@ -37,7 +39,7 @@ export async function translateWalkedElement(
     const isFlexParent = computedStyle.display.includes("flex")
 
     if (!hasBlockNodeChild) {
-      promises.push(translateNodes([element], walkId, toggle, config))
+      promises.push(translateNodes([element], walkId, toggle, config, false, surface))
     }
     else {
       // prevent children change during iteration
@@ -46,7 +48,7 @@ export async function translateWalkedElement(
       for (const child of children) {
         if (isTransNode(child) && isBlockTransNode(child) && !isTextNode(child)) {
           // force the children to be block translation style unless the parent is a flex parent
-          promises.push(translateNodes(consecutiveInlineNodes, walkId, toggle, config, !isFlexParent))
+          promises.push(translateNodes(consecutiveInlineNodes, walkId, toggle, config, !isFlexParent, surface))
           consecutiveInlineNodes = []
           promises.push(translateWalkedElement(child, walkId, config, toggle))
         }
@@ -56,7 +58,7 @@ export async function translateWalkedElement(
       }
 
       if (consecutiveInlineNodes.length) {
-        promises.push(translateNodes(consecutiveInlineNodes, walkId, toggle, config, !isFlexParent))
+        promises.push(translateNodes(consecutiveInlineNodes, walkId, toggle, config, !isFlexParent, surface))
         consecutiveInlineNodes = []
       }
     }

--- a/src/utils/host/translate/translate-text.ts
+++ b/src/utils/host/translate/translate-text.ts
@@ -2,6 +2,7 @@ import type { LangCodeISO6393, LangLevel } from "@read-frog/definitions"
 import type { Config } from "@/types/config/config"
 import type { ProviderConfig } from "@/types/config/provider"
 import type { WebPagePromptContext } from "@/types/content"
+import type { KnowledgeBaseSurface } from "@/types/knowledge-base"
 import { LANG_CODE_TO_EN_NAME } from "@read-frog/definitions"
 import { toast } from "sonner"
 import { i18n } from "#imports"
@@ -114,6 +115,10 @@ export interface TranslateTextOptions {
   enableAIContentAware?: boolean
   extraHashTags?: string[]
   webPageContext?: WebPagePromptContext
+  surface?: KnowledgeBaseSurface
+  url?: string | null
+  title?: string | null
+  contextText?: string | null
 }
 
 /**
@@ -128,6 +133,10 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     enableAIContentAware = false,
     extraHashTags = [],
     webPageContext,
+    surface,
+    url,
+    title,
+    contextText,
   } = options
 
   const preparedText = prepareTranslationText(text)
@@ -157,6 +166,10 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     webTitle: normalizedWebPageContext?.webTitle,
     webContent: normalizedWebPageContext?.webContent,
     webSummary: normalizedWebPageContext?.webSummary,
+    surface,
+    url,
+    title,
+    contextText,
   })
 }
 

--- a/src/utils/host/translate/translate-variants.ts
+++ b/src/utils/host/translate/translate-variants.ts
@@ -1,5 +1,6 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { Config, InputTranslationLang } from "@/types/config/config"
+import type { KnowledgeBaseSurface } from "@/types/knowledge-base"
 import { isLLMProviderConfig } from "@/types/config/provider"
 import { getDetectedCodeFromStorage, getFinalSourceCode } from "@/utils/config/languages"
 import { resolveProviderConfig } from "@/utils/constants/feature-providers"
@@ -59,6 +60,8 @@ async function translateTextUsingPageConfig(
   options: {
     extraHashTags?: string[]
     webPageContext?: { webTitle?: string | null, webContent?: string | null, webSummary?: string | null }
+    surface?: KnowledgeBaseSurface
+    contextText?: string | null
   } = {},
 ): Promise<string> {
   const preparedText = prepareTranslationText(text)
@@ -97,6 +100,10 @@ async function translateTextUsingPageConfig(
     enableAIContentAware: config.translate.enableAIContentAware,
     extraHashTags: options.extraHashTags,
     webPageContext: options.webPageContext,
+    surface: options.surface ?? "page",
+    url: window.location.href,
+    title: document.title,
+    contextText: options.contextText ?? text,
   })
 }
 
@@ -104,12 +111,14 @@ async function translateTextUsingPageConfig(
  * Page translation — uses FEATURE_PROVIDER_DEFS['translate'].
  * Includes skip-language logic (page translation only).
  */
-export async function translateTextForPage(text: string): Promise<string> {
+export async function translateTextForPage(text: string, surface: KnowledgeBaseSurface = "page"): Promise<string> {
   const config = await getConfigOrThrow()
   const providerConfig = resolveProviderConfig(config, "translate")
   const webPageContext = await getWebPagePromptContext(providerConfig, config.translate.enableAIContentAware, true)
 
   return translateTextUsingPageConfig(config, text, {
+    surface,
+    contextText: text,
     webPageContext,
   })
 }
@@ -127,6 +136,8 @@ export async function translateTextForPageTitle(text: string): Promise<string> {
 
   return translateTextUsingPageConfig(config, text, {
     extraHashTags: ["pageTitleTranslation"],
+    surface: "page",
+    contextText: text,
     webPageContext: {
       webTitle: text,
       webContent: webPageContext?.webContent,
@@ -184,5 +195,9 @@ export async function translateTextForInput(
     providerConfig,
     enableAIContentAware: config.translate.enableAIContentAware,
     webPageContext,
+    surface: "input",
+    url: window.location.href,
+    title: document.title,
+    contextText: text,
   })
 }

--- a/src/utils/host/translate/ui/spinner.ts
+++ b/src/utils/host/translate/ui/spinner.ts
@@ -1,4 +1,5 @@
 import type { APICallError } from "ai"
+import type { KnowledgeBaseSurface } from "@/types/knowledge-base"
 import * as React from "react"
 import textSmallCSS from "@/assets/styles/text-small.css?inline"
 import themeCSS from "@/assets/styles/theme.css?inline"
@@ -83,11 +84,12 @@ export async function getTranslatedTextAndRemoveSpinner(
   textContent: string,
   spinner: HTMLElement,
   translatedWrapperNode: HTMLElement,
+  surface: KnowledgeBaseSurface,
 ): Promise<string | undefined> {
   let translatedText: string | undefined
 
   try {
-    translatedText = await translateTextForPage(textContent)
+    translatedText = await translateTextForPage(textContent, surface)
   }
   catch (error) {
     const errorComponent = React.createElement(TranslationError, {

--- a/src/utils/knowledge-base/__tests__/translation-memory.test.ts
+++ b/src/utils/knowledge-base/__tests__/translation-memory.test.ts
@@ -1,0 +1,275 @@
+import type { Config } from "@/types/config/config"
+import type { ProviderConfig } from "@/types/config/provider"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+
+const items: any[] = []
+const events: any[] = []
+const queue: any[] = []
+
+const fetchMock = vi.fn()
+
+function createTable(store: any[]) {
+  return {
+    put: vi.fn(async (value: any) => {
+      const key = value.id
+      const index = store.findIndex(item => item.id === key)
+      if (index >= 0) {
+        store[index] = value
+      }
+      else {
+        store.push(value)
+      }
+    }),
+    clear: vi.fn(async () => {
+      store.splice(0)
+    }),
+    count: vi.fn(async () => store.length),
+    delete: vi.fn(async (id: string) => {
+      const index = store.findIndex(item => item.id === id)
+      if (index >= 0) {
+        store.splice(index, 1)
+      }
+    }),
+    where: vi.fn((field: string) => ({
+      equals: (value: unknown) => ({
+        first: vi.fn(async () => store.find(item => item[field] === value)),
+      }),
+    })),
+    orderBy: vi.fn((field: string) => ({
+      toArray: vi.fn(async () => [...store].sort((a, b) => Number(a[field]) - Number(b[field]))),
+      limit: (count: number) => ({
+        toArray: vi.fn(async () => [...store].sort((a, b) => Number(a[field]) - Number(b[field])).slice(0, count)),
+      }),
+    })),
+  }
+}
+
+const translationMemoryItemsTable = createTable(items)
+const translationMemoryEventsTable = createTable(events)
+const knowledgeSyncQueueTable = createTable(queue)
+
+vi.mock("@/utils/db/dexie/db", () => ({
+  db: {
+    translationMemoryItems: translationMemoryItemsTable,
+    translationMemoryEvents: translationMemoryEventsTable,
+    knowledgeSyncQueue: knowledgeSyncQueueTable,
+  },
+}))
+
+const microsoftProvider: ProviderConfig = {
+  id: "microsoft-translate-default",
+  name: "Microsoft Translate",
+  provider: "microsoft-translate",
+  enabled: true,
+}
+
+function createConfig(patch: Partial<Config["knowledgeBase"]> = {}): Config {
+  return {
+    ...DEFAULT_CONFIG,
+    knowledgeBase: {
+      ...DEFAULT_CONFIG.knowledgeBase,
+      ...patch,
+      remoteSync: {
+        ...DEFAULT_CONFIG.knowledgeBase.remoteSync,
+        ...patch.remoteSync,
+      },
+    },
+  }
+}
+
+describe("translation memory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    items.splice(0)
+    events.splice(0)
+    queue.splice(0)
+    fetchMock.mockResolvedValue({ ok: true, status: 200, statusText: "OK" })
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  it("adds a translation memory item and event", async () => {
+    const { recordTranslationMemory, getTranslationMemoryStats } = await import("../translation-memory")
+
+    await recordTranslationMemory({
+      sourceText: " Hello   world ",
+      translatedText: "你好，世界",
+      sourceLang: "eng",
+      targetLang: "cmn",
+      providerConfig: microsoftProvider,
+      surface: "page",
+      url: "https://example.com",
+      title: "Example",
+      contextText: "Hello world",
+    }, createConfig())
+
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      sourceText: "Hello world",
+      translatedText: "你好，世界",
+      sourceLang: "eng",
+      targetLang: "cmn",
+      providerId: "microsoft-translate-default",
+      useCount: 1,
+      surfaces: ["page"],
+    })
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({
+      itemId: items[0].id,
+      surface: "page",
+      url: "https://example.com",
+      title: "Example",
+    })
+    await expect(getTranslationMemoryStats()).resolves.toEqual({
+      itemCount: 1,
+      eventCount: 1,
+      queuedSyncCount: 0,
+    })
+  })
+
+  it("updates use count for the same source target and provider", async () => {
+    const { recordTranslationMemory } = await import("../translation-memory")
+    const config = createConfig()
+
+    await recordTranslationMemory({
+      sourceText: "Hello world",
+      translatedText: "你好，世界",
+      sourceLang: "eng",
+      targetLang: "cmn",
+      providerConfig: microsoftProvider,
+      surface: "page",
+    }, config)
+    await recordTranslationMemory({
+      sourceText: "Hello   world",
+      translatedText: "你好世界",
+      sourceLang: "eng",
+      targetLang: "cmn",
+      providerConfig: microsoftProvider,
+      surface: "selection",
+    }, config)
+
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      translatedText: "你好世界",
+      useCount: 2,
+      surfaces: ["page", "selection"],
+    })
+    expect(events).toHaveLength(2)
+  })
+
+  it("creates a separate item for a different target language", async () => {
+    const { recordTranslationMemory } = await import("../translation-memory")
+    const config = createConfig()
+
+    await recordTranslationMemory({
+      sourceText: "Hello world",
+      translatedText: "你好，世界",
+      sourceLang: "eng",
+      targetLang: "cmn",
+      providerConfig: microsoftProvider,
+      surface: "page",
+    }, config)
+    await recordTranslationMemory({
+      sourceText: "Hello world",
+      translatedText: "Hola mundo",
+      sourceLang: "eng",
+      targetLang: "spa",
+      providerConfig: microsoftProvider,
+      surface: "page",
+    }, config)
+
+    expect(items).toHaveLength(2)
+  })
+
+  it("does not record when disabled", async () => {
+    const { recordTranslationMemory } = await import("../translation-memory")
+
+    await recordTranslationMemory({
+      sourceText: "Hello world",
+      translatedText: "你好，世界",
+      sourceLang: "eng",
+      targetLang: "cmn",
+      providerConfig: microsoftProvider,
+      surface: "page",
+    }, createConfig({ enabled: false }))
+
+    expect(items).toHaveLength(0)
+    expect(events).toHaveLength(0)
+  })
+
+  it("queues failed remote sync payloads", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, statusText: "Server Error" })
+    const { recordTranslationMemory } = await import("../translation-memory")
+
+    await recordTranslationMemory({
+      sourceText: "Hello world",
+      translatedText: "你好，世界",
+      sourceLang: "eng",
+      targetLang: "cmn",
+      providerConfig: microsoftProvider,
+      surface: "page",
+    }, createConfig({
+      remoteSync: {
+        enabled: true,
+        endpoint: "https://example.com/api/memory",
+        token: "secret",
+      },
+    }))
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/api/memory",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer secret",
+        }),
+      }),
+    )
+    expect(queue).toHaveLength(1)
+  })
+
+  it("removes queued sync items after retry success", async () => {
+    const { retryKnowledgeSyncQueue } = await import("../translation-memory")
+    queue.push({
+      id: "queued-1",
+      payload: {
+        schemaVersion: 1,
+        sourceApp: "readfrog",
+        item: {
+          id: "item-1",
+          sourceText: "Hello",
+          translatedText: "你好",
+          sourceLang: "eng",
+          targetLang: "cmn",
+          normalizedSourceHash: "hash",
+          providerId: "provider",
+          provider: "test",
+          model: null,
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+          lastUsedAt: new Date(0).toISOString(),
+          useCount: 1,
+        },
+        event: {
+          id: "event-1",
+          itemId: "item-1",
+          surface: "page",
+          createdAt: new Date(0).toISOString(),
+        },
+      },
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+      attempts: 0,
+    })
+
+    await retryKnowledgeSyncQueue(createConfig({
+      remoteSync: {
+        enabled: true,
+        endpoint: "https://example.com/api/memory",
+        token: "",
+      },
+    }))
+
+    expect(queue).toHaveLength(0)
+  })
+})

--- a/src/utils/knowledge-base/translation-memory.ts
+++ b/src/utils/knowledge-base/translation-memory.ts
@@ -1,0 +1,369 @@
+import type { Config } from "@/types/config/config"
+import type { ProviderConfig } from "@/types/config/provider"
+import type {
+  KnowledgeBaseConfig,
+  KnowledgeBaseSurface,
+  TranslationMemoryEventDTO,
+  TranslationMemoryItemDTO,
+  TranslationMemoryRecordInput,
+  TranslationMemoryStats,
+  TranslationMemorySyncPayload,
+} from "@/types/knowledge-base"
+import type { LangCodeISO6393 } from "@read-frog/definitions"
+import { db } from "@/utils/db/dexie/db"
+import { Sha256Hex } from "@/utils/hash"
+import { logger } from "@/utils/logger"
+import { getRandomUUID } from "../crypto-polyfill"
+
+export type TranslationMemoryExportFormat = "jsonl" | "json"
+
+interface TranslationMemoryItemRecord {
+  id: string
+  sourceText: string
+  translatedText: string
+  sourceLang: LangCodeISO6393 | "auto"
+  targetLang: LangCodeISO6393
+  normalizedSourceHash: string
+  dedupeKey: string
+  providerId: string
+  provider: string
+  model?: string | null
+  createdAt: Date
+  updatedAt: Date
+  lastUsedAt: Date
+  useCount: number
+  surfaces: KnowledgeBaseSurface[]
+}
+
+interface TranslationMemoryEventRecord {
+  id: string
+  itemId: string
+  surface: KnowledgeBaseSurface
+  url?: string | null
+  title?: string | null
+  contextText?: string | null
+  createdAt: Date
+}
+
+function normalizeSourceText(text: string): string {
+  return text.trim().replace(/\s+/g, " ")
+}
+
+function normalizeOptionalText(value: string | null | undefined): string | null {
+  const normalized = value?.trim()
+  return normalized ? normalized : null
+}
+
+function dateToISO(date: Date): string {
+  return date.toISOString()
+}
+
+function resolveProviderModel(providerConfig: ProviderConfig): string | null {
+  if (!("model" in providerConfig)) {
+    return null
+  }
+
+  const model = providerConfig.model
+  return model.isCustomModel
+    ? model.customModel?.trim() || null
+    : model.model?.trim() || null
+}
+
+function buildDedupeKey(input: Pick<TranslationMemoryRecordInput, "sourceText" | "sourceLang" | "targetLang" | "providerConfig">) {
+  const normalizedSourceHash = Sha256Hex(normalizeSourceText(input.sourceText))
+  return {
+    normalizedSourceHash,
+    dedupeKey: Sha256Hex(
+      normalizedSourceHash,
+      input.sourceLang,
+      input.targetLang,
+      input.providerConfig.id,
+    ),
+  }
+}
+
+function toItemDTO(item: TranslationMemoryItemRecord): TranslationMemoryItemDTO {
+  return {
+    id: item.id,
+    sourceText: item.sourceText,
+    translatedText: item.translatedText,
+    sourceLang: item.sourceLang,
+    targetLang: item.targetLang,
+    normalizedSourceHash: item.normalizedSourceHash,
+    providerId: item.providerId,
+    provider: item.provider,
+    model: item.model ?? null,
+    createdAt: dateToISO(item.createdAt),
+    updatedAt: dateToISO(item.updatedAt),
+    lastUsedAt: dateToISO(item.lastUsedAt),
+    useCount: item.useCount,
+  }
+}
+
+function toEventDTO(event: TranslationMemoryEventRecord): TranslationMemoryEventDTO {
+  return {
+    id: event.id,
+    itemId: event.itemId,
+    surface: event.surface,
+    url: event.url ?? null,
+    title: event.title ?? null,
+    contextText: event.contextText ?? null,
+    createdAt: dateToISO(event.createdAt),
+  }
+}
+
+function createSyncPayload(item: TranslationMemoryItemRecord, event: TranslationMemoryEventRecord): TranslationMemorySyncPayload {
+  return {
+    schemaVersion: 1,
+    sourceApp: "readfrog",
+    item: toItemDTO(item),
+    event: toEventDTO(event),
+  }
+}
+
+function shouldRecordTranslation(input: TranslationMemoryRecordInput, config: Config): boolean {
+  if (!config.knowledgeBase.enabled) {
+    return false
+  }
+
+  if (!config.knowledgeBase.captureSurfaces.includes(input.surface)) {
+    return false
+  }
+
+  return normalizeSourceText(input.sourceText) !== "" && input.translatedText.trim() !== ""
+}
+
+async function postSyncPayload(remoteSync: KnowledgeBaseConfig["remoteSync"], payload: TranslationMemorySyncPayload): Promise<void> {
+  const endpoint = remoteSync.endpoint.trim()
+  if (!endpoint) {
+    throw new Error("Knowledge base endpoint is empty")
+  }
+
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  }
+  const token = remoteSync.token.trim()
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(payload),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Knowledge base sync failed: ${response.status} ${response.statusText}`)
+  }
+}
+
+async function enqueueSyncPayload(payload: TranslationMemorySyncPayload, error: unknown): Promise<void> {
+  const now = new Date()
+  await db.knowledgeSyncQueue.put({
+    id: getRandomUUID(),
+    payload,
+    createdAt: now,
+    updatedAt: now,
+    attempts: 0,
+    lastError: error instanceof Error ? error.message : String(error),
+  })
+}
+
+export async function syncPayloadOrQueue(remoteSync: KnowledgeBaseConfig["remoteSync"], payload: TranslationMemorySyncPayload): Promise<void> {
+  if (!remoteSync.enabled) {
+    return
+  }
+
+  try {
+    await postSyncPayload(remoteSync, payload)
+  }
+  catch (error) {
+    await enqueueSyncPayload(payload, error)
+    logger.warn("Queued translation memory sync payload after failure", error)
+  }
+}
+
+export async function recordTranslationMemory(input: TranslationMemoryRecordInput, config: Config): Promise<void> {
+  if (!shouldRecordTranslation(input, config)) {
+    return
+  }
+
+  const now = new Date()
+  const normalizedSourceText = normalizeSourceText(input.sourceText)
+  const { dedupeKey, normalizedSourceHash } = buildDedupeKey(input)
+  const existingItem = await db.translationMemoryItems
+    .where("dedupeKey")
+    .equals(dedupeKey)
+    .first()
+
+  const item = existingItem
+    ? {
+        ...existingItem,
+        sourceText: existingItem.sourceText || input.sourceText,
+        translatedText: input.translatedText,
+        updatedAt: now,
+        lastUsedAt: now,
+        useCount: existingItem.useCount + 1,
+        surfaces: Array.from(new Set([...(existingItem.surfaces ?? []), input.surface])),
+      }
+    : {
+        id: getRandomUUID(),
+        sourceText: normalizedSourceText,
+        translatedText: input.translatedText,
+        sourceLang: input.sourceLang,
+        targetLang: input.targetLang,
+        normalizedSourceHash,
+        dedupeKey,
+        providerId: input.providerConfig.id,
+        provider: input.providerConfig.provider,
+        model: resolveProviderModel(input.providerConfig),
+        createdAt: now,
+        updatedAt: now,
+        lastUsedAt: now,
+        useCount: 1,
+        surfaces: [input.surface],
+      }
+
+  await db.translationMemoryItems.put(item)
+
+  const event = {
+    id: getRandomUUID(),
+    itemId: item.id,
+    surface: input.surface,
+    url: normalizeOptionalText(input.url),
+    title: normalizeOptionalText(input.title),
+    contextText: normalizeOptionalText(input.contextText),
+    createdAt: now,
+  }
+
+  await db.translationMemoryEvents.put(event)
+
+  await syncPayloadOrQueue(config.knowledgeBase.remoteSync, createSyncPayload(item, event))
+}
+
+export async function retryKnowledgeSyncQueue(config: Pick<Config, "knowledgeBase">): Promise<void> {
+  const remoteSync = config.knowledgeBase.remoteSync
+  if (!remoteSync.enabled) {
+    return
+  }
+
+  const queuedItems = await db.knowledgeSyncQueue
+    .orderBy("createdAt")
+    .limit(50)
+    .toArray()
+
+  for (const queued of queuedItems) {
+    try {
+      await postSyncPayload(remoteSync, queued.payload)
+      await db.knowledgeSyncQueue.delete(queued.id)
+    }
+    catch (error) {
+      await db.knowledgeSyncQueue.put({
+        ...queued,
+        attempts: queued.attempts + 1,
+        updatedAt: new Date(),
+        lastError: error instanceof Error ? error.message : String(error),
+      })
+    }
+  }
+}
+
+export async function exportTranslationMemory(format: TranslationMemoryExportFormat = "jsonl"): Promise<string> {
+  const [items, events] = await Promise.all([
+    db.translationMemoryItems.orderBy("createdAt").toArray(),
+    db.translationMemoryEvents.orderBy("createdAt").toArray(),
+  ])
+
+  const eventsByItemId = new Map<string, TranslationMemoryEventRecord[]>()
+  for (const event of events) {
+    const itemEvents = eventsByItemId.get(event.itemId) ?? []
+    itemEvents.push(event)
+    eventsByItemId.set(event.itemId, itemEvents)
+  }
+
+  const records = items.map(item => ({
+    item: toItemDTO(item),
+    events: (eventsByItemId.get(item.id) ?? []).map(toEventDTO),
+  }))
+
+  if (format === "json") {
+    return JSON.stringify({
+      schemaVersion: 1,
+      sourceApp: "readfrog",
+      exportedAt: new Date().toISOString(),
+      records,
+    }, null, 2)
+  }
+
+  return records.map(record => JSON.stringify({
+    schemaVersion: 1,
+    sourceApp: "readfrog",
+    ...record,
+  })).join("\n")
+}
+
+export async function clearTranslationMemory(): Promise<void> {
+  await Promise.all([
+    db.translationMemoryItems.clear(),
+    db.translationMemoryEvents.clear(),
+    db.knowledgeSyncQueue.clear(),
+  ])
+}
+
+export async function getTranslationMemoryStats(): Promise<TranslationMemoryStats> {
+  const [itemCount, eventCount, queuedSyncCount] = await Promise.all([
+    db.translationMemoryItems.count(),
+    db.translationMemoryEvents.count(),
+    db.knowledgeSyncQueue.count(),
+  ])
+
+  return { itemCount, eventCount, queuedSyncCount }
+}
+
+export async function testKnowledgeBaseSync(data: { endpoint: string, token?: string }): Promise<{ ok: boolean, message?: string }> {
+  try {
+    await postSyncPayload(
+      {
+        enabled: true,
+        endpoint: data.endpoint,
+        token: data.token ?? "",
+      },
+      {
+        schemaVersion: 1,
+        sourceApp: "readfrog",
+        item: {
+          id: "test-item",
+          sourceText: "Read Frog test",
+          translatedText: "Read Frog test",
+          sourceLang: "eng",
+          targetLang: "cmn",
+          normalizedSourceHash: Sha256Hex("Read Frog test"),
+          providerId: "test-provider",
+          provider: "test",
+          model: null,
+          createdAt: new Date(0).toISOString(),
+          updatedAt: new Date(0).toISOString(),
+          lastUsedAt: new Date(0).toISOString(),
+          useCount: 1,
+        },
+        event: {
+          id: "test-event",
+          itemId: "test-item",
+          surface: "translationHub",
+          url: null,
+          title: "Read Frog knowledge base test",
+          contextText: null,
+          createdAt: new Date(0).toISOString(),
+        },
+      },
+    )
+    return { ok: true }
+  }
+  catch (error) {
+    return {
+      ok: false,
+      message: error instanceof Error ? error.message : String(error),
+    }
+  }
+}

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -12,6 +12,7 @@ import type {
   EdgeTTSSynthesizeRequest,
   EdgeTTSSynthesizeWireResponse,
 } from "@/types/edge-tts"
+import type { TranslationMemoryRecordInput, TranslationMemoryStats } from "@/types/knowledge-base"
 import type { ProxyRequest, ProxyResponse } from "@/types/proxy-fetch"
 import type {
   TTSOffscreenStopRequest,
@@ -53,9 +54,9 @@ interface ProtocolMap {
   getPinState: () => boolean
   returnPinState: (data: { isPinned: boolean }) => void
   // request
-  enqueueTranslateRequest: (data: { text: string, langConfig: Config["language"], providerConfig: ProviderConfig, scheduleAt: number, hash: string, webTitle?: string | null, webContent?: string | null, webSummary?: string | null }) => Promise<string>
+  enqueueTranslateRequest: (data: { text: string, langConfig: Config["language"], providerConfig: ProviderConfig, scheduleAt: number, hash: string, webTitle?: string | null, webContent?: string | null, webSummary?: string | null, surface?: TranslationMemoryRecordInput["surface"], url?: string | null, title?: string | null, contextText?: string | null }) => Promise<string>
   getOrGenerateWebPageSummary: (data: { webTitle: string, webContent: string, providerConfig: ProviderConfig }) => Promise<string | null>
-  enqueueSubtitlesTranslateRequest: (data: { text: string, langConfig: Config["language"], providerConfig: ProviderConfig, scheduleAt: number, hash: string, videoTitle?: string | null, summary?: string | null }) => Promise<string>
+  enqueueSubtitlesTranslateRequest: (data: { text: string, langConfig: Config["language"], providerConfig: ProviderConfig, scheduleAt: number, hash: string, videoTitle?: string | null, summary?: string | null, url?: string | null, contextText?: string | null }) => Promise<string>
   getSubtitlesSummary: (data: { videoTitle: string, subtitlesContext: string, providerConfig: ProviderConfig }) => Promise<string | null>
   backgroundGenerateText: (data: BackgroundGenerateTextPayload) => Promise<BackgroundGenerateTextResponse>
   // AI subtitle segmentation
@@ -72,6 +73,12 @@ interface ProtocolMap {
   // cache management
   clearAllTranslationRelatedCache: () => Promise<void>
   clearAiSegmentationCache: () => Promise<void>
+  // knowledge base
+  recordTranslationMemory: (data: TranslationMemoryRecordInput) => Promise<void>
+  exportTranslationMemory: (data?: { format?: "jsonl" | "json" }) => Promise<string>
+  clearTranslationMemory: () => Promise<void>
+  getTranslationMemoryStats: () => Promise<TranslationMemoryStats>
+  testKnowledgeBaseSync: (data: { endpoint: string, token?: string }) => Promise<{ ok: boolean, message?: string }>
   // edge tts
   edgeTtsSynthesize: (data: EdgeTTSSynthesizeRequest) => Promise<EdgeTTSSynthesizeWireResponse>
   edgeTtsListVoices: () => Promise<EdgeTTSVoice[]>

--- a/src/utils/subtitles/processor/translator.ts
+++ b/src/utils/subtitles/processor/translator.ts
@@ -139,6 +139,8 @@ async function translateSingleSubtitle(
     hash: Sha256Hex(...hashComponents),
     videoTitle: enableAIContentAware ? subtitlePromptContext.videoTitle : undefined,
     summary: enableAIContentAware ? subtitlePromptContext.videoSummary : undefined,
+    url: globalThis.location?.href,
+    contextText: videoContext.subtitlesTextContent,
   })
 }
 


### PR DESCRIPTION
## Type of Changes

- [x] New feature (feat)
- [x] Test related (test)
- [x] Internationalization (i18n)

## Description

Adds a local-first translation memory knowledge base for persisted learning data:

- Stores successful translations in long-term IndexedDB tables separate from the 7-day translation cache.
- Records translation events with source surface, page title, URL, context, and timestamps.
- Adds optional webhook sync with Bearer token support and retry queue for failed syncs.
- Adds a Knowledge Base settings page for local capture controls, sync configuration, stats, JSON/JSONL export, and clearing data.
- Adds config schema version 74 and a frozen v073-to-v074 migration.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Validation run locally:

```bash
SKIP_FREE_API=true pnpm test
pnpm type-check
```

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Remote sync posts schemaVersion 1 payloads to the user-configured endpoint and keeps local persistence enabled by default while remote sync stays disabled by default.