### PR TITLE
perf(subtitles): speed up translated srt export

### DIFF
--- a/.changeset/fast-translated-srt-export.md
+++ b/.changeset/fast-translated-srt-export.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+perf(subtitles): translate exported SRT batches concurrently

--- a/src/entrypoints/subtitles.content/__tests__/translated-subtitles-downloader.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/translated-subtitles-downloader.test.ts
@@ -118,6 +118,65 @@ describe("translatedSubtitlesDownloader", () => {
     }))
   })
 
+  it("translates exported SRT batches with a bounded two-batch window", async () => {
+    const fragments = lines(15)
+    const resolvers: Array<(value: SubtitlesFragment[]) => void> = []
+    let activeBatches = 0
+    let maxActiveBatches = 0
+    mocks.translateSubtitles.mockImplementation(async () => {
+      activeBatches += 1
+      maxActiveBatches = Math.max(maxActiveBatches, activeBatches)
+      const translatedBatch = await new Promise<SubtitlesFragment[]>(resolve => resolvers.push(resolve))
+      activeBatches -= 1
+      return translatedBatch
+    })
+    const { downloader } = createDownloader(fragments)
+
+    const download = downloader.download()
+    await vi.waitFor(() => expect(mocks.translateSubtitles).toHaveBeenCalledTimes(2))
+
+    expect(maxActiveBatches).toBe(2)
+    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(1, fragments.slice(0, 5), expect.any(Object), expect.any(Object))
+    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(2, fragments.slice(5, 10), expect.any(Object), expect.any(Object))
+
+    resolvers[1](translated(fragments.slice(5, 10)))
+    await vi.waitFor(() => expect(activeBatches).toBe(1))
+    expect(mocks.translateSubtitles).toHaveBeenCalledTimes(2)
+
+    resolvers[0](translated(fragments.slice(0, 5)))
+    await vi.waitFor(() => expect(mocks.translateSubtitles).toHaveBeenCalledTimes(3))
+    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(3, fragments.slice(10), expect.any(Object), expect.any(Object))
+
+    resolvers[2](translated(fragments.slice(10)))
+    await download
+
+    expect(mocks.downloadSubtitlesAsSrt).toHaveBeenCalledWith(expect.objectContaining({
+      subtitles: translated(fragments).map(({ translation, ...fragment }) => ({ ...fragment, text: translation })),
+    }))
+  })
+
+  it("fails closed when one concurrent export batch fails", async () => {
+    const fragments = lines(10)
+    let finishSlowBatch!: (value: SubtitlesFragment[]) => void
+    mocks.translateSubtitles
+      .mockRejectedValueOnce(new Error("Batch failed"))
+      .mockImplementationOnce(async () => await new Promise<SubtitlesFragment[]>((resolve) => {
+        finishSlowBatch = resolve
+      }))
+    const { downloader } = createDownloader(fragments)
+
+    const download = downloader.download()
+    await vi.waitFor(() => expect(mocks.translateSubtitles).toHaveBeenCalledTimes(2))
+    await download
+
+    expect(mocks.downloadSubtitlesAsSrt).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith("Batch failed")
+    expect(status()).toEqual({ phase: TranslatedDownloadPhase.Error, progress: null })
+
+    finishSlowBatch(translated(fragments.slice(5)))
+    await vi.waitFor(() => expect(status()).toEqual({ phase: TranslatedDownloadPhase.Error, progress: null }))
+  })
+
   it.each([
     ["missing result", (fragments: SubtitlesFragment[]) => translated(fragments.slice(0, -1))],
     ["empty translation", (fragments: SubtitlesFragment[]) => fragments.map(fragment => ({ ...fragment, translation: "" }))],
@@ -162,20 +221,24 @@ describe("translatedSubtitlesDownloader", () => {
   })
 
   it("invalidates an in-flight export on dispose and allows a new download", async () => {
-    let finishOldTranslation!: (value: SubtitlesFragment[]) => void
-    mocks.translateSubtitles
-      .mockImplementationOnce(async () => await new Promise<SubtitlesFragment[]>((resolve) => {
-        finishOldTranslation = resolve
-      }))
-      .mockImplementationOnce(async (fragments: SubtitlesFragment[]) => translated(fragments))
-    const { downloader, fetcher } = createDownloader(lines(1))
+    const fragments = lines(10)
+    const finishOldTranslations: Array<(value: SubtitlesFragment[]) => void> = []
+    mocks.translateSubtitles.mockImplementation(async (batch: SubtitlesFragment[]) => {
+      if (finishOldTranslations.length < 2) {
+        return await new Promise<SubtitlesFragment[]>(resolve => finishOldTranslations.push(resolve))
+      }
+      return translated(batch)
+    })
+    const { downloader, fetcher } = createDownloader(fragments)
 
     const oldDownload = downloader.download()
-    await vi.waitFor(() => expect(mocks.translateSubtitles).toHaveBeenCalledTimes(1))
+    await vi.waitFor(() => expect(mocks.translateSubtitles).toHaveBeenCalledTimes(2))
     downloader.dispose()
     const newDownload = downloader.download()
+    await vi.waitFor(() => expect(mocks.translateSubtitles).toHaveBeenCalledTimes(4))
     await newDownload
-    finishOldTranslation(translated(lines(1)))
+    finishOldTranslations[0](translated(fragments.slice(0, 5)))
+    finishOldTranslations[1](translated(fragments.slice(5)))
     await oldDownload
 
     expect(fetcher.fetch).toHaveBeenCalledTimes(2)

--- a/src/entrypoints/subtitles.content/translated-subtitles-downloader.ts
+++ b/src/entrypoints/subtitles.content/translated-subtitles-downloader.ts
@@ -160,38 +160,29 @@ export class TranslatedSubtitlesDownloader {
 
     for (let index = 0; index < batches.length; index += TRANSLATED_EXPORT_BATCH_CONCURRENCY) {
       const batchWindow = batches.slice(index, index + TRANSLATED_EXPORT_BATCH_CONCURRENCY)
-      let windowFailed = false
       const translatedBatchWindow = await Promise.all(
         batchWindow.map(async (batch) => {
-          try {
-            const translatedBatch = await translateSubtitles(batch, videoContext, config)
-            this.assertActive(operationId)
-            if (windowFailed) {
-              return []
-            }
-            if (
-              translatedBatch.length !== batch.length
-              || this.hasIncompleteTranslatedFragments(translatedBatch)
-            ) {
-              throw new Error(i18n.t("subtitles.errors.translatedExportIncomplete"))
-            }
-
-            translatedCount += translatedBatch.length
-            this.setStatus(
-              TranslatedDownloadPhase.Translating,
-              Math.min(100, Math.round((translatedCount / fragments.length) * 100)),
-            )
-
-            return translatedBatch
+          const translatedBatch = await translateSubtitles(batch, videoContext, config)
+          this.assertActive(operationId)
+          if (
+            translatedBatch.length !== batch.length
+            || this.hasIncompleteTranslatedFragments(translatedBatch)
+          ) {
+            throw new Error(i18n.t("subtitles.errors.translatedExportIncomplete"))
           }
-          catch (error) {
-            windowFailed = true
-            throw error
-          }
+
+          return translatedBatch
         }),
       )
       this.assertActive(operationId)
-      translatedFragments.push(...translatedBatchWindow.flat())
+      for (const translatedBatch of translatedBatchWindow) {
+        translatedFragments.push(...translatedBatch)
+        translatedCount += translatedBatch.length
+        this.setStatus(
+          TranslatedDownloadPhase.Translating,
+          Math.min(100, Math.round((translatedCount / fragments.length) * 100)),
+        )
+      }
     }
 
     if (

--- a/src/entrypoints/subtitles.content/translated-subtitles-downloader.ts
+++ b/src/entrypoints/subtitles.content/translated-subtitles-downloader.ts
@@ -16,6 +16,7 @@ import { downloadSubtitlesAsSrt } from "@/utils/subtitles/srt"
 import { subtitlesStore, TranslatedDownloadPhase, translatedSubtitlesDownloadStatusAtom } from "./atoms"
 
 const SUCCESS_MESSAGE_DURATION_MS = 4000
+const TRANSLATED_EXPORT_BATCH_CONCURRENCY = 2
 
 export class TranslatedSubtitlesDownloader {
   private isDownloading = false
@@ -154,23 +155,43 @@ export class TranslatedSubtitlesDownloader {
     const videoContext = await this.buildExportVideoContext(sourceSubtitles, config, operationId, pageTitle)
     this.assertActive(operationId)
     const translatedFragments: SubtitlesFragment[] = []
+    let translatedCount = 0
+    const batches = this.buildTranslationBatches(fragments)
 
-    for (let index = 0; index < fragments.length; index += TRANSLATION_BATCH_SIZE) {
-      const batch = fragments.slice(index, index + TRANSLATION_BATCH_SIZE)
-      const translatedBatch = await translateSubtitles(batch, videoContext, config)
-      this.assertActive(operationId)
-      if (
-        translatedBatch.length !== batch.length
-        || this.hasIncompleteTranslatedFragments(translatedBatch)
-      ) {
-        throw new Error(i18n.t("subtitles.errors.translatedExportIncomplete"))
-      }
+    for (let index = 0; index < batches.length; index += TRANSLATED_EXPORT_BATCH_CONCURRENCY) {
+      const batchWindow = batches.slice(index, index + TRANSLATED_EXPORT_BATCH_CONCURRENCY)
+      let windowFailed = false
+      const translatedBatchWindow = await Promise.all(
+        batchWindow.map(async (batch) => {
+          try {
+            const translatedBatch = await translateSubtitles(batch, videoContext, config)
+            this.assertActive(operationId)
+            if (windowFailed) {
+              return []
+            }
+            if (
+              translatedBatch.length !== batch.length
+              || this.hasIncompleteTranslatedFragments(translatedBatch)
+            ) {
+              throw new Error(i18n.t("subtitles.errors.translatedExportIncomplete"))
+            }
 
-      translatedFragments.push(...translatedBatch)
-      this.setStatus(
-        TranslatedDownloadPhase.Translating,
-        Math.min(100, Math.round((translatedFragments.length / fragments.length) * 100)),
+            translatedCount += translatedBatch.length
+            this.setStatus(
+              TranslatedDownloadPhase.Translating,
+              Math.min(100, Math.round((translatedCount / fragments.length) * 100)),
+            )
+
+            return translatedBatch
+          }
+          catch (error) {
+            windowFailed = true
+            throw error
+          }
+        }),
       )
+      this.assertActive(operationId)
+      translatedFragments.push(...translatedBatchWindow.flat())
     }
 
     if (
@@ -185,6 +206,16 @@ export class TranslatedSubtitlesDownloader {
 
   private hasIncompleteTranslatedFragments(fragments: SubtitlesFragment[]): boolean {
     return fragments.some(fragment => !fragment.translation?.trim())
+  }
+
+  private buildTranslationBatches(fragments: SubtitlesFragment[]): SubtitlesFragment[][] {
+    const batches: SubtitlesFragment[][] = []
+
+    for (let index = 0; index < fragments.length; index += TRANSLATION_BATCH_SIZE) {
+      batches.push(fragments.slice(index, index + TRANSLATION_BATCH_SIZE))
+    }
+
+    return batches
   }
 
   private async buildExportProcessedSubtitles(


### PR DESCRIPTION
## Summary

- translate exported SRT batches with a bounded two-batch window instead of waiting for each outer batch serially
- preserve output order and fail closed if any concurrent batch fails or returns incomplete translations
- cover concurrency, fail-closed behavior, and dispose invalidation with focused downloader tests

## Impact

For multi-batch translated SRT exports, the outer export loop now runs at most two translation batches at a time. With equal-cost batches, wall-clock work changes from `N` sequential rounds to `ceil(N / 2)` rounds, which is at least about a 33% reduction for multi-batch exports and 50% for common even-batch cases. Actual gains still depend on provider latency, request queue limits, and rate limits.

The change intentionally stays local to the downloader path and does not alter the background queue or message protocol.

## Validation

- `SKIP_FREE_API=true pnpm exec vitest run src/entrypoints/subtitles.content/__tests__/translated-subtitles-downloader.test.ts`
- `pnpm exec eslint src/entrypoints/subtitles.content/translated-subtitles-downloader.ts src/entrypoints/subtitles.content/__tests__/translated-subtitles-downloader.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `SKIP_FREE_API=true pnpm test`
- pre-push hook: lint, type-check, and full test suite
- subagent code review: no blocking/high/medium findings after feedback was addressed
