### PR TITLE
style(provider-selector): use compact provider select triggers

### DIFF
--- a/.changeset/compact-provider-selector.md
+++ b/.changeset/compact-provider-selector.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+style(provider-selector): use compact provider select triggers

--- a/src/components/llm-providers/provider-selector.tsx
+++ b/src/components/llm-providers/provider-selector.tsx
@@ -94,7 +94,7 @@ function TranslateGroupedSelect({
       }}
       itemToStringValue={p => p.id}
     >
-      <SelectTrigger className={className}>
+      <SelectTrigger className={className} size="sm">
         <SelectValue placeholder={placeholder}>
           {(provider: ProviderConfig) => (
             <ProviderIcon logo={PROVIDER_ITEMS[provider.provider].logo(theme)} name={provider.name} size="sm" />
@@ -151,7 +151,7 @@ function FlatSelect({
       itemToStringValue={p => p.id}
       disabled={providers.length === 0}
     >
-      <SelectTrigger className={className}>
+      <SelectTrigger className={className} size="sm">
         <SelectValue placeholder={placeholder}>
           {(provider: ProviderConfig) => (
             <ProviderIcon logo={PROVIDER_ITEMS[provider.provider].logo(theme)} name={provider.name} size="sm" />


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [x] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Use the compact `sm` select trigger size for both grouped and flat LLM provider selectors so their controls align with the compact provider icon presentation.

## Related Issue

N/A

## How Has This Been Tested?

- [ ] Added unit tests
- [ ] Verified through manual testing

Automated validation:

- `pnpm exec eslint src/components/llm-providers/provider-selector.tsx`
- `pnpm type-check`
- Push hook: `pnpm lint`, `pnpm type-check`, `pnpm test` (155 test files, 1306 tests passed)

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Added a patch changeset for `@read-frog/extension`.