### PR TITLE
feat(subtitles): support YouTube Shorts subtitle translation

### DIFF
--- a/.changeset/youtube-shorts-subtitles.md
+++ b/.changeset/youtube-shorts-subtitles.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(subtitles): support YouTube Shorts subtitle translation

--- a/src/entrypoints/interceptor.content/inject-player-api.ts
+++ b/src/entrypoints/interceptor.content/inject-player-api.ts
@@ -40,6 +40,10 @@ interface SelectedTrackSnapshot {
 }
 
 function findYoutubePlayer(): YouTubePlayer | null {
+  const shortsActive = document.querySelector<YouTubePlayer>("#reel-overlay-container .html5-video-player")
+  if (shortsActive)
+    return shortsActive
+
   return document.querySelector(
     ".html5-video-player.playing-mode, .html5-video-player.paused-mode",
   ) ?? document.querySelector(".html5-video-player")

--- a/src/entrypoints/subtitles.content/init-youtube-subtitles.ts
+++ b/src/entrypoints/subtitles.content/init-youtube-subtitles.ts
@@ -1,7 +1,8 @@
-import { YOUTUBE_EMBED_PATH_PATTERN, YOUTUBE_NAVIGATE_FINISH_EVENT, YOUTUBE_WATCH_URL_PATTERN } from "@/utils/constants/subtitles"
+import { YOUTUBE_EMBED_PATH_PATTERN, YOUTUBE_NAVIGATE_FINISH_EVENT, YOUTUBE_SHORTS_PATH_PATTERN, YOUTUBE_WATCH_URL_PATTERN } from "@/utils/constants/subtitles"
 import { createYoutubeSubtitlesAdapter } from "./platforms/youtube"
 import { createYoutubeCaptionTrackListener } from "./platforms/youtube/caption-track-listener"
 import { getYoutubeConfig } from "./platforms/youtube/config"
+import { watchShortsActiveReel } from "./platforms/youtube/shorts-active-reel-watcher"
 import { mountSubtitlesUI } from "./renderer/mount-subtitles-ui"
 
 function isYoutubeWatch(): boolean {
@@ -12,15 +13,21 @@ function isYoutubeEmbed(): boolean {
   return YOUTUBE_EMBED_PATH_PATTERN.test(window.location.pathname)
 }
 
+function isYoutubeShorts(): boolean {
+  return YOUTUBE_SHORTS_PATH_PATTERN.test(window.location.pathname)
+}
+
 export function initYoutubeSubtitles() {
   let initialized = false
   let adapter: ReturnType<typeof createYoutubeSubtitlesAdapter> | null = null
 
+  const shorts = isYoutubeShorts()
   const embedded = isYoutubeEmbed()
-  const config = getYoutubeConfig({ embedded })
+  const mode = shorts ? "shorts" : embedded ? "embed" : "watch"
+  const config = getYoutubeConfig({ mode })
 
   const tryInit = async () => {
-    if (!isYoutubeWatch() && !embedded) {
+    if (!isYoutubeWatch() && !embedded && !shorts) {
       return
     }
 
@@ -47,11 +54,16 @@ export function initYoutubeSubtitles() {
     })
     trackListener.start()
     void adapter.initialize()
+
+    if (shorts) {
+      const shortsAdapter = adapter
+      watchShortsActiveReel(() => shortsAdapter.notifyNavigation())
+    }
   }
 
   void tryInit()
 
-  if (!embedded) {
+  if (!embedded && !shorts) {
     window.addEventListener(YOUTUBE_NAVIGATE_FINISH_EVENT, () => void tryInit())
   }
 }

--- a/src/entrypoints/subtitles.content/platforms/index.ts
+++ b/src/entrypoints/subtitles.content/platforms/index.ts
@@ -6,11 +6,13 @@ export interface ControlsConfig {
 
 export interface PlatformConfig {
   embedded?: boolean
+  silentErrors?: boolean
+  containerShrinkRatio?: (container: HTMLElement) => number | null
 
   selectors: {
     video: string
     playerContainer: string
-    controlsBar: string
+    controlsBar?: string
     nativeSubtitles: string
   }
 

--- a/src/entrypoints/subtitles.content/platforms/youtube/config.ts
+++ b/src/entrypoints/subtitles.content/platforms/youtube/config.ts
@@ -7,56 +7,90 @@ import {
 } from "@/utils/constants/subtitles"
 import { getYoutubeVideoId } from "@/utils/subtitles/video-id"
 
+type YoutubeMode = "watch" | "embed" | "shorts"
+
 interface YoutubeConfigOptions {
-  embedded?: boolean
+  mode?: YoutubeMode
 }
 
-export function getYoutubeConfig(options: YoutubeConfigOptions = {}): PlatformConfig {
-  const { embedded } = options
+const NAVIGATE_EVENTS = {
+  navigateStart: YOUTUBE_NAVIGATE_START_EVENT,
+  navigateFinish: YOUTUBE_NAVIGATE_FINISH_EVENT,
+}
 
-  return {
-    embedded,
+const SHORTS_ACTIVE_PLAYER = "#reel-overlay-container .html5-video-player"
 
+const YOUTUBE_MODE_CONFIGS: Record<YoutubeMode, PlatformConfig> = {
+  watch: {
+    embedded: false,
     selectors: {
       video: "video.html5-main-video",
       playerContainer: "#movie_player.html5-video-player",
-      controlsBar: embedded ? ".quick-actions-wrapper" : "#movie_player .ytp-right-controls",
+      controlsBar: "#movie_player .ytp-right-controls",
       nativeSubtitles: YOUTUBE_NATIVE_SUBTITLES_CLASS,
     },
-
-    events: embedded
-      ? {}
-      : {
-          navigateStart: YOUTUBE_NAVIGATE_START_EVENT,
-          navigateFinish: YOUTUBE_NAVIGATE_FINISH_EVENT,
-        },
-
-    controls: embedded
-      ? {
-          findVideoContainer: () => document.querySelector<HTMLElement>("#movie_player"),
-          measureHeight: () => {
-            const wrapper = document.querySelector(".quick-actions-wrapper")
-            const player = document.querySelector("#movie_player")
-            const progressBar = player?.querySelector(".ytp-progress-bar-container")
-            if (!wrapper || !progressBar)
-              return DEFAULT_CONTROLS_HEIGHT
-            return wrapper.getBoundingClientRect().top - progressBar.getBoundingClientRect().top
-          },
-          checkVisibility: () => true,
-        }
-      : {
-          measureHeight: (container) => {
-            const player = container.closest(".html5-video-player")
-            const progressBar = player?.querySelector(".ytp-progress-bar-container")
-            const controlsBar = progressBar?.parentElement
-            return controlsBar?.getBoundingClientRect().height ?? DEFAULT_CONTROLS_HEIGHT
-          },
-          checkVisibility: (container) => {
-            const player = container.closest(".html5-video-player")
-            return !!player && !player.classList.contains("ytp-autohide")
-          },
-        },
-
+    events: NAVIGATE_EVENTS,
+    controls: {
+      measureHeight: (container) => {
+        const player = container.closest(".html5-video-player")
+        const progressBar = player?.querySelector(".ytp-progress-bar-container")
+        const controlsBar = progressBar?.parentElement
+        return controlsBar?.getBoundingClientRect().height ?? DEFAULT_CONTROLS_HEIGHT
+      },
+      checkVisibility: (container) => {
+        const player = container.closest(".html5-video-player")
+        return !!player && !player.classList.contains("ytp-autohide")
+      },
+    },
     getVideoId: getYoutubeVideoId,
-  }
+  },
+
+  embed: {
+    embedded: true,
+    selectors: {
+      video: "video.html5-main-video",
+      playerContainer: "#movie_player.html5-video-player",
+      controlsBar: ".quick-actions-wrapper",
+      nativeSubtitles: YOUTUBE_NATIVE_SUBTITLES_CLASS,
+    },
+    events: {},
+    controls: {
+      findVideoContainer: () => document.querySelector<HTMLElement>("#movie_player"),
+      measureHeight: () => {
+        const wrapper = document.querySelector(".quick-actions-wrapper")
+        const player = document.querySelector("#movie_player")
+        const progressBar = player?.querySelector(".ytp-progress-bar-container")
+        if (!wrapper || !progressBar)
+          return DEFAULT_CONTROLS_HEIGHT
+        return wrapper.getBoundingClientRect().top - progressBar.getBoundingClientRect().top
+      },
+      checkVisibility: () => true,
+    },
+    getVideoId: getYoutubeVideoId,
+  },
+
+  shorts: {
+    embedded: true,
+    silentErrors: true,
+    containerShrinkRatio: (container) => {
+      const ratio = Number.parseFloat(getComputedStyle(container).getPropertyValue("--ytd-shorts-player-ratio"))
+      return Number.isFinite(ratio) && ratio > 0 ? ratio : null
+    },
+    selectors: {
+      video: "video.html5-main-video",
+      playerContainer: SHORTS_ACTIVE_PLAYER,
+      nativeSubtitles: YOUTUBE_NATIVE_SUBTITLES_CLASS,
+    },
+    events: {},
+    controls: {
+      findVideoContainer: () => document.querySelector<HTMLElement>(SHORTS_ACTIVE_PLAYER),
+      measureHeight: () => DEFAULT_CONTROLS_HEIGHT,
+      checkVisibility: () => true,
+    },
+    getVideoId: getYoutubeVideoId,
+  },
+}
+
+export function getYoutubeConfig({ mode = "watch" }: YoutubeConfigOptions = {}): PlatformConfig {
+  return YOUTUBE_MODE_CONFIGS[mode]
 }

--- a/src/entrypoints/subtitles.content/platforms/youtube/shorts-active-reel-watcher.ts
+++ b/src/entrypoints/subtitles.content/platforms/youtube/shorts-active-reel-watcher.ts
@@ -1,0 +1,28 @@
+import debounce from "debounce"
+
+const OVERLAY_CONTAINER_SELECTOR = "#reel-overlay-container"
+const ACTIVE_REEL_SELECTOR = ".reel-video-in-sequence-new"
+const SHORTS_CONTAINER_SELECTOR = "ytd-shorts"
+const ACTIVE_REEL_CHANGE_DEBOUNCE_MS = 200
+
+function getActiveReel(): HTMLElement | null {
+  return document.querySelector(OVERLAY_CONTAINER_SELECTOR)?.closest<HTMLElement>(ACTIVE_REEL_SELECTOR) ?? null
+}
+
+export function watchShortsActiveReel(onActiveReelChanged: () => void) {
+  let lastReel = getActiveReel()
+  const trigger = debounce(onActiveReelChanged, ACTIVE_REEL_CHANGE_DEBOUNCE_MS)
+
+  const root = document.querySelector(SHORTS_CONTAINER_SELECTOR) ?? document.body
+  const observer = new MutationObserver(() => {
+    const reel = getActiveReel()
+    if (!reel || reel === lastReel) {
+      return
+    }
+
+    lastReel = reel
+    trigger()
+  })
+
+  observer.observe(root, { childList: true, subtree: true })
+}

--- a/src/entrypoints/subtitles.content/ui/state-message.tsx
+++ b/src/entrypoints/subtitles.content/ui/state-message.tsx
@@ -26,6 +26,9 @@ export function StateMessage({ state, message }: StateMessageProps) {
 
   const text = state === "error" ? message : getText()
 
+  if (!text)
+    return null
+
   return (
     <div
       className={`${STATE_MESSAGE_CLASS} absolute left-4 bottom-18 pointer-events-auto`}

--- a/src/entrypoints/subtitles.content/ui/subtitles-ui-context.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-ui-context.tsx
@@ -10,6 +10,7 @@ interface SubtitlesUIContextValue {
   downloadTranslatedSubtitles: () => Promise<void>
   controlsConfig?: ControlsConfig
   embedded?: boolean
+  containerShrinkRatio?: (container: HTMLElement) => number | null
 }
 
 export const SubtitlesUIContext = createContext<SubtitlesUIContextValue | null>(null)
@@ -24,7 +25,7 @@ export function useSubtitlesUI() {
 
 export type SubtitlesProvidersAdapter = Pick<
   UniversalVideoAdapter,
-  "downloadSourceSubtitles" | "downloadTranslatedSubtitles" | "embedded" | "getControlsConfig" | "toggleSubtitlesManually"
+  "downloadSourceSubtitles" | "downloadTranslatedSubtitles" | "embedded" | "containerShrinkRatio" | "getControlsConfig" | "toggleSubtitlesManually"
 >
 
 export function SubtitlesProviders({
@@ -43,6 +44,7 @@ export function SubtitlesProviders({
           downloadTranslatedSubtitles: adapter.downloadTranslatedSubtitles,
           controlsConfig: adapter.getControlsConfig(),
           embedded: adapter.embedded,
+          containerShrinkRatio: adapter.containerShrinkRatio,
         }}
       >
         {children}

--- a/src/entrypoints/subtitles.content/ui/subtitles-view.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-view.tsx
@@ -1,13 +1,11 @@
 import { IconGripHorizontal } from "@tabler/icons-react"
-import { useAtomValue, useSetAtom } from "jotai"
-import { Activity, useRef } from "react"
+import { useAtomValue } from "jotai"
+import { Activity } from "react"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { SUBTITLES_VIEW_CLASS } from "@/utils/constants/subtitles"
 import { cn } from "@/utils/styles/utils"
 import { currentSubtitleAtom } from "../atoms"
 import { MainSubtitle, TranslationSubtitle } from "./subtitle-lines"
-import { useSubtitlesUI } from "./subtitles-ui-context"
-import { useControlsInfo } from "./use-controls-visible"
 import { useVerticalDrag } from "./use-vertical-drag"
 
 interface SubtitlesViewProps {
@@ -48,20 +46,11 @@ function SubtitlesContent() {
 }
 
 export function SubtitlesView({ showContent }: SubtitlesViewProps) {
-  const windowRef = useRef<HTMLDivElement>(null)
-  const { controlsConfig } = useSubtitlesUI()
-  const { controlsVisible, controlsHeight } = useControlsInfo(windowRef, controlsConfig)
-  const setVideoSubtitles = useSetAtom(configFieldsAtomMap.videoSubtitles)
-
-  const { refs, windowStyle, positionStyle, isDragging } = useVerticalDrag({
-    controlsVisible,
-    controlsHeight,
-    onDragEnd: pos => void setVideoSubtitles({ position: pos }),
-  })
+  const { refs, windowStyle, positionStyle, isDragging } = useVerticalDrag()
 
   return (
     <div
-      ref={windowRef}
+      ref={refs.window}
       style={{
         width: windowStyle.width,
         height: windowStyle.height,

--- a/src/entrypoints/subtitles.content/ui/use-vertical-drag.ts
+++ b/src/entrypoints/subtitles.content/ui/use-vertical-drag.ts
@@ -1,10 +1,13 @@
 import type { RefObject } from "react"
 import type { SubtitlePosition } from "../atoms"
-import { useAtom } from "jotai"
+import { useAtom, useSetAtom } from "jotai"
 import { useEffect, useEffectEvent, useRef, useState } from "react"
+import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { DEFAULT_SUBTITLE_POSITION } from "@/utils/constants/subtitles"
 import { getContainingShadowRoot } from "@/utils/host/dom/node"
 import { subtitlesPositionAtom } from "../atoms"
+import { useSubtitlesUI } from "./subtitles-ui-context"
+import { useControlsInfo } from "./use-controls-visible"
 
 const BASE_FONT_RATIO = 0.03
 
@@ -79,13 +82,11 @@ function calculateAnchorPosition(ctx: AnchorPositionContext): SubtitlePosition {
   return { percent: Math.max(0, percent), anchor: "bottom" }
 }
 
-interface UseVerticalDragOptions {
-  controlsVisible: boolean
-  controlsHeight: number
-  onDragEnd?: (position: SubtitlePosition) => void
-}
-
-export function useVerticalDrag({ controlsVisible, controlsHeight, onDragEnd }: UseVerticalDragOptions) {
+export function useVerticalDrag() {
+  const { controlsConfig, containerShrinkRatio } = useSubtitlesUI()
+  const windowRef = useRef<HTMLDivElement>(null)
+  const { controlsVisible, controlsHeight } = useControlsInfo(windowRef, controlsConfig)
+  const setVideoSubtitles = useSetAtom(configFieldsAtomMap.videoSubtitles)
   const containerRef = useRef<HTMLDivElement>(null)
   const handleRef = useRef<HTMLDivElement>(null)
   const isDraggingRef = useRef(false)
@@ -104,10 +105,12 @@ export function useVerticalDrag({ controlsVisible, controlsHeight, onDragEnd }: 
     if (!rects)
       return
 
+    const shrinkRatio = containerShrinkRatio?.(rects.videoContainer) ?? 1
+
     setWindowStyle({
       width: rects.videoRect.width,
       height: rects.videoRect.height,
-      fontSize: rects.videoRect.height * BASE_FONT_RATIO,
+      fontSize: rects.videoRect.height * BASE_FONT_RATIO * shrinkRatio,
     })
   })
 
@@ -174,7 +177,7 @@ export function useVerticalDrag({ controlsVisible, controlsHeight, onDragEnd }: 
     isDraggingRef.current = false
     setIsDragging(false)
 
-    onDragEnd?.(position)
+    void setVideoSubtitles({ position })
   })
 
   const clampPosition = useEffectEvent(() => {
@@ -234,7 +237,7 @@ export function useVerticalDrag({ controlsVisible, controlsHeight, onDragEnd }: 
     : { bottom: `${position.percent + controlsOffsetPercent}%`, top: "unset" }
 
   return {
-    refs: { container: containerRef, handle: handleRef },
+    refs: { window: windowRef, container: containerRef, handle: handleRef },
     windowStyle,
     positionStyle,
     isDragging,

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -53,6 +53,10 @@ export class UniversalVideoAdapter {
     return this.config.embedded
   }
 
+  get containerShrinkRatio() {
+    return this.config.containerShrinkRatio
+  }
+
   get videoIdChanged() {
     const currentVideoId = this.config.getVideoId?.()
     return !!(this.sessionVideoId && currentVideoId && currentVideoId !== this.sessionVideoId)
@@ -75,7 +79,6 @@ export class UniversalVideoAdapter {
     void this.renderTranslateButton()
 
     await this.initializeScheduler()
-    void this.getOrLoadSourceSubtitles().catch(() => {})
     await this.tryAutoStartSubtitles()
     this.setupNavigationListeners()
   }
@@ -266,6 +269,17 @@ export class UniversalVideoAdapter {
     }, NAVIGATION_HANDLER_DELAY)
   }
 
+  notifyNavigation() {
+    this.hasPendingNavigationReset = true
+    this.clearVisibleStateForNavigation()
+
+    this.clearNavigationReinitTimeout()
+    this.navigationReinitTimeoutId = setTimeout(() => {
+      this.navigationReinitTimeoutId = null
+      void this.handleNavigation()
+    }, NAVIGATION_HANDLER_DELAY)
+  }
+
   private async handleNavigation() {
     if (!this.hasPendingNavigationReset || !this.videoIdChanged) {
       return
@@ -276,12 +290,16 @@ export class UniversalVideoAdapter {
     void this.renderTranslateButton()
 
     await this.initializeScheduler()
-    void this.getOrLoadSourceSubtitles().catch(() => {})
     await this.tryAutoStartSubtitles()
   }
 
   private async renderTranslateButton() {
-    const container = await waitForElement(this.config.selectors.controlsBar)
+    const controlsBar = this.config.selectors.controlsBar
+    if (!controlsBar) {
+      return
+    }
+
+    const container = await waitForElement(controlsBar)
     if (!container) {
       if (!this.config.embedded)
         toast.error(i18n.t("subtitles.errors.controlsBarNotFound"))
@@ -476,7 +494,7 @@ export class UniversalVideoAdapter {
         toast.error(errorMessage)
       }
       else {
-        this.subtitlesScheduler?.setState("error", { message: errorMessage })
+        this.subtitlesScheduler?.setState("error", { message: this.config.silentErrors ? "" : errorMessage })
       }
     }
   }

--- a/src/utils/constants/subtitles.ts
+++ b/src/utils/constants/subtitles.ts
@@ -27,6 +27,7 @@ export const TRANSLATE_BUTTON_CLASS = "read-frog-subtitles-translate-button"
 // YouTube specific
 export const YOUTUBE_WATCH_URL_PATTERN = "youtube.com/watch"
 export const YOUTUBE_EMBED_PATH_PATTERN = /\/embed\/[^/?]+/
+export const YOUTUBE_SHORTS_PATH_PATTERN = /\/shorts\/[^/?]+/
 export const YOUTUBE_NAVIGATE_START_EVENT = "yt-navigate-start"
 export const YOUTUBE_NAVIGATE_FINISH_EVENT = "yt-navigate-finish"
 export const YOUTUBE_NATIVE_SUBTITLES_CLASS = ".ytp-caption-window-container"

--- a/src/utils/subtitles/video-id/youtube.ts
+++ b/src/utils/subtitles/video-id/youtube.ts
@@ -1,4 +1,5 @@
 const EMBED_PATH_PATTERN = /\/embed\/([^/?]+)/
+const SHORTS_PATH_PATTERN = /\/shorts\/([^/?]+)/
 const SHORT_URL_PATH_PATTERN = /^\/([^/?]+)/
 
 export function getYoutubeVideoId(): string | null {
@@ -10,6 +11,10 @@ export function getYoutubeVideoId(): string | null {
   const embedMatch = window.location.pathname.match(EMBED_PATH_PATTERN)
   if (embedMatch)
     return embedMatch[1]
+
+  const shortsMatch = window.location.pathname.match(SHORTS_PATH_PATTERN)
+  if (shortsMatch)
+    return shortsMatch[1]
 
   if (window.location.hostname === "youtu.be") {
     const pathMatch = window.location.pathname.match(SHORT_URL_PATH_PATTERN)


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)

## Description

Adds bilingual subtitle translation support for **YouTube Shorts** (`youtube.com/shorts/<id>`), alongside the existing watch and embed modes.

Key points:
- **Mode-based config table** (`getYoutubeConfig` → `YOUTUBE_MODE_CONFIGS`) with a new `shorts` entry; video-id extraction now handles `/shorts/<id>`.
- **Active-reel scoping**: Shorts preloads multiple reel players with duplicate `#shorts-player` ids, so the player container and the main-world `findYoutubePlayer()` bridge are scoped to the active reel via `#reel-overlay-container`, fixing wrong-reel `VIDEO_ID_MISMATCH` (false "no subtitles").
- **Reel-switch handling**: a lightweight watcher detects the active reel change (the `#reel-overlay-container` move) and drives re-init through the adapter's existing navigation flow (`notifyNavigation()` — clears old subtitles immediately, debounced/coalesced, `videoIdChanged`-guarded), so swiping re-fetches for the new short without stale subtitles or duplicate requests.
- **Container scaling**: subtitle font scales by the player's `--ytd-shorts-player-ratio` so the overlay fits the actual video area.
- **Quiet failures**: Shorts has many no-subtitle videos, so subtitle errors are suppressed in shorts (`silentErrors`), and the state bubble is hidden when its message is empty.
- Removed a redundant concurrent `getOrLoadSourceSubtitles()` prefetch that caused two simultaneous `timedtext` requests per load/navigation.

## Related Issue

Closes #1416

## How Has This Been Tested?

- [x] Verified through manual testing
- [x] Existing unit tests pass (`pnpm test`: 1316 passed)

Also verified `pnpm type-check` and `pnpm lint` clean. Manually tested on Shorts: subtitles render and translate, bottom-positioned and ratio-scaled; swiping between shorts clears and reloads for the new video with a single timedtext request; no-subtitle shorts no longer pop an error; watch/embed unaffected.

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)