### PR TITLE
fix(youtube-subtitles): recover off-track dialogue in stylized karaoke videos

### DIFF
--- a/.changeset/fix-stylized-karaoke-offtrack-subtitles.md
+++ b/.changeset/fix-stylized-karaoke-offtrack-subtitles.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(youtube-subtitles): recover off-track dialogue dropped in stylized karaoke videos

--- a/src/utils/subtitles/__tests__/youtube-parsers.test.ts
+++ b/src/utils/subtitles/__tests__/youtube-parsers.test.ts
@@ -236,6 +236,59 @@ describe("youTube Subtitle Parsers", () => {
       expect(result[0].text).toBe("Do you think even the worst person")
       expect(result[1].text).toBe("Can change...?")
     })
+
+    it("should keep off-track dialogue that ends before the main track starts", () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 1000, dDurationMs: 1000, wpWinPosId: 2, segs: [{ utf8: "​嘿呀" }] },
+        { tStartMs: 2000, dDurationMs: 1000, wpWinPosId: 2, segs: [{ utf8: "​你一直很忙,對吧?" }] },
+        { tStartMs: 10000, dDurationMs: 200, wpWinPosId: 3, segs: [{ utf8: "​Can /​change...?" }] },
+        { tStartMs: 10200, dDurationMs: 200, wpWinPosId: 3, segs: [{ utf8: "​Can change...?/" }] },
+      ]
+
+      const result = parseStylizedKaraokeSubtitles(events)
+
+      expect(result).toHaveLength(3)
+      expect(result[0].text).toBe("嘿呀")
+      expect(result[1].text).toBe("你一直很忙,對吧?")
+      expect(result[2].text).toBe("Can change...?")
+      expect(result[0].start).toBeLessThan(result[1].start)
+    })
+
+    it("should still drop off-track events that overlap the main track", () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 1000, dDurationMs: 200, wpWinPosId: 2, segs: [{ utf8: "​Do you think even the wor/​st person" }] },
+        { tStartMs: 1200, dDurationMs: 200, wpWinPosId: 2, segs: [{ utf8: "​Do you think even the worst person/" }] },
+        { tStartMs: 1100, dDurationMs: 200, wpWinPosId: 3, segs: [{ utf8: "Sparse overlay" }] },
+      ]
+
+      const result = parseStylizedKaraokeSubtitles(events)
+
+      expect(result).toHaveLength(1)
+      expect(result[0].text).toBe("Do you think even the worst person")
+    })
+
+    it("should recover intro dialogue while still collapsing repeated song frames", () => {
+      const events: YoutubeTimedText[] = [
+        { tStartMs: 217, dDurationMs: 1835, wpWinPosId: 2, pPenId: 2, segs: [{ utf8: "​嘿呀" }] },
+        { tStartMs: 2052, dDurationMs: 1936, wpWinPosId: 2, pPenId: 2, segs: [{ utf8: "​你一直很忙,對吧?" }] },
+        { tStartMs: 58008, dDurationMs: 2069, wpWinPosId: 3, segs: [{ utf8: "​你知道嗎，我總是在想" }] },
+        { tStartMs: 58008, dDurationMs: 2069, wpWinPosId: 3, segs: [{ utf8: "​你知道嗎，我總是在想" }] },
+        { tStartMs: 58008, dDurationMs: 2069, wpWinPosId: 3, segs: [{ utf8: "​你知道嗎，我總是在想" }] },
+        { tStartMs: 60077, dDurationMs: 1935, wpWinPosId: 3, segs: [{ utf8: "​關於你我相戰" }] },
+      ] as YoutubeTimedText[]
+
+      const result = parseStylizedKaraokeSubtitles(events)
+
+      const texts = result.map(fragment => fragment.text)
+      expect(texts).toContain("嘿呀")
+      expect(texts).toContain("你一直很忙,對吧?")
+      expect(texts.filter(text => text === "你知道嗎，我總是在想")).toHaveLength(1)
+
+      for (let i = 1; i < result.length; i++) {
+        expect(result[i].start).toBeGreaterThanOrEqual(result[i - 1].start)
+        expect(result[i - 1].end).toBeLessThanOrEqual(result[i].start)
+      }
+    })
   })
 
   describe("scrolling ASR Parser", () => {

--- a/src/utils/subtitles/fetchers/youtube/parser/stylized-karaoke-parser.ts
+++ b/src/utils/subtitles/fetchers/youtube/parser/stylized-karaoke-parser.ts
@@ -111,18 +111,11 @@ function shouldReplaceFamilyText(currentText: string, nextText: string): boolean
   return nextText.length > currentText.length
 }
 
-export function parseStylizedKaraokeSubtitles(events: YoutubeTimedText[]): SubtitlesFragment[] {
-  const mainTrackId = selectMainTrack(events)
-  if (mainTrackId === null)
-    return []
-
+function mergeFamilies(events: YoutubeTimedText[]): SubtitlesFragment[] {
   const result: SubtitlesFragment[] = []
   let currentFamily: SentenceFamily | null = null
 
   for (const event of events) {
-    if (event.wpWinPosId !== mainTrackId)
-      continue
-
     const text = cleanStylizedText(getEventText(event))
     if (!text)
       continue
@@ -172,6 +165,44 @@ export function parseStylizedKaraokeSubtitles(events: YoutubeTimedText[]): Subti
       start: currentFamily.start,
       end: currentFamily.end,
     })
+  }
+
+  return result
+}
+
+function overlapsAny(start: number, end: number, intervals: SubtitlesFragment[]): boolean {
+  return intervals.some(interval => start < interval.end && end > interval.start)
+}
+
+export function parseStylizedKaraokeSubtitles(events: YoutubeTimedText[]): SubtitlesFragment[] {
+  const mainTrackId = selectMainTrack(events)
+  if (mainTrackId === null)
+    return []
+
+  const mainFragments = mergeFamilies(
+    events.filter(event => event.wpWinPosId === mainTrackId),
+  )
+
+  const offTrackEvents = events.filter((event) => {
+    if (event.wpWinPosId === mainTrackId)
+      return false
+    if (!cleanStylizedText(getEventText(event)))
+      return false
+
+    const start = event.tStartMs
+    const end = start + (event.dDurationMs ?? 0)
+    return !overlapsAny(start, end, mainFragments)
+  })
+
+  const offFragments = mergeFamilies(offTrackEvents)
+
+  const merged = [...mainFragments, ...offFragments].sort(
+    (left, right) => left.start - right.start,
+  )
+
+  const result: SubtitlesFragment[] = []
+  for (const fragment of merged) {
+    pushFragment(result, { ...fragment })
   }
 
   return result


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Some YouTube videos use a **mixed subtitle format**: spoken dialogue on one `wpWinPosId` track and sung lyrics (drawn as pen-layered duplicates with zero-width markers) on another. `detectFormat` classifies the whole stream as `karaoke-stylized`, and `parseStylizedKaraokeSubtitles` previously selected only the **densest main track** and `continue`d past every event on any other track.

As a result, the non-overlapping intro dialogue — which lives on a different track than the lyrics — was silently discarded. For the reported video (`cb3XdH78Jb4`), this dropped the entire first ~40 seconds of dialogue.

### Fix

`parseStylizedKaraokeSubtitles` now runs in two passes:

1. **Main track** — the existing sentence-family dedup/expansion merge (unchanged output).
2. **Off-track recovery** — events on other tracks that do **not temporally overlap** any main-track fragment are merged back in (intro dialogue, interludes, outro). Events that *do* overlap a main fragment are still dropped, since those are the simultaneous decorative overlay layers the existing behavior intentionally suppresses.

Fragments from both passes are merged in time order with the existing overlap-fixer. The shared merge logic was extracted into a `mergeFamilies` helper reused by both passes.

## Related Issue

Closes #1559

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Added 4 tests to `youtube-parsers.test.ts`: off-track intro dialogue is kept and ordered first, overlapping overlays are still dropped (guards the original behavior), and a regression fixture from the reported video confirms the intro lines survive while the triple-drawn song frames still collapse into single cues with no overlap. Full subtitle suite passes (100 tests). Manually verified the 0–40s dialogue now renders on the reported video via `wxt` dev build.

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.