### PR TITLE
feat(tts): support Firefox playback adapters

### DIFF
--- a/.changeset/firefox-tts-playback.md
+++ b/.changeset/firefox-tts-playback.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(tts): support Firefox background audio playback

--- a/src/entrypoints/background/__tests__/tts-playback.test.ts
+++ b/src/entrypoints/background/__tests__/tts-playback.test.ts
@@ -1,8 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const onMessageMock = vi.fn()
 const sendMessageMock = vi.fn()
 const loggerWarnMock = vi.fn()
+const createObjectURLDescriptor = Object.getOwnPropertyDescriptor(URL, "createObjectURL")
+const revokeObjectURLDescriptor = Object.getOwnPropertyDescriptor(URL, "revokeObjectURL")
 
 vi.mock("#imports", () => ({
   browser: {
@@ -23,25 +25,75 @@ vi.mock("@/utils/logger", () => ({
   },
 }))
 
-function getRegisteredMessageHandler(name: string) {
+function getRegisteredMessageHandler<TData = unknown, TResult = unknown>(name: string) {
   const registration = onMessageMock.mock.calls.find(call => call[0] === name)
   if (!registration) {
     throw new Error(`Message handler not registered: ${name}`)
   }
 
-  return registration[1] as (message: {
-    data: {
-      requestId: string
-      audioBase64: string
-      contentType: string
+  return registration[1] as (message: { data: TData }) => Promise<TResult>
+}
+
+function installFakeAudio() {
+  const createObjectURLMock = vi.fn(() => "blob:tts-test")
+  const revokeObjectURLMock = vi.fn()
+
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: createObjectURLMock,
+  })
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: revokeObjectURLMock,
+  })
+
+  class FakeAudio {
+    static instances: FakeAudio[] = []
+
+    onended: (() => void) | null = null
+    onerror: (() => void) | null = null
+    play = vi.fn().mockResolvedValue(undefined)
+    pause = vi.fn()
+    removeAttribute = vi.fn()
+    load = vi.fn()
+
+    constructor(readonly src: string) {
+      FakeAudio.instances.push(this)
     }
-  }) => Promise<{ ok: boolean }>
+  }
+
+  vi.stubGlobal("Audio", FakeAudio)
+
+  return {
+    FakeAudio,
+    createObjectURLMock,
+    revokeObjectURLMock,
+  }
 }
 
 describe("setupTTSPlaybackMessageHandlers", () => {
   beforeEach(() => {
     vi.resetModules()
     vi.clearAllMocks()
+    vi.unstubAllEnvs()
+    ;(globalThis as { chrome?: unknown }).chrome = undefined
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    if (createObjectURLDescriptor) {
+      Object.defineProperty(URL, "createObjectURL", createObjectURLDescriptor)
+    }
+    else {
+      delete (URL as { createObjectURL?: unknown }).createObjectURL
+    }
+
+    if (revokeObjectURLDescriptor) {
+      Object.defineProperty(URL, "revokeObjectURL", revokeObjectURLDescriptor)
+    }
+    else {
+      delete (URL as { revokeObjectURL?: unknown }).revokeObjectURL
+    }
   })
 
   it("recreates offscreen document after it disappears", async () => {
@@ -70,7 +122,11 @@ describe("setupTTSPlaybackMessageHandlers", () => {
 
     const { setupTTSPlaybackMessageHandlers } = await import("../tts-playback")
     setupTTSPlaybackMessageHandlers()
-    const startHandler = getRegisteredMessageHandler("ttsPlaybackStart")
+    const startHandler = getRegisteredMessageHandler<{
+      requestId: string
+      audioBase64: string
+      contentType: string
+    }, { ok: boolean }>("ttsPlaybackStart")
 
     const payload = {
       data: {
@@ -118,7 +174,11 @@ describe("setupTTSPlaybackMessageHandlers", () => {
 
     const { setupTTSPlaybackMessageHandlers } = await import("../tts-playback")
     setupTTSPlaybackMessageHandlers()
-    const startHandler = getRegisteredMessageHandler("ttsPlaybackStart")
+    const startHandler = getRegisteredMessageHandler<{
+      requestId: string
+      audioBase64: string
+      contentType: string
+    }, { ok: boolean }>("ttsPlaybackStart")
 
     const result = await startHandler({
       data: {
@@ -131,5 +191,97 @@ describe("setupTTSPlaybackMessageHandlers", () => {
     expect(result).toEqual({ ok: true })
     expect(sendMessageMock.mock.calls.filter(call => call[0] === "ttsOffscreenPlay")).toHaveLength(2)
     expect(loggerWarnMock).toHaveBeenCalled()
+  })
+
+  it("uses offscreen playback whenever the offscreen API is available", async () => {
+    vi.stubEnv("BROWSER", "custom-chromium")
+    const getContextsMock = vi.fn().mockResolvedValue([])
+    const createDocumentMock = vi.fn().mockResolvedValue(undefined)
+    ;(globalThis as { chrome?: unknown }).chrome = {
+      runtime: {
+        getContexts: getContextsMock,
+      },
+      offscreen: {
+        createDocument: createDocumentMock,
+      },
+    }
+
+    sendMessageMock.mockImplementation(async (type: string) => {
+      if (type === "ttsOffscreenStop" || type === "ttsOffscreenPlay") {
+        return { ok: true as const }
+      }
+
+      throw new Error(`Unexpected message: ${type}`)
+    })
+
+    const { setupTTSPlaybackMessageHandlers } = await import("../tts-playback")
+    setupTTSPlaybackMessageHandlers()
+    const prepareHandler = getRegisteredMessageHandler<undefined, { ok: true }>("ttsPlaybackPrepare")
+
+    await prepareHandler({ data: undefined })
+
+    expect(createDocumentMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("uses background DOM audio playback in Firefox when offscreen is unavailable", async () => {
+    vi.stubEnv("BROWSER", "firefox")
+    const { FakeAudio, revokeObjectURLMock } = installFakeAudio()
+
+    const { setupTTSPlaybackMessageHandlers } = await import("../tts-playback")
+    setupTTSPlaybackMessageHandlers()
+    const startHandler = getRegisteredMessageHandler<{
+      requestId: string
+      audioBase64: string
+      contentType: string
+    }, { ok: boolean }>("ttsPlaybackStart")
+
+    const playbackPromise = startHandler({
+      data: {
+        requestId: "req-firefox",
+        audioBase64: "ZmFrZQ==",
+        contentType: "audio/mpeg",
+      },
+    })
+    await Promise.resolve()
+
+    expect(FakeAudio.instances).toHaveLength(1)
+    expect(FakeAudio.instances[0]!.play).toHaveBeenCalled()
+    expect(sendMessageMock).not.toHaveBeenCalled()
+
+    FakeAudio.instances[0]!.onended?.()
+
+    await expect(playbackPromise).resolves.toEqual({ ok: true })
+    expect(revokeObjectURLMock).toHaveBeenCalledWith("blob:tts-test")
+  })
+
+  it("stops only the active Firefox background playback request", async () => {
+    vi.stubEnv("BROWSER", "firefox")
+    const { FakeAudio } = installFakeAudio()
+
+    const { setupTTSPlaybackMessageHandlers } = await import("../tts-playback")
+    setupTTSPlaybackMessageHandlers()
+    const startHandler = getRegisteredMessageHandler<{
+      requestId: string
+      audioBase64: string
+      contentType: string
+    }, { ok: boolean }>("ttsPlaybackStart")
+    const stopHandler = getRegisteredMessageHandler<{ requestId?: string }, { ok: true }>("ttsPlaybackStop")
+
+    const playbackPromise = startHandler({
+      data: {
+        requestId: "req-active",
+        audioBase64: "ZmFrZQ==",
+        contentType: "audio/mpeg",
+      },
+    })
+    await Promise.resolve()
+
+    await stopHandler({ data: { requestId: "req-other" } })
+    expect(FakeAudio.instances[0]!.pause).not.toHaveBeenCalled()
+
+    await stopHandler({ data: { requestId: "req-active" } })
+
+    await expect(playbackPromise).resolves.toEqual({ ok: false, reason: "stopped" })
+    expect(FakeAudio.instances[0]!.pause).toHaveBeenCalled()
   })
 })

--- a/src/entrypoints/background/tts-playback.ts
+++ b/src/entrypoints/background/tts-playback.ts
@@ -1,7 +1,12 @@
-import type { TTSOffscreenStopRequest, TTSPlaybackStartResponse } from "@/types/tts-playback"
+import type {
+  TTSPlaybackStartRequest,
+  TTSPlaybackStartResponse,
+  TTSPlaybackStopRequest,
+} from "@/types/tts-playback"
 import { browser } from "#imports"
 import { logger } from "@/utils/logger"
 import { onMessage, sendMessage } from "@/utils/message"
+import { DOMAudioPlaybackController } from "@/utils/tts-playback/dom-audio-controller"
 
 const OFFSCREEN_DOCUMENT_PATH = "/offscreen.html" as const
 const OFFSCREEN_DOCUMENT_URL = browser.runtime.getURL(OFFSCREEN_DOCUMENT_PATH)
@@ -26,10 +31,24 @@ interface ChromeLike {
   offscreen?: ChromeOffscreenApi
 }
 
-let ensureOffscreenPromise: Promise<void> | null = null
+interface TTSPlaybackAdapter {
+  prepare: () => Promise<void>
+  play: (request: TTSPlaybackStartRequest) => Promise<TTSPlaybackStartResponse>
+  stop: (request: TTSPlaybackStopRequest) => Promise<void>
+}
 
 function getChromeLike(): ChromeLike {
   return (globalThis as { chrome?: ChromeLike }).chrome ?? {}
+}
+
+function hasChromeOffscreenApi(): boolean {
+  return typeof getChromeLike().offscreen?.createDocument === "function"
+}
+
+function hasBackgroundDOMAudioApi(): boolean {
+  return typeof Audio === "function"
+    && typeof Blob === "function"
+    && typeof URL.createObjectURL === "function"
 }
 
 function isSingleOffscreenDocumentError(error: unknown): boolean {
@@ -45,118 +64,155 @@ function isMissingReceiverError(error: unknown): boolean {
     || message.includes("No response")
 }
 
-async function hasOffscreenDocument(): Promise<boolean> {
-  const chromeApi = getChromeLike()
-  if (!chromeApi.runtime?.getContexts) {
-    return false
-  }
+class ChromeOffscreenPlaybackAdapter implements TTSPlaybackAdapter {
+  private ensureOffscreenPromise: Promise<void> | null = null
 
-  const contexts = await chromeApi.runtime.getContexts({
-    contextTypes: ["OFFSCREEN_DOCUMENT"],
-    documentUrls: [OFFSCREEN_DOCUMENT_URL],
-  })
-
-  return contexts.some(context => context.contextType === "OFFSCREEN_DOCUMENT")
-}
-
-async function ensureOffscreenDocument(): Promise<void> {
-  if (await hasOffscreenDocument()) {
-    return
-  }
-
-  if (ensureOffscreenPromise) {
-    return ensureOffscreenPromise
-  }
-
-  ensureOffscreenPromise = (async () => {
-    const chromeApi = getChromeLike()
-    if (!chromeApi.offscreen?.createDocument) {
-      throw new Error("Offscreen API is unavailable in this browser")
+  async prepare(): Promise<void> {
+    if (await this.hasOffscreenDocument()) {
+      return
     }
+
+    if (this.ensureOffscreenPromise) {
+      return this.ensureOffscreenPromise
+    }
+
+    this.ensureOffscreenPromise = (async () => {
+      const chromeApi = getChromeLike()
+      if (!chromeApi.offscreen?.createDocument) {
+        throw new Error("Offscreen API is unavailable in this browser")
+      }
+
+      try {
+        await chromeApi.offscreen.createDocument({
+          url: OFFSCREEN_DOCUMENT_PATH,
+          reasons: [OFFSCREEN_REASON],
+          justification: OFFSCREEN_JUSTIFICATION,
+        })
+      }
+      catch (error) {
+        if (!isSingleOffscreenDocumentError(error)) {
+          throw error
+        }
+      }
+    })().finally(() => {
+      this.ensureOffscreenPromise = null
+    })
+
+    return this.ensureOffscreenPromise
+  }
+
+  async play(request: TTSPlaybackStartRequest): Promise<TTSPlaybackStartResponse> {
+    await this.prepare()
+
+    // Latest request wins: always stop any in-progress playback first.
+    await this.stop({ reason: "interrupted" })
 
     try {
-      await chromeApi.offscreen.createDocument({
-        url: OFFSCREEN_DOCUMENT_PATH,
-        reasons: [OFFSCREEN_REASON],
-        justification: OFFSCREEN_JUSTIFICATION,
-      })
+      return await sendMessage("ttsOffscreenPlay", request)
     }
     catch (error) {
-      if (!isSingleOffscreenDocumentError(error)) {
+      if (!isMissingReceiverError(error)) {
+        throw error
+      }
+
+      logger.warn("[Background][TTSPlayback] offscreen receiver missing, retrying once", error)
+
+      // Offscreen documents can be reclaimed by the browser and briefly lose handlers.
+      await this.prepare()
+      return sendMessage("ttsOffscreenPlay", request)
+    }
+  }
+
+  async stop(request: TTSPlaybackStopRequest): Promise<void> {
+    try {
+      await sendMessage("ttsOffscreenStop", request)
+    }
+    catch (error) {
+      if (!isMissingReceiverError(error)) {
         throw error
       }
     }
-  })().finally(() => {
-    ensureOffscreenPromise = null
-  })
-
-  return ensureOffscreenPromise
-}
-
-async function stopOffscreenPlayback(data: TTSOffscreenStopRequest): Promise<void> {
-  try {
-    await sendMessage("ttsOffscreenStop", data)
   }
-  catch (error) {
-    if (!isMissingReceiverError(error)) {
-      throw error
-    }
-  }
-}
 
-async function startOffscreenPlayback(
-  requestId: string,
-  audioBase64: string,
-  contentType: string,
-): Promise<TTSPlaybackStartResponse> {
-  await ensureOffscreenDocument()
-
-  // Latest request wins: always stop any in-progress playback first.
-  await stopOffscreenPlayback({ reason: "interrupted" })
-
-  try {
-    return await sendMessage("ttsOffscreenPlay", {
-      requestId,
-      audioBase64,
-      contentType,
-    })
-  }
-  catch (error) {
-    if (!isMissingReceiverError(error)) {
-      throw error
+  private async hasOffscreenDocument(): Promise<boolean> {
+    const chromeApi = getChromeLike()
+    if (!chromeApi.runtime?.getContexts) {
+      return false
     }
 
-    logger.warn("[Background][TTSPlayback] offscreen receiver missing, retrying once", error)
-
-    // Offscreen documents can be reclaimed by the browser and briefly lose handlers.
-    await ensureOffscreenDocument()
-    return sendMessage("ttsOffscreenPlay", {
-      requestId,
-      audioBase64,
-      contentType,
+    const contexts = await chromeApi.runtime.getContexts({
+      contextTypes: ["OFFSCREEN_DOCUMENT"],
+      documentUrls: [OFFSCREEN_DOCUMENT_URL],
     })
+
+    return contexts.some(context => context.contextType === "OFFSCREEN_DOCUMENT")
   }
+}
+
+class BackgroundDOMAudioPlaybackAdapter implements TTSPlaybackAdapter {
+  private readonly controller = new DOMAudioPlaybackController("Failed to play audio in background page")
+
+  async prepare(): Promise<void> {
+    if (!hasBackgroundDOMAudioApi()) {
+      throw new Error("DOM Audio playback is unavailable in background context")
+    }
+  }
+
+  async play(request: TTSPlaybackStartRequest): Promise<TTSPlaybackStartResponse> {
+    await this.prepare()
+    return this.controller.play(request)
+  }
+
+  async stop(request: TTSPlaybackStopRequest): Promise<void> {
+    this.controller.stop(request)
+  }
+}
+
+class UnsupportedPlaybackAdapter implements TTSPlaybackAdapter {
+  constructor(private readonly browserName: string) {}
+
+  async prepare(): Promise<void> {
+    throw new Error(`TTS playback is not supported in ${this.browserName}`)
+  }
+
+  async play(): Promise<TTSPlaybackStartResponse> {
+    await this.prepare()
+    return { ok: false, reason: "stopped" }
+  }
+
+  async stop(): Promise<void> {
+  }
+}
+
+function createTTSPlaybackAdapter(): TTSPlaybackAdapter {
+  if (hasChromeOffscreenApi()) {
+    return new ChromeOffscreenPlaybackAdapter()
+  }
+
+  if (hasBackgroundDOMAudioApi()) {
+    return new BackgroundDOMAudioPlaybackAdapter()
+  }
+
+  return new UnsupportedPlaybackAdapter(import.meta.env.BROWSER)
 }
 
 export function setupTTSPlaybackMessageHandlers() {
-  onMessage("ttsPlaybackEnsureOffscreen", async () => {
-    await ensureOffscreenDocument()
+  const adapter = createTTSPlaybackAdapter()
+
+  onMessage("ttsPlaybackPrepare", async () => {
+    await adapter.prepare()
     return { ok: true as const }
   })
 
   onMessage("ttsPlaybackStart", async (message) => {
-    return startOffscreenPlayback(
-      message.data.requestId,
-      message.data.audioBase64,
-      message.data.contentType,
-    )
+    return adapter.play(message.data)
   })
 
   onMessage("ttsPlaybackStop", async (message) => {
     try {
-      await stopOffscreenPlayback({
+      await adapter.stop({
         requestId: message.data.requestId,
-        reason: "stopped",
+        reason: message.data.reason ?? "stopped",
       })
     }
     catch (error) {

--- a/src/entrypoints/offscreen/main.ts
+++ b/src/entrypoints/offscreen/main.ts
@@ -1,118 +1,13 @@
-import type { TTSPlaybackStartResponse, TTSPlaybackStopReason } from "@/types/tts-playback"
 import { onMessage } from "@/utils/message"
+import { DOMAudioPlaybackController } from "@/utils/tts-playback/dom-audio-controller"
 
-interface ActivePlayback {
-  requestId: string
-  audio: HTMLAudioElement
-  audioUrl: string
-  settled: boolean
-  resolve: (response: TTSPlaybackStartResponse) => void
-  reject: (error: Error) => void
-}
-
-let activePlayback: ActivePlayback | null = null
-
-function base64ToUint8Array(base64: string): Uint8Array {
-  const binary = atob(base64)
-  const bytes = new Uint8Array(binary.length)
-  for (let index = 0; index < binary.length; index++) {
-    bytes[index] = binary.charCodeAt(index)
-  }
-  return bytes
-}
-
-function cleanupPlayback(playback: ActivePlayback) {
-  playback.audio.onended = null
-  playback.audio.onerror = null
-  playback.audio.pause()
-  playback.audio.removeAttribute("src")
-  playback.audio.load()
-  URL.revokeObjectURL(playback.audioUrl)
-}
-
-function settlePlayback(playback: ActivePlayback, response: TTSPlaybackStartResponse): boolean {
-  if (playback.settled) {
-    return false
-  }
-
-  playback.settled = true
-  cleanupPlayback(playback)
-  if (activePlayback === playback) {
-    activePlayback = null
-  }
-  playback.resolve(response)
-  return true
-}
-
-function failPlayback(playback: ActivePlayback, error: Error): boolean {
-  if (playback.settled) {
-    return false
-  }
-
-  playback.settled = true
-  cleanupPlayback(playback)
-  if (activePlayback === playback) {
-    activePlayback = null
-  }
-  playback.reject(error)
-  return true
-}
-
-function stopActivePlayback(reason: TTSPlaybackStopReason, requestId?: string): boolean {
-  const playback = activePlayback
-  if (!playback) {
-    return false
-  }
-
-  if (requestId && playback.requestId !== requestId) {
-    return false
-  }
-
-  return settlePlayback(playback, { ok: false, reason })
-}
+const playbackController = new DOMAudioPlaybackController("Failed to play audio in offscreen document")
 
 onMessage("ttsOffscreenPlay", async (message) => {
-  stopActivePlayback("interrupted")
-
-  const { requestId, audioBase64, contentType } = message.data
-
-  return new Promise<TTSPlaybackStartResponse>((resolve, reject) => {
-    const bytes = base64ToUint8Array(audioBase64)
-    const audioBuffer = new ArrayBuffer(bytes.byteLength)
-    new Uint8Array(audioBuffer).set(bytes)
-    const blob = new Blob([audioBuffer], { type: contentType })
-    const audioUrl = URL.createObjectURL(blob)
-    const audio = new Audio(audioUrl)
-
-    const playback: ActivePlayback = {
-      requestId,
-      audio,
-      audioUrl,
-      settled: false,
-      resolve,
-      reject,
-    }
-
-    activePlayback = playback
-
-    audio.onended = () => {
-      settlePlayback(playback, { ok: true })
-    }
-
-    audio.onerror = () => {
-      failPlayback(playback, new Error("Failed to play audio in offscreen document"))
-    }
-
-    audio.play().catch((error) => {
-      const normalizedError = error instanceof Error
-        ? error
-        : new Error(typeof error === "string" ? error : "Unknown audio playback error")
-      failPlayback(playback, normalizedError)
-    })
-  })
+  return playbackController.play(message.data)
 })
 
 onMessage("ttsOffscreenStop", async (message) => {
-  stopActivePlayback(message.data.reason ?? "stopped", message.data.requestId)
+  playbackController.stop(message.data)
   return { ok: true as const }
 })

--- a/src/entrypoints/options/app-sidebar/nav-items.ts
+++ b/src/entrypoints/options/app-sidebar/nav-items.ts
@@ -8,7 +8,7 @@ export const ROUTE_DEFS = [
   { path: "/selection-toolbar" },
   { path: "/context-menu" },
   { path: "/input-translation" },
-  ...(import.meta.env.BROWSER === "firefox" ? [] : [{ path: "/tts" }]),
+  { path: "/tts" },
   { path: "/statistics" },
   { path: "/config" },
 ] as const

--- a/src/entrypoints/options/app-sidebar/settings-nav.tsx
+++ b/src/entrypoints/options/app-sidebar/settings-nav.tsx
@@ -23,7 +23,6 @@ const OVERLAY_TOOLS_PATHS = ["/floating-button", "/selection-toolbar", "/context
 export function SettingsNav() {
   const { pathname } = useLocation()
   const isOverlayToolsActive = OVERLAY_TOOLS_PATHS.includes(pathname)
-  const isFirefox = import.meta.env.BROWSER === "firefox"
 
   return (
     <SidebarGroup>
@@ -104,14 +103,12 @@ export function SettingsNav() {
             </SidebarMenuItem>
           </Collapsible>
 
-          {!isFirefox && (
-            <SidebarMenuItem>
-              <SidebarMenuButton render={<Link to="/tts" />} isActive={pathname === "/tts"}>
-                <Icon icon="tabler:speakerphone" />
-                <span>{i18n.t("options.tts.title")}</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          )}
+          <SidebarMenuItem>
+            <SidebarMenuButton render={<Link to="/tts" />} isActive={pathname === "/tts"}>
+              <Icon icon="tabler:speakerphone" />
+              <span>{i18n.t("options.tts.title")}</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
 
           <SidebarMenuItem>
             <SidebarMenuButton render={<Link to="/statistics" />} isActive={pathname === "/statistics"}>

--- a/src/entrypoints/options/command-palette/search-items.ts
+++ b/src/entrypoints/options/command-palette/search-items.ts
@@ -10,23 +10,19 @@ export interface SearchItem {
   pageKey: string
 }
 
-const IS_FIREFOX = import.meta.env.BROWSER === "firefox"
-
 type SearchItemDefinition = Omit<SearchItem, "titleKey" | "descriptionKey" | "pageKey"> & {
   titleKey: I18nKey
   descriptionKey?: I18nKey
   pageKey: I18nKey
 }
 
-const TTS_SEARCH_ITEMS: SearchItemDefinition[] = !IS_FIREFOX
-  ? [{
-      sectionId: "tts-config",
-      route: "/tts",
-      titleKey: "options.tts.title",
-      descriptionKey: "options.tts.description",
-      pageKey: "options.tts.title",
-    }]
-  : []
+const TTS_SEARCH_ITEMS: SearchItemDefinition[] = [{
+  sectionId: "tts-config",
+  route: "/tts",
+  titleKey: "options.tts.title",
+  descriptionKey: "options.tts.description",
+  pageKey: "options.tts.title",
+}]
 
 const CONFIG_SEARCH_ITEMS = [
   {

--- a/src/entrypoints/options/pages/selection-toolbar/selection-toolbar-feature-toggles.tsx
+++ b/src/entrypoints/options/pages/selection-toolbar/selection-toolbar-feature-toggles.tsx
@@ -7,7 +7,6 @@ import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { ConfigCard } from "../../components/config-card"
 
 export function SelectionToolbarFeatureToggles() {
-  const isFirefox = import.meta.env.BROWSER === "firefox"
   const [selectionToolbar, setSelectionToolbar] = useAtom(
     configFieldsAtomMap.selectionToolbar,
   )
@@ -44,18 +43,16 @@ export function SelectionToolbarFeatureToggles() {
             onCheckedChange={checked => setFeatureEnabled("translate", checked)}
           />
         </div>
-        {!isFirefox && (
-          <div className="flex items-center justify-between">
-            <span className="flex items-center gap-2 text-sm">
-              <IconVolume className="size-4 text-muted-foreground" />
-              {i18n.t("options.floatingButtonAndToolbar.selectionToolbar.featureToggles.speak")}
-            </span>
-            <Switch
-              checked={features.speak.enabled}
-              onCheckedChange={checked => setFeatureEnabled("speak", checked)}
-            />
-          </div>
-        )}
+        <div className="flex items-center justify-between">
+          <span className="flex items-center gap-2 text-sm">
+            <IconVolume className="size-4 text-muted-foreground" />
+            {i18n.t("options.floatingButtonAndToolbar.selectionToolbar.featureToggles.speak")}
+          </span>
+          <Switch
+            checked={features.speak.enabled}
+            onCheckedChange={checked => setFeatureEnabled("speak", checked)}
+          />
+        </div>
       </div>
     </ConfigCard>
   )

--- a/src/entrypoints/selection.content/selection-toolbar/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/index.tsx
@@ -215,7 +215,6 @@ function applyDirectionOffset(
 }
 
 export function SelectionToolbar() {
-  const isFirefox = import.meta.env.BROWSER === "firefox"
   const tooltipRef = useRef<HTMLDivElement>(null)
   const tooltipContainerRef = useRef<HTMLDivElement>(null)
   const selectionPositionRef = useRef<{ x: number, y: number } | null>(null) // store selection position (base position without direction offset)
@@ -430,7 +429,7 @@ export function SelectionToolbar() {
   const { features } = selectionToolbar
   const hasAnyEnabledFeature
     = features.translate.enabled
-      || (!isFirefox && features.speak.enabled)
+      || features.speak.enabled
       || selectionToolbar.customActions.some(a => a.enabled !== false)
 
   return (
@@ -455,7 +454,7 @@ export function SelectionToolbar() {
           >
             <div className="flex items-center overflow-x-auto overflow-y-hidden rounded-sm max-w-105 no-scrollbar">
               {features.translate.enabled && <TranslateButton />}
-              {!isFirefox && features.speak.enabled && <SpeakButton />}
+              {features.speak.enabled && <SpeakButton />}
               <SelectionToolbarCustomActionButtons />
             </div>
             <CloseButton />

--- a/src/hooks/use-text-to-speech.tsx
+++ b/src/hooks/use-text-to-speech.tsx
@@ -159,7 +159,7 @@ export function useTextToSpeech(surface: AnalyticsSurface = ANALYTICS_SURFACE.SE
       }
       const chunks = splitTextByUtf8Bytes(text)
       setTotalChunks(chunks.length)
-      await sendMessage("ttsPlaybackEnsureOffscreen")
+      await sendMessage("ttsPlaybackPrepare")
 
       const fetchChunkAudio = async (chunk: string) => {
         logger.info("[TextToSpeech] Fetching chunk audio", { text: chunk, voice: selectedVoice, rate: ttsConfig.rate, pitch: ttsConfig.pitch, volume: ttsConfig.volume })

--- a/src/types/tts-playback.ts
+++ b/src/types/tts-playback.ts
@@ -12,9 +12,5 @@ export type TTSPlaybackStartResponse
 
 export interface TTSPlaybackStopRequest {
   requestId?: string
-}
-
-export interface TTSOffscreenStopRequest {
-  requestId?: string
   reason?: TTSPlaybackStopReason
 }

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -14,7 +14,6 @@ import type {
 } from "@/types/edge-tts"
 import type { ProxyRequest, ProxyResponse } from "@/types/proxy-fetch"
 import type {
-  TTSOffscreenStopRequest,
   TTSPlaybackStartRequest,
   TTSPlaybackStartResponse,
   TTSPlaybackStopRequest,
@@ -77,12 +76,12 @@ interface ProtocolMap {
   edgeTtsListVoices: () => Promise<EdgeTTSVoice[]>
   edgeTtsHealthCheck: () => Promise<EdgeTTSHealthStatus>
   // tts playback
-  ttsPlaybackEnsureOffscreen: () => Promise<{ ok: true }>
+  ttsPlaybackPrepare: () => Promise<{ ok: true }>
   ttsPlaybackStart: (data: TTSPlaybackStartRequest) => Promise<TTSPlaybackStartResponse>
   ttsPlaybackStop: (data: TTSPlaybackStopRequest) => Promise<{ ok: true }>
   // offscreen internal
   ttsOffscreenPlay: (data: TTSPlaybackStartRequest) => Promise<TTSPlaybackStartResponse>
-  ttsOffscreenStop: (data: TTSOffscreenStopRequest) => Promise<{ ok: true }>
+  ttsOffscreenStop: (data: TTSPlaybackStopRequest) => Promise<{ ok: true }>
 }
 
 export const { sendMessage, onMessage }

--- a/src/utils/server/edge-tts/browser.ts
+++ b/src/utils/server/edge-tts/browser.ts
@@ -1,8 +1,20 @@
 import { EDGE_TTS_HTTP_ENABLED, EDGE_TTS_SUPPORTED_BROWSERS } from "./constants"
 import { EdgeTTSError } from "./errors"
 
+interface ChromeLike {
+  offscreen?: {
+    createDocument?: unknown
+  }
+}
+
+function hasChromeOffscreenApi(): boolean {
+  const chromeApi = (globalThis as { chrome?: ChromeLike }).chrome
+  return typeof chromeApi?.offscreen?.createDocument === "function"
+}
+
 export function isEdgeTTSBrowserSupported(): boolean {
-  return EDGE_TTS_SUPPORTED_BROWSERS.includes(import.meta.env.BROWSER as "chrome" | "edge")
+  return hasChromeOffscreenApi()
+    || (EDGE_TTS_SUPPORTED_BROWSERS as readonly string[]).includes(import.meta.env.BROWSER)
 }
 
 export function assertEdgeTTSAvailable(): void {

--- a/src/utils/server/edge-tts/constants.ts
+++ b/src/utils/server/edge-tts/constants.ts
@@ -56,4 +56,4 @@ export const EDGE_TTS_USER_AGENT
 
 export const EDGE_TTS_HTTP_ENABLED = import.meta.env.WXT_EDGE_TTS_HTTP_ENABLED !== "false"
 
-export const EDGE_TTS_SUPPORTED_BROWSERS = ["chrome", "edge"] as const
+export const EDGE_TTS_SUPPORTED_BROWSERS = ["chrome", "edge", "firefox"] as const

--- a/src/utils/tts-playback/__tests__/dom-audio-controller.test.ts
+++ b/src/utils/tts-playback/__tests__/dom-audio-controller.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { DOMAudioPlaybackController } from "../dom-audio-controller"
+
+const createObjectURLDescriptor = Object.getOwnPropertyDescriptor(URL, "createObjectURL")
+const revokeObjectURLDescriptor = Object.getOwnPropertyDescriptor(URL, "revokeObjectURL")
+
+function installFakeAudio() {
+  const createObjectURLMock = vi.fn(() => `blob:tts-test-${createObjectURLMock.mock.calls.length}`)
+  const revokeObjectURLMock = vi.fn()
+
+  Object.defineProperty(URL, "createObjectURL", {
+    configurable: true,
+    value: createObjectURLMock,
+  })
+  Object.defineProperty(URL, "revokeObjectURL", {
+    configurable: true,
+    value: revokeObjectURLMock,
+  })
+
+  class FakeAudio {
+    static instances: FakeAudio[] = []
+
+    onended: (() => void) | null = null
+    onerror: (() => void) | null = null
+    play = vi.fn().mockResolvedValue(undefined)
+    pause = vi.fn()
+    removeAttribute = vi.fn()
+    load = vi.fn()
+
+    constructor(readonly src: string) {
+      FakeAudio.instances.push(this)
+    }
+  }
+
+  vi.stubGlobal("Audio", FakeAudio)
+
+  return {
+    FakeAudio,
+    createObjectURLMock,
+    revokeObjectURLMock,
+  }
+}
+
+describe("dom audio playback controller", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    if (createObjectURLDescriptor) {
+      Object.defineProperty(URL, "createObjectURL", createObjectURLDescriptor)
+    }
+    else {
+      delete (URL as { createObjectURL?: unknown }).createObjectURL
+    }
+
+    if (revokeObjectURLDescriptor) {
+      Object.defineProperty(URL, "revokeObjectURL", revokeObjectURLDescriptor)
+    }
+    else {
+      delete (URL as { revokeObjectURL?: unknown }).revokeObjectURL
+    }
+  })
+
+  it("plays audio and cleans up object URLs after playback ends", async () => {
+    const { FakeAudio, revokeObjectURLMock } = installFakeAudio()
+    const controller = new DOMAudioPlaybackController("playback failed")
+
+    const playbackPromise = controller.play({
+      requestId: "req-1",
+      audioBase64: "ZmFrZQ==",
+      contentType: "audio/mpeg",
+    })
+
+    expect(FakeAudio.instances).toHaveLength(1)
+    expect(FakeAudio.instances[0]!.play).toHaveBeenCalled()
+
+    FakeAudio.instances[0]!.onended?.()
+
+    await expect(playbackPromise).resolves.toEqual({ ok: true })
+    expect(FakeAudio.instances[0]!.pause).toHaveBeenCalled()
+    expect(FakeAudio.instances[0]!.removeAttribute).toHaveBeenCalledWith("src")
+    expect(FakeAudio.instances[0]!.load).toHaveBeenCalled()
+    expect(revokeObjectURLMock).toHaveBeenCalledWith("blob:tts-test-1")
+  })
+
+  it("does not stop playback when requestId does not match", async () => {
+    const { FakeAudio } = installFakeAudio()
+    const controller = new DOMAudioPlaybackController("playback failed")
+
+    const playbackPromise = controller.play({
+      requestId: "req-active",
+      audioBase64: "ZmFrZQ==",
+      contentType: "audio/mpeg",
+    })
+
+    expect(controller.stop({ requestId: "req-other" })).toBe(false)
+    expect(FakeAudio.instances[0]!.pause).not.toHaveBeenCalled()
+
+    expect(controller.stop({ requestId: "req-active" })).toBe(true)
+
+    await expect(playbackPromise).resolves.toEqual({ ok: false, reason: "stopped" })
+    expect(FakeAudio.instances[0]!.pause).toHaveBeenCalled()
+  })
+
+  it("interrupts the previous playback when a new request starts", async () => {
+    const { FakeAudio } = installFakeAudio()
+    const controller = new DOMAudioPlaybackController("playback failed")
+
+    const firstPlayback = controller.play({
+      requestId: "req-1",
+      audioBase64: "ZmFrZQ==",
+      contentType: "audio/mpeg",
+    })
+    const secondPlayback = controller.play({
+      requestId: "req-2",
+      audioBase64: "ZmFrZQ==",
+      contentType: "audio/mpeg",
+    })
+
+    await expect(firstPlayback).resolves.toEqual({ ok: false, reason: "interrupted" })
+    expect(FakeAudio.instances[0]!.pause).toHaveBeenCalled()
+
+    FakeAudio.instances[1]!.onended?.()
+    await expect(secondPlayback).resolves.toEqual({ ok: true })
+  })
+
+  it("rejects and cleans up when the audio element fails", async () => {
+    const { FakeAudio, revokeObjectURLMock } = installFakeAudio()
+    const controller = new DOMAudioPlaybackController("playback failed")
+
+    const playbackPromise = controller.play({
+      requestId: "req-1",
+      audioBase64: "ZmFrZQ==",
+      contentType: "audio/mpeg",
+    })
+
+    FakeAudio.instances[0]!.onerror?.()
+
+    await expect(playbackPromise).rejects.toThrow("playback failed")
+    expect(FakeAudio.instances[0]!.pause).toHaveBeenCalled()
+    expect(revokeObjectURLMock).toHaveBeenCalledWith("blob:tts-test-1")
+  })
+})

--- a/src/utils/tts-playback/dom-audio-controller.ts
+++ b/src/utils/tts-playback/dom-audio-controller.ts
@@ -1,0 +1,138 @@
+import type {
+  TTSPlaybackStartRequest,
+  TTSPlaybackStartResponse,
+  TTSPlaybackStopReason,
+  TTSPlaybackStopRequest,
+} from "@/types/tts-playback"
+
+interface ActivePlayback {
+  requestId: string
+  audio: HTMLAudioElement
+  audioUrl: string
+  settled: boolean
+  resolve: (response: TTSPlaybackStartResponse) => void
+  reject: (error: Error) => void
+}
+
+function base64ToUint8Array(base64: string): Uint8Array {
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let index = 0; index < binary.length; index++) {
+    bytes[index] = binary.charCodeAt(index)
+  }
+  return bytes
+}
+
+function toError(error: unknown, fallbackMessage: string): Error {
+  if (error instanceof Error) {
+    return error
+  }
+  return new Error(typeof error === "string" ? error : fallbackMessage)
+}
+
+export class DOMAudioPlaybackController {
+  private activePlayback: ActivePlayback | null = null
+
+  constructor(private readonly playbackErrorMessage: string) {}
+
+  play(request: TTSPlaybackStartRequest): Promise<TTSPlaybackStartResponse> {
+    this.stop({ reason: "interrupted" })
+
+    return new Promise<TTSPlaybackStartResponse>((resolve, reject) => {
+      let playback: ActivePlayback | null = null
+
+      try {
+        const bytes = base64ToUint8Array(request.audioBase64)
+        const audioBuffer = new ArrayBuffer(bytes.byteLength)
+        new Uint8Array(audioBuffer).set(bytes)
+        const blob = new Blob([audioBuffer], { type: request.contentType })
+        const audioUrl = URL.createObjectURL(blob)
+        const audio = new Audio(audioUrl)
+
+        playback = {
+          requestId: request.requestId,
+          audio,
+          audioUrl,
+          settled: false,
+          resolve,
+          reject,
+        }
+
+        this.activePlayback = playback
+
+        audio.onended = () => {
+          this.settlePlayback(playback!, { ok: true })
+        }
+
+        audio.onerror = () => {
+          this.failPlayback(playback!, new Error(this.playbackErrorMessage))
+        }
+
+        audio.play().catch((error) => {
+          this.failPlayback(playback!, toError(error, "Unknown audio playback error"))
+        })
+      }
+      catch (error) {
+        if (playback) {
+          this.failPlayback(playback, toError(error, this.playbackErrorMessage))
+          return
+        }
+        reject(toError(error, this.playbackErrorMessage))
+      }
+    })
+  }
+
+  stop(request: TTSPlaybackStopRequest = {}): boolean {
+    return this.stopActivePlayback(request.reason ?? "stopped", request.requestId)
+  }
+
+  private cleanupPlayback(playback: ActivePlayback) {
+    playback.audio.onended = null
+    playback.audio.onerror = null
+    playback.audio.pause()
+    playback.audio.removeAttribute("src")
+    playback.audio.load()
+    URL.revokeObjectURL(playback.audioUrl)
+  }
+
+  private settlePlayback(playback: ActivePlayback, response: TTSPlaybackStartResponse): boolean {
+    if (playback.settled) {
+      return false
+    }
+
+    playback.settled = true
+    this.cleanupPlayback(playback)
+    if (this.activePlayback === playback) {
+      this.activePlayback = null
+    }
+    playback.resolve(response)
+    return true
+  }
+
+  private failPlayback(playback: ActivePlayback, error: Error): boolean {
+    if (playback.settled) {
+      return false
+    }
+
+    playback.settled = true
+    this.cleanupPlayback(playback)
+    if (this.activePlayback === playback) {
+      this.activePlayback = null
+    }
+    playback.reject(error)
+    return true
+  }
+
+  private stopActivePlayback(reason: TTSPlaybackStopReason, requestId?: string): boolean {
+    const playback = this.activePlayback
+    if (!playback) {
+      return false
+    }
+
+    if (requestId && playback.requestId !== requestId) {
+      return false
+    }
+
+    return this.settlePlayback(playback, { ok: false, reason })
+  }
+}


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [x] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Adds layered TTS playback selection so callers prepare/start/stop playback without knowing whether audio is hosted by an offscreen document or a background page.

- Uses `chrome.offscreen.createDocument` capability detection first so Brave/custom Chromium builds with offscreen continue using offscreen playback.
- Falls back to background DOM Audio playback for Firefox-style background pages.
- Extracts shared DOM audio lifecycle management for offscreen and background playback.
- Enables the Speak UI and TTS settings/search entries on Firefox.
- Adds a patch changeset for the extension.

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

- `SKIP_FREE_API=true pnpm test src/entrypoints/background/__tests__/tts-playback.test.ts src/utils/tts-playback/__tests__/dom-audio-controller.test.ts src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx src/entrypoints/selection.content/selection-toolbar/__tests__/text-wrapping.test.tsx src/entrypoints/selection.content/components/__tests__/action-tooltips.test.tsx`
- `SKIP_FREE_API=true pnpm type-check`
- `pnpm lint`
- `pnpm build`
- `pnpm build:firefox`
- pre-push: `nx run @read-frog/extension:lint`
- pre-push: `nx run @read-frog/extension:type-check`
- pre-push: `nx run @read-frog/extension:test` (160 files, 1341 tests)

## Screenshots

Not applicable.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Manual Firefox playback acceptance still needs to be done in a real browser: GitHub selection speak, long multi-chunk text, stop/interrupt, tab navigation/background event page behavior.