### PR TITLE
fix(subtitles): mount subtitle toast at body level for correct styling and stacking

### DIFF
--- a/.changeset/fix-youtube-subtitle-toast-overlay.md
+++ b/.changeset/fix-youtube-subtitle-toast-overlay.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(subtitles): render subtitle toast at body level so it shows above the player with correct sonner styling

--- a/src/entrypoints/subtitles.content/renderer/mount-subtitles-toast.tsx
+++ b/src/entrypoints/subtitles.content/renderer/mount-subtitles-toast.tsx
@@ -1,0 +1,50 @@
+import ReactDOM from "react-dom/client"
+import { Toaster } from "sonner"
+import themeCSS from "@/assets/styles/theme.css?inline"
+import { NOTRANSLATE_CLASS, REACT_SHADOW_HOST_CLASS } from "@/utils/constants/dom-labels"
+import { SUBTITLES_THEME } from "@/utils/constants/subtitles"
+import { ShadowHostBuilder } from "@/utils/react-shadow-host/shadow-host-builder"
+import { mirrorDynamicStyles } from "@/utils/styles"
+import { applyTheme } from "@/utils/theme"
+
+const SUBTITLES_TOAST_HOST_ID = "read-frog-subtitles-toast-host"
+
+export function mountSubtitlesToast(): () => void {
+  const existingHost = document.getElementById(SUBTITLES_TOAST_HOST_ID)
+  if (existingHost) {
+    return (existingHost as any).__cleanup ?? (() => {})
+  }
+
+  const target = document.body ?? document.documentElement
+  const shadowHost = document.createElement("div")
+  shadowHost.id = SUBTITLES_TOAST_HOST_ID
+  shadowHost.classList.add(REACT_SHADOW_HOST_CLASS)
+
+  const shadowRoot = shadowHost.attachShadow({ mode: "open" })
+  const hostBuilder = new ShadowHostBuilder(shadowRoot, {
+    position: "block",
+    cssContent: [themeCSS],
+    inheritStyles: false,
+  })
+  const reactContainer = hostBuilder.build()
+  applyTheme(reactContainer, SUBTITLES_THEME)
+  const cleanupMirroredStyles = mirrorDynamicStyles("style", shadowRoot, "[data-sonner-toaster]")
+
+  const reactRoot = ReactDOM.createRoot(reactContainer)
+  reactRoot.render(
+    <div className={NOTRANSLATE_CLASS}>
+      <Toaster richColors />
+    </div>,
+  )
+
+  target.appendChild(shadowHost)
+
+  const cleanup = () => {
+    cleanupMirroredStyles()
+    reactRoot.unmount()
+    hostBuilder.cleanup()
+    shadowHost.remove()
+  }
+  ;(shadowHost as any).__cleanup = cleanup
+  return cleanup
+}

--- a/src/entrypoints/subtitles.content/renderer/mount-subtitles-ui.tsx
+++ b/src/entrypoints/subtitles.content/renderer/mount-subtitles-ui.tsx
@@ -1,7 +1,6 @@
 import type { SubtitlesProvidersAdapter } from "../ui/subtitles-ui-context"
 import type { PlatformConfig } from "@/entrypoints/subtitles.content/platforms"
 import ReactDOM from "react-dom/client"
-import { Toaster } from "sonner"
 import themeCSS from "@/assets/styles/theme.css?inline"
 import { REACT_SHADOW_HOST_CLASS } from "@/utils/constants/dom-labels"
 import { SUBTITLES_THEME } from "@/utils/constants/subtitles"
@@ -11,6 +10,7 @@ import { ShadowHostBuilder } from "@/utils/react-shadow-host/shadow-host-builder
 import { applyTheme } from "@/utils/theme"
 import { SubtitlesContainer } from "../ui/subtitles-container"
 import { SubtitlesProviders } from "../ui/subtitles-ui-context"
+import { mountSubtitlesToast } from "./mount-subtitles-toast"
 
 const SUBTITLES_UI_HOST_ID = "read-frog-subtitles-ui-host"
 
@@ -76,8 +76,10 @@ export async function mountSubtitlesUI(
   applyTheme(reactContainer, SUBTITLES_THEME)
 
   const reactRoot = ReactDOM.createRoot(reactContainer)
+  const cleanupToast = mountSubtitlesToast()
 
   ;(shadowHost as any).__reactShadowContainerCleanup = () => {
+    cleanupToast()
     reactRoot?.unmount()
     hostBuilder.cleanup()
   }
@@ -88,7 +90,6 @@ export async function mountSubtitlesUI(
     <ShadowWrapperContext value={reactContainer}>
       <SubtitlesProviders adapter={adapter}>
         <SubtitlesContainer />
-        <Toaster richColors className="z-2147483647 notranslate" />
       </SubtitlesProviders>
     </ShadowWrapperContext>
   )


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

The subtitle error toasts (e.g. "source and target languages are the same") had two display problems:

1. **No sonner card styling** — they rendered as a bare warning icon + text, with no background/rounded corners/shadow.
2. **Covered by other content** — the toast was hidden behind YouTube's right-hand recommendations sidebar.

Root cause: the `<Toaster>` was mounted inside the player-container shadow host (`#read-frog-subtitles-ui-host`), which has `position: absolute; z-index: 9999` and therefore creates a **stacking context**. As a result:

- the toast's effective stacking level was clamped to the parent's `9999`, so it could not escape the player container and got covered by elements with a higher stacking level / later in the DOM;
- sonner's `[data-sonner-toaster]` styles were never injected into that shadow root (the host only injects `themeCSS`), so the toast had no styling.

Fix: move the `<Toaster>` into its own `<body>`-level shadow host (`mount-subtitles-toast.tsx`), free of the player container's stacking constraint, so sonner's own `position: fixed` + high z-index take effect. Sonner injects its styles into `document.head` at runtime, so we mirror them into the shadow root via `mirrorDynamicStyles`. The new host is deduplicated by a fixed id, and its cleanup is wired into the subtitle UI host's `__reactShadowContainerCleanup` so it is torn down with the same lifecycle.

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Verified through manual testing

Triggered a subtitle error toast on a YouTube video page and confirmed: the toast renders as a styled sonner card (background/rounded corners) and floats on the top layer, no longer hidden behind the recommendations sidebar.

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This PR only fixes the toast's styling and stacking issues; the separate issue of subtitle toasts possibly showing twice is out of scope here.