### PR TITLE
feat(selection-toolbar): add custom action settings shortcut

### DIFF
--- a/.changeset/custom-action-tool-button.md
+++ b/.changeset/custom-action-tool-button.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(selection-toolbar): add custom action settings shortcut

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import type { ReactElement } from "react"
+import type { ReactElement, ReactNode } from "react"
 import type {
   BackgroundStructuredObjectStreamSnapshot,
   BackgroundTextStreamSnapshot,
@@ -184,6 +184,7 @@ vi.mock("../../components/selection-toolbar-title-content", () => ({
 
 vi.mock("../../components/selection-toolbar-footer-content", () => ({
   SelectionToolbarFooterContent: ({
+    children,
     paragraphsText,
     onProviderChange,
     onRegenerate,
@@ -191,6 +192,7 @@ vi.mock("../../components/selection-toolbar-footer-content", () => ({
     titleText,
     value,
   }: {
+    children?: ReactNode
     paragraphsText: string | null | undefined
     onProviderChange: (id: string) => void
     onRegenerate: () => void
@@ -204,6 +206,7 @@ vi.mock("../../components/selection-toolbar-footer-content", () => ({
       <div>
         <span data-testid="footer-title">{titleText}</span>
         <span data-testid="footer-paragraphs">{paragraphsText}</span>
+        {children}
         <button type="button" aria-label="Regenerate" onClick={onRegenerate}>
           Regenerate
         </button>
@@ -1303,6 +1306,39 @@ describe("selection toolbar requests", () => {
         action_name: action.name,
       }),
     )
+  })
+
+  it("renders a custom action footer tool button that opens the action options", async () => {
+    streamBackgroundStructuredObjectMock.mockResolvedValue(createStructuredObjectSnapshot({ summary: "done" }))
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    setSelectionState(store, { text: "Selected text" })
+    renderWithProviders(<SelectionToolbarCustomActionButtons />, store)
+
+    const action = DEFAULT_CONFIG.selectionToolbar.customActions[0]
+    if (!action) {
+      throw new Error("Default custom action is missing")
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: action.name }))
+
+    await waitFor(() => {
+      expect(streamBackgroundStructuredObjectMock).toHaveBeenCalledTimes(1)
+    })
+
+    const customizeButton = screen.getByRole("button", { name: "action.customizeCustomAction" })
+
+    expect(customizeButton).toHaveClass("size-7")
+
+    const { sendMessage } = await import("@/utils/message")
+    vi.mocked(sendMessage).mockClear()
+
+    fireEvent.click(customizeButton)
+
+    expect(vi.mocked(sendMessage)).toHaveBeenCalledWith("openOptionsPage", {
+      route: `/custom-actions?actionId=${encodeURIComponent(action.id)}`,
+    })
   })
 
   it("renders the custom action tooltip as non-interactive and closes it on hover leave", async () => {

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/custom-action-tool-button.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/custom-action-tool-button.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import type { SelectionToolbarCustomAction } from "@/types/config/selection-toolbar"
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { TooltipProvider } from "@/components/ui/base-ui/tooltip"
+import { sendMessage } from "@/utils/message"
+import { CustomActionToolButton } from "../custom-action-tool-button"
+
+vi.mock("#i18n", () => ({
+  i18n: {
+    t: (key: string, args?: string[]) => {
+      if (key === "action.customizeCustomAction") {
+        return `Customize ${args?.[0]} action`
+      }
+
+      return key
+    },
+  },
+}))
+
+vi.mock("@/utils/message", () => ({
+  sendMessage: vi.fn(),
+}))
+
+function createAction(): SelectionToolbarCustomAction {
+  return {
+    id: "action 1",
+    name: "Summarize",
+    icon: "tabler:sparkles",
+    providerId: "openai-default",
+    systemPrompt: "system",
+    prompt: "prompt",
+    outputSchema: [
+      {
+        id: "summary",
+        name: "Summary",
+        type: "string",
+        description: "",
+        speaking: false,
+      },
+    ],
+  }
+}
+
+describe("customActionToolButton", () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    document.body.innerHTML = ""
+  })
+
+  it("opens the selected custom action options page", () => {
+    render(
+      <TooltipProvider>
+        <CustomActionToolButton action={createAction()} />
+      </TooltipProvider>,
+    )
+
+    const button = screen.getByRole("button", { name: "Customize Summarize action" })
+
+    expect(button).toHaveAttribute("title", "Customize Summarize action")
+    expect(button).toHaveClass("size-7")
+
+    fireEvent.click(button)
+
+    expect(sendMessage).toHaveBeenCalledWith("openOptionsPage", {
+      route: "/custom-actions?actionId=action%201",
+    })
+  })
+
+  it("renders the action-specific tooltip", async () => {
+    render(
+      <TooltipProvider>
+        <CustomActionToolButton action={createAction()} />
+      </TooltipProvider>,
+    )
+
+    const button = screen.getByRole("button", { name: "Customize Summarize action" })
+
+    fireEvent.mouseEnter(button)
+    fireEvent.focus(button)
+
+    await waitFor(() => {
+      expect(document.querySelector("[data-slot='tooltip-content']")).toHaveTextContent("Customize Summarize action")
+    })
+  })
+})

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/custom-action-tool-button.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/custom-action-tool-button.tsx
@@ -1,0 +1,48 @@
+import type { SelectionToolbarCustomAction } from "@/types/config/selection-toolbar"
+import { IconTool } from "@tabler/icons-react"
+import { useCallback } from "react"
+import { i18n } from "#imports"
+import { buttonVariants } from "@/components/ui/base-ui/button"
+import { sendMessage } from "@/utils/message"
+import { cn } from "@/utils/styles/utils"
+import {
+  SelectionPopoverTooltip,
+  useSelectionTooltipState,
+} from "../../components/selection-tooltip"
+
+export function CustomActionToolButton({
+  action,
+  className,
+}: {
+  action: SelectionToolbarCustomAction
+  className?: string
+}) {
+  const { handlePress, onOpenChange: handleTooltipOpenChange, open: tooltipOpen } = useSelectionTooltipState()
+  const label = i18n.t("action.customizeCustomAction", [action.name])
+
+  const handleClick = useCallback(() => {
+    handlePress()
+    void sendMessage("openOptionsPage", {
+      route: `/custom-actions?actionId=${encodeURIComponent(action.id)}`,
+    })
+  }, [action.id, handlePress])
+
+  return (
+    <SelectionPopoverTooltip
+      content={label}
+      open={tooltipOpen}
+      onOpenChange={handleTooltipOpenChange}
+      render={(
+        <button
+          type="button"
+          className={cn(buttonVariants({ variant: "ghost-secondary", size: "icon-sm" }), className)}
+          onClick={handleClick}
+          aria-label={label}
+          title={label}
+        />
+      )}
+    >
+      <IconTool />
+    </SelectionPopoverTooltip>
+  )
+}

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/provider.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/provider.tsx
@@ -24,6 +24,7 @@ import {
 import { createSelectionToolbarPrecheckError } from "../inline-error"
 import { useSelectionOpenRequestResolver } from "../use-selection-open-request"
 import { CustomActionContent } from "./custom-action-content"
+import { CustomActionToolButton } from "./custom-action-tool-button"
 import { SaveToNotebaseButton } from "./save-to-notebase-button"
 import { isSaveToNotebaseDialogOpenAtom } from "./save-to-notebase-dialog-atom"
 import { SaveToNotebaseDialogHost } from "./save-to-notebase-dialog-host"
@@ -397,11 +398,14 @@ export function SelectionCustomActionProvider({
             onRegenerate={handleRegenerate}
           >
             {activeAction && (
-              <SaveToNotebaseButton
-                action={activeAction}
-                isRunning={displayedIsRunning}
-                result={displayedResult}
-              />
+              <>
+                <SaveToNotebaseButton
+                  action={activeAction}
+                  isRunning={displayedIsRunning}
+                  result={displayedResult}
+                />
+                <CustomActionToolButton action={activeAction} />
+              </>
             )}
           </SelectionToolbarFooterContent>
         </SelectionPopover.Content>

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1011,6 +1011,7 @@ action:
   copied: Copied
   regenerate: Regenerate
   viewContextDetails: Context
+  customizeCustomAction: Customize $1 action
   saveToNotebase: Save to Notebase
   saveToNotebaseSaving: Saving...
   saveToNotebaseSuccess: Saved to Notebase

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -1011,6 +1011,7 @@ action:
   copied: Copiado
   regenerate: Regenerar
   viewContextDetails: Contexto
+  customizeCustomAction: Personalizar la acción $1
   saveToNotebase: Guardar en Notebase
   saveToNotebaseSaving: Guardando...
   saveToNotebaseSuccess: Guardado en Notebase

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -896,6 +896,7 @@ action:
   copied: コピー済み
   regenerate: 再生成
   viewContextDetails: コンテキスト
+  customizeCustomAction: $1 アクションをカスタマイズ
   saveToNotebase: Notebase に保存
   saveToNotebaseSaving: 保存中...
   saveToNotebaseSuccess: Notebase に保存しました

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -896,6 +896,7 @@ action:
   copied: 복사됨
   regenerate: 다시 생성
   viewContextDetails: 컨텍스트
+  customizeCustomAction: $1 작업 맞춤 설정
   saveToNotebase: Notebase에 저장
   saveToNotebaseSaving: 저장 중...
   saveToNotebaseSuccess: Notebase에 저장했습니다

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -896,6 +896,7 @@ action:
   copied: Скопировано
   regenerate: Сгенерировать заново
   viewContextDetails: Контекст
+  customizeCustomAction: Настроить действие $1
   saveToNotebase: Сохранить в Notebase
   saveToNotebaseSaving: Сохранение...
   saveToNotebaseSuccess: Сохранено в Notebase

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -896,6 +896,7 @@ action:
   copied: Kopyalandı
   regenerate: Yeniden oluştur
   viewContextDetails: Bağlam
+  customizeCustomAction: $1 eylemini özelleştir
   saveToNotebase: Notebase'e Kaydet
   saveToNotebaseSaving: Kaydediliyor...
   saveToNotebaseSuccess: Notebase'e kaydedildi

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -896,6 +896,7 @@ action:
   copied: Đã sao chép
   regenerate: Tạo lại
   viewContextDetails: Ngữ cảnh
+  customizeCustomAction: Tùy chỉnh hành động $1
   saveToNotebase: Lưu vào Notebase
   saveToNotebaseSaving: Đang lưu...
   saveToNotebaseSuccess: Đã lưu vào Notebase

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -1011,6 +1011,7 @@ action:
   copied: 已复制
   regenerate: 重新生成
   viewContextDetails: 上下文
+  customizeCustomAction: 定制“$1”动作
   saveToNotebase: 保存到笔记库
   saveToNotebaseSaving: 保存中...
   saveToNotebaseSuccess: 已保存到笔记库

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -896,6 +896,7 @@ action:
   copied: 已複製
   regenerate: 重新產生
   viewContextDetails: 上下文
+  customizeCustomAction: 定製「$1」動作
   saveToNotebase: 儲存到筆記庫
   saveToNotebaseSaving: 儲存中…
   saveToNotebaseSuccess: 已儲存到筆記庫


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)
- [x] 🌐 Internationalization (i18n)
- [x] ✅ Test related (test)

## Description

Adds a footer-right tool/settings shortcut to the custom AI action popover. The button uses the existing bottom-right popover icon-button styling, shows an action-specific tooltip such as `Customize Summarize action`, and opens the Custom AI Actions options page for the active action.

Also adds localized action-focused tooltip copy across all extension locales and a patch changeset.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Commands run:

- `SKIP_FREE_API=true pnpm exec vitest run src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/custom-action-tool-button.test.tsx src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx`
- `pnpm exec eslint src/entrypoints/selection.content/selection-toolbar/custom-action-button/custom-action-tool-button.tsx src/entrypoints/selection.content/selection-toolbar/custom-action-button/provider.tsx src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/custom-action-tool-button.test.tsx src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx`
- `pnpm exec tsc --noEmit`
- Pre-push: `SKIP_FREE_API=true git push -u origin codex/custom-action-tool-button` ran lint, type-check, and tests with `free-api.test.ts` excluded per repo testing guidance.

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The locale source uses WXT `$1` placeholders instead of `%s` so typed `i18n.t` substitutions compile correctly while rendering the requested wording.