### PR TITLE
feat: add API key rotation fallback

### DIFF
--- a/.changeset/api-key-rotation.md
+++ b/.changeset/api-key-rotation.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+Add comma-separated API key rotation with sequential or random selection, cooldown for failed keys, and immediate fallback to another configured key.

--- a/src/entrypoints/background/__tests__/background-stream.test.ts
+++ b/src/entrypoints/background/__tests__/background-stream.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const streamTextMock = vi.fn()
 const outputObjectMock = vi.fn((params: Record<string, unknown>) => params)
-const getModelByIdMock = vi.fn()
+const withLanguageModelByIdAPIKeyRotationMock = vi.fn()
 const loggerErrorMock = vi.fn()
 const parsePartialJsonMock = vi.fn(async (text: string | undefined) => {
   if (!text) {
@@ -39,7 +39,7 @@ vi.mock("ai", () => ({
 }))
 
 vi.mock("@/utils/providers/model", () => ({
-  getModelById: getModelByIdMock,
+  withLanguageModelByIdAPIKeyRotation: withLanguageModelByIdAPIKeyRotationMock,
 }))
 
 vi.mock("@/utils/logger", () => ({
@@ -101,10 +101,10 @@ describe("background-stream", () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    withLanguageModelByIdAPIKeyRotationMock.mockImplementation((_providerId, operation) => operation("mock-model"))
   })
 
   it("streams structured object output from background", async () => {
-    getModelByIdMock.mockResolvedValue("mock-model")
     streamTextMock.mockReturnValue({
       fullStream: (async function* () {
         yield { type: "text-delta", text: "{\"score\":97" }
@@ -136,7 +136,7 @@ describe("background-stream", () => {
       },
     )
 
-    expect(getModelByIdMock).toHaveBeenCalledWith("openai-default")
+    expect(withLanguageModelByIdAPIKeyRotationMock).toHaveBeenCalledWith("openai-default", expect.any(Function), expect.any(Object))
     expect(streamTextMock).toHaveBeenCalledWith(expect.objectContaining({
       model: "mock-model",
       prompt: "Analyze selection",
@@ -186,7 +186,6 @@ describe("background-stream", () => {
   })
 
   it("streams text via background stream port handler", async () => {
-    getModelByIdMock.mockResolvedValue("mock-model")
     streamTextMock.mockReturnValue({
       fullStream: (async function* () {
         yield { type: "text-delta", text: "Hello" }
@@ -208,7 +207,7 @@ describe("background-stream", () => {
       },
     })
 
-    expect(getModelByIdMock).toHaveBeenCalledWith("openai-default")
+    expect(withLanguageModelByIdAPIKeyRotationMock).toHaveBeenCalledWith("openai-default", expect.any(Function), expect.any(Object))
     expect(mockPort.postMessage).toHaveBeenNthCalledWith(1, {
       type: "chunk",
       requestId: "req-text-1",
@@ -245,8 +244,70 @@ describe("background-stream", () => {
     expect(mockPort.disconnect).toHaveBeenCalledTimes(1)
   })
 
+  it("falls back to another API key when text streaming fails before emitting chunks", async () => {
+    withLanguageModelByIdAPIKeyRotationMock.mockImplementation(async (_providerId, operation, options) => {
+      try {
+        return await operation("bad-model")
+      }
+      catch (error) {
+        if (options.shouldFallback?.(error, { apiKey: "bad-key", apiKeyCount: 2, apiKeyIndex: 0 }) === false) {
+          throw error
+        }
+        return operation("good-model")
+      }
+    })
+    streamTextMock
+      .mockReturnValueOnce({
+        fullStream: (async function* () {
+          throw new Error("bad key")
+        })(),
+      })
+      .mockReturnValueOnce({
+        fullStream: (async function* () {
+          yield { type: "text-delta", text: "Recovered" }
+        })(),
+      })
+
+    const { handleStreamTextPort } = await import("../background-stream")
+    const mockPort = createMockPort("stream-text")
+
+    handleStreamTextPort(mockPort.port as never)
+    await mockPort.emitMessage({
+      type: "start",
+      requestId: "req-text-fallback",
+      payload: {
+        providerId: "openai-default",
+        prompt: "Say hello",
+      },
+    })
+
+    expect(streamTextMock).toHaveBeenNthCalledWith(1, expect.objectContaining({ model: "bad-model" }))
+    expect(streamTextMock).toHaveBeenNthCalledWith(2, expect.objectContaining({ model: "good-model" }))
+    expect(mockPort.postMessage).toHaveBeenNthCalledWith(1, {
+      type: "chunk",
+      requestId: "req-text-fallback",
+      data: {
+        output: "Recovered",
+        thinking: {
+          status: "thinking",
+          text: "",
+        },
+      },
+    })
+    expect(mockPort.postMessage).toHaveBeenNthCalledWith(2, {
+      type: "done",
+      requestId: "req-text-fallback",
+      data: {
+        output: "Recovered",
+        thinking: {
+          status: "complete",
+          text: "",
+        },
+      },
+    })
+  })
+
   it("prefers stream onError root cause and posts error once", async () => {
-    getModelByIdMock.mockResolvedValue("mock-model")
     const rootCause = Object.assign(new Error("Incorrect API key provided"), {
       responseBody: "{\"error\":{\"message\":\"Incorrect API key provided\"}}",
     })
@@ -292,7 +353,7 @@ describe("background-stream", () => {
   })
 
   it("keeps outer catch as fallback for pre-stream errors", async () => {
-    getModelByIdMock.mockRejectedValue(new Error("Model is undefined"))
+    withLanguageModelByIdAPIKeyRotationMock.mockRejectedValue(new Error("Model is undefined"))
     const { handleStreamTextPort } = await import("../background-stream")
     const mockPort = createMockPort("stream-text")
 
@@ -317,7 +378,6 @@ describe("background-stream", () => {
   })
 
   it("treats stream port disconnect aborts as expected cancellation", async () => {
-    getModelByIdMock.mockResolvedValue("mock-model")
     let streamSignal: AbortSignal | undefined
 
     streamTextMock.mockImplementation((options: { abortSignal?: AbortSignal }) => {
@@ -379,7 +439,7 @@ describe("background-stream", () => {
       error: { message: "Invalid stream start payload" },
     })
     expect(mockPort.disconnect).toHaveBeenCalledTimes(1)
-    expect(getModelByIdMock).not.toHaveBeenCalled()
+    expect(withLanguageModelByIdAPIKeyRotationMock).not.toHaveBeenCalled()
   })
 
   it("returns error for invalid structured payload and disconnects", async () => {

--- a/src/entrypoints/background/__tests__/llm-generate-text.test.ts
+++ b/src/entrypoints/background/__tests__/llm-generate-text.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const onMessageMock = vi.fn()
-const getModelByIdMock = vi.fn()
+const withLanguageModelByIdAPIKeyRotationMock = vi.fn()
 const generateTextMock = vi.fn()
 const loggerErrorMock = vi.fn()
 
@@ -10,7 +10,7 @@ vi.mock("@/utils/message", () => ({
 }))
 
 vi.mock("@/utils/providers/model", () => ({
-  getModelById: getModelByIdMock,
+  withLanguageModelByIdAPIKeyRotation: withLanguageModelByIdAPIKeyRotationMock,
 }))
 
 vi.mock("ai", () => ({
@@ -35,10 +35,10 @@ describe("llm-generate-text", () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    withLanguageModelByIdAPIKeyRotationMock.mockImplementation((_providerId, operation) => operation("mock-model"))
   })
 
   it("runs generateText with resolved model in background", async () => {
-    getModelByIdMock.mockResolvedValue("mock-model")
     generateTextMock.mockResolvedValue({ text: "eng" })
 
     const { runGenerateTextInBackground } = await import("../llm-generate-text")
@@ -50,7 +50,7 @@ describe("llm-generate-text", () => {
       maxRetries: 0,
     })
 
-    expect(getModelByIdMock).toHaveBeenCalledWith("openai-default")
+    expect(withLanguageModelByIdAPIKeyRotationMock).toHaveBeenCalledWith("openai-default", expect.any(Function))
     expect(generateTextMock).toHaveBeenCalledWith({
       model: "mock-model",
       system: "system",
@@ -62,7 +62,6 @@ describe("llm-generate-text", () => {
   })
 
   it("registers backgroundGenerateText message handler", async () => {
-    getModelByIdMock.mockResolvedValue("mock-model")
     generateTextMock.mockResolvedValue({ text: "cmn" })
 
     const { setupLLMGenerateTextMessageHandlers } = await import("../llm-generate-text")
@@ -80,7 +79,7 @@ describe("llm-generate-text", () => {
   })
 
   it("logs and rethrows handler errors", async () => {
-    getModelByIdMock.mockRejectedValue(new Error("provider unavailable"))
+    withLanguageModelByIdAPIKeyRotationMock.mockRejectedValue(new Error("provider unavailable"))
 
     const { setupLLMGenerateTextMessageHandlers } = await import("../llm-generate-text")
     setupLLMGenerateTextMessageHandlers()

--- a/src/entrypoints/background/ai-segmentation.ts
+++ b/src/entrypoints/background/ai-segmentation.ts
@@ -5,7 +5,7 @@ import { db } from "@/utils/db/dexie/db"
 import { Sha256Hex } from "@/utils/hash"
 import { logger } from "@/utils/logger"
 import { getSubtitlesSegmentationPrompt } from "@/utils/prompts/subtitles-segmentation"
-import { getModelById } from "@/utils/providers/model"
+import { withLanguageModelAPIKeyRotation } from "@/utils/providers/model"
 import { resolveModelId } from "@/utils/providers/model-id"
 import { getProviderOptionsWithOverride } from "@/utils/providers/options"
 import { ensureInitializedConfig } from "./config"
@@ -76,18 +76,20 @@ export async function runAiSegmentSubtitles(data: AiSegmentSubtitlesData): Promi
   const { model: providerModel, provider, providerOptions: userProviderOptions, temperature } = providerConfig
   const modelName = resolveModelId(providerModel)
   const providerOptions = getProviderOptionsWithOverride(modelName ?? "", provider, userProviderOptions)
-  const model = await getModelById(providerId)
 
   const { systemPrompt, prompt } = getSubtitlesSegmentationPrompt(jsonContent)
 
   try {
-    const { text: segmentedVtt } = await generateText({
-      model,
-      system: systemPrompt,
-      prompt,
-      temperature,
-      providerOptions,
-      maxRetries: 0,
+    const segmentedVtt = await withLanguageModelAPIKeyRotation(providerConfig, async (model) => {
+      const { text: result } = await generateText({
+        model,
+        system: systemPrompt,
+        prompt,
+        temperature,
+        providerOptions,
+        maxRetries: 0,
+      })
+      return result
     })
 
     const result = cleanVttResponse(segmentedVtt)

--- a/src/entrypoints/background/background-stream.ts
+++ b/src/entrypoints/background/background-stream.ts
@@ -19,7 +19,7 @@ import { z } from "zod"
 import { BACKGROUND_STREAM_PORTS } from "@/types/background-stream"
 import { extractAISDKErrorMessage } from "@/utils/error/extract-message"
 import { logger } from "@/utils/logger"
-import { getModelById } from "@/utils/providers/model"
+import { withLanguageModelByIdAPIKeyRotation } from "@/utils/providers/model"
 
 const invalidStreamStartPayloadMessage = "Invalid stream start payload"
 
@@ -251,61 +251,68 @@ export async function runStreamTextInBackground(
     throw new DOMException("stream aborted", "AbortError")
   }
 
-  const model = await getModelById(providerId)
   let cumulativeText = ""
   let thinking: ThinkingSnapshot = {
     status: "thinking",
     text: "",
   }
+  let didEmitChunk = false
 
-  const result = streamText({
-    ...(streamTextParams as Parameters<typeof streamText>[0]),
-    model,
-    abortSignal: signal,
-    onError: ({ error }) => {
-      onError?.(error)
-    },
+  return withLanguageModelByIdAPIKeyRotation(providerId, async (model) => {
+    const result = streamText({
+      ...(streamTextParams as Parameters<typeof streamText>[0]),
+      model,
+      abortSignal: signal,
+      onError: ({ error }) => {
+        onError?.(error)
+      },
+    })
+
+    for await (const part of result.fullStream) {
+      if (signal?.aborted) {
+        throw new DOMException("stream aborted", "AbortError")
+      }
+
+      switch (part.type) {
+        case "text-delta": {
+          cumulativeText += part.text
+          didEmitChunk = true
+          onChunk?.(createStreamSnapshot(cumulativeText, thinking))
+          break
+        }
+        case "reasoning-delta": {
+          thinking = {
+            status: "thinking",
+            text: thinking.text + part.text,
+          }
+          didEmitChunk = true
+          onChunk?.(createStreamSnapshot(cumulativeText, thinking))
+          break
+        }
+        case "reasoning-end": {
+          thinking = {
+            ...thinking,
+            status: "complete",
+          }
+          didEmitChunk = true
+          onChunk?.(createStreamSnapshot(cumulativeText, thinking))
+          break
+        }
+        case "error": {
+          throw part.error
+        }
+      }
+    }
+
+    thinking = {
+      ...thinking,
+      status: "complete",
+    }
+
+    return createStreamSnapshot(cumulativeText, thinking)
+  }, {
+    shouldFallback: () => !didEmitChunk,
   })
-
-  for await (const part of result.fullStream) {
-    if (signal?.aborted) {
-      throw new DOMException("stream aborted", "AbortError")
-    }
-
-    switch (part.type) {
-      case "text-delta": {
-        cumulativeText += part.text
-        onChunk?.(createStreamSnapshot(cumulativeText, thinking))
-        break
-      }
-      case "reasoning-delta": {
-        thinking = {
-          status: "thinking",
-          text: thinking.text + part.text,
-        }
-        onChunk?.(createStreamSnapshot(cumulativeText, thinking))
-        break
-      }
-      case "reasoning-end": {
-        thinking = {
-          ...thinking,
-          status: "complete",
-        }
-        onChunk?.(createStreamSnapshot(cumulativeText, thinking))
-        break
-      }
-      case "error": {
-        throw part.error
-      }
-    }
-  }
-
-  thinking = {
-    ...thinking,
-    status: "complete",
-  }
-
-  return createStreamSnapshot(cumulativeText, thinking)
 }
 
 export async function runStructuredObjectStreamInBackground(
@@ -319,7 +326,6 @@ export async function runStructuredObjectStreamInBackground(
     throw new DOMException("stream aborted", "AbortError")
   }
 
-  const model = await getModelById(providerId)
   let cumulativeValue: Record<string, unknown> = {}
   let thinking: ThinkingSnapshot = {
     status: "thinking",
@@ -336,66 +342,74 @@ export async function runStructuredObjectStreamInBackground(
     schemaShape[field.name] = fieldTypeToZodSchema[field.type] ?? z.string().nullable()
   }
   const objectSchema = z.object(schemaShape).strict()
+  let didEmitChunk = false
 
-  const result = streamText({
-    ...(streamParams as Parameters<typeof streamText>[0]),
-    model,
-    output: Output.object({
-      schema: objectSchema,
-    }),
-    abortSignal: signal,
-    onError: ({ error }) => {
-      onError?.(error)
-    },
-  })
-  let cumulativeText = ""
+  return withLanguageModelByIdAPIKeyRotation(providerId, async (model) => {
+    const result = streamText({
+      ...(streamParams as Parameters<typeof streamText>[0]),
+      model,
+      output: Output.object({
+        schema: objectSchema,
+      }),
+      abortSignal: signal,
+      onError: ({ error }) => {
+        onError?.(error)
+      },
+    })
+    let cumulativeText = ""
 
-  for await (const part of result.fullStream) {
-    if (signal?.aborted) {
-      throw new DOMException("stream aborted", "AbortError")
-    }
+    for await (const part of result.fullStream) {
+      if (signal?.aborted) {
+        throw new DOMException("stream aborted", "AbortError")
+      }
 
-    switch (part.type) {
-      case "text-delta": {
-        cumulativeText += part.text
-        const partial = await parsePartialJson(cumulativeText)
-        if (isRecord(partial.value)) {
-          cumulativeValue = { ...cumulativeValue, ...partial.value }
+      switch (part.type) {
+        case "text-delta": {
+          cumulativeText += part.text
+          const partial = await parsePartialJson(cumulativeText)
+          if (isRecord(partial.value)) {
+            cumulativeValue = { ...cumulativeValue, ...partial.value }
+            didEmitChunk = true
+            onChunk?.(createStreamSnapshot(cumulativeValue, thinking))
+          }
+          break
+        }
+        case "reasoning-delta": {
+          thinking = {
+            status: "thinking",
+            text: thinking.text + part.text,
+          }
+          didEmitChunk = true
           onChunk?.(createStreamSnapshot(cumulativeValue, thinking))
+          break
         }
-        break
-      }
-      case "reasoning-delta": {
-        thinking = {
-          status: "thinking",
-          text: thinking.text + part.text,
+        case "reasoning-end": {
+          thinking = {
+            ...thinking,
+            status: "complete",
+          }
+          didEmitChunk = true
+          onChunk?.(createStreamSnapshot(cumulativeValue, thinking))
+          break
         }
-        onChunk?.(createStreamSnapshot(cumulativeValue, thinking))
-        break
-      }
-      case "reasoning-end": {
-        thinking = {
-          ...thinking,
-          status: "complete",
+        case "error": {
+          throw part.error
         }
-        onChunk?.(createStreamSnapshot(cumulativeValue, thinking))
-        break
-      }
-      case "error": {
-        throw part.error
       }
     }
-  }
 
-  const finalJson = await parsePartialJson(cumulativeText)
-  const finalValue = objectSchema.parse(finalJson.value)
+    const finalJson = await parsePartialJson(cumulativeText)
+    const finalValue = objectSchema.parse(finalJson.value)
 
-  thinking = {
-    ...thinking,
-    status: "complete",
-  }
+    thinking = {
+      ...thinking,
+      status: "complete",
+    }
 
-  return createStreamSnapshot(finalValue, thinking)
+    return createStreamSnapshot(finalValue, thinking)
+  }, {
+    shouldFallback: () => !didEmitChunk,
+  })
 }
 
 const parseStreamTextStartMessage = createStartMessageParser<BackgroundStreamTextSerializablePayload>(streamTextPayloadSchema)

--- a/src/entrypoints/background/llm-generate-text.ts
+++ b/src/entrypoints/background/llm-generate-text.ts
@@ -5,17 +5,19 @@ import type {
 import { generateText } from "ai"
 import { logger } from "@/utils/logger"
 import { onMessage } from "@/utils/message"
-import { getModelById } from "@/utils/providers/model"
+import { withLanguageModelByIdAPIKeyRotation } from "@/utils/providers/model"
 
 export async function runGenerateTextInBackground(
   payload: BackgroundGenerateTextPayload,
 ): Promise<BackgroundGenerateTextResponse> {
   const { providerId, ...generateTextParams } = payload
-  const model = await getModelById(providerId)
 
-  const { text } = await generateText({
-    ...generateTextParams,
-    model,
+  const text = await withLanguageModelByIdAPIKeyRotation(providerId, async (model) => {
+    const { text: result } = await generateText({
+      ...generateTextParams,
+      model,
+    })
+    return result
   })
 
   return { text }

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/api-key-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/api-key-field.tsx
@@ -31,7 +31,11 @@ export const APIKeyField = withForm({
                 />
               )}
               type={showAPIKey ? "text" : "password"}
+              placeholder="key-1, key-2, key-3"
             />
+            <p className="text-xs text-muted-foreground">
+              Use commas to add multiple API keys. Requests rotate across keys and failed keys cool down before reuse.
+            </p>
             <div className="mt-0.5 flex items-center space-x-2">
               <Checkbox
                 id={`apiKey-${providerConfig.id}`}

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/api-key-rotation-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/api-key-rotation-field.tsx
@@ -1,0 +1,50 @@
+import type { APIProviderConfig } from "@/types/config/provider"
+import { useStore } from "@tanstack/react-form"
+import { SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/base-ui/select"
+import { DEFAULT_API_KEY_COOLDOWN_SECONDS, DEFAULT_API_KEY_ROTATION_MODE } from "@/utils/providers/api-key-rotation"
+import { withForm } from "./form"
+
+export const APIKeyRotationField = withForm({
+  ...{ defaultValues: {} as APIProviderConfig },
+  render: function Render({ form }) {
+    const providerConfig = useStore(form.store, state => state.values)
+
+    if (providerConfig.provider === "ollama")
+      return null
+
+    return (
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <form.AppField name="apiKeyRotationMode">
+          {field => (
+            <field.SelectFieldAutoSave
+              formForSubmit={form}
+              label="API key rotation"
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder={DEFAULT_API_KEY_ROTATION_MODE} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value="sequential">Sequential</SelectItem>
+                  <SelectItem value="random">Random</SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </field.SelectFieldAutoSave>
+          )}
+        </form.AppField>
+
+        <form.AppField name="apiKeyCooldownSeconds">
+          {field => (
+            <field.InputFieldAutoSave
+              formForSubmit={form}
+              label="Key cooldown seconds"
+              type="number"
+              min={0}
+              placeholder={String(DEFAULT_API_KEY_COOLDOWN_SECONDS)}
+            />
+          )}
+        </form.AppField>
+      </div>
+    )
+  },
+})

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/connection-button.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/connection-button.tsx
@@ -9,6 +9,7 @@ import { getObjectWithoutAPIKeys } from "@/utils/config/api"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { executeTranslate } from "@/utils/host/translate/execute-translate"
 import { getTranslatePrompt } from "@/utils/prompts/translate"
+import { parseProviderAPIKeys } from "@/utils/providers/api-key-rotation"
 
 function ConnectionSuccessIcon() {
   return (
@@ -39,6 +40,7 @@ const ConnectionTestResultIconMap = {
 
 export function ConnectionTestButton({ providerConfig }: { providerConfig: APIProviderConfig }) {
   const { apiKey, provider } = providerConfig
+  const hasAPIKey = parseProviderAPIKeys(apiKey).length > 0
   const baseURL = "baseURL" in providerConfig ? providerConfig.baseURL : undefined
   const providerSpecificSettings = "providerSpecificSettings" in providerConfig
     ? providerConfig.providerSpecificSettings
@@ -71,7 +73,7 @@ export function ConnectionTestButton({ providerConfig }: { providerConfig: APIPr
         size="xs"
         variant="outline"
         onClick={handleTestConnection}
-        disabled={mutation.isPending || (!apiKey && provider !== "deeplx" && provider !== "ollama")}
+        disabled={mutation.isPending || (!hasAPIKey && provider !== "deeplx" && provider !== "ollama")}
       >
         {mutation.isPending
           ? (

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/model-suggestion-button.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/model-suggestion-button.tsx
@@ -1,3 +1,4 @@
+import type { APIProviderConfig } from "@/types/config/provider"
 import { Combobox as ComboboxPrimitive } from "@base-ui/react"
 import { Icon } from "@iconify/react"
 import { useMutation } from "@tanstack/react-query"
@@ -13,6 +14,7 @@ import {
   ComboboxList,
 } from "@/components/ui/base-ui/combobox"
 import { extractErrorMessage } from "@/utils/error/extract-message"
+import { withProviderAPIKeyRotation } from "@/utils/providers/api-key-rotation"
 
 interface ModelsResponse {
   object: string
@@ -20,37 +22,38 @@ interface ModelsResponse {
 }
 
 interface ModelSuggestionButtonProps {
-  baseURL: string
-  apiKey?: string
+  providerConfig: APIProviderConfig & { baseURL: string }
   onSelect: (model: string) => void
   disabled?: boolean
 }
 
 export function ModelSuggestionButton({
-  baseURL,
-  apiKey,
+  providerConfig,
   onSelect,
   disabled,
 }: ModelSuggestionButtonProps) {
+  const { baseURL } = providerConfig
   const mutation = useMutation({
-    mutationKey: ["fetchModels", baseURL],
+    mutationKey: ["fetchModels", providerConfig.id, baseURL],
     meta: {
       errorDescription: i18n.t("options.apiProviders.form.models.fetchError"),
     },
     mutationFn: async () => {
-      if (!apiKey) {
-        throw new Error(i18n.t("options.apiProviders.form.models.apiKeyRequired"))
-      }
+      return withProviderAPIKeyRotation(providerConfig, async (apiKey) => {
+        if (!apiKey) {
+          throw new Error(i18n.t("options.apiProviders.form.models.apiKeyRequired"))
+        }
 
-      const response = await fetch(`${baseURL}/models`, {
-        headers: { Authorization: `Bearer ${apiKey}` },
+        const response = await fetch(`${baseURL}/models`, {
+          headers: { Authorization: `Bearer ${apiKey}` },
+        })
+        if (!response.ok) {
+          throw new Error(await extractErrorMessage(response))
+        }
+
+        const data: ModelsResponse = await response.json()
+        return data.data.map(m => m.id)
       })
-      if (!response.ok) {
-        throw new Error(await extractErrorMessage(response))
-      }
-
-      const data: ModelsResponse = await response.json()
-      return data.data.map(m => m.id)
     },
   })
 

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
@@ -31,6 +31,7 @@ import { cn } from "@/utils/styles/utils"
 import { selectedProviderIdAtom } from "../atoms"
 import { duplicateProvider } from "../utils"
 import { APIKeyField } from "./api-key-field"
+import { APIKeyRotationField } from "./api-key-rotation-field"
 import { BaseURLField } from "./base-url-field"
 import { AdvancedOptionsSection } from "./components/advanced-options-section"
 import { ConfigHeader } from "./config-header"
@@ -165,6 +166,7 @@ export function ProviderConfigForm() {
           </form.AppField>
 
           <APIKeyField form={form} />
+          <APIKeyRotationField form={form} />
           <BaseURLField form={form} />
           <ProviderSpecificSettingsField form={form} />
           {isTranslateProviderType && (

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
@@ -51,8 +51,7 @@ export const TranslateModelSelector = withForm({
                         {recommendationTrigger}
                         {isCustomLLMProviderConfig(providerConfig) && (
                           <ModelSuggestionButton
-                            baseURL={providerConfig.baseURL}
-                            apiKey={providerConfig.apiKey}
+                            providerConfig={providerConfig}
                             onSelect={(model) => {
                               field.handleChange(model)
                               void form.handleSubmit()

--- a/src/entrypoints/options/pages/general/feature-providers-config.tsx
+++ b/src/entrypoints/options/pages/general/feature-providers-config.tsx
@@ -10,6 +10,7 @@ import { configAtom, configFieldsAtomMap, writeConfigAtom } from "@/utils/atoms/
 import { featureProviderConfigAtom } from "@/utils/atoms/provider"
 import { filterEnabledProvidersConfig, getProviderConfigById } from "@/utils/config/helpers"
 import { buildFeatureProviderPatch, FEATURE_PROVIDER_DEFS, getFeatureLabelI18nKey } from "@/utils/constants/feature-providers"
+import { parseProviderAPIKeys } from "@/utils/providers/api-key-rotation"
 import { ConfigCard } from "../../components/config-card"
 import { SetApiKeyWarning } from "../../components/set-api-key-warning"
 
@@ -18,7 +19,7 @@ function needsApiKeyWarning(providerConfig: ProviderConfig | null): boolean {
   return !!providerConfig
     && isAPIProviderConfig(providerConfig)
     && !isPureAPIProvider(providerConfig.provider)
-    && !providerConfig.apiKey
+    && parseProviderAPIKeys(providerConfig.apiKey).length === 0
 }
 
 function FeatureProviderField({ featureKey }: {

--- a/src/types/config/provider/schemas.ts
+++ b/src/types/config/provider/schemas.ts
@@ -37,6 +37,8 @@ export const baseProviderConfigSchema = z.strictObject({
 
 export const baseAPIProviderConfigSchema = baseProviderConfigSchema.extend({
   apiKey: z.string().optional(),
+  apiKeyRotationMode: z.enum(["sequential", "random"]).optional(),
+  apiKeyCooldownSeconds: z.number().min(0).optional(),
   baseURL: z.string().optional(),
   temperature: z.number().min(0).optional(),
   providerOptions: z.record(z.string(), z.any()).optional(),

--- a/src/utils/content/summary.ts
+++ b/src/utils/content/summary.ts
@@ -1,7 +1,7 @@
 import type { LLMProviderConfig } from "@/types/config/provider"
 import { generateText } from "ai"
 import { logger } from "@/utils/logger"
-import { getModelById } from "@/utils/providers/model"
+import { withLanguageModelAPIKeyRotation } from "@/utils/providers/model"
 import { resolveModelId } from "@/utils/providers/model-id"
 import { getProviderOptionsWithOverride } from "@/utils/providers/options"
 import { cleanText } from "./utils"
@@ -24,7 +24,6 @@ export async function generateArticleSummary(
     const { model: providerModel, provider, providerOptions: userProviderOptions, temperature } = providerConfig
     const modelName = resolveModelId(providerModel)
     const providerOptions = getProviderOptionsWithOverride(modelName ?? "", provider, userProviderOptions)
-    const model = await getModelById(providerConfig.id)
 
     const prompt = `Summarize the following article in 2-3 sentences. Focus on the main topic and key points. Return ONLY the summary, no explanations or formatting.
 
@@ -33,11 +32,14 @@ Title: ${title}
 Content:
 ${preparedText}`
 
-    const { text: summary } = await generateText({
-      model,
-      prompt,
-      temperature,
-      providerOptions,
+    const summary = await withLanguageModelAPIKeyRotation(providerConfig, async (model) => {
+      const { text: result } = await generateText({
+        model,
+        prompt,
+        temperature,
+        providerOptions,
+      })
+      return result
     })
 
     const cleanedSummary = summary.trim()

--- a/src/utils/host/translate/api/__tests__/ai.test.ts
+++ b/src/utils/host/translate/api/__tests__/ai.test.ts
@@ -5,7 +5,7 @@ import { aiTranslate } from "../ai"
 
 const mocks = vi.hoisted(() => ({
   generateText: vi.fn(),
-  getModelById: vi.fn(),
+  withLanguageModelAPIKeyRotation: vi.fn(),
   resolveModelId: vi.fn(),
   getProviderOptionsWithOverride: vi.fn(),
 }))
@@ -15,7 +15,7 @@ vi.mock("ai", () => ({
 }))
 
 vi.mock("@/utils/providers/model", () => ({
-  getModelById: mocks.getModelById,
+  withLanguageModelAPIKeyRotation: mocks.withLanguageModelAPIKeyRotation,
 }))
 
 vi.mock("@/utils/providers/model-id", () => ({
@@ -43,7 +43,7 @@ const promptResolver = vi.fn().mockResolvedValue({
 describe("aiTranslate", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mocks.getModelById.mockResolvedValue("model")
+    mocks.withLanguageModelAPIKeyRotation.mockImplementation((_providerConfig, operation) => operation("model"))
     mocks.resolveModelId.mockReturnValue("gpt-5-mini")
     mocks.getProviderOptionsWithOverride.mockReturnValue({})
   })

--- a/src/utils/host/translate/api/__tests__/deepl.test.ts
+++ b/src/utils/host/translate/api/__tests__/deepl.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { clearAPIKeyRotationStateForTests } from "@/utils/providers/api-key-rotation"
 import { deeplTranslate, getDeepLBaseURL } from "../deepl"
 
 const fetchMock = vi.fn()
@@ -6,6 +7,7 @@ const fetchMock = vi.fn()
 describe("deepl translate adapter", () => {
   beforeEach(() => {
     fetchMock.mockReset()
+    clearAPIKeyRotationStateForTests()
     vi.stubGlobal("fetch", fetchMock)
   })
 
@@ -98,5 +100,39 @@ describe("deepl translate adapter", () => {
       provider: "deepl",
       apiKey: "test-key",
     })).rejects.toThrow("DeepL translation response count mismatch")
+  })
+
+  it("falls back to the next API key when a DeepL request fails", async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        json: vi.fn(),
+        text: vi.fn().mockResolvedValue("bad key"),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: vi.fn().mockResolvedValue({
+          translations: [{ text: "你好" }],
+        }),
+        text: vi.fn().mockResolvedValue(""),
+      })
+
+    const result = await deeplTranslate("Hello", "auto", "zh", {
+      id: "deepl-default",
+      enabled: true,
+      name: "DeepL",
+      provider: "deepl",
+      apiKey: "bad-key, good-key",
+      apiKeyCooldownSeconds: 60,
+    })
+
+    expect(result).toBe("你好")
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[0]?.[1].headers.Authorization).toBe("DeepL-Auth-Key bad-key")
+    expect(fetchMock.mock.calls[1]?.[1].headers.Authorization).toBe("DeepL-Auth-Key good-key")
   })
 })

--- a/src/utils/host/translate/api/ai.ts
+++ b/src/utils/host/translate/api/ai.ts
@@ -2,7 +2,7 @@ import type { LLMProviderConfig } from "@/types/config/provider"
 import type { TranslatePromptOptions, TranslatePromptResult } from "@/utils/prompts/translate"
 import { generateText } from "ai"
 import { extractAISDKErrorMessage } from "@/utils/error/extract-message"
-import { getModelById } from "@/utils/providers/model"
+import { withLanguageModelAPIKeyRotation } from "@/utils/providers/model"
 import { resolveModelId } from "@/utils/providers/model-id"
 import { getProviderOptionsWithOverride } from "@/utils/providers/options"
 import { attachRequestErrorMeta, getRequestErrorMeta } from "@/utils/request/retry-policy"
@@ -22,21 +22,23 @@ export async function aiTranslate<TContext>(
   promptResolver: PromptResolver<TContext>,
   options?: { isBatch?: boolean, context?: TContext },
 ) {
-  const { id: providerId, model: providerModel, provider, providerOptions: userProviderOptions, temperature } = providerConfig
+  const { model: providerModel, provider, providerOptions: userProviderOptions, temperature } = providerConfig
   const modelName = resolveModelId(providerModel)
-  const model = await getModelById(providerId)
 
   const providerOptions = getProviderOptionsWithOverride(modelName ?? "", provider, userProviderOptions)
   const { systemPrompt, prompt } = await promptResolver(targetLangName, text, options)
 
   try {
-    const { text: translatedText } = await generateText({
-      model,
-      system: systemPrompt,
-      prompt,
-      temperature,
-      providerOptions,
-      maxRetries: 0, // Disable SDK built-in retries, let RequestQueue/BatchQueue handle it
+    const translatedText = await withLanguageModelAPIKeyRotation(providerConfig, async (model) => {
+      const { text: result } = await generateText({
+        model,
+        system: systemPrompt,
+        prompt,
+        temperature,
+        providerOptions,
+        maxRetries: 0, // Disable SDK built-in retries, let RequestQueue/BatchQueue handle it
+      })
+      return result
     })
 
     const [, finalTranslation = translatedText] = translatedText.match(THINK_TAG_RE) || []

--- a/src/utils/host/translate/api/deepl.ts
+++ b/src/utils/host/translate/api/deepl.ts
@@ -1,6 +1,7 @@
 import type { LangCodeISO6391 } from "@read-frog/definitions"
 import type { ProviderConfig } from "@/types/config/provider"
 import { sendMessage } from "@/utils/message"
+import { withProviderAPIKeyRotation } from "@/utils/providers/api-key-rotation"
 
 type DeepLProviderConfig = Extract<ProviderConfig, { provider: "deepl" }>
 
@@ -24,12 +25,15 @@ export async function deeplTranslate(
   providerConfig: DeepLProviderConfig,
   options?: { forceBackgroundFetch?: boolean },
 ): Promise<string> {
-  const [translatedText] = await requestDeepLTranslations(
-    [sourceText],
-    fromLang,
-    toLang,
+  const [translatedText] = await withProviderAPIKeyRotation(
     providerConfig,
-    options,
+    apiKey => requestDeepLTranslations(
+      [sourceText],
+      fromLang,
+      toLang,
+      apiKey,
+      options,
+    ),
   )
 
   if (translatedText === undefined) {
@@ -43,10 +47,9 @@ async function requestDeepLTranslations(
   sourceTexts: string[],
   fromLang: LangCodeISO6391 | "auto",
   toLang: LangCodeISO6391,
-  providerConfig: DeepLProviderConfig,
+  apiKey: string | undefined,
   options?: { forceBackgroundFetch?: boolean },
 ): Promise<string[]> {
-  const apiKey = providerConfig.apiKey?.trim()
   if (!apiKey) {
     throw new Error("DeepL API key is not configured")
   }

--- a/src/utils/host/translate/api/deeplx.ts
+++ b/src/utils/host/translate/api/deeplx.ts
@@ -2,6 +2,7 @@ import type { LangCodeISO6391 } from "@read-frog/definitions"
 import type { ProviderConfig } from "@/types/config/provider"
 import { DEFAULT_PROVIDER_CONFIG } from "@/utils/constants/providers"
 import { sendMessage } from "@/utils/message"
+import { withProviderAPIKeyRotation } from "@/utils/providers/api-key-rotation"
 
 type DeepLXProviderConfig = Extract<ProviderConfig, { provider: "deeplx" }>
 const API_KEY_PLACEHOLDER_RE = /\{\{apiKey\}\}/g
@@ -14,7 +15,6 @@ export async function deeplxTranslate(
   options?: { forceBackgroundFetch?: boolean },
 ): Promise<string> {
   const baseURL = providerConfig.baseURL || DEFAULT_PROVIDER_CONFIG.deeplx.baseURL
-  const apiKey = providerConfig.apiKey
 
   if (!baseURL) {
     throw new Error("DeepLX baseURL is not configured")
@@ -29,19 +29,21 @@ export async function deeplxTranslate(
     return formattedLang
   }
 
-  const url = buildDeepLXUrl(baseURL, apiKey)
+  return withProviderAPIKeyRotation(providerConfig, async (apiKey) => {
+    const url = buildDeepLXUrl(baseURL, apiKey)
 
-  const requestBody = JSON.stringify({
-    text: sourceText,
-    source_lang: formatLang(fromLang),
-    target_lang: formatLang(toLang),
+    const requestBody = JSON.stringify({
+      text: sourceText,
+      source_lang: formatLang(fromLang),
+      target_lang: formatLang(toLang),
+    })
+
+    const fetchResponse = options?.forceBackgroundFetch
+      ? await fetchViaBackground(url, requestBody)
+      : await fetchDirect(url, requestBody)
+
+    return parseDeepLXResponse(fetchResponse)
   })
-
-  const fetchResponse = options?.forceBackgroundFetch
-    ? await fetchViaBackground(url, requestBody)
-    : await fetchDirect(url, requestBody)
-
-  return parseDeepLXResponse(fetchResponse)
 }
 
 async function fetchViaBackground(url: string, body: string) {

--- a/src/utils/host/translate/translate-text.ts
+++ b/src/utils/host/translate/translate-text.ts
@@ -11,6 +11,7 @@ import { getProviderConfigById } from "@/utils/config/helpers"
 import { detectLanguage } from "@/utils/content/language"
 import { logger } from "@/utils/logger"
 import { getTranslatePrompt } from "@/utils/prompts/translate"
+import { parseProviderAPIKeys } from "@/utils/providers/api-key-rotation"
 import { Sha256Hex } from "../../hash"
 import { sendMessage } from "../../message"
 import { prepareTranslationText } from "./text-preparation"
@@ -176,7 +177,7 @@ export function validateTranslationConfigAndToast(
   }
 
   // check if the API key is configured
-  if (isAPIProviderConfig(providerConfig) && !providerConfig.apiKey?.trim() && !["deeplx", "ollama"].includes(providerConfig.provider)) {
+  if (isAPIProviderConfig(providerConfig) && parseProviderAPIKeys(providerConfig.apiKey).length === 0 && !["deeplx", "ollama"].includes(providerConfig.provider)) {
     toast.error(i18n.t("noAPIKeyConfig.warning"))
     logger.info("validateTranslationConfig: returning false (no API key)")
     return false

--- a/src/utils/providers/__tests__/api-key-rotation.test.ts
+++ b/src/utils/providers/__tests__/api-key-rotation.test.ts
@@ -1,0 +1,85 @@
+import type { APIProviderConfig } from "@/types/config/provider"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  clearAPIKeyRotationStateForTests,
+  getNextProviderAPIKey,
+  parseProviderAPIKeys,
+  withProviderAPIKeyRotation,
+} from "../api-key-rotation"
+
+function provider(overrides: Partial<APIProviderConfig> = {}): APIProviderConfig {
+  return {
+    id: "provider-1",
+    name: "Provider",
+    enabled: true,
+    provider: "deepl",
+    apiKey: "key-a,key-b,key-c",
+    ...overrides,
+  } as APIProviderConfig
+}
+
+describe("api key rotation", () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    clearAPIKeyRotationStateForTests()
+  })
+
+  it("parses comma-separated keys, trims blanks, and removes duplicates", () => {
+    expect(parseProviderAPIKeys(" key-a, key-b ,, key-a ,key-c ")).toEqual([
+      "key-a",
+      "key-b",
+      "key-c",
+    ])
+  })
+
+  it("rotates sequentially across configured keys", () => {
+    const config = provider()
+
+    expect(getNextProviderAPIKey(config)).toBe("key-a")
+    expect(getNextProviderAPIKey(config)).toBe("key-b")
+    expect(getNextProviderAPIKey(config)).toBe("key-c")
+    expect(getNextProviderAPIKey(config)).toBe("key-a")
+  })
+
+  it("can select a key randomly", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.9)
+
+    expect(getNextProviderAPIKey(provider({ apiKeyRotationMode: "random" }))).toBe("key-c")
+  })
+
+  it("cools down a failed key and immediately falls back to the next key", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+
+    const config = provider({ apiKey: "bad-key,good-key", apiKeyCooldownSeconds: 60 })
+    const attempts: string[] = []
+
+    const result = await withProviderAPIKeyRotation(config, async (apiKey) => {
+      attempts.push(apiKey ?? "")
+      if (apiKey === "bad-key")
+        throw new Error("bad key")
+      return "translated"
+    })
+
+    expect(result).toBe("translated")
+    expect(attempts).toEqual(["bad-key", "good-key"])
+
+    expect(getNextProviderAPIKey(config)).toBe("good-key")
+
+    vi.setSystemTime(61_000)
+    expect(getNextProviderAPIKey(config)).toBe("bad-key")
+  })
+
+  it("reports when every key is cooling down", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+
+    const config = provider({ apiKey: "key-a,key-b", apiKeyCooldownSeconds: 60 })
+    await expect(withProviderAPIKeyRotation(config, async () => {
+      throw new Error("failed")
+    })).rejects.toThrow("All configured API keys failed")
+
+    expect(() => getNextProviderAPIKey(config)).toThrow("cooling down")
+  })
+})

--- a/src/utils/providers/__tests__/model.test.ts
+++ b/src/utils/providers/__tests__/model.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { storage } from "#imports"
+import { clearAPIKeyRotationStateForTests } from "../api-key-rotation"
 import { DEFAULT_PROVIDER_HEADERS } from "../headers"
 
 let getStorageItemMock: ReturnType<typeof vi.fn>
@@ -82,6 +83,7 @@ function createOpenRouterProviderConfig(headers?: Record<string, unknown>) {
 describe("getModelById", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    clearAPIKeyRotationStateForTests()
     anthropicLanguageModelMock.mockReturnValue("anthropic-model")
     openRouterLanguageModelMock.mockReturnValue("openrouter-model")
     openAICompatibleLanguageModelMock.mockReturnValue("custom-model")
@@ -103,6 +105,28 @@ describe("getModelById", () => {
       headers: DEFAULT_PROVIDER_HEADERS.anthropic,
     }))
     expect(anthropicLanguageModelMock).toHaveBeenCalledWith("claude-haiku-4-5")
+  })
+
+  it("rotates comma-separated API keys before creating SDK providers", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [
+        {
+          ...createAnthropicProviderConfig(),
+          apiKey: "key-a, key-b",
+        },
+      ],
+    })
+
+    const { getModelById } = await import("../model")
+    await getModelById("anthropic-default")
+    await getModelById("anthropic-default")
+
+    expect(createAnthropicMock.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      apiKey: "key-a",
+    }))
+    expect(createAnthropicMock.mock.calls[1]?.[0]).toEqual(expect.objectContaining({
+      apiKey: "key-b",
+    }))
   })
 
   it("passes attribution headers for OpenRouter when user headers are undefined", async () => {

--- a/src/utils/providers/api-key-rotation.ts
+++ b/src/utils/providers/api-key-rotation.ts
@@ -1,0 +1,215 @@
+import type { APIProviderConfig } from "@/types/config/provider"
+
+export const DEFAULT_API_KEY_ROTATION_MODE = "sequential"
+export const DEFAULT_API_KEY_COOLDOWN_SECONDS = 300
+
+export interface APIKeyAttemptContext {
+  apiKey?: string
+  apiKeyCount: number
+  apiKeyIndex: number
+}
+
+export interface APIKeyRotationOptions {
+  shouldFallback?: (error: Error, context: APIKeyAttemptContext) => boolean
+}
+
+interface APIKeyRotationState {
+  nextIndex: number
+  cooldownUntilByKey: Map<string, number>
+}
+
+const rotationStateByProviderId = new Map<string, APIKeyRotationState>()
+
+function getRotationState(providerId: string): APIKeyRotationState {
+  const existing = rotationStateByProviderId.get(providerId)
+  if (existing)
+    return existing
+
+  const state: APIKeyRotationState = {
+    nextIndex: 0,
+    cooldownUntilByKey: new Map(),
+  }
+  rotationStateByProviderId.set(providerId, state)
+  return state
+}
+
+export function parseProviderAPIKeys(apiKey?: string): string[] {
+  if (!apiKey)
+    return []
+
+  const seen = new Set<string>()
+  const keys: string[] = []
+  for (const key of apiKey.split(",").map(item => item.trim()).filter(Boolean)) {
+    if (seen.has(key))
+      continue
+    seen.add(key)
+    keys.push(key)
+  }
+  return keys
+}
+
+function getRotationMode(providerConfig: APIProviderConfig) {
+  return providerConfig.apiKeyRotationMode ?? DEFAULT_API_KEY_ROTATION_MODE
+}
+
+function getCooldownMs(providerConfig: APIProviderConfig) {
+  return (providerConfig.apiKeyCooldownSeconds ?? DEFAULT_API_KEY_COOLDOWN_SECONDS) * 1000
+}
+
+function isCoolingDown(state: APIKeyRotationState, apiKey: string, now: number) {
+  const cooldownUntil = state.cooldownUntilByKey.get(apiKey)
+  if (!cooldownUntil)
+    return false
+
+  if (cooldownUntil <= now) {
+    state.cooldownUntilByKey.delete(apiKey)
+    return false
+  }
+
+  return true
+}
+
+function getAvailableIndexes(
+  apiKeys: string[],
+  state: APIKeyRotationState,
+  attemptedIndexes: Set<number>,
+  now: number,
+) {
+  return apiKeys
+    .map((apiKey, index) => ({ apiKey, index }))
+    .filter(({ apiKey, index }) => !attemptedIndexes.has(index) && !isCoolingDown(state, apiKey, now))
+}
+
+function selectSequentialAPIKey(
+  apiKeys: string[],
+  state: APIKeyRotationState,
+  attemptedIndexes: Set<number>,
+  now: number,
+) {
+  const startIndex = state.nextIndex % apiKeys.length
+  for (let offset = 0; offset < apiKeys.length; offset++) {
+    const index = (startIndex + offset) % apiKeys.length
+    const apiKey = apiKeys[index]
+    if (attemptedIndexes.has(index) || isCoolingDown(state, apiKey, now))
+      continue
+
+    state.nextIndex = (index + 1) % apiKeys.length
+    return { apiKey, index }
+  }
+}
+
+function selectRandomAPIKey(
+  apiKeys: string[],
+  state: APIKeyRotationState,
+  attemptedIndexes: Set<number>,
+  now: number,
+) {
+  const available = getAvailableIndexes(apiKeys, state, attemptedIndexes, now)
+  if (available.length === 0)
+    return undefined
+
+  return available[Math.floor(Math.random() * available.length)]
+}
+
+function selectAPIKey(
+  providerConfig: APIProviderConfig,
+  apiKeys: string[],
+  attemptedIndexes: Set<number>,
+  now: number,
+) {
+  const state = getRotationState(providerConfig.id)
+  if (getRotationMode(providerConfig) === "random")
+    return selectRandomAPIKey(apiKeys, state, attemptedIndexes, now)
+
+  return selectSequentialAPIKey(apiKeys, state, attemptedIndexes, now)
+}
+
+function markAPIKeyCoolingDown(providerConfig: APIProviderConfig, apiKey: string) {
+  const cooldownMs = getCooldownMs(providerConfig)
+  if (cooldownMs <= 0)
+    return
+
+  getRotationState(providerConfig.id).cooldownUntilByKey.set(apiKey, Date.now() + cooldownMs)
+}
+
+function buildNoAvailableKeyError(providerConfig: APIProviderConfig, apiKeyCount: number) {
+  return new Error(
+    `No API key is currently available for "${providerConfig.name}". `
+    + `${apiKeyCount} configured API key(s) are cooling down.`,
+  )
+}
+
+export function getNextProviderAPIKey(providerConfig: APIProviderConfig): string | undefined {
+  const apiKeys = parseProviderAPIKeys(providerConfig.apiKey)
+  if (apiKeys.length <= 1)
+    return apiKeys[0]
+
+  const selected = selectAPIKey(providerConfig, apiKeys, new Set(), Date.now())
+  if (!selected)
+    throw buildNoAvailableKeyError(providerConfig, apiKeys.length)
+
+  return selected.apiKey
+}
+
+export async function withProviderAPIKeyRotation<T>(
+  providerConfig: APIProviderConfig,
+  operation: (apiKey: string | undefined, context: APIKeyAttemptContext) => Promise<T>,
+  options: APIKeyRotationOptions = {},
+): Promise<T> {
+  const apiKeys = parseProviderAPIKeys(providerConfig.apiKey)
+
+  if (apiKeys.length <= 1) {
+    return operation(apiKeys[0], {
+      apiKey: apiKeys[0],
+      apiKeyCount: apiKeys.length,
+      apiKeyIndex: apiKeys.length === 1 ? 0 : -1,
+    })
+  }
+
+  const attemptedIndexes = new Set<number>()
+  const errors: Error[] = []
+
+  while (attemptedIndexes.size < apiKeys.length) {
+    const selected = selectAPIKey(providerConfig, apiKeys, attemptedIndexes, Date.now())
+    if (!selected)
+      break
+
+    attemptedIndexes.add(selected.index)
+
+    try {
+      const context: APIKeyAttemptContext = {
+        apiKey: selected.apiKey,
+        apiKeyCount: apiKeys.length,
+        apiKeyIndex: selected.index,
+      }
+      return await operation(selected.apiKey, context)
+    }
+    catch (error) {
+      const normalizedError = error instanceof Error ? error : new Error(String(error))
+      if (options.shouldFallback?.(normalizedError, {
+        apiKey: selected.apiKey,
+        apiKeyCount: apiKeys.length,
+        apiKeyIndex: selected.index,
+      }) === false) {
+        throw normalizedError
+      }
+
+      markAPIKeyCoolingDown(providerConfig, selected.apiKey)
+      errors.push(normalizedError)
+    }
+  }
+
+  const lastError = errors.at(-1)
+  if (lastError) {
+    throw new Error(
+      `All configured API keys failed for "${providerConfig.name}". Last error: ${lastError.message}`,
+      { cause: lastError },
+    )
+  }
+
+  throw buildNoAvailableKeyError(providerConfig, apiKeys.length)
+}
+
+export function clearAPIKeyRotationStateForTests() {
+  rotationStateByProviderId.clear()
+}

--- a/src/utils/providers/model.ts
+++ b/src/utils/providers/model.ts
@@ -1,4 +1,6 @@
+import type { APIKeyRotationOptions } from "./api-key-rotation"
 import type { Config } from "@/types/config/config"
+import type { LLMProviderConfig } from "@/types/config/provider"
 import { createAlibaba } from "@ai-sdk/alibaba"
 import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock"
 import { createAnthropic } from "@ai-sdk/anthropic"
@@ -27,6 +29,7 @@ import { isCustomLLMProvider } from "@/types/config/provider"
 import { compactObject } from "@/types/utils"
 import { getLLMProvidersConfig, getProviderConfigById } from "../config/helpers"
 import { CONFIG_STORAGE_KEY } from "../constants/config"
+import { getNextProviderAPIKey, withProviderAPIKeyRotation } from "./api-key-rotation"
 import { getProviderHeadersWithOverride } from "./headers"
 import { resolveModelId } from "./model-id"
 
@@ -59,7 +62,7 @@ const CREATE_AI_MAPPER = {
   "huggingface": createHuggingFace,
 } as const
 
-async function getLanguageModelById(providerId: string) {
+async function getLLMProviderConfigById(providerId: string): Promise<LLMProviderConfig> {
   const config = await storage.getItem<Config>(`local:${CONFIG_STORAGE_KEY}`)
   if (!config) {
     throw new Error("Config not found")
@@ -71,10 +74,15 @@ async function getLanguageModelById(providerId: string) {
     throw new Error(`Provider ${providerId} not found`)
   }
 
+  return providerConfig
+}
+
+export function getLanguageModelFromProviderConfig(providerConfig: LLMProviderConfig, apiKeyOverride?: string) {
   const headers = getProviderHeadersWithOverride(providerConfig.provider, providerConfig.headers)
   const providerSpecificSettings = "providerSpecificSettings" in providerConfig
     ? compactObject(providerConfig.providerSpecificSettings ?? {})
     : {}
+  const apiKey = apiKeyOverride ?? getNextProviderAPIKey(providerConfig)
 
   const provider = isCustomLLMProvider(providerConfig.provider)
     ? CREATE_AI_MAPPER[providerConfig.provider]({
@@ -82,13 +90,13 @@ async function getLanguageModelById(providerId: string) {
         name: providerConfig.provider,
         baseURL: providerConfig.baseURL ?? "",
         supportsStructuredOutputs: true,
-        ...(providerConfig.apiKey && { apiKey: providerConfig.apiKey }),
+        ...(apiKey && { apiKey }),
         ...(headers && { headers }),
       })
     : CREATE_AI_MAPPER[providerConfig.provider]({
         ...providerSpecificSettings,
         ...(providerConfig.baseURL && { baseURL: providerConfig.baseURL }),
-        ...(providerConfig.apiKey && { apiKey: providerConfig.apiKey }),
+        ...(apiKey && { apiKey }),
         ...(headers && { headers }),
       })
 
@@ -101,6 +109,31 @@ async function getLanguageModelById(providerId: string) {
   return provider.languageModel(modelId)
 }
 
+async function getLanguageModelById(providerId: string) {
+  const providerConfig = await getLLMProviderConfigById(providerId)
+  return getLanguageModelFromProviderConfig(providerConfig)
+}
+
 export async function getModelById(providerId: string) {
   return getLanguageModelById(providerId)
+}
+
+export async function withLanguageModelByIdAPIKeyRotation<T>(
+  providerId: string,
+  operation: (model: ReturnType<typeof getLanguageModelFromProviderConfig>) => Promise<T>,
+  options?: APIKeyRotationOptions,
+): Promise<T> {
+  const providerConfig = await getLLMProviderConfigById(providerId)
+  return withLanguageModelAPIKeyRotation(providerConfig, operation, options)
+}
+
+export async function withLanguageModelAPIKeyRotation<T>(
+  providerConfig: LLMProviderConfig,
+  operation: (model: ReturnType<typeof getLanguageModelFromProviderConfig>) => Promise<T>,
+  options?: APIKeyRotationOptions,
+): Promise<T> {
+  return withProviderAPIKeyRotation(providerConfig, async (apiKey) => {
+    const model = getLanguageModelFromProviderConfig(providerConfig, apiKey)
+    return operation(model)
+  }, options)
 }


### PR DESCRIPTION
## Summary
- allow comma-separated API keys for API providers
- add sequential/random key rotation and configurable failed-key cooldown
- immediately fall back to another key for API/LLM translation, DeepL/DeepLX, generateText, summaries, segmentation, and pre-output stream failures

## Verification
- pnpm exec tsc --noEmit
- pnpm exec eslint on affected files
- pnpm exec vitest run src/entrypoints/background/__tests__/background-stream.test.ts src/entrypoints/background/__tests__/llm-generate-text.test.ts src/entrypoints/background/__tests__/translation-queues.test.ts src/utils/providers/__tests__/api-key-rotation.test.ts src/utils/providers/__tests__/model.test.ts src/utils/host/translate/api/__tests__/ai.test.ts src/utils/host/translate/api/__tests__/deepl.test.ts
- pnpm exec vitest run src/utils/host/translate/ui/__tests__/spinner.test.ts

Note: full `pnpm exec vitest run` still has the existing spinner test timing/mock-isolation failure when run with the full suite, while the spinner test passes standalone.