### PR TITLE
fix(subtitles): reject unsafe translated SRT timings

### DIFF
--- a/.changeset/translated-srt-timings.md
+++ b/.changeset/translated-srt-timings.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(subtitles): reject unsafe AI timings in translated SRT export

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,8 @@
 - `src/utils/host/translate/api/__tests__/free-api.test.ts` depends on live external translation services.
 - When running tests locally as an AI agent, set `SKIP_FREE_API=true`.
 - If `SKIP_FREE_API=true` is set, treat `free-api.test.ts` as intentionally skipped during local validation.
+
+## PR Notes
+
+- PR titles must use conventional commit format, such as `fix(subtitles): ...`; avoid extra prefixes like `[codex]`.
+- User-facing fixes and features should include a `.changeset/*.md` file for `@read-frog/extension` unless the change intentionally does not need a release.

--- a/src/entrypoints/subtitles.content/__tests__/translated-subtitles-downloader.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/translated-subtitles-downloader.test.ts
@@ -310,6 +310,26 @@ describe("translatedSubtitlesDownloader", () => {
     }))
   })
 
+  it("falls back when optimization hides a raw collapsed AI segment", async () => {
+    mocks.getLocalConfig.mockResolvedValue(createConfig({ aiSegmentation: true }))
+    mocks.aiSegmentBlock.mockResolvedValue([
+      { text: "Hi.", start: 500, end: 501 },
+      { text: "OK.", start: 501, end: 1000 },
+    ])
+
+    await createDownloader([
+      { text: "Hi.", start: 0, end: 500 },
+      { text: "OK.", start: 500, end: 1000 },
+    ], false).downloader.download()
+
+    expect(mocks.aiSegmentBlock).toHaveBeenCalledTimes(1)
+    expect(mocks.downloadSubtitlesAsSrt).toHaveBeenCalledWith(expect.objectContaining({
+      subtitles: [
+        { text: "zh:Hi. OK.", start: 0, end: 1000 },
+      ],
+    }))
+  })
+
   it("falls back to optimized source timing when AI segmentation collapses a cue to a boundary", async () => {
     const followUpText = "Actually this next cue contains enough words that it should remain separate from the short greeting during subtitle optimization across many different transcript timing examples."
     mocks.getLocalConfig.mockResolvedValue(createConfig({ aiSegmentation: true }))

--- a/src/entrypoints/subtitles.content/__tests__/translated-subtitles-downloader.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/translated-subtitles-downloader.test.ts
@@ -199,6 +199,48 @@ describe("translatedSubtitlesDownloader", () => {
     }))
   })
 
+  it("falls back to optimized source timing when AI segmentation creates overlapping export cues", async () => {
+    const questionText = "I was wondering whether you have tested scaling laws when source text is transformed into image inputs across many different controlled experiments."
+    mocks.getLocalConfig.mockResolvedValue(createConfig({ aiSegmentation: true }))
+    mocks.aiSegmentBlock.mockResolvedValue([
+      { text: "Hello.", start: 0, end: 3420 },
+      { text: questionText, start: 500, end: 3420 },
+    ])
+
+    await createDownloader([
+      { text: "Hello.", start: 0, end: 500 },
+      { text: questionText, start: 500, end: 3420 },
+    ], false).downloader.download()
+
+    expect(mocks.downloadSubtitlesAsSrt).toHaveBeenCalledWith(expect.objectContaining({
+      subtitles: [
+        { text: "zh:Hello.", start: 0, end: 500 },
+        { text: `zh:${questionText}`, start: 500, end: 3420 },
+      ],
+    }))
+  })
+
+  it("falls back to optimized source timing when AI segmentation collapses a cue to a boundary", async () => {
+    const followUpText = "Actually this next cue contains enough words that it should remain separate from the short greeting during subtitle optimization across many different transcript timing examples."
+    mocks.getLocalConfig.mockResolvedValue(createConfig({ aiSegmentation: true }))
+    mocks.aiSegmentBlock.mockResolvedValue([
+      { text: "Hi.", start: 500, end: 501 },
+      { text: followUpText, start: 501, end: 3500 },
+    ])
+
+    await createDownloader([
+      { text: "Hi.", start: 0, end: 500 },
+      { text: followUpText, start: 500, end: 3500 },
+    ], false).downloader.download()
+
+    expect(mocks.downloadSubtitlesAsSrt).toHaveBeenCalledWith(expect.objectContaining({
+      subtitles: [
+        { text: "zh:Hi.", start: 0, end: 500 },
+        { text: `zh:${followUpText}`, start: 500, end: 3500 },
+      ],
+    }))
+  })
+
   it("continues without a summary when summary generation fails", async () => {
     mocks.fetchSubtitlesSummary.mockRejectedValue(new Error("Summary failed"))
     await createDownloader(lines(1)).downloader.download()

--- a/src/entrypoints/subtitles.content/translated-subtitles-downloader.ts
+++ b/src/entrypoints/subtitles.content/translated-subtitles-downloader.ts
@@ -248,7 +248,7 @@ export class TranslatedSubtitlesDownloader {
 
     const optimized = optimizeSubtitles(segmented, sourceLanguage)
 
-    if (!this.hasUnsafeExportTiming(chunk, optimized)) {
+    if (!this.hasUnsafeSegmentedExportTiming(chunk, segmented, optimized)) {
       return optimized
     }
 
@@ -269,7 +269,7 @@ export class TranslatedSubtitlesDownloader {
 
         const retryOptimized = optimizeSubtitles(retrySegmented, sourceLanguage)
 
-        if (this.hasUnsafeExportTiming(retryChunk, retryOptimized)) {
+        if (this.hasUnsafeSegmentedExportTiming(retryChunk, retrySegmented, retryOptimized)) {
           return optimizeSubtitles(chunk, sourceLanguage)
         }
 
@@ -284,6 +284,14 @@ export class TranslatedSubtitlesDownloader {
 
   private hasUnsafeExportTiming(source: SubtitlesFragment[], candidate: SubtitlesFragment[]): boolean {
     return this.hasInvalidTimingShape(source, candidate) || this.hasTimingCoverageGap(source, candidate)
+  }
+
+  private hasUnsafeSegmentedExportTiming(
+    source: SubtitlesFragment[],
+    segmented: SubtitlesFragment[],
+    optimized: SubtitlesFragment[],
+  ): boolean {
+    return this.hasInvalidTimingShape(source, segmented) || this.hasUnsafeExportTiming(source, optimized)
   }
 
   private buildSourceSubtitleChunks(

--- a/src/entrypoints/subtitles.content/translated-subtitles-downloader.ts
+++ b/src/entrypoints/subtitles.content/translated-subtitles-downloader.ts
@@ -16,6 +16,7 @@ import { downloadSubtitlesAsSrt } from "@/utils/subtitles/srt"
 import { subtitlesStore, TranslatedDownloadPhase, translatedSubtitlesDownloadStatusAtom } from "./atoms"
 
 const SUCCESS_MESSAGE_DURATION_MS = 4000
+const MAX_COLLAPSED_AI_SEGMENT_DURATION_MS = 1
 
 export class TranslatedSubtitlesDownloader {
   private isDownloading = false
@@ -225,7 +226,7 @@ export class TranslatedSubtitlesDownloader {
 
     const optimized = optimizeSubtitles(segmented, sourceLanguage)
 
-    if (!this.hasTimingCoverageGap(chunk, optimized)) {
+    if (!this.hasUnsafeExportTiming(chunk, optimized)) {
       return optimized
     }
 
@@ -246,7 +247,7 @@ export class TranslatedSubtitlesDownloader {
 
         const retryOptimized = optimizeSubtitles(retrySegmented, sourceLanguage)
 
-        if (this.hasTimingCoverageGap(retryChunk, retryOptimized)) {
+        if (this.hasUnsafeExportTiming(retryChunk, retryOptimized)) {
           return optimizeSubtitles(chunk, sourceLanguage)
         }
 
@@ -257,6 +258,10 @@ export class TranslatedSubtitlesDownloader {
     }
 
     return optimizeSubtitles(chunk, sourceLanguage)
+  }
+
+  private hasUnsafeExportTiming(source: SubtitlesFragment[], candidate: SubtitlesFragment[]): boolean {
+    return this.hasInvalidTimingShape(source, candidate) || this.hasTimingCoverageGap(source, candidate)
   }
 
   private buildSourceSubtitleChunks(
@@ -306,6 +311,36 @@ export class TranslatedSubtitlesDownloader {
       }
 
       if (sourceInterval.end - coveredUntil > MAX_GAP_MS) {
+        return true
+      }
+    }
+
+    return false
+  }
+
+  private hasInvalidTimingShape(source: SubtitlesFragment[], candidate: SubtitlesFragment[]): boolean {
+    if (source.length === 0 || candidate.length === 0) {
+      return true
+    }
+
+    const sourceStart = Math.min(...source.map(fragment => fragment.start))
+    const sourceEnd = Math.max(...source.map(fragment => fragment.end))
+    const sortedCandidates = [...candidate].sort((a, b) => a.start - b.start || a.end - b.end)
+
+    for (let index = 0; index < sortedCandidates.length; index++) {
+      const fragment = sortedCandidates[index]
+      if (
+        !Number.isFinite(fragment.start)
+        || !Number.isFinite(fragment.end)
+        || fragment.end - fragment.start <= MAX_COLLAPSED_AI_SEGMENT_DURATION_MS
+        || fragment.start < sourceStart
+        || fragment.end > sourceEnd
+      ) {
+        return true
+      }
+
+      const previous = sortedCandidates[index - 1]
+      if (previous && previous.end > fragment.start) {
         return true
       }
     }


### PR DESCRIPTION
## Summary

- Reject unsafe AI segmentation timings before translated SRT export accepts them.
- Fall back to optimized source timing when AI output produces overlapping cues, duplicate/covered ranges, collapsed 0-1ms cues, out-of-range timestamps, or large timing coverage gaps.
- Add focused regression coverage for overlapping AI export cues and collapsed boundary cues.

## Root Cause

Translated SRT export trusted AI segmentation timestamps after only checking for large coverage gaps. That allowed structurally bad timing maps to pass through when coverage still looked continuous, such as a short cue stretched over the next cue or a cue collapsed to a 1ms boundary. Translation preserved those fragment timings, and the SRT writer exported the overlap.

## Impact

This is scoped to translated subtitle download/export. It does not change AI segmentation prompts, background segmentation, segmentation cache, YouTube fetching/parsing, realtime subtitle rendering, or the SRT formatter.

## Validation

- `pnpm test src/entrypoints/subtitles.content/__tests__/translated-subtitles-downloader.test.ts`
- `pnpm test src/entrypoints/subtitles.content src/utils/subtitles`
- `pnpm type-check`
- `pnpm exec eslint src/entrypoints/subtitles.content/translated-subtitles-downloader.ts src/entrypoints/subtitles.content/__tests__/translated-subtitles-downloader.test.ts`
- `pnpm test`
- pre-push hook: lint, type-check, full test suite