### PR TITLE
feat: cancel export subtitle translations

### DIFF
--- a/.changeset/cancel-translated-srt-export.md
+++ b/.changeset/cancel-translated-srt-export.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(subtitles): cancel translated SRT export work on dispose

--- a/src/entrypoints/background/__tests__/translation-queues.test.ts
+++ b/src/entrypoints/background/__tests__/translation-queues.test.ts
@@ -1,5 +1,5 @@
 import type { ProviderConfig } from "@/types/config/provider"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 
 const onMessageMock = vi.fn()
@@ -108,6 +108,10 @@ describe("translation queue helpers", () => {
     articleSummaryCachePutMock.mockResolvedValue(undefined)
     translationCacheGetMock.mockResolvedValue(undefined)
     translationCachePutMock.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it(
@@ -459,5 +463,274 @@ describe("translation queue helpers", () => {
       "Generated summary",
     ])
     expect(generateArticleSummaryMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("cancels pending subtitle translation requests in the same export group before flushing a batch", async () => {
+    vi.useFakeTimers()
+    ensureInitializedConfigMock.mockResolvedValue({
+      ...DEFAULT_CONFIG,
+      translate: {
+        ...DEFAULT_CONFIG.translate,
+        enableAIContentAware: true,
+      },
+      videoSubtitles: {
+        ...DEFAULT_CONFIG.videoSubtitles,
+        providerId: llmProvider.id,
+        requestQueueConfig: {
+          rate: 10,
+          capacity: 10,
+        },
+        batchQueueConfig: {
+          maxCharactersPerBatch: 1000,
+          maxItemsPerBatch: 10,
+        },
+      },
+    })
+
+    const { setUpSubtitlesTranslationQueue } = await import("../translation-queues")
+    await setUpSubtitlesTranslationQueue()
+
+    const enqueueHandler = getRegisteredMessageHandler("enqueueSubtitlesTranslateRequest")
+    const cancelHandler = getRegisteredMessageHandler("cancelSubtitlesTranslateRequestGroup")
+    const request = enqueueHandler({
+      data: {
+        text: "hello",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: llmProvider,
+        scheduleAt: Date.now(),
+        hash: "subtitle-hash",
+        cancelGroupId: "export-group",
+      },
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    await cancelHandler({ data: { cancelGroupId: "export-group" } })
+
+    await expect(request).rejects.toThrow("Batch group cancelled: export-group")
+    await vi.runAllTimersAsync()
+    expect(executeTranslateMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects late subtitle translation requests after their export group was already cancelled", async () => {
+    vi.useFakeTimers()
+    const { setUpSubtitlesTranslationQueue } = await import("../translation-queues")
+    await setUpSubtitlesTranslationQueue()
+
+    const enqueueHandler = getRegisteredMessageHandler("enqueueSubtitlesTranslateRequest")
+    const cancelHandler = getRegisteredMessageHandler("cancelSubtitlesTranslateRequestGroup")
+
+    await cancelHandler({ data: { cancelGroupId: "export-group" } })
+    const lateRequest = enqueueHandler({
+      data: {
+        text: "late request",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: llmProvider,
+        scheduleAt: Date.now(),
+        hash: "late-subtitle-hash",
+        cancelGroupId: "export-group",
+      },
+    })
+
+    await expect(lateRequest).rejects.toThrow("Subtitles translation group cancelled: export-group")
+    expect(translationCacheGetMock).not.toHaveBeenCalled()
+    expect(executeTranslateMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects subtitle translation requests cancelled while reading the translation cache", async () => {
+    vi.useFakeTimers()
+    let resolveCacheLookup!: (value: undefined) => void
+    translationCacheGetMock.mockImplementationOnce(
+      () => new Promise<undefined>((resolve) => {
+        resolveCacheLookup = resolve
+      }),
+    )
+
+    const { setUpSubtitlesTranslationQueue } = await import("../translation-queues")
+    await setUpSubtitlesTranslationQueue()
+
+    const enqueueHandler = getRegisteredMessageHandler("enqueueSubtitlesTranslateRequest")
+    const cancelHandler = getRegisteredMessageHandler("cancelSubtitlesTranslateRequestGroup")
+    const request = enqueueHandler({
+      data: {
+        text: "cache race request",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: llmProvider,
+        scheduleAt: Date.now(),
+        hash: "cache-race-subtitle-hash",
+        cancelGroupId: "export-group",
+      },
+    })
+
+    await Promise.resolve()
+    await cancelHandler({ data: { cancelGroupId: "export-group" } })
+    resolveCacheLookup(undefined)
+
+    await expect(request).rejects.toThrow("Subtitles translation group cancelled: export-group")
+    expect(executeTranslateMock).not.toHaveBeenCalled()
+    expect(translationCachePutMock).not.toHaveBeenCalled()
+  })
+
+  it("forgets cancelled subtitle translation groups after the cancellation guard TTL", async () => {
+    vi.useFakeTimers()
+    const { setUpSubtitlesTranslationQueue } = await import("../translation-queues")
+    await setUpSubtitlesTranslationQueue()
+
+    const enqueueHandler = getRegisteredMessageHandler("enqueueSubtitlesTranslateRequest")
+    const cancelHandler = getRegisteredMessageHandler("cancelSubtitlesTranslateRequestGroup")
+
+    await cancelHandler({ data: { cancelGroupId: "export-group" } })
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000)
+
+    const request = enqueueHandler({
+      data: {
+        text: "fresh request after ttl",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: llmProvider,
+        scheduleAt: Date.now(),
+        hash: "fresh-subtitle-hash",
+        cancelGroupId: "export-group",
+      },
+    })
+
+    await expect(request).resolves.toBe("translated subtitle")
+    expect(translationCacheGetMock).toHaveBeenCalledWith("fresh-subtitle-hash")
+    expect(executeTranslateMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps different export groups and uncancellable subtitle requests running when one group is cancelled", async () => {
+    vi.useFakeTimers()
+    ensureInitializedConfigMock.mockResolvedValue({
+      ...DEFAULT_CONFIG,
+      translate: {
+        ...DEFAULT_CONFIG.translate,
+        enableAIContentAware: true,
+      },
+      videoSubtitles: {
+        ...DEFAULT_CONFIG.videoSubtitles,
+        providerId: llmProvider.id,
+        requestQueueConfig: {
+          rate: 10,
+          capacity: 10,
+        },
+        batchQueueConfig: {
+          maxCharactersPerBatch: 1000,
+          maxItemsPerBatch: 10,
+        },
+      },
+    })
+
+    const { setUpSubtitlesTranslationQueue } = await import("../translation-queues")
+    await setUpSubtitlesTranslationQueue()
+
+    const enqueueHandler = getRegisteredMessageHandler("enqueueSubtitlesTranslateRequest")
+    const cancelHandler = getRegisteredMessageHandler("cancelSubtitlesTranslateRequestGroup")
+    const cancelledRequest = enqueueHandler({
+      data: {
+        text: "cancelled",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: llmProvider,
+        scheduleAt: Date.now(),
+        hash: "cancelled-hash",
+        cancelGroupId: "export-group",
+      },
+    })
+    const otherGroupRequest = enqueueHandler({
+      data: {
+        text: "other group",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: llmProvider,
+        scheduleAt: Date.now(),
+        hash: "other-group-hash",
+        cancelGroupId: "other-group",
+      },
+    })
+    const uncancellableRequest = enqueueHandler({
+      data: {
+        text: "playback",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: llmProvider,
+        scheduleAt: Date.now(),
+        hash: "playback-hash",
+      },
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+    await cancelHandler({ data: { cancelGroupId: "export-group" } })
+    await expect(cancelledRequest).rejects.toThrow("Batch group cancelled: export-group")
+    await vi.runAllTimersAsync()
+
+    await expect(otherGroupRequest).resolves.toBe("translated subtitle")
+    await expect(uncancellableRequest).resolves.toBe("translated subtitle")
+    expect(executeTranslateMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("cancels an executing batched subtitle translation without waiting for the provider response", async () => {
+    let finishProvider!: (value: string) => void
+    executeTranslateMock.mockImplementation(
+      () => new Promise((resolve: (value: string) => void) => {
+        finishProvider = resolve
+      }),
+    )
+
+    const { setUpSubtitlesTranslationQueue } = await import("../translation-queues")
+    await setUpSubtitlesTranslationQueue()
+
+    const enqueueHandler = getRegisteredMessageHandler("enqueueSubtitlesTranslateRequest")
+    const cancelHandler = getRegisteredMessageHandler("cancelSubtitlesTranslateRequestGroup")
+    const request = enqueueHandler({
+      data: {
+        text: "hello",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: llmProvider,
+        scheduleAt: Date.now(),
+        hash: "subtitle-hash",
+        cancelGroupId: "export-group",
+      },
+    })
+
+    await vi.waitFor(() => expect(executeTranslateMock).toHaveBeenCalledTimes(1))
+    await cancelHandler({ data: { cancelGroupId: "export-group" } })
+
+    await expect(request).rejects.toThrow("Batch group cancelled: export-group")
+    expect(translationCachePutMock).not.toHaveBeenCalled()
+
+    finishProvider("late translated subtitle")
+    await Promise.resolve()
+  })
+
+  it("cancels an executing non-batched subtitle translation in the same export group", async () => {
+    let finishProvider!: (value: string) => void
+    executeTranslateMock.mockImplementation(
+      () => new Promise((resolve: (value: string) => void) => {
+        finishProvider = resolve
+      }),
+    )
+
+    const { setUpSubtitlesTranslationQueue } = await import("../translation-queues")
+    await setUpSubtitlesTranslationQueue()
+
+    const enqueueHandler = getRegisteredMessageHandler("enqueueSubtitlesTranslateRequest")
+    const cancelHandler = getRegisteredMessageHandler("cancelSubtitlesTranslateRequestGroup")
+    const request = enqueueHandler({
+      data: {
+        text: "hello",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: googleProvider,
+        scheduleAt: Date.now(),
+        hash: "google-subtitle-hash",
+        cancelGroupId: "export-group",
+      },
+    })
+
+    await vi.waitFor(() => expect(executeTranslateMock).toHaveBeenCalledTimes(1))
+    await cancelHandler({ data: { cancelGroupId: "export-group" } })
+
+    await expect(request).rejects.toThrow("Request group cancelled: export-group")
+    expect(translationCachePutMock).not.toHaveBeenCalled()
+
+    finishProvider("late translated subtitle")
+    await Promise.resolve()
   })
 })

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -152,6 +152,7 @@ export interface TranslateBatchData<TContext = unknown> {
   hash: string
   scheduleAt: number
   context?: TContext
+  cancelGroupId?: string
 }
 
 interface TranslationQueueSetupConfig<TContext = unknown> {
@@ -183,10 +184,11 @@ async function createTranslationQueues<TContext>(config: TranslationQueueSetupCo
       return Sha256Hex(
         `${data.langConfig.sourceCode}-${data.langConfig.targetCode}-${data.providerConfig.id}`,
         data.context ? JSON.stringify(data.context) : "",
+        data.cancelGroupId ?? "",
       )
     },
     getCharacters: data => data.text.length,
-    executeBatch: async (dataList) => {
+    executeBatch: async (dataList, executionContext) => {
       const { providerConfig } = dataList[0]
       const hash = Sha256Hex(...dataList.map(d => d.hash))
       const earliestScheduleAt = Math.min(...dataList.map(d => d.scheduleAt))
@@ -196,15 +198,30 @@ async function createTranslationQueues<TContext>(config: TranslationQueueSetupCo
         return await executeBatchTranslation(dataList, promptResolver)
       }
 
-      return requestQueue.enqueue(batchThunk, earliestScheduleAt, hash)
+      return requestQueue.enqueue(
+        batchThunk,
+        earliestScheduleAt,
+        hash,
+        executionContext.cancelGroupId ? { cancelGroupId: executionContext.cancelGroupId } : undefined,
+      )
     },
-    executeIndividual: async (data) => {
+    executeIndividual: async (data, executionContext) => {
       const { text, langConfig, providerConfig, hash, scheduleAt, context } = data
       const thunk = async () => {
         await putBatchRequestRecord({ originalRequestCount: 1, providerConfig })
         return executeTranslate(text, langConfig, providerConfig, promptResolver, { context })
       }
-      return requestQueue.enqueue(thunk, scheduleAt, hash)
+      return requestQueue.enqueue(
+        thunk,
+        scheduleAt,
+        hash,
+        executionContext.cancelGroupId ? { cancelGroupId: executionContext.cancelGroupId } : undefined,
+      )
+    },
+    cancelExecution: (executionContext) => {
+      if (executionContext.cancelGroupId) {
+        requestQueue.cancelGroup(executionContext.cancelGroupId)
+      }
     },
     onError: (error, context) => {
       const errorType = context.isFallback ? "Individual request" : "Batch request"
@@ -216,6 +233,15 @@ async function createTranslationQueues<TContext>(config: TranslationQueueSetupCo
   })
 
   return { requestQueue, batchQueue }
+}
+
+const CANCELLED_SUBTITLES_TRANSLATE_GROUP_TTL_MS = 5 * 60 * 1000
+
+class SubtitlesTranslateRequestGroupCancelledError extends Error {
+  constructor(cancelGroupId: string) {
+    super(`Subtitles translation group cancelled: ${cancelGroupId}`)
+    this.name = "SubtitlesTranslateRequestGroupCancelledError"
+  }
 }
 
 export async function setUpWebPageTranslationQueue() {
@@ -304,9 +330,29 @@ export async function setUpSubtitlesTranslationQueue() {
     batchQueueConfig,
     promptResolver: getSubtitlesTranslatePrompt,
   })
+  const cancelledGroupTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+  function rememberCancelledGroup(cancelGroupId: string): void {
+    const existingTimer = cancelledGroupTimers.get(cancelGroupId)
+    if (existingTimer) {
+      clearTimeout(existingTimer)
+    }
+
+    const cleanupTimer = setTimeout(() => {
+      cancelledGroupTimers.delete(cancelGroupId)
+    }, CANCELLED_SUBTITLES_TRANSLATE_GROUP_TTL_MS)
+    cancelledGroupTimers.set(cancelGroupId, cleanupTimer)
+  }
+
+  function throwIfGroupCancelled(cancelGroupId?: string): void {
+    if (cancelGroupId && cancelledGroupTimers.has(cancelGroupId)) {
+      throw new SubtitlesTranslateRequestGroupCancelledError(cancelGroupId)
+    }
+  }
 
   onMessage("enqueueSubtitlesTranslateRequest", async (message) => {
-    const { data: { text, langConfig, providerConfig, scheduleAt, hash, webTitle, webDescription, summary } } = message
+    const { data: { text, langConfig, providerConfig, scheduleAt, hash, webTitle, webDescription, summary, cancelGroupId } } = message
+    throwIfGroupCancelled(cancelGroupId)
 
     if (hash) {
       const cached = await db.translationCache.get(hash)
@@ -314,6 +360,7 @@ export async function setUpSubtitlesTranslationQueue() {
         return normalizeTranslationOutput(providerConfig, cached.translation)
       }
     }
+    throwIfGroupCancelled(cancelGroupId)
 
     let result = ""
     const context: SubtitlePromptContext = {
@@ -323,12 +370,20 @@ export async function setUpSubtitlesTranslationQueue() {
     }
 
     if (shouldUseBatchQueue(providerConfig)) {
-      const data = { text, langConfig, providerConfig, hash, scheduleAt, context }
-      result = await batchQueue.enqueue(data)
+      const data = { text, langConfig, providerConfig, hash, scheduleAt, context, cancelGroupId }
+      result = await batchQueue.enqueue(
+        data,
+        cancelGroupId ? { cancelGroupId } : undefined,
+      )
     }
     else {
       const thunk = () => executeTranslate(text, langConfig, providerConfig, getSubtitlesTranslatePrompt)
-      result = await requestQueue.enqueue(thunk, scheduleAt, hash)
+      result = await requestQueue.enqueue(
+        thunk,
+        scheduleAt,
+        hash,
+        cancelGroupId ? { cancelGroupId } : undefined,
+      )
     }
 
     if (result && hash) {
@@ -351,6 +406,13 @@ export async function setUpSubtitlesTranslationQueue() {
     }
 
     return await getOrGenerateSubtitleSummary(videoTitle, subtitlesContext, providerConfig, requestQueue)
+  })
+
+  onMessage("cancelSubtitlesTranslateRequestGroup", (message) => {
+    const { cancelGroupId } = message.data
+    rememberCancelledGroup(cancelGroupId)
+    batchQueue.cancelGroup(cancelGroupId)
+    requestQueue.cancelGroup(cancelGroupId)
   })
 
   onMessage("microsoftBatchTranslate", async (message) => {

--- a/src/entrypoints/subtitles.content/__tests__/translated-subtitles-downloader.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/translated-subtitles-downloader.test.ts
@@ -8,18 +8,22 @@ import { TranslatedSubtitlesDownloader } from "../translated-subtitles-downloade
 
 const mocks = vi.hoisted(() => ({
   aiSegmentBlock: vi.fn(),
+  cancelSubtitlesTranslateRequestGroup: vi.fn(),
   downloadSubtitlesAsSrt: vi.fn(),
   fetchSubtitlesSummary: vi.fn(),
   getLocalConfig: vi.fn(),
+  getRandomUUID: vi.fn(),
   toastError: vi.fn(),
   translateSubtitles: vi.fn(),
 }))
 
 vi.mock("sonner", () => ({ toast: { error: mocks.toastError } }))
 vi.mock("@/utils/config/storage", () => ({ getLocalConfig: mocks.getLocalConfig }))
+vi.mock("@/utils/crypto-polyfill", () => ({ getRandomUUID: mocks.getRandomUUID }))
 vi.mock("@/utils/subtitles/processor/ai-segmentation", () => ({ aiSegmentBlock: mocks.aiSegmentBlock }))
 vi.mock("@/utils/subtitles/processor/translator", () => ({
   buildSubtitlesSummaryContextHash: () => "summary-hash",
+  cancelSubtitlesTranslateRequestGroup: mocks.cancelSubtitlesTranslateRequestGroup,
   fetchSubtitlesSummary: mocks.fetchSubtitlesSummary,
   translateSubtitles: mocks.translateSubtitles,
 }))
@@ -86,7 +90,10 @@ describe("translatedSubtitlesDownloader", () => {
       progress: null,
     })
     mocks.getLocalConfig.mockResolvedValue(createConfig())
+    mocks.cancelSubtitlesTranslateRequestGroup.mockResolvedValue(undefined)
     mocks.fetchSubtitlesSummary.mockResolvedValue(null)
+    let nextCancelGroup = 0
+    mocks.getRandomUUID.mockImplementation(() => `cancel-group-${++nextCancelGroup}`)
     mocks.translateSubtitles.mockImplementation(async (fragments: SubtitlesFragment[]) => translated(fragments))
   })
 
@@ -103,8 +110,8 @@ describe("translatedSubtitlesDownloader", () => {
 
     expect(mocks.getLocalConfig).toHaveBeenCalledTimes(1)
     expect(mocks.fetchSubtitlesSummary).toHaveBeenCalledWith(expect.any(Object), config)
-    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(1, fragments.slice(0, 5), expect.any(Object), config)
-    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(2, fragments.slice(5), expect.any(Object), config)
+    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(1, fragments.slice(0, 5), expect.any(Object), config, { cancelGroupId: "cancel-group-1" })
+    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(2, fragments.slice(5), expect.any(Object), config, { cancelGroupId: "cancel-group-1" })
     expect(statuses).toEqual(expect.arrayContaining([
       { phase: TranslatedDownloadPhase.Preparing, progress: 0 },
       { phase: TranslatedDownloadPhase.Translating, progress: 83 },
@@ -136,8 +143,8 @@ describe("translatedSubtitlesDownloader", () => {
     await vi.waitFor(() => expect(mocks.translateSubtitles).toHaveBeenCalledTimes(2))
 
     expect(maxActiveBatches).toBe(2)
-    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(1, fragments.slice(0, 5), expect.any(Object), expect.any(Object))
-    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(2, fragments.slice(5, 10), expect.any(Object), expect.any(Object))
+    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(1, fragments.slice(0, 5), expect.any(Object), expect.any(Object), { cancelGroupId: "cancel-group-1" })
+    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(2, fragments.slice(5, 10), expect.any(Object), expect.any(Object), { cancelGroupId: "cancel-group-1" })
 
     resolvers[1](translated(fragments.slice(5, 10)))
     await vi.waitFor(() => expect(activeBatches).toBe(1))
@@ -145,7 +152,7 @@ describe("translatedSubtitlesDownloader", () => {
 
     resolvers[0](translated(fragments.slice(0, 5)))
     await vi.waitFor(() => expect(mocks.translateSubtitles).toHaveBeenCalledTimes(3))
-    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(3, fragments.slice(10), expect.any(Object), expect.any(Object))
+    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(3, fragments.slice(10), expect.any(Object), expect.any(Object), { cancelGroupId: "cancel-group-1" })
 
     resolvers[2](translated(fragments.slice(10)))
     await download
@@ -242,6 +249,9 @@ describe("translatedSubtitlesDownloader", () => {
     await oldDownload
 
     expect(fetcher.fetch).toHaveBeenCalledTimes(2)
+    expect(mocks.cancelSubtitlesTranslateRequestGroup).toHaveBeenCalledWith("cancel-group-1")
+    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(3, fragments.slice(0, 5), expect.any(Object), expect.any(Object), { cancelGroupId: "cancel-group-2" })
+    expect(mocks.translateSubtitles).toHaveBeenNthCalledWith(4, fragments.slice(5), expect.any(Object), expect.any(Object), { cancelGroupId: "cancel-group-2" })
     expect(mocks.downloadSubtitlesAsSrt).toHaveBeenCalledTimes(1)
     expect(mocks.toastError).not.toHaveBeenCalled()
     expect(status().phase).toBe(TranslatedDownloadPhase.Complete)
@@ -359,6 +369,7 @@ describe("translatedSubtitlesDownloader", () => {
       expect.any(Array),
       expect.objectContaining({ summary: null }),
       expect.any(Object),
+      { cancelGroupId: "cancel-group-1" },
     )
     expect(mocks.downloadSubtitlesAsSrt).toHaveBeenCalled()
   })

--- a/src/entrypoints/subtitles.content/translated-subtitles-downloader.ts
+++ b/src/entrypoints/subtitles.content/translated-subtitles-downloader.ts
@@ -9,9 +9,10 @@ import { getProviderConfigById } from "@/utils/config/helpers"
 import { getLocalConfig } from "@/utils/config/storage"
 import { MAX_GAP_MS, PROCESS_LOOK_AHEAD_MS, TRANSLATION_BATCH_SIZE } from "@/utils/constants/subtitles"
 import { resolveLanguageCodeFromLocale } from "@/utils/content/page-language"
+import { getRandomUUID } from "@/utils/crypto-polyfill"
 import { aiSegmentBlock } from "@/utils/subtitles/processor/ai-segmentation"
 import { optimizeSubtitles } from "@/utils/subtitles/processor/optimizer"
-import { buildSubtitlesSummaryContextHash, fetchSubtitlesSummary, translateSubtitles } from "@/utils/subtitles/processor/translator"
+import { buildSubtitlesSummaryContextHash, cancelSubtitlesTranslateRequestGroup, fetchSubtitlesSummary, translateSubtitles } from "@/utils/subtitles/processor/translator"
 import { downloadSubtitlesAsSrt } from "@/utils/subtitles/srt"
 import { subtitlesStore, TranslatedDownloadPhase, translatedSubtitlesDownloadStatusAtom } from "./atoms"
 
@@ -22,6 +23,7 @@ const TRANSLATED_EXPORT_BATCH_CONCURRENCY = 2
 export class TranslatedSubtitlesDownloader {
   private isDownloading = false
   private operationId = 0
+  private activeCancelGroupId: string | null = null
   private successTimeout: ReturnType<typeof setTimeout> | null = null
 
   constructor(
@@ -37,6 +39,8 @@ export class TranslatedSubtitlesDownloader {
     this.clearSuccessTimeout()
     this.isDownloading = true
     const operationId = ++this.operationId
+    const cancelGroupId = getRandomUUID()
+    this.activeCancelGroupId = cancelGroupId
     const pageTitle = document.title || ""
     const videoId = this.config.getVideoId?.()
     this.setStatus(TranslatedDownloadPhase.Preparing, 0)
@@ -64,6 +68,7 @@ export class TranslatedSubtitlesDownloader {
         sourceProcessedSubtitles,
         configSnapshot,
         operationId,
+        cancelGroupId,
         pageTitle,
       )
 
@@ -98,15 +103,21 @@ export class TranslatedSubtitlesDownloader {
     finally {
       if (this.isActive(operationId)) {
         this.isDownloading = false
+        this.activeCancelGroupId = null
       }
     }
   }
 
   dispose(): void {
+    const cancelGroupId = this.activeCancelGroupId
+    this.activeCancelGroupId = null
     this.operationId++
     this.isDownloading = false
     this.clearSuccessTimeout()
     this.setStatus(TranslatedDownloadPhase.Idle, null)
+    if (cancelGroupId) {
+      void cancelSubtitlesTranslateRequestGroup(cancelGroupId).catch(() => {})
+    }
   }
 
   private clearSuccessTimeout(): void {
@@ -144,6 +155,7 @@ export class TranslatedSubtitlesDownloader {
     sourceProcessedSubtitles: SubtitlesFragment[],
     config: Config,
     operationId: number,
+    cancelGroupId: string,
     pageTitle: string,
   ): Promise<SubtitlesFragment[]> {
     const fragments = await this.buildExportProcessedSubtitles(
@@ -163,7 +175,7 @@ export class TranslatedSubtitlesDownloader {
       const batchWindow = batches.slice(index, index + TRANSLATED_EXPORT_BATCH_CONCURRENCY)
       const translatedBatchWindow = await Promise.all(
         batchWindow.map(async (batch) => {
-          const translatedBatch = await translateSubtitles(batch, videoContext, config)
+          const translatedBatch = await translateSubtitles(batch, videoContext, config, { cancelGroupId })
           this.assertActive(operationId)
           if (
             translatedBatch.length !== batch.length

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -55,7 +55,8 @@ interface ProtocolMap {
   // request
   enqueueTranslateRequest: (data: { text: string, langConfig: Config["language"], providerConfig: ProviderConfig, scheduleAt: number, hash: string, webTitle?: string | null, webDescription?: string | null, webContent?: string | null, webSummary?: string | null }) => Promise<string>
   getOrGenerateWebPageSummary: (data: { webTitle: string, webContent: string, providerConfig: ProviderConfig }) => Promise<string | null>
-  enqueueSubtitlesTranslateRequest: (data: { text: string, langConfig: Config["language"], providerConfig: ProviderConfig, scheduleAt: number, hash: string, webTitle?: string | null, webDescription?: string | null, summary?: string | null }) => Promise<string>
+  enqueueSubtitlesTranslateRequest: (data: { text: string, langConfig: Config["language"], providerConfig: ProviderConfig, scheduleAt: number, hash: string, webTitle?: string | null, webDescription?: string | null, summary?: string | null, cancelGroupId?: string }) => Promise<string>
+  cancelSubtitlesTranslateRequestGroup: (data: { cancelGroupId: string }) => void
   getSubtitlesSummary: (data: { videoTitle: string, subtitlesContext: string, providerConfig: ProviderConfig }) => Promise<string | null>
   backgroundGenerateText: (data: BackgroundGenerateTextPayload) => Promise<BackgroundGenerateTextResponse>
   // AI subtitle segmentation

--- a/src/utils/request/batch-queue.ts
+++ b/src/utils/request/batch-queue.ts
@@ -15,6 +15,9 @@ interface BatchTask<T, R> {
   data: T
   resolve: (value: R) => void
   reject: (error: Error) => void
+  cancelGroupId?: string
+  executionCancelGroupId?: string
+  drained: boolean
 }
 
 interface PendingBatch<T, R> {
@@ -22,6 +25,11 @@ interface PendingBatch<T, R> {
   tasks: BatchTask<T, R>[]
   totalCharacters: number
   createdAt: number
+  executionCancelGroupId?: string
+}
+
+export interface BatchQueueExecutionContext {
+  cancelGroupId?: string
 }
 
 export interface BatchOptions<T, R> {
@@ -32,13 +40,26 @@ export interface BatchOptions<T, R> {
   enableFallbackToIndividual?: boolean
   getBatchKey: (data: T) => string
   getCharacters: (data: T) => number
-  executeBatch: (dataList: T[]) => Promise<R[]>
-  executeIndividual?: (data: T) => Promise<R>
+  executeBatch: (dataList: T[], context: BatchQueueExecutionContext) => Promise<R[]>
+  executeIndividual?: (data: T, context: BatchQueueExecutionContext) => Promise<R>
+  cancelExecution?: (context: BatchQueueExecutionContext) => void
   onError?: (error: Error, context: { batchKey: string, retryCount: number, isFallback: boolean }) => void
+}
+
+export interface BatchQueueEnqueueOptions {
+  cancelGroupId?: string
+}
+
+export class BatchQueueCancelledError extends Error {
+  constructor(cancelGroupId: string) {
+    super(`Batch group cancelled: ${cancelGroupId}`)
+    this.name = "BatchQueueCancelledError"
+  }
 }
 
 export class BatchQueue<T, R> {
   private pendingBatchMap = new Map<string, PendingBatch<T, R>>()
+  private executingBatchMap = new Map<string, PendingBatch<T, R>>()
   private nextScheduleTimer: NodeJS.Timeout | null = null
   private maxCharactersPerBatch: number
   private maxItemsPerBatch: number
@@ -47,8 +68,9 @@ export class BatchQueue<T, R> {
   private enableFallbackToIndividual: boolean
   private getBatchKey: (data: T) => string
   private getCharacters: (data: T) => number
-  private executeBatch: (dataList: T[]) => Promise<R[]>
-  private executeIndividual?: (data: T) => Promise<R>
+  private executeBatch: (dataList: T[], context: BatchQueueExecutionContext) => Promise<R[]>
+  private executeIndividual?: (data: T, context: BatchQueueExecutionContext) => Promise<R>
+  private cancelExecution?: (context: BatchQueueExecutionContext) => void
   private onError?: (error: Error, context: { batchKey: string, retryCount: number, isFallback: boolean }) => void
 
   constructor(config: BatchOptions<T, R>) {
@@ -61,10 +83,11 @@ export class BatchQueue<T, R> {
     this.getCharacters = config.getCharacters
     this.executeBatch = config.executeBatch
     this.executeIndividual = config.executeIndividual
+    this.cancelExecution = config.cancelExecution
     this.onError = config.onError
   }
 
-  enqueue(data: T): Promise<R> {
+  enqueue(data: T, options: BatchQueueEnqueueOptions = {}): Promise<R> {
     let resolve!: (value: R) => void
     let reject!: (error: Error) => void
     const promise = new Promise<R>((res, rej) => {
@@ -73,12 +96,39 @@ export class BatchQueue<T, R> {
     })
 
     const batchKey = this.getBatchKey(data)
-    const task: BatchTask<T, R> = { data, resolve, reject }
+    const task: BatchTask<T, R> = {
+      data,
+      resolve,
+      reject,
+      cancelGroupId: options.cancelGroupId,
+      drained: false,
+    }
 
     this.addTaskToBatch(task, batchKey)
     this.schedule()
 
     return promise
+  }
+
+  cancelGroup(cancelGroupId: string): void {
+    const error = new BatchQueueCancelledError(cancelGroupId)
+
+    for (const [batchKey, batch] of this.pendingBatchMap.entries()) {
+      this.cancelTasksForGroup(batch, cancelGroupId, error)
+      this.removeDrainedTasks(batch)
+      if (batch.tasks.length === 0) {
+        this.pendingBatchMap.delete(batchKey)
+      }
+    }
+
+    for (const batch of this.executingBatchMap.values()) {
+      this.cancelTasksForGroup(batch, cancelGroupId, error)
+      if (!this.hasActiveTasks(batch)) {
+        this.cancelBatchExecution(batch)
+      }
+    }
+
+    this.schedule()
   }
 
   private schedule() {
@@ -157,14 +207,32 @@ export class BatchQueue<T, R> {
 
     this.pendingBatchMap.delete(batchKey)
 
-    const { tasks } = pendingBatch
+    if (pendingBatch.tasks.length === 0)
+      return
 
-    void this.executeBatchWithRetry(tasks, batchKey, 0)
+    this.executingBatchMap.set(pendingBatch.id, pendingBatch)
+
+    void this.executeBatchWithRetry(pendingBatch, batchKey, 0)
   }
 
-  private async executeBatchWithRetry(tasks: BatchTask<T, R>[], batchKey: string, retryCount: number): Promise<void> {
+  private async executeBatchWithRetry(batch: PendingBatch<T, R>, batchKey: string, retryCount: number): Promise<void> {
+    this.removeDrainedTasks(batch)
+
+    if (!this.hasActiveTasks(batch)) {
+      this.executingBatchMap.delete(batch.id)
+      return
+    }
+
+    const tasks = [...batch.tasks]
+
     try {
-      const results = await this.executeBatch(tasks.map(task => task.data))
+      const context = this.getBatchExecutionContext(batch)
+      const results = await this.executeBatch(tasks.map(task => task.data), context)
+
+      if (!this.hasActiveTasks(batch)) {
+        this.executingBatchMap.delete(batch.id)
+        return
+      }
 
       if (!results) {
         throw new Error("Batch execution results are undefined")
@@ -174,10 +242,17 @@ export class BatchQueue<T, R> {
         throw new BatchCountMismatchError(tasks.length, results.length, results)
       }
 
-      tasks.forEach((task, index) => task.resolve(results[index]))
+      tasks.forEach((task, index) => this.resolveTask(task, results[index]))
+      this.executingBatchMap.delete(batch.id)
     }
     catch (error) {
       const err = error as Error
+      this.removeDrainedTasks(batch)
+
+      if (!this.hasActiveTasks(batch)) {
+        this.executingBatchMap.delete(batch.id)
+        return
+      }
 
       this.onError?.(err, { batchKey, retryCount, isFallback: false })
 
@@ -185,34 +260,42 @@ export class BatchQueue<T, R> {
       if (retryCount < this.maxRetries && err instanceof BatchCountMismatchError) {
         const delay = this.calculateBackoffDelay(retryCount)
         await this.sleep(delay)
-        return this.executeBatchWithRetry(tasks, batchKey, retryCount + 1)
+        return this.executeBatchWithRetry(batch, batchKey, retryCount + 1)
       }
 
       if (this.enableFallbackToIndividual && this.executeIndividual && err instanceof BatchCountMismatchError) {
-        return this.executeFallbackIndividual(tasks, batchKey)
+        return this.executeFallbackIndividual(batch, batchKey)
       }
 
-      tasks.forEach(task => task.reject(err))
+      batch.tasks.forEach(task => this.rejectTask(task, err))
+      this.executingBatchMap.delete(batch.id)
     }
   }
 
-  private async executeFallbackIndividual(tasks: BatchTask<T, R>[], batchKey: string) {
+  private async executeFallbackIndividual(batch: PendingBatch<T, R>, batchKey: string) {
     await Promise.allSettled(
-      tasks.map(async (task) => {
+      batch.tasks.map(async (task) => {
         try {
+          if (task.drained) {
+            return
+          }
           if (!this.executeIndividual) {
             throw new Error("executeIndividual is not defined")
           }
-          const result = await this.executeIndividual(task.data)
-          task.resolve(result)
+          const context = this.createTaskExecutionContext(task)
+          const result = await this.executeIndividual(task.data, context)
+          this.resolveTask(task, result)
+          task.executionCancelGroupId = undefined
         }
         catch (error) {
           const err = error as Error
           this.onError?.(err, { batchKey, retryCount: this.maxRetries, isFallback: true })
-          task.reject(err)
+          this.rejectTask(task, err)
+          task.executionCancelGroupId = undefined
         }
       }),
     )
+    this.executingBatchMap.delete(batch.id)
   }
 
   private calculateBackoffDelay(retryCount: number): number {
@@ -221,6 +304,76 @@ export class BatchQueue<T, R> {
 
   private sleep(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms))
+  }
+
+  private createTaskExecutionContext(task: BatchTask<T, R>): BatchQueueExecutionContext {
+    if (!task.cancelGroupId) {
+      return {}
+    }
+
+    task.executionCancelGroupId = getRandomUUID()
+    return { cancelGroupId: task.executionCancelGroupId }
+  }
+
+  private getBatchExecutionContext(batch: PendingBatch<T, R>): BatchQueueExecutionContext {
+    if (!batch.tasks.some(task => task.cancelGroupId)) {
+      return {}
+    }
+
+    batch.executionCancelGroupId ??= getRandomUUID()
+    return { cancelGroupId: batch.executionCancelGroupId }
+  }
+
+  private cancelTasksForGroup(batch: PendingBatch<T, R>, cancelGroupId: string, error: Error) {
+    for (const task of batch.tasks) {
+      if (task.cancelGroupId === cancelGroupId) {
+        this.rejectTask(task, error)
+        this.cancelTaskExecution(task)
+      }
+    }
+  }
+
+  private hasActiveTasks(batch: PendingBatch<T, R>): boolean {
+    return batch.tasks.some(task => !task.drained)
+  }
+
+  private removeDrainedTasks(batch: PendingBatch<T, R>) {
+    batch.tasks = batch.tasks.filter(task => !task.drained)
+    batch.totalCharacters = batch.tasks.reduce((total, task) => total + this.getCharacters(task.data), 0)
+  }
+
+  private resolveTask(task: BatchTask<T, R>, value: R) {
+    if (task.drained) {
+      return
+    }
+    task.drained = true
+    task.resolve(value)
+  }
+
+  private rejectTask(task: BatchTask<T, R>, error: Error) {
+    if (task.drained) {
+      return
+    }
+    task.drained = true
+    task.reject(error)
+  }
+
+  private cancelBatchExecution(batch: PendingBatch<T, R>) {
+    if (!batch.executionCancelGroupId) {
+      return
+    }
+
+    this.cancelExecution?.({ cancelGroupId: batch.executionCancelGroupId })
+    batch.executionCancelGroupId = undefined
+  }
+
+  private cancelTaskExecution(task: BatchTask<T, R>) {
+    if (!task.executionCancelGroupId) {
+      return
+    }
+
+    this.cancelExecution?.({ cancelGroupId: task.executionCancelGroupId })
+    task.executionCancelGroupId = undefined
   }
 
   setBatchConfig(config: Partial<Pick<BatchOptions<T, R>, "maxCharactersPerBatch" | "maxItemsPerBatch">>) {

--- a/src/utils/request/request-queue.ts
+++ b/src/utils/request/request-queue.ts
@@ -15,9 +15,21 @@ export interface RequestTask {
   createdAt: number
   retryCount: number
   drained: boolean
+  cancelGroupId?: string
 }
 
 type QueuedRequestTask = RequestTask & { hash: string }
+
+export interface RequestQueueEnqueueOptions {
+  cancelGroupId?: string
+}
+
+export class RequestQueueCancelledError extends Error {
+  constructor(cancelGroupId: string) {
+    super(`Request group cancelled: ${cancelGroupId}`)
+    this.name = "RequestQueueCancelledError"
+  }
+}
 
 export interface QueueOptions {
   rate: number // tokens/sec
@@ -47,8 +59,14 @@ export class RequestQueue {
     this.waitingQueue = new BinaryHeapPQ<QueuedRequestTask>()
   }
 
-  enqueue<T>(thunk: () => Promise<T>, scheduleAt: number, hash: string): Promise<T> {
-    const duplicateTask = this.duplicateTask(hash)
+  enqueue<T>(
+    thunk: () => Promise<T>,
+    scheduleAt: number,
+    hash: string,
+    options: RequestQueueEnqueueOptions = {},
+  ): Promise<T> {
+    const queueHash = this.buildQueueHash(hash, options.cancelGroupId)
+    const duplicateTask = this.duplicateTask(queueHash)
     if (duplicateTask) {
       // console.info(`🔄 Found duplicate task for hash: ${hash}, returning existing promise`)
       return duplicateTask.promise
@@ -63,7 +81,7 @@ export class RequestQueue {
 
     const task: QueuedRequestTask = {
       id: getRandomUUID(),
-      hash,
+      hash: queueHash,
       thunk,
       promise,
       resolve,
@@ -72,15 +90,32 @@ export class RequestQueue {
       createdAt: Date.now(),
       retryCount: 0,
       drained: false,
+      cancelGroupId: options.cancelGroupId,
     }
 
-    this.waitingTasks.set(hash, task)
+    this.waitingTasks.set(queueHash, task)
     this.waitingQueue.push(task, scheduleAt)
 
     // console.info(`✅ Task ${task.id} added to queue. Queue size: ${this.waitingQueue.size()}, waiting: ${this.waitingTasks.size}, executing: ${this.executingTasks.size}`)
 
     this.schedule()
     return promise
+  }
+
+  cancelGroup(cancelGroupId: string): void {
+    const error = new RequestQueueCancelledError(cancelGroupId)
+    const tasks = [
+      ...this.waitingTasks.values(),
+      ...this.executingTasks.values(),
+    ]
+
+    for (const task of tasks) {
+      if (task.cancelGroupId === cancelGroupId) {
+        this.rejectDrainedTask(task, error)
+      }
+    }
+
+    this.schedule()
   }
 
   setQueueOptions(options: Partial<QueueOptions>) {
@@ -101,17 +136,27 @@ export class RequestQueue {
 
   private schedule() {
     this.refillTokens()
+    this.popDrainedWaitingTasks()
 
     while (this.bucketTokens >= 1 && this.waitingQueue.size() > 0) {
       const now = Date.now()
 
       const task = this.waitingQueue.peek()
+      if (task?.drained) {
+        this.waitingQueue.pop()
+        if (this.waitingTasks.get(task.hash) === task) {
+          this.waitingTasks.delete(task.hash)
+        }
+        continue
+      }
+
       if (task && task.scheduleAt <= now) {
         this.waitingQueue.pop()
         this.waitingTasks.delete(task.hash)
         this.executingTasks.set(task.hash, task)
         this.bucketTokens--
         void this.executeTask(task)
+        this.popDrainedWaitingTasks()
       }
       else {
         break
@@ -237,6 +282,24 @@ export class RequestQueue {
     return undefined
   }
 
+  private buildQueueHash(hash: string, cancelGroupId?: string): string {
+    return cancelGroupId ? `${hash}:cancelGroup:${cancelGroupId}` : hash
+  }
+
+  private popDrainedWaitingTasks(): void {
+    while (this.waitingQueue.size() > 0) {
+      const task = this.waitingQueue.peek()
+      if (!task?.drained) {
+        return
+      }
+
+      this.waitingQueue.pop()
+      if (this.waitingTasks.get(task.hash) === task) {
+        this.waitingTasks.delete(task.hash)
+      }
+    }
+  }
+
   private failCurrentBacklog(error: unknown) {
     if (this.nextScheduleTimer) {
       clearTimeout(this.nextScheduleTimer)
@@ -261,6 +324,12 @@ export class RequestQueue {
     }
 
     task.drained = true
+    if (this.waitingTasks.get(task.hash) === task) {
+      this.waitingTasks.delete(task.hash)
+    }
+    if (this.executingTasks.get(task.hash) === task) {
+      this.executingTasks.delete(task.hash)
+    }
     task.reject(error)
   }
 

--- a/src/utils/subtitles/processor/__tests__/translator.test.ts
+++ b/src/utils/subtitles/processor/__tests__/translator.test.ts
@@ -213,6 +213,32 @@ describe("subtitles translator", () => {
     )
   })
 
+  it("passes a cancel group only for explicit cancellable subtitle translations", async () => {
+    const { cancelSubtitlesTranslateRequestGroup, translateSubtitles } = await import("../translator")
+    const fragments = [{ text: "hello", start: 0, end: 1_000 }]
+    const videoContext = { videoTitle: "Video title", subtitlesTextContent: "subtitle transcript" }
+
+    await translateSubtitles(fragments, videoContext, undefined, { cancelGroupId: "export-group" })
+    await translateSubtitles(fragments, videoContext)
+    await cancelSubtitlesTranslateRequestGroup("export-group")
+
+    expect(sendMessageMock).toHaveBeenNthCalledWith(
+      1,
+      "enqueueSubtitlesTranslateRequest",
+      expect.objectContaining({ cancelGroupId: "export-group" }),
+    )
+    expect(sendMessageMock).toHaveBeenNthCalledWith(
+      2,
+      "enqueueSubtitlesTranslateRequest",
+      expect.not.objectContaining({ cancelGroupId: expect.any(String) }),
+    )
+    expect(sendMessageMock).toHaveBeenNthCalledWith(
+      3,
+      "cancelSubtitlesTranslateRequestGroup",
+      { cancelGroupId: "export-group" },
+    )
+  })
+
   it("builds subtitle summary context hashes from subtitles text and provider config", async () => {
     const { buildSubtitlesSummaryContextHash } = await import("../translator")
 

--- a/src/utils/subtitles/processor/translator.ts
+++ b/src/utils/subtitles/processor/translator.ts
@@ -46,6 +46,10 @@ export interface SubtitlesVideoContext {
   summary?: string | null
 }
 
+export interface TranslateSubtitlesOptions {
+  cancelGroupId?: string
+}
+
 export function buildSubtitlesSummaryContextHash(
   videoContext: Pick<SubtitlesVideoContext, "subtitlesTextContent">,
   providerConfig?: ProviderConfig,
@@ -123,6 +127,7 @@ async function translateSingleSubtitle(
   providerConfig: ProviderConfig,
   enableAIContentAware: boolean,
   videoContext: SubtitlesVideoContext,
+  options: TranslateSubtitlesOptions = {},
 ): Promise<string> {
   const subtitlePromptContext = normalizeSubtitlePromptContext(videoContext)
   const hashComponents = await buildSubtitleHashComponents(
@@ -148,7 +153,12 @@ async function translateSingleSubtitle(
     webTitle: subtitlePromptContext.webTitle,
     webDescription: subtitlePromptContext.webDescription,
     summary: enableAIContentAware ? subtitlePromptContext.videoSummary : undefined,
+    ...(options.cancelGroupId ? { cancelGroupId: options.cancelGroupId } : {}),
   })
+}
+
+export async function cancelSubtitlesTranslateRequestGroup(cancelGroupId: string): Promise<void> {
+  await sendMessage("cancelSubtitlesTranslateRequestGroup", { cancelGroupId })
 }
 
 export async function fetchSubtitlesSummary(
@@ -181,6 +191,7 @@ export async function translateSubtitles(
   fragments: SubtitlesFragment[],
   videoContext: SubtitlesVideoContext,
   configOverride?: Config,
+  options: TranslateSubtitlesOptions = {},
 ): Promise<SubtitlesFragment[]> {
   const config = configOverride ?? await getLocalConfig()
   if (!config) {
@@ -197,7 +208,7 @@ export async function translateSubtitles(
   const enableAIContentAware = !!config.translate.enableAIContentAware
 
   const translationPromises = fragments.map(fragment =>
-    translateSingleSubtitle(fragment.text, langConfig, providerConfig, enableAIContentAware, videoContext),
+    translateSingleSubtitle(fragment.text, langConfig, providerConfig, enableAIContentAware, videoContext, options),
   )
 
   const results = await Promise.allSettled(translationPromises)


### PR DESCRIPTION
## Summary

- Add an export-scoped cancellation group for translated subtitle SRT export and cancel that group when the downloader is disposed.
- Teach the subtitle translation queues to reject pending and executing work by cancellation group, including a short-lived late-enqueue guard for requests that arrive after cancellation.
- Keep ungrouped subtitle/page translation behavior unchanged while separating cancellation groups from the existing request de-dupe/cache path.

## Scope

This PR intentionally does not:

- abort provider HTTP requests that are already in flight;
- add a user-facing cancel button;
- add background or resumable export behavior.

## Validation

- `pnpm exec vitest run src/entrypoints/background/__tests__/translation-queues.test.ts`
- `pnpm exec vitest run src/entrypoints/subtitles.content/__tests__/translated-subtitles-downloader.test.ts src/utils/subtitles/processor/__tests__/translator.test.ts`
- `pnpm exec vitest run src/utils/request/__tests__/request-queue.test.ts src/utils/request/__tests__/batch-queue.test.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec eslint src/entrypoints/background/translation-queues.ts src/entrypoints/background/__tests__/translation-queues.test.ts src/entrypoints/subtitles.content/translated-subtitles-downloader.ts src/entrypoints/subtitles.content/__tests__/translated-subtitles-downloader.test.ts src/utils/message.ts src/utils/request/request-queue.ts src/utils/request/batch-queue.ts src/utils/subtitles/processor/translator.ts src/utils/subtitles/processor/__tests__/translator.test.ts`
- `git diff --check`
- pre-push hook: `@read-frog/extension:lint`, `@read-frog/extension:type-check`, `@read-frog/extension:test` (159 test files, 1341 tests)