### PR TITLE
fix(subtitles): only capture pointer events on the YouTube drag handle

### DIFF
--- a/.changeset/youtube-subtitle-handle-pointer-events.md
+++ b/.changeset/youtube-subtitle-handle-pointer-events.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(subtitles): only capture pointer events on the YouTube drag handle so player menus stay clickable

--- a/src/entrypoints/subtitles.content/ui/subtitles-view.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-view.tsx
@@ -82,7 +82,7 @@ export function SubtitlesView({ showContent }: SubtitlesViewProps) {
         )}
         style={positionStyle}
       >
-        <div className="w-full flex justify-center pointer-events-auto">
+        <div className="pointer-events-auto">
           <div
             ref={refs.handle}
             className="mb-0.5 px-2 py-1 rounded cursor-grab active:cursor-grabbing bg-black/75 opacity-0 group-hover:opacity-100 active:opacity-100 transition-opacity duration-200"


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

The YouTube translated-subtitle overlay's drag-handle wrapper was `w-full` **and** `pointer-events-auto`, so it intercepted clicks across the **entire width** of the video at the subtitle's vertical position. This blocked YouTube's own controls (playback-speed menu) and the SponsorBlock panel whenever they overlapped that horizontal band — even though only the small six-dot grip should be interactive.

The fix removes the full-width hit area (`subtitles-view.tsx`), leaving only the centered six-dot grip with `pointer-events-auto`. The parent container already has `flex flex-col items-center`, so the handle stays horizontally centered. Hover-to-reveal and vertical dragging are unaffected (`useVerticalDrag` reads container height only, and the `mousedown` listener is bound to the grip, not the wrapper).

## Related Issue

Closes #1630

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

Lint and type-check pass. Verified the playback-speed menu and SponsorBlock panel are clickable in the subtitle band, the handle remains centered and hover-revealed, and vertical drag still repositions/persists the subtitle.

## Screenshots

N/A — interaction/hit-area fix; no visual change to the subtitle or handle.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)