### PR TITLE
feat(popup): add translation mode quick toggle

### DIFF
--- a/.changeset/tidy-mode-toggle.md
+++ b/.changeset/tidy-mode-toggle.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(popup): add a quick toggle for bilingual and translation-only modes

--- a/src/entrypoints/popup/app.tsx
+++ b/src/entrypoints/popup/app.tsx
@@ -30,11 +30,11 @@ function App() {
           </div>
         </div>
         <LanguageOptionsSelector />
-        <TranslationModeSelector />
         <TranslateProviderField />
         <TranslatePromptSelector />
-        <div className="w-full">
-          <TranslateButton className="w-full" />
+        <div className="flex w-full items-center gap-2">
+          <TranslationModeSelector />
+          <TranslateButton className="min-w-0 flex-1" />
         </div>
         <SiteControlToggle />
         <AlwaysTranslate />

--- a/src/entrypoints/popup/components/translation-mode-selector.tsx
+++ b/src/entrypoints/popup/components/translation-mode-selector.tsx
@@ -1,59 +1,66 @@
 import type { TranslationMode as TranslationModeType } from "@/types/config/translate"
-import { deepmerge } from "deepmerge-ts"
+import { Icon } from "@iconify/react"
 import { useAtom } from "jotai"
 import { i18n } from "#imports"
-import { HelpTooltip } from "@/components/help-tooltip"
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/base-ui/select"
-import { TRANSLATION_MODES } from "@/types/config/translate"
+import { Button } from "@/components/ui/base-ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/base-ui/tooltip"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
+
+const MODE_ICON: Record<TranslationModeType, { icon: string, className?: string, strokeWidth?: number }> = {
+  bilingual: { icon: "system-uicons:translate", strokeWidth: 1.6 },
+  translationOnly: { icon: "mingcute:text-area-line" },
+}
+
+const NEXT_MODE: Record<TranslationModeType, TranslationModeType> = {
+  bilingual: "translationOnly",
+  translationOnly: "bilingual",
+}
+
+const MODE_TOOLTIP_KEY = {
+  bilingual: {
+    current: "popup.translationModeToggle.tooltip.bilingual.current",
+    action: "popup.translationModeToggle.tooltip.bilingual.action",
+  },
+  translationOnly: {
+    current: "popup.translationModeToggle.tooltip.translationOnly.current",
+    action: "popup.translationModeToggle.tooltip.translationOnly.action",
+  },
+} as const
 
 export default function TranslationModeSelector() {
   const [translateConfig, setTranslateConfig] = useAtom(configFieldsAtomMap.translate)
   const currentMode = translateConfig.mode
+  const nextMode = NEXT_MODE[currentMode]
+  const tooltipKey = MODE_TOOLTIP_KEY[currentMode]
+  const actionLabel = i18n.t(tooltipKey.action)
 
-  const handleModeChange = (mode: TranslationModeType | null) => {
-    if (!mode)
-      return
-
+  const handleModeToggle = () => {
     void setTranslateConfig(
-      deepmerge(translateConfig, { mode }),
+      { mode: nextMode },
     )
   }
 
   return (
-    <div className="flex items-center justify-between gap-2">
-      <span className="text-[13px] font-medium flex items-center gap-1.5">
-        {i18n.t("options.translation.translationMode.title")}
-        <HelpTooltip>
-          {i18n.t("options.translation.translationMode.description")}
-        </HelpTooltip>
-      </span>
-      <Select
-        value={currentMode}
-        onValueChange={handleModeChange}
+    <Tooltip>
+      <TooltipTrigger
+        render={(
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            aria-label={actionLabel}
+            onClick={handleModeToggle}
+          />
+        )}
       >
-        <SelectTrigger className="h-7! w-31">
-          <SelectValue>
-            {i18n.t(`options.translation.translationMode.mode.${currentMode}`)}
-          </SelectValue>
-        </SelectTrigger>
-        <SelectContent>
-          <SelectGroup>
-            {TRANSLATION_MODES.map(mode => (
-              <SelectItem key={mode} value={mode}>
-                {i18n.t(`options.translation.translationMode.mode.${mode}`)}
-              </SelectItem>
-            ))}
-          </SelectGroup>
-        </SelectContent>
-      </Select>
-    </div>
+        <Icon {...MODE_ICON[currentMode]} className="size-4.5" />
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="whitespace-nowrap">
+          <p>{i18n.t(tooltipKey.current)}</p>
+          <p>{actionLabel}</p>
+        </div>
+      </TooltipContent>
+    </Tooltip>
   )
 }

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -28,6 +28,14 @@ popup:
   options: Options
   hover: Hover
   translateParagraph: to translate paragraph
+  translationModeToggle:
+    tooltip:
+      bilingual:
+        current: Currently bilingual
+        action: Click to switch to translation only
+      translationOnly:
+        current: Currently translation only
+        action: Click to switch to bilingual
   hub:
     tooltip: Translate text with multiple models simultaneously
   discord:

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -28,6 +28,14 @@ popup:
   options: Opciones
   hover: Pasar el cursor
   translateParagraph: para traducir el párrafo
+  translationModeToggle:
+    tooltip:
+      bilingual:
+        current: Modo bilingüe actual
+        action: Haz clic para cambiar a solo traducción
+      translationOnly:
+        current: Modo solo traducción actual
+        action: Haz clic para cambiar a bilingüe
   hub:
     tooltip: Traduce texto con varios modelos al mismo tiempo
   discord:

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -28,6 +28,14 @@ popup:
   options: オプション
   hover: ホバー
   translateParagraph: 段落を翻訳
+  translationModeToggle:
+    tooltip:
+      bilingual:
+        current: 現在はバイリンガル
+        action: クリックして翻訳のみへ切り替え
+      translationOnly:
+        current: 現在は翻訳のみ
+        action: クリックしてバイリンガルへ切り替え
   hub:
     tooltip: 複数の翻訳モデルで同時にテキストを翻訳
   discord:

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -28,6 +28,14 @@ popup:
   options: 옵션
   hover: 마우스 오버
   translateParagraph: 단락 번역
+  translationModeToggle:
+    tooltip:
+      bilingual:
+        current: 현재 이중 언어 모드
+        action: 클릭하여 번역만으로 전환
+      translationOnly:
+        current: 현재 번역만 모드
+        action: 클릭하여 이중 언어로 전환
   hub:
     tooltip: 여러 번역 모델로 동시에 텍스트 번역
   discord:

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -28,6 +28,14 @@ popup:
   options: Настройки
   hover: Наведение
   translateParagraph: для перевода абзаца
+  translationModeToggle:
+    tooltip:
+      bilingual:
+        current: "Текущий режим: двуязычный"
+        action: Нажмите, чтобы переключиться на только перевод
+      translationOnly:
+        current: "Текущий режим: только перевод"
+        action: Нажмите, чтобы переключиться на двуязычный
   hub:
     tooltip: Переводите текст несколькими моделями одновременно
   discord:

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -28,6 +28,14 @@ popup:
   options: Seçenekler
   hover: Üzerine Gel
   translateParagraph: paragrafı çevirmek için
+  translationModeToggle:
+    tooltip:
+      bilingual:
+        current: "Geçerli mod: İki dilli"
+        action: Yalnızca çeviriye geçmek için tıklayın
+      translationOnly:
+        current: "Geçerli mod: Yalnızca çeviri"
+        action: İki dilli moda geçmek için tıklayın
   hub:
     tooltip: Birden fazla çeviri modeliyle aynı anda metin çevirin
   discord:

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -28,6 +28,14 @@ popup:
   options: Tùy chọn
   hover: Di chuột
   translateParagraph: để dịch đoạn văn
+  translationModeToggle:
+    tooltip:
+      bilingual:
+        current: Hiện tại là song ngữ
+        action: Nhấp để chuyển sang chỉ bản dịch
+      translationOnly:
+        current: Hiện tại chỉ bản dịch
+        action: Nhấp để chuyển sang song ngữ
   hub:
     tooltip: Dịch văn bản với nhiều mô hình đồng thời
   discord:

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -28,6 +28,14 @@ popup:
   options: 选项
   hover: 鼠标悬停
   translateParagraph: 来翻译段落
+  translationModeToggle:
+    tooltip:
+      bilingual:
+        current: 当前为双语对照
+        action: 点击切换为仅译文
+      translationOnly:
+        current: 当前为仅译文
+        action: 点击切换为双语对照
   hub:
     tooltip: 一次性调用多个翻译模型翻译文本
   discord:

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -28,6 +28,14 @@ popup:
   options: 選項
   hover: 滑鼠停留
   translateParagraph: 翻譯段落
+  translationModeToggle:
+    tooltip:
+      bilingual:
+        current: 當前為雙語對照
+        action: 點擊切換為僅譯文
+      translationOnly:
+        current: 當前為僅譯文
+        action: 點擊切換為雙語對照
   hub:
     tooltip: 一次使用多個翻譯模型翻譯文字
   discord:


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [x] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Adds a compact translation mode quick toggle to the popup Translate row so users can switch between bilingual and translation-only modes without opening the old mode dropdown.

- Replaces the popup Translation Mode selector row with a square icon toggle next to the Translate button
- Shows the current mode via Iconify icons and localized tooltip text
- Keeps the Options page translation mode selector unchanged
- Adds popup tooltip copy across supported locales

## Related Issue

Closes #1667

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

Validated locally with:

- `SKIP_FREE_API=true pnpm type-check`
- `pnpm lint src/entrypoints/popup/app.tsx src/entrypoints/popup/components/translation-mode-selector.tsx`
- `WXT_SKIP_ENV_VALIDATION=true SKIP_FREE_API=true pnpm build`
- Real Edge popup visual check using the built unpacked extension
- Push hook also passed full lint, type-check, and Vitest suite: 155 test files / 1306 tests

## Screenshots

Not attached.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

A patch changeset is included for the user-visible popup enhancement.