### PR TITLE
fix(subtitles): force dark theme for embedded YouTube subtitle menu

### DIFF
--- a/.changeset/fix-embedded-subtitle-menu-theme.md
+++ b/.changeset/fix-embedded-subtitle-menu-theme.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(subtitles): force dark theme for the embedded YouTube subtitle menu

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -15,9 +15,11 @@ export const ThemeContext = createContext<ThemeContextI | undefined>(undefined)
 export function ThemeProvider({
   children,
   container,
+  theme: forcedTheme,
 }: {
   children: React.ReactNode
   container?: HTMLElement
+  theme?: Theme
 }) {
   const [themeMode, setThemeMode] = useAtom(themeModeAtom)
 
@@ -34,9 +36,9 @@ export function ThemeProvider({
     () => !!window?.matchMedia?.("(prefers-color-scheme: dark)")?.matches,
   )
 
-  const theme: Theme = themeMode === "system"
+  const theme: Theme = forcedTheme ?? (themeMode === "system"
     ? (prefersDark ? "dark" : "light")
-    : themeMode
+    : themeMode)
 
   // Apply theme to document or shadow root container
   useLayoutEffect(() => {

--- a/src/components/providers/theme-provider.tsx
+++ b/src/components/providers/theme-provider.tsx
@@ -15,11 +15,11 @@ export const ThemeContext = createContext<ThemeContextI | undefined>(undefined)
 export function ThemeProvider({
   children,
   container,
-  theme: forcedTheme,
+  forcedTheme,
 }: {
   children: React.ReactNode
   container?: HTMLElement
-  theme?: Theme
+  forcedTheme?: Theme
 }) {
   const [themeMode, setThemeMode] = useAtom(themeModeAtom)
 

--- a/src/entrypoints/subtitles.content/renderer/render-translate-button.tsx
+++ b/src/entrypoints/subtitles.content/renderer/render-translate-button.tsx
@@ -58,7 +58,7 @@ export function renderSubtitlesTranslateButton(adapter: SubtitlesProvidersAdapte
     position: "inline",
     inheritStyles: false,
     cssContent: [themeCSS, adapter.embedded ? embedWrapperCSS : wrapperCSS],
-    theme: SUBTITLES_THEME,
+    forcedTheme: SUBTITLES_THEME,
     ...(adapter.embedded && { style: { position: "relative" } }),
   }) as HTMLDivElement
 

--- a/src/entrypoints/subtitles.content/renderer/render-translate-button.tsx
+++ b/src/entrypoints/subtitles.content/renderer/render-translate-button.tsx
@@ -1,7 +1,11 @@
 import type { SubtitlesProvidersAdapter } from "../ui/subtitles-ui-context"
+import ReactDOM from "react-dom/client"
 import themeCSS from "@/assets/styles/theme.css?inline"
+import { REACT_SHADOW_HOST_CLASS } from "@/utils/constants/dom-labels"
 import { SUBTITLES_THEME, TRANSLATE_BUTTON_CONTAINER_ID } from "@/utils/constants/subtitles"
-import { createReactShadowHost } from "@/utils/react-shadow-host/create-shadow-host"
+import { ShadowWrapperContext } from "@/utils/react-shadow-host/create-shadow-host"
+import { ShadowHostBuilder } from "@/utils/react-shadow-host/shadow-host-builder"
+import { applyTheme } from "@/utils/theme"
 import { SubtitlesSettingsPanel } from "../ui/subtitles-settings-panel"
 import { SubtitlesTranslateButton } from "../ui/subtitles-translate-button"
 import { SubtitlesProviders } from "../ui/subtitles-ui-context"
@@ -54,14 +58,32 @@ export function renderSubtitlesTranslateButton(adapter: SubtitlesProvidersAdapte
       )
     : <SubtitlesTranslateButton />
 
-  const shadowHost = createReactShadowHost(component, {
+  const shadowHost = document.createElement("div")
+  shadowHost.id = TRANSLATE_BUTTON_CONTAINER_ID
+  shadowHost.classList.add(REACT_SHADOW_HOST_CLASS)
+  shadowHost.style.display = "inline"
+
+  const shadowRoot = shadowHost.attachShadow({ mode: "open" })
+  const hostBuilder = new ShadowHostBuilder(shadowRoot, {
     position: "inline",
     inheritStyles: false,
     cssContent: [themeCSS, adapter.embedded ? embedWrapperCSS : wrapperCSS],
     ...(adapter.embedded && { style: { position: "relative" } }),
-  }) as HTMLDivElement
+  })
+  const reactContainer = hostBuilder.build()
+  applyTheme(reactContainer, SUBTITLES_THEME)
 
-  shadowHost.id = TRANSLATE_BUTTON_CONTAINER_ID
+  const root = ReactDOM.createRoot(reactContainer)
+  root.render(
+    <ShadowWrapperContext value={reactContainer}>
+      {component}
+    </ShadowWrapperContext>,
+  )
+
+  ;(shadowHost as any).__reactShadowContainerCleanup = () => {
+    root.unmount()
+    hostBuilder.cleanup()
+  }
 
   if (adapter.embedded) {
     for (const eventType of ["click", "mousedown", "pointerdown", "dblclick"]) {

--- a/src/entrypoints/subtitles.content/renderer/render-translate-button.tsx
+++ b/src/entrypoints/subtitles.content/renderer/render-translate-button.tsx
@@ -1,11 +1,7 @@
 import type { SubtitlesProvidersAdapter } from "../ui/subtitles-ui-context"
-import ReactDOM from "react-dom/client"
 import themeCSS from "@/assets/styles/theme.css?inline"
-import { REACT_SHADOW_HOST_CLASS } from "@/utils/constants/dom-labels"
 import { SUBTITLES_THEME, TRANSLATE_BUTTON_CONTAINER_ID } from "@/utils/constants/subtitles"
-import { ShadowWrapperContext } from "@/utils/react-shadow-host/create-shadow-host"
-import { ShadowHostBuilder } from "@/utils/react-shadow-host/shadow-host-builder"
-import { applyTheme } from "@/utils/theme"
+import { createReactShadowHost } from "@/utils/react-shadow-host/create-shadow-host"
 import { SubtitlesSettingsPanel } from "../ui/subtitles-settings-panel"
 import { SubtitlesTranslateButton } from "../ui/subtitles-translate-button"
 import { SubtitlesProviders } from "../ui/subtitles-ui-context"
@@ -58,32 +54,15 @@ export function renderSubtitlesTranslateButton(adapter: SubtitlesProvidersAdapte
       )
     : <SubtitlesTranslateButton />
 
-  const shadowHost = document.createElement("div")
-  shadowHost.id = TRANSLATE_BUTTON_CONTAINER_ID
-  shadowHost.classList.add(REACT_SHADOW_HOST_CLASS)
-  shadowHost.style.display = "inline"
-
-  const shadowRoot = shadowHost.attachShadow({ mode: "open" })
-  const hostBuilder = new ShadowHostBuilder(shadowRoot, {
+  const shadowHost = createReactShadowHost(component, {
     position: "inline",
     inheritStyles: false,
     cssContent: [themeCSS, adapter.embedded ? embedWrapperCSS : wrapperCSS],
+    theme: SUBTITLES_THEME,
     ...(adapter.embedded && { style: { position: "relative" } }),
-  })
-  const reactContainer = hostBuilder.build()
-  applyTheme(reactContainer, SUBTITLES_THEME)
+  }) as HTMLDivElement
 
-  const root = ReactDOM.createRoot(reactContainer)
-  root.render(
-    <ShadowWrapperContext value={reactContainer}>
-      {component}
-    </ShadowWrapperContext>,
-  )
-
-  ;(shadowHost as any).__reactShadowContainerCleanup = () => {
-    root.unmount()
-    hostBuilder.cleanup()
-  }
+  shadowHost.id = TRANSLATE_BUTTON_CONTAINER_ID
 
   if (adapter.embedded) {
     for (const eventType of ["click", "mousedown", "pointerdown", "dblclick"]) {

--- a/src/utils/react-shadow-host/create-shadow-host.tsx
+++ b/src/utils/react-shadow-host/create-shadow-host.tsx
@@ -1,3 +1,4 @@
+import type { Theme } from "@/types/config/theme"
 import { createContext } from "react"
 import ReactDOM from "react-dom/client"
 import { ThemeProvider } from "@/components/providers/theme-provider"
@@ -15,9 +16,10 @@ export function createReactShadowHost(
     className?: string
     cssContent?: string[]
     style?: Partial<CSSStyleDeclaration>
+    theme?: Theme
   },
 ) {
-  const { className, position, inheritStyles, cssContent, style } = options
+  const { className, position, inheritStyles, cssContent, style, theme } = options
 
   const shadowHost = document.createElement("div")
   if (className)
@@ -38,7 +40,7 @@ export function createReactShadowHost(
   const root = ReactDOM.createRoot(innerReactContainer)
   const wrappedComponent = (
     <ShadowWrapperContext value={innerReactContainer}>
-      <ThemeProvider container={innerReactContainer}>
+      <ThemeProvider container={innerReactContainer} theme={theme}>
         <TooltipProvider>
           {component}
         </TooltipProvider>

--- a/src/utils/react-shadow-host/create-shadow-host.tsx
+++ b/src/utils/react-shadow-host/create-shadow-host.tsx
@@ -16,10 +16,10 @@ export function createReactShadowHost(
     className?: string
     cssContent?: string[]
     style?: Partial<CSSStyleDeclaration>
-    theme?: Theme
+    forcedTheme?: Theme
   },
 ) {
-  const { className, position, inheritStyles, cssContent, style, theme } = options
+  const { className, position, inheritStyles, cssContent, style, forcedTheme } = options
 
   const shadowHost = document.createElement("div")
   if (className)
@@ -40,7 +40,7 @@ export function createReactShadowHost(
   const root = ReactDOM.createRoot(innerReactContainer)
   const wrappedComponent = (
     <ShadowWrapperContext value={innerReactContainer}>
-      <ThemeProvider container={innerReactContainer} theme={theme}>
+      <ThemeProvider container={innerReactContainer} forcedTheme={forcedTheme}>
         <TooltipProvider>
           {component}
         </TooltipProvider>


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

On YouTube videos **embedded in other sites via iframe**, the Read Frog subtitle menu (the "Read Frog Video Subtitles" popover with the toggle, download items, and Subtitle Style) rendered in **light mode**, while on youtube.com it is correctly **dark**.

### Root cause

The two render paths derive their theme differently:

- **youtube.com**: the menu is mounted by `mount-subtitles-ui.tsx`, which calls `applyTheme(reactContainer, SUBTITLES_THEME)` — **forced `"dark"`**.
- **embedded (`adapter.embedded`)**: the button + menu are mounted by `render-translate-button.tsx` via `createReactShadowHost`, which wraps content in `ThemeProvider`. That provider **follows** `themeMode` / system `prefers-color-scheme`, so the menu turned light.

`SUBTITLES_THEME = "dark"` is intentional — the subtitle UI sits on top of arbitrary host pages and is kept fixed to dark for readability. The regression traces to #1436, which forced dark for `mount-subtitles-ui` but missed the embedded path.

### Fix

Mount the translate-button host the same way `mount-subtitles-ui` does: build the shadow root with `ShadowHostBuilder` and call `applyTheme(reactContainer, SUBTITLES_THEME)`, skipping `ThemeProvider` (and the unused `TooltipProvider`). No changes to the shared `ThemeProvider` / `createReactShadowHost`.

The subtitle UI components do not use Tooltip, so dropping `TooltipProvider` here is safe. The non-embedded translate button icon is now also fixed to dark, consistent with the "subtitle UI is always dark" design.

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Verified through manual testing

- Embedded YouTube (iframe on a docs site): subtitle menu renders dark.
- youtube.com: menu and button still dark and functional.
- With system/extension theme set to light: subtitle menu stays dark.

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.