### PR TITLE
fix(provider-options): match model recommendations case-insensitively

### DIFF
--- a/.changeset/brave-ravens-compare.md
+++ b/.changeset/brave-ravens-compare.md
@@ -2,4 +2,4 @@
 "@read-frog/extension": patch
 ---
 
-fix(provider-options): match DeepSeek recommended options case-insensitively
+fix(provider-options): match recommended provider option models case-insensitively

--- a/.changeset/brave-ravens-compare.md
+++ b/.changeset/brave-ravens-compare.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(provider-options): match DeepSeek recommended options case-insensitively

--- a/src/entrypoints/popup/components/translation-mode-selector.tsx
+++ b/src/entrypoints/popup/components/translation-mode-selector.tsx
@@ -5,10 +5,11 @@ import { i18n } from "#imports"
 import { Button } from "@/components/ui/base-ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/base-ui/tooltip"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { cn } from "@/utils/styles/utils"
 
 const MODE_ICON: Record<TranslationModeType, { icon: string, className?: string, strokeWidth?: number }> = {
-  bilingual: { icon: "system-uicons:translate", strokeWidth: 1.6 },
-  translationOnly: { icon: "mingcute:text-area-line" },
+  bilingual: { icon: "garden:translation-exists-stroke-12" },
+  translationOnly: { icon: "tabler:text-resize" },
 }
 
 const NEXT_MODE: Record<TranslationModeType, TranslationModeType> = {
@@ -53,7 +54,7 @@ export default function TranslationModeSelector() {
           />
         )}
       >
-        <Icon {...MODE_ICON[currentMode]} className="size-4.5" />
+        <Icon {...MODE_ICON[currentMode]} className={cn(currentMode === "translationOnly" && "size-4.5")} />
       </TooltipTrigger>
       <TooltipContent>
         <div className="whitespace-nowrap">

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -130,6 +130,9 @@ describe("getProviderOptions", () => {
       const deepseekV4FlashOptions = getProviderOptions("deepseek-v4-flash", "deepseek")
       expect(deepseekV4FlashOptions.deepseek?.thinking).toEqual({ type: "disabled" })
 
+      const mixedCaseDeepseekV4FlashOptions = getProviderOptions("DeepSeek-V4-Flash", "deepseek")
+      expect(mixedCaseDeepseekV4FlashOptions.deepseek?.thinking).toEqual({ type: "disabled" })
+
       const deepseekV4ProOptions = getProviderOptions("deepseek-v4-pro", "deepseek")
       expect(deepseekV4ProOptions.deepseek?.thinking).toEqual({ type: "disabled" })
 
@@ -336,6 +339,10 @@ describe("getProviderOptions", () => {
 
       expect(getRecommendedProviderOptionsMatch("qwen3.5-flash")?.options).toEqual({
         enableThinking: false,
+      })
+
+      expect(getRecommendedProviderOptionsMatch("DeepSeek-V4-Flash")?.options).toEqual({
+        thinking: { type: "disabled" },
       })
     })
   })

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -12,6 +12,9 @@ describe("getProviderOptions", () => {
       const options = getProviderOptions("gemini-2.5-pro", "google")
       expect(options.google).toBeDefined()
       expect(options.google?.thinkingConfig).toMatchObject({ thinkingBudget: 0, includeThoughts: false })
+
+      const mixedCaseOptions = getProviderOptions("Gemini-2.5-Pro", "google")
+      expect(mixedCaseOptions.google?.thinkingConfig).toMatchObject({ thinkingBudget: 0, includeThoughts: false })
     })
 
     it("should handle thinking models correctly", () => {
@@ -41,6 +44,9 @@ describe("getProviderOptions", () => {
       const options = getProviderOptions("claude-3-5-sonnet", "anthropic")
       expect(options.anthropic).toBeDefined()
       expect(options.anthropic?.thinking).toEqual({ type: "disabled" })
+
+      const mixedCaseOptions = getProviderOptions("Claude-3-5-Sonnet", "anthropic")
+      expect(mixedCaseOptions.anthropic?.thinking).toEqual({ type: "disabled" })
     })
 
     it("should return options for OpenAI o1/o3/o4 reasoning models", () => {
@@ -52,6 +58,9 @@ describe("getProviderOptions", () => {
 
       const o4MiniOptions = getProviderOptions("o4-mini", "openai")
       expect(o4MiniOptions.openai?.reasoningEffort).toBe("minimal")
+
+      const mixedCaseO4MiniOptions = getProviderOptions("O4-Mini", "openai")
+      expect(mixedCaseO4MiniOptions.openai?.reasoningEffort).toBe("minimal")
     })
 
     it("should expose the supported OpenAI GPT-5.4 model ids", () => {
@@ -67,6 +76,9 @@ describe("getProviderOptions", () => {
     it("should return the documented floor for GPT-5 model-specific reasoning", () => {
       const gpt54ProOptions = getProviderOptions("gpt-5.4-pro", "openai")
       expect(gpt54ProOptions.openai?.reasoningEffort).toBe("medium")
+
+      const mixedCaseGpt54ProOptions = getProviderOptions("GPT-5.4-Pro", "openai")
+      expect(mixedCaseGpt54ProOptions.openai?.reasoningEffort).toBe("medium")
 
       const gpt52ProOptions = getProviderOptions("gpt-5.2-pro", "openai")
       expect(gpt52ProOptions.openai?.reasoningEffort).toBe("medium")
@@ -121,6 +133,9 @@ describe("getProviderOptions", () => {
       const grokOptions = getProviderOptions("grok-4-fast-reasoning", "xai")
       expect(grokOptions.xai?.reasoningEffort).toBe("low")
 
+      const mixedCaseGrokOptions = getProviderOptions("Grok-4-Fast-Reasoning", "xai")
+      expect(mixedCaseGrokOptions.xai?.reasoningEffort).toBe("low")
+
       const grok41FastOptions = getProviderOptions("grok-4-1-fast-reasoning", "xai")
       expect(grok41FastOptions).toEqual({})
 
@@ -138,6 +153,9 @@ describe("getProviderOptions", () => {
 
       const cohereReasoningOptions = getProviderOptions("command-a-reasoning-08-2025", "cohere")
       expect(cohereReasoningOptions.cohere?.thinking).toEqual({ type: "disabled" })
+
+      const mixedCaseCohereReasoningOptions = getProviderOptions("Command-A-Reasoning-08-2025", "cohere")
+      expect(mixedCaseCohereReasoningOptions.cohere?.thinking).toEqual({ type: "disabled" })
 
       const moonshotOptions = getProviderOptions("kimi-k2.5", "moonshotai")
       expect(moonshotOptions.moonshotai?.thinking).toEqual({ type: "disabled" })
@@ -343,6 +361,10 @@ describe("getProviderOptions", () => {
 
       expect(getRecommendedProviderOptionsMatch("DeepSeek-V4-Flash")?.options).toEqual({
         thinking: { type: "disabled" },
+      })
+
+      expect(getRecommendedProviderOptionsMatch("GPT-5.4-Pro")?.options).toEqual({
+        reasoningEffort: "medium",
       })
     })
   })

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -57,42 +57,42 @@ export const PURE_TRANSLATE_PROVIDERS = ["google-translate", "microsoft-translat
 
 const OPENAI_GPT5_REASONING_EFFORT_POLICIES: OpenAIGPT5ReasoningEffortPolicy[] = [
   {
-    pattern: /^gpt-5\.4-pro$/,
+    pattern: /^gpt-5\.4-pro$/i,
     supportedValues: ["medium", "high", "xhigh"],
     recommendedValue: "medium",
   },
   {
-    pattern: /^gpt-5\.2-pro$/,
+    pattern: /^gpt-5\.2-pro$/i,
     supportedValues: ["medium", "high", "xhigh"],
     recommendedValue: "medium",
   },
   {
-    pattern: /^gpt-5-pro$/,
+    pattern: /^gpt-5-pro$/i,
     supportedValues: ["high"],
     recommendedValue: "high",
   },
   {
-    pattern: /^(?:gpt-5\.4|gpt-5\.4-mini|gpt-5\.4-nano)$/,
+    pattern: /^(?:gpt-5\.4|gpt-5\.4-mini|gpt-5\.4-nano)$/i,
     supportedValues: ["none", "low", "medium", "high", "xhigh"],
     recommendedValue: "none",
   },
   {
-    pattern: /^gpt-5\.2$/,
+    pattern: /^gpt-5\.2$/i,
     supportedValues: ["none", "low", "medium", "high", "xhigh"],
     recommendedValue: "none",
   },
   {
-    pattern: /^(?:gpt-5\.1|gpt-5\.1-codex|gpt-5\.1-codex-mini)$/,
+    pattern: /^(?:gpt-5\.1|gpt-5\.1-codex|gpt-5\.1-codex-mini)$/i,
     supportedValues: ["none", "low", "medium", "high"],
     recommendedValue: "none",
   },
   {
-    pattern: /^(?:gpt-5|gpt-5-mini|gpt-5-nano|gpt-5-codex)$/,
+    pattern: /^(?:gpt-5|gpt-5-mini|gpt-5-nano|gpt-5-codex)$/i,
     supportedValues: ["minimal", "low", "medium", "high"],
     recommendedValue: "minimal",
   },
   {
-    pattern: /^(?:gpt-5-chat-latest|gpt-5\.1-chat-latest|gpt-5\.2-chat-latest|gpt-5\.3-chat-latest)$/,
+    pattern: /^(?:gpt-5-chat-latest|gpt-5\.1-chat-latest|gpt-5\.2-chat-latest|gpt-5\.3-chat-latest)$/i,
     supportedValues: [],
   },
 ]
@@ -126,28 +126,28 @@ export const LLM_MODEL_OPTIONS: Array<{
 }> = [
   // Gemini - specific patterns first
   {
-    pattern: /^gemini-3(?:\.\d+)?-.*?(?:-preview(?:-customtools)?)?$/,
+    pattern: /^gemini-3(?:\.\d+)?-.*?(?:-preview(?:-customtools)?)?$/i,
     options: { thinkingConfig: { thinkingLevel: "minimal", includeThoughts: false } } satisfies GoogleGenerativeAIProviderOptions as Record<string, JSONValue>,
   },
   {
-    pattern: /^gemini-2\.5-/,
+    pattern: /^gemini-2\.5-/i,
     options: { thinkingConfig: { thinkingBudget: 0, includeThoughts: false } } satisfies GoogleGenerativeAIProviderOptions as Record<string, JSONValue>,
   },
   {
     // Default for all other Gemini models
-    pattern: /^gemini-/,
+    pattern: /^gemini-/i,
     options: { thinkingConfig: { thinkingBudget: 0, includeThoughts: false } } satisfies GoogleGenerativeAIProviderOptions as Record<string, JSONValue>,
   },
 
   // Claude - disable thinking
   {
-    pattern: /^claude-/,
+    pattern: /^claude-/i,
     options: { thinking: { type: "disabled" } } satisfies AnthropicProviderOptions as Record<string, JSONValue>,
   },
 
   // OpenAI reasoning models - use the lowest supported reasoning effort
   {
-    pattern: /^(?:o1|o3|o4-mini)(?:-|$)/,
+    pattern: /^(?:o1|o3|o4-mini)(?:-|$)/i,
     options: { reasoningEffort: "minimal" } satisfies OpenAIResponsesProviderOptions as Record<string, JSONValue>,
   },
 
@@ -158,7 +158,7 @@ export const LLM_MODEL_OPTIONS: Array<{
   // xAI Grok reasoning-capable text models - keep effort at the lowest supported level.
   // Exclude Grok 4.1 Fast because xAI documents that it reasons automatically and errors if reasoning_effort is specified.
   {
-    pattern: /^grok-(?:4(?:-fast-reasoning|-latest|-0709)?|4-1|3(?:-mini)?(?:-latest)?)$/,
+    pattern: /^grok-(?:4(?:-fast-reasoning|-latest|-0709)?|4-1|3(?:-mini)?(?:-latest)?)$/i,
     options: { reasoningEffort: "low" } satisfies XaiProviderOptions as Record<string, JSONValue>,
   },
 
@@ -183,7 +183,7 @@ export const LLM_MODEL_OPTIONS: Array<{
 
   // Cohere reasoning models - disable thinking by default
   {
-    pattern: /^command-a-reasoning(?:-.+)?$/,
+    pattern: /^command-a-reasoning(?:-.+)?$/i,
     options: { thinking: { type: "disabled" } } satisfies CohereLanguageModelOptions as Record<string, JSONValue>,
   },
 

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -177,7 +177,7 @@ export const LLM_MODEL_OPTIONS: Array<{
 
   // DeepSeek reasoning models - disable thinking by default
   {
-    pattern: /^deepseek-(?:reasoner|v4-(?:flash|pro))$/,
+    pattern: /^deepseek-(?:reasoner|v4-(?:flash|pro))$/i,
     options: { thinking: { type: "disabled" } } satisfies DeepSeekLanguageModelOptions as Record<string, JSONValue>,
   },
 


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Make recommended provider option model matchers case-insensitive so custom model names like `DeepSeek-V4-Flash`, `GPT-5.4-Pro`, `Gemini-2.5-Pro`, `Claude-3-5-Sonnet`, `Grok-4-Fast-Reasoning`, and `Command-A-Reasoning-08-2025` trigger the same recommendations as their lowercase forms.

This covers DeepSeek plus the remaining recommendation regexes that were still case-sensitive: OpenAI GPT-5 policies, Gemini, Claude, OpenAI o-series, xAI Grok, and Cohere.

Also adds regression coverage for provider option generation and recommendation metadata lookup.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Validated with:

- `SKIP_FREE_API=true pnpm test src/utils/constants/__tests__/model.test.ts`
- `SKIP_FREE_API=true pnpm test src/utils/host/translate/ui/__tests__/spinner.test.ts`
- pre-push attempt: `nx run @read-frog/extension:lint` passed
- pre-push attempt: `nx run @read-frog/extension:type-check` passed

Note: full pre-push `nx run @read-frog/extension:test` was attempted twice and both runs hit the same unrelated `src/utils/host/translate/ui/__tests__/spinner.test.ts` timeout/call-count failure under full-suite concurrency. That test file passes when run directly.

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Includes a patch changeset for `@read-frog/extension`.