### PR TITLE
feat(providers): add Azure provider

### DIFF
--- a/.changeset/azure-openai-provider.md
+++ b/.changeset/azure-openai-provider.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(providers): add Azure provider.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@ai-sdk/alibaba": "^1.0.29",
     "@ai-sdk/amazon-bedrock": "^4.0.119",
     "@ai-sdk/anthropic": "^3.0.85",
+    "@ai-sdk/azure": "^3.0.76",
     "@ai-sdk/cerebras": "^2.0.57",
     "@ai-sdk/cohere": "^3.0.39",
     "@ai-sdk/deepinfra": "^2.0.55",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@ai-sdk/anthropic':
         specifier: ^3.0.85
         version: 3.0.85(zod@4.4.3)
+      '@ai-sdk/azure':
+        specifier: ^3.0.76
+        version: 3.0.76(zod@4.4.3)
       '@ai-sdk/cerebras':
         specifier: ^2.0.57
         version: 2.0.57(zod@4.4.3)
@@ -419,6 +422,12 @@ packages:
 
   '@ai-sdk/anthropic@3.0.85':
     resolution: {integrity: sha512-fNeDB644l5wbRNQU0FnI+F7UTtOenMnPtACfMPUJaS2zJfuBlseEa1TMg+otHkETZgaJB+6Na51NQEv0+m7czw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/azure@3.0.76':
+    resolution: {integrity: sha512-Z7CsB0Vc/UsM3gkrUb9BiEJ/Lvf1mABj17UMjHFuK0GzyYRRMb6anxvJ9FtP7G5lItnifRHZ4ZrTSi5e7ghTYQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -7674,6 +7683,14 @@ snapshots:
 
   '@ai-sdk/anthropic@3.0.85(zod@4.4.3)':
     dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/azure@3.0.76(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/deepseek': 2.0.39(zod@4.4.3)
+      '@ai-sdk/openai': 3.0.73(zod@4.4.3)
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
       zod: 4.4.3

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-specific-settings-field.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-specific-settings-field.test.tsx
@@ -62,6 +62,32 @@ describe("providerSpecificSettingsField", () => {
     expect(screen.getByLabelText("persisted-provider-specific-settings")).toHaveTextContent("{\"region\":\"us-west-2\"}")
   })
 
+  it("renders Azure settings without a region field and persists non-empty values", async () => {
+    render(<ProviderSpecificSettingsFieldHarness initialConfig={DEFAULT_PROVIDER_CONFIG.azure} />)
+
+    expect(screen.queryByLabelText("options.apiProviders.form.providerSettingLabels.region")).not.toBeInTheDocument()
+
+    const apiModeSelect = screen.getByLabelText("options.apiProviders.form.providerSettingLabels.apiMode")
+    const resourceNameInput = screen.getByLabelText("options.apiProviders.form.providerSettingLabels.resourceName")
+    const apiVersionInput = screen.getByLabelText("options.apiProviders.form.providerSettingLabels.apiVersion")
+
+    expect(apiModeSelect).toHaveTextContent("options.apiProviders.form.providerSettingOptionLabels.responses")
+    expect(resourceNameInput).toHaveValue("")
+    expect(apiVersionInput).toHaveValue("v1")
+
+    fireEvent.change(resourceNameInput, { target: { value: "read-frog-openai" } })
+    fireEvent.change(apiVersionInput, { target: { value: "2025-04-01-preview" } })
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+      await Promise.resolve()
+    })
+
+    expect(screen.getByLabelText("persisted-provider-specific-settings")).toHaveTextContent(
+      "{\"apiMode\":\"responses\",\"apiVersion\":\"2025-04-01-preview\",\"resourceName\":\"read-frog-openai\"}",
+    )
+  })
+
   it("does not render or write settings for providers without provider-specific schemas", async () => {
     render(<ProviderSpecificSettingsFieldHarness initialConfig={DEFAULT_PROVIDER_CONFIG.openai} />)
 

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/base-url-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/base-url-field.tsx
@@ -3,6 +3,7 @@ import type { APIProviderConfig } from "@/types/config/provider"
 import { useStore } from "@tanstack/react-form"
 import { i18n } from "#imports"
 import { isNonCustomLLMProvider } from "@/types/config/provider"
+import { PROVIDER_BASE_URL_PLACEHOLDERS } from "@/utils/constants/providers"
 import { ConnectionTestButton } from "./components/connection-button"
 import { withForm } from "./form"
 
@@ -27,6 +28,7 @@ export const BaseURLField = withForm({
           <field.InputFieldAutoSave
             formForSubmit={form}
             label={labelText}
+            placeholder={PROVIDER_BASE_URL_PLACEHOLDERS[providerType]}
             labelExtra={providerType === "ollama" && (
               <ConnectionTestButton
                 providerConfig={providerConfig}

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/provider-specific-settings-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/provider-specific-settings-field.tsx
@@ -4,6 +4,7 @@ import { useEffect, useEffectEvent, useMemo, useState } from "react"
 import { i18n } from "#imports"
 import { Field, FieldGroup, FieldLabel } from "@/components/ui/base-ui/field"
 import { Input } from "@/components/ui/base-ui/input"
+import { Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/base-ui/select"
 import { useDebouncedValue } from "@/hooks/use-debounced-value"
 import { getProviderSpecificSettingFields, isLLMProvider, PROVIDER_SPECIFIC_SETTINGS_SCHEMAS } from "@/types/config/provider"
 import { compactObject } from "@/types/utils"
@@ -68,6 +69,39 @@ export const ProviderSpecificSettingsField = withForm({
       const fieldId = `${def.key}-${providerConfig.id}`
       const fieldLabel = i18n.t(`options.apiProviders.form.providerSettingLabels.${def.labelKey}` as Parameters<typeof i18n.t>[0])
       const fieldValue = localSettings[def.key]
+
+      if (def.type === "select") {
+        const selectedValue = typeof fieldValue === "string" ? fieldValue : def.defaultValue
+        const selectedOption = def.options.find(option => option.value === selectedValue)
+
+        return (
+          <Field key={fieldId}>
+            <FieldLabel htmlFor={fieldId}>{fieldLabel}</FieldLabel>
+            <Select
+              value={selectedValue}
+              onValueChange={value => setLocalSettings(prev => ({ ...prev, [def.key]: value }))}
+            >
+              <SelectTrigger id={fieldId} className="w-full">
+                <SelectValue placeholder={def.placeholder}>
+                  {selectedOption
+                    ? i18n.t(`options.apiProviders.form.providerSettingOptionLabels.${selectedOption.labelKey}` as Parameters<typeof i18n.t>[0])
+                    : undefined}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {def.options.map(option => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {i18n.t(`options.apiProviders.form.providerSettingOptionLabels.${option.labelKey}` as Parameters<typeof i18n.t>[0])}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </Field>
+        )
+      }
+
       return (
         <Field key={fieldId}>
           <FieldLabel htmlFor={fieldId}>{fieldLabel}</FieldLabel>

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -141,6 +141,12 @@ options:
       advancedOptions: Advanced Options
       providerSettingLabels:
         region: Region
+        apiMode: API mode
+        resourceName: Azure resource name (Optional)
+        apiVersion: API version
+      providerSettingOptionLabels:
+        responses: Responses API
+        chatCompletions: Chat Completions
       temperature: Temperature
       temperatureHint: Controls randomness in responses. Lower values (0) are more deterministic, higher values are more creative. Range varies by provider. Leave empty to use provider default.
       headers: Headers
@@ -157,6 +163,7 @@ options:
     providers:
       description:
         openai: Provides models like GPT-4o
+        azure: Azure-hosted OpenAI models through your deployments
         deepseek: Recommend to use in China
         openrouter: Unified interface for multiple LLM providers with pay-per-use pricing
         ollama: Run large language models locally on your machine for complete privacy

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -141,6 +141,12 @@ options:
       advancedOptions: Opciones avanzadas
       providerSettingLabels:
         region: Región
+        apiMode: Modo de API
+        resourceName: Nombre del recurso de Azure (opcional)
+        apiVersion: Versión de API
+      providerSettingOptionLabels:
+        responses: Responses API
+        chatCompletions: Chat Completions
       temperature: Temperatura
       temperatureHint: Controla la aleatoriedad en las respuestas. Los valores más bajos (0) son más deterministas; los más altos son más creativos. El rango varía según el proveedor. Déjalo vacío para usar el valor predeterminado del proveedor.
       headers: Encabezados
@@ -157,6 +163,7 @@ options:
     providers:
       description:
         openai: Proporciona modelos como GPT-4o
+        azure: Modelos OpenAI hospedados en Azure mediante tus implementaciones
         deepseek: Recomendado para usar en China
         openrouter: Interfaz unificada para varios proveedores LLM con precios de pago por uso
         ollama: Ejecuta modelos de lenguaje grandes localmente en tu equipo con privacidad completa

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -140,6 +140,12 @@ options:
       advancedOptions: 詳細オプション
       providerSettingLabels:
         region: リージョン
+        apiMode: API モード
+        resourceName: Azure リソース名（任意）
+        apiVersion: API バージョン
+      providerSettingOptionLabels:
+        responses: Responses API
+        chatCompletions: Chat Completions
       temperature: 温度
       temperatureHint: 応答のランダム性を制御します。低い値（0）はより決定的で、高い値はより創造的です。範囲はプロバイダーによって異なります。空欄の場合はプロバイダーのデフォルト値を使用します。
       headers: ヘッダー
@@ -156,6 +162,7 @@ options:
     providers:
       description:
         openai: GPT-4oなどのモデルを提供
+        azure: Azure のデプロイ経由で OpenAI モデルを利用
         deepseek: 中国国内での使用を推奨
         openrouter: 複数のLLMプロバイダの統合インターフェース、従量課金制
         ollama: ローカル大規模言語モデルサービス

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -140,6 +140,12 @@ options:
       advancedOptions: 고급 옵션
       providerSettingLabels:
         region: 리전
+        apiMode: API 모드
+        resourceName: Azure 리소스 이름(선택 사항)
+        apiVersion: API 버전
+      providerSettingOptionLabels:
+        responses: Responses API
+        chatCompletions: Chat Completions
       temperature: 온도
       temperatureHint: 응답의 무작위성을 제어합니다. 낮은 값(0)은 더 결정적이고, 높은 값은 더 창의적입니다. 범위는 제공자에 따라 다릅니다. 비워두면 제공자 기본값을 사용합니다.
       headers: 헤더
@@ -156,6 +162,7 @@ options:
     providers:
       description:
         openai: GPT-4o 같은 모델을 제공합니다
+        azure: Azure 배포를 통해 OpenAI 모델 사용
         deepseek: 중국에서 사용을 권장합니다
         openrouter: 여러 LLM 제공업체를 위한 통합 인터페이스, 사용량 기반 과금
         ollama: 로컬 LLM

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -140,6 +140,12 @@ options:
       advancedOptions: Расширенные настройки
       providerSettingLabels:
         region: Регион
+        apiMode: Режим API
+        resourceName: Имя ресурса Azure (необязательно)
+        apiVersion: Версия API
+      providerSettingOptionLabels:
+        responses: Responses API
+        chatCompletions: Chat Completions
       temperature: Температура
       temperatureHint: Контролирует случайность ответов. Низкие значения (0) более детерминированы, высокие — более креативны. Диапазон зависит от провайдера. Оставьте пустым для использования значения по умолчанию.
       headers: Заголовки
@@ -156,6 +162,7 @@ options:
     providers:
       description:
         openai: Предоставляет модели, такие как GPT-4o
+        azure: Модели OpenAI в Azure через ваши развертывания
         deepseek: Рекомендуется для использования в Китае
         openrouter: Единый интерфейс для нескольких LLM-провайдеров с оплатой за использование
         ollama: Запускайте большие языковые модели локально на вашем компьютере для полной конфиденциальности

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -140,6 +140,12 @@ options:
       advancedOptions: Gelişmiş Seçenekler
       providerSettingLabels:
         region: Bölge
+        apiMode: API modu
+        resourceName: Azure kaynak adı (isteğe bağlı)
+        apiVersion: API sürümü
+      providerSettingOptionLabels:
+        responses: Responses API
+        chatCompletions: Chat Completions
       temperature: Sıcaklık
       temperatureHint: Yanıtlardaki rastgeleliği kontrol eder. Düşük değerler (0) daha belirleyici, yüksek değerler daha yaratıcıdır. Aralık sağlayıcıya göre değişir. Sağlayıcı varsayılanını kullanmak için boş bırakın.
       headers: Başlıklar
@@ -156,6 +162,7 @@ options:
     providers:
       description:
         openai: GPT-4o gibi modeller sağlar
+        azure: Azure dağıtımlarınız üzerinden OpenAI modelleri
         deepseek: Çin'de kullanım için önerilir
         openrouter: Kullandıkça öde fiyatlandırmasıyla birden fazla LLM sağlayıcısı için birleşik arayüz
         ollama: Tam gizlilik için büyük dil modellerini makinenizde yerel olarak çalıştırın

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -140,6 +140,12 @@ options:
       advancedOptions: Tùy chọn nâng cao
       providerSettingLabels:
         region: Khu vực
+        apiMode: Chế độ API
+        resourceName: Tên tài nguyên Azure (tùy chọn)
+        apiVersion: Phiên bản API
+      providerSettingOptionLabels:
+        responses: Responses API
+        chatCompletions: Chat Completions
       temperature: Nhiệt độ
       temperatureHint: Kiểm soát tính ngẫu nhiên trong phản hồi. Giá trị thấp (0) mang tính xác định hơn, giá trị cao mang tính sáng tạo hơn. Phạm vi thay đổi theo nhà cung cấp. Để trống để sử dụng giá trị mặc định của nhà cung cấp.
       headers: Header
@@ -156,6 +162,7 @@ options:
     providers:
       description:
         openai: Cung cấp các mô hình như GPT-4o
+        azure: Mô hình OpenAI lưu trữ trên Azure qua các bản triển khai của bạn
         deepseek: Khuyến nghị sử dụng ở Trung Quốc
         openrouter: Giao diện thống nhất cho nhiều nhà cung cấp LLM với giá trả theo lần sử dụng
         ollama: Chạy các mô hình ngôn ngữ lớn cục bộ trên máy của bạn để bảo mật hoàn toàn

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -141,6 +141,12 @@ options:
       advancedOptions: 高级选项
       providerSettingLabels:
         region: 区域
+        apiMode: API 模式
+        resourceName: Azure 资源名称（可选）
+        apiVersion: API 版本
+      providerSettingOptionLabels:
+        responses: Responses API
+        chatCompletions: Chat Completions
       temperature: 温度
       temperatureHint: 控制响应的随机性。较低的值（0）更确定性，较高的值更具创造性。范围因提供商而异。留空则使用提供商默认值。
       headers: 请求头
@@ -157,6 +163,7 @@ options:
     providers:
       description:
         openai: 提供 GPT-4o 等模型
+        azure: 通过 Azure 部署使用 OpenAI 模型
         deepseek: 推荐在中国使用
         openrouter: 多个 LLM 提供商的统一接口，按使用量付费
         ollama: 在本地机器上运行大语言模型，确保完全隐私

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -141,6 +141,12 @@ options:
       advancedOptions: 進階選項
       providerSettingLabels:
         region: 區域
+        apiMode: API 模式
+        resourceName: Azure 資源名稱（選填）
+        apiVersion: API 版本
+      providerSettingOptionLabels:
+        responses: Responses API
+        chatCompletions: Chat Completions
       temperature: 溫度
       temperatureHint: 控制回應的隨機性。數值越低（如 0）越穩定，數值越高越有創造性。可用範圍依提供者而異。留空則使用提供者預設值。
       headers: 請求標頭
@@ -157,6 +163,7 @@ options:
     providers:
       description:
         openai: 提供 GPT-4o 等模型
+        azure: 透過 Azure 部署使用 OpenAI 模型
         deepseek: 建議在中國使用
         openrouter: 多個 LLM 提供者的統一介面，按使用量付費
         ollama: 在本機執行大型語言模型，確保完整隱私

--- a/src/types/config/__tests__/provider-specific-settings.test.ts
+++ b/src/types/config/__tests__/provider-specific-settings.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
-import { bedrockProviderSpecificSettingsSchema, getProviderSpecificSettingFields } from "../provider"
+import { azureProviderSpecificSettingsSchema, bedrockProviderSpecificSettingsSchema, getProviderSpecificSettingFields } from "../provider"
 
 describe("provider-specific settings metadata", () => {
   it("returns the Bedrock region field from Zod metadata", () => {
@@ -10,6 +10,33 @@ describe("provider-specific settings metadata", () => {
         labelKey: "region",
         type: "text",
         placeholder: "us-east-1",
+      },
+    ])
+  })
+
+  it("returns the Azure resource fields from Zod metadata", () => {
+    expect(getProviderSpecificSettingFields(azureProviderSpecificSettingsSchema)).toEqual([
+      {
+        key: "apiMode",
+        labelKey: "apiMode",
+        type: "select",
+        defaultValue: "responses",
+        options: [
+          { value: "responses", labelKey: "responses" },
+          { value: "chat", labelKey: "chatCompletions" },
+        ],
+      },
+      {
+        key: "resourceName",
+        labelKey: "resourceName",
+        type: "text",
+        placeholder: "my-azure-openai-resource",
+      },
+      {
+        key: "apiVersion",
+        labelKey: "apiVersion",
+        type: "text",
+        placeholder: "v1",
       },
     ])
   })

--- a/src/types/config/provider/constants.ts
+++ b/src/types/config/provider/constants.ts
@@ -8,7 +8,7 @@ export { LLM_PROVIDER_MODELS, NON_API_TRANSLATE_PROVIDERS, NON_API_TRANSLATE_PRO
   ────────────────────────────── */
 
 // translate provider names
-export const TRANSLATE_PROVIDER_TYPES = ["google-translate", "microsoft-translate", "deeplx", "deepl", "openai", "deepseek", "google", "anthropic", "xai", "openai-compatible", "siliconflow", "tensdaq", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
+export const TRANSLATE_PROVIDER_TYPES = ["google-translate", "microsoft-translate", "deeplx", "deepl", "openai", "deepseek", "google", "anthropic", "xai", "openai-compatible", "siliconflow", "tensdaq", "azure", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
   (keyof typeof LLM_PROVIDER_MODELS | typeof PURE_TRANSLATE_PROVIDERS[number])[]
 >
 export type TranslateProviderTypes = typeof TRANSLATE_PROVIDER_TYPES[number]
@@ -16,7 +16,7 @@ export function isTranslateProvider(provider: string): provider is TranslateProv
   return TRANSLATE_PROVIDER_TYPES.includes(provider)
 }
 
-export const LLM_PROVIDER_TYPES = ["openai", "deepseek", "google", "anthropic", "xai", "openai-compatible", "siliconflow", "tensdaq", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
+export const LLM_PROVIDER_TYPES = ["openai", "deepseek", "google", "anthropic", "xai", "openai-compatible", "siliconflow", "tensdaq", "azure", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
   (keyof typeof LLM_PROVIDER_MODELS)[]
 >
 export type LLMProviderTypes = typeof LLM_PROVIDER_TYPES[number]
@@ -32,7 +32,7 @@ export function isCustomLLMProvider(provider: string): provider is CustomLLMProv
   return CUSTOM_LLM_PROVIDER_TYPES.includes(provider)
 }
 
-export const NON_CUSTOM_LLM_PROVIDER_TYPES = ["openai", "deepseek", "google", "anthropic", "xai", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
+export const NON_CUSTOM_LLM_PROVIDER_TYPES = ["openai", "deepseek", "google", "anthropic", "xai", "azure", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
   Exclude<keyof typeof LLM_PROVIDER_MODELS, CustomLLMProviderTypes>[]
 >
 export type NonCustomLLMProviderTypes = typeof NON_CUSTOM_LLM_PROVIDER_TYPES[number]
@@ -40,7 +40,7 @@ export function isNonCustomLLMProvider(provider: string): provider is NonCustomL
   return NON_CUSTOM_LLM_PROVIDER_TYPES.includes(provider)
 }
 
-export const API_PROVIDER_TYPES = ["siliconflow", "tensdaq", "openai-compatible", "openai", "deepseek", "google", "anthropic", "xai", "deeplx", "deepl", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
+export const API_PROVIDER_TYPES = ["siliconflow", "tensdaq", "openai-compatible", "openai", "deepseek", "google", "anthropic", "xai", "deeplx", "deepl", "azure", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
   (keyof typeof LLM_PROVIDER_MODELS | "deeplx" | "deepl")[]
 >
 export type APIProviderTypes = typeof API_PROVIDER_TYPES[number]
@@ -62,7 +62,7 @@ export function isNonAPIProvider(provider: string): provider is NonAPIProviderTy
 }
 
 // all provider names
-export const ALL_PROVIDER_TYPES = ["google-translate", "microsoft-translate", "deeplx", "deepl", "siliconflow", "tensdaq", "openai-compatible", "openai", "deepseek", "google", "anthropic", "xai", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
+export const ALL_PROVIDER_TYPES = ["google-translate", "microsoft-translate", "deeplx", "deepl", "siliconflow", "tensdaq", "openai-compatible", "openai", "deepseek", "google", "anthropic", "xai", "azure", "bedrock", "groq", "deepinfra", "mistral", "togetherai", "cohere", "fireworks", "cerebras", "replicate", "perplexity", "vercel", "openrouter", "ollama", "volcengine", "minimax", "alibaba", "moonshotai", "huggingface"] as const satisfies Readonly<
   TranslateProviderTypes[]
 >
 export type AllProviderTypes = typeof ALL_PROVIDER_TYPES[number]

--- a/src/types/config/provider/provider-specific-settings.ts
+++ b/src/types/config/provider/provider-specific-settings.ts
@@ -2,11 +2,29 @@ import type { LLMProviderTypes } from "./constants"
 
 import { z } from "zod"
 
-export interface ProviderSettingUiMeta {
+export const AZURE_API_MODES = ["responses", "chat"] as const
+export type AzureApiMode = typeof AZURE_API_MODES[number]
+export const DEFAULT_AZURE_API_MODE: AzureApiMode = "responses"
+
+interface ProviderSettingBaseUiMeta {
   labelKey: string
-  type: "text"
   placeholder?: string
 }
+
+interface ProviderSettingTextUiMeta extends ProviderSettingBaseUiMeta {
+  type: "text"
+}
+
+interface ProviderSettingSelectUiMeta extends ProviderSettingBaseUiMeta {
+  type: "select"
+  defaultValue?: string
+  options: Array<{
+    value: string
+    labelKey: string
+  }>
+}
+
+export type ProviderSettingUiMeta = ProviderSettingTextUiMeta | ProviderSettingSelectUiMeta
 
 declare module "zod" {
   interface GlobalMeta {
@@ -14,7 +32,7 @@ declare module "zod" {
   }
 }
 
-export interface ProviderSpecificSettingField extends ProviderSettingUiMeta {
+export type ProviderSpecificSettingField = ProviderSettingUiMeta & {
   key: string
 }
 
@@ -30,7 +48,36 @@ export const bedrockProviderSpecificSettingsSchema = z.strictObject({
   }),
 })
 
+export const azureProviderSpecificSettingsSchema = z.strictObject({
+  apiMode: z.enum(AZURE_API_MODES).optional().meta({
+    providerSettingUi: {
+      labelKey: "apiMode",
+      type: "select",
+      defaultValue: DEFAULT_AZURE_API_MODE,
+      options: [
+        { value: "responses", labelKey: "responses" },
+        { value: "chat", labelKey: "chatCompletions" },
+      ],
+    },
+  }),
+  resourceName: z.string().trim().optional().meta({
+    providerSettingUi: {
+      labelKey: "resourceName",
+      type: "text",
+      placeholder: "my-azure-openai-resource",
+    },
+  }),
+  apiVersion: z.string().trim().optional().meta({
+    providerSettingUi: {
+      labelKey: "apiVersion",
+      type: "text",
+      placeholder: "v1",
+    },
+  }),
+})
+
 export const PROVIDER_SPECIFIC_SETTINGS_SCHEMAS: Partial<Record<LLMProviderTypes, ProviderSpecificSettingsSchema>> = {
+  azure: azureProviderSpecificSettingsSchema,
   bedrock: bedrockProviderSpecificSettingsSchema,
 }
 
@@ -44,15 +91,13 @@ export function getProviderSpecificSettingFields(
       throw new Error(`providerSpecificSettings.${key} is missing providerSettingUi metadata`)
     }
 
-    if (ui.type !== "text") {
-      throw new Error(`Unsupported providerSpecificSettings.${key} field type: ${String(ui.type)}`)
+    if (ui.type !== "text" && ui.type !== "select") {
+      throw new Error(`Unsupported providerSpecificSettings.${key} field type: ${(ui as { type: unknown }).type}`)
     }
 
     return {
       key,
-      labelKey: ui.labelKey,
-      type: ui.type,
-      placeholder: ui.placeholder,
+      ...ui,
     }
   })
 }

--- a/src/types/config/provider/schemas.ts
+++ b/src/types/config/provider/schemas.ts
@@ -11,7 +11,7 @@ import type {
 import { z } from "zod"
 
 import { LLM_PROVIDER_MODELS } from "./constants"
-import { bedrockProviderSpecificSettingsSchema } from "./provider-specific-settings"
+import { azureProviderSpecificSettingsSchema, bedrockProviderSpecificSettingsSchema } from "./provider-specific-settings"
 
 /* ──────────────────────────────
   Providers config schema
@@ -67,6 +67,11 @@ const llmProviderConfigSchemaList = [
   baseAPIProviderConfigSchema.extend({
     provider: z.literal("openai"),
     model: createProviderModelSchema<"openai">("openai"),
+  }),
+  baseAPIProviderConfigSchema.extend({
+    provider: z.literal("azure"),
+    model: createProviderModelSchema<"azure">("azure"),
+    providerSpecificSettings: azureProviderSpecificSettingsSchema.optional(),
   }),
   baseAPIProviderConfigSchema.extend({
     provider: z.literal("deepseek"),

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -74,6 +74,18 @@ describe("getProviderOptions", () => {
       ]))
     })
 
+    it("should expose Azure shortcut deployment names for GPT, DeepSeek, and Grok", () => {
+      expect(LLM_PROVIDER_MODELS.azure).toEqual(expect.arrayContaining([
+        "gpt-5.4-mini",
+        "gpt-5.4",
+        "DeepSeek-V4-Flash",
+        "DeepSeek-V4-Pro",
+        "grok-4.3",
+        "grok-4-20-non-reasoning",
+        "grok-4-20-reasoning",
+      ]))
+    })
+
     it("should expose the supported Anthropic Fable model ids", () => {
       expect(LLM_PROVIDER_MODELS.anthropic).toContain("claude-fable-5")
       expect(LLM_PROVIDER_MODELS.bedrock).toContain("us.anthropic.claude-fable-5")

--- a/src/utils/constants/__tests__/providers.test.ts
+++ b/src/utils/constants/__tests__/providers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { API_PROVIDER_TYPES, apiProviderConfigItemSchema, NON_CUSTOM_LLM_PROVIDER_TYPES } from "@/types/config/provider"
+import { DEFAULT_PROVIDER_CONFIG, PROVIDER_BASE_URL_PLACEHOLDERS, PROVIDER_ITEMS } from "../providers"
+
+describe("provider constants", () => {
+  it("defines Azure with the LobeHub color icon and GPT shortcut defaults", () => {
+    expect(PROVIDER_ITEMS.azure.logo("light")).toContain("/light/azure-color.webp")
+    expect(PROVIDER_ITEMS.azure.logo("dark")).toContain("/dark/azure-color.webp")
+
+    expect(DEFAULT_PROVIDER_CONFIG.azure).toEqual(expect.objectContaining({
+      id: "azure-default",
+      name: "Azure",
+      provider: "azure",
+      model: {
+        model: "gpt-5.4-mini",
+        isCustomModel: false,
+        customModel: null,
+      },
+      providerSpecificSettings: {
+        apiMode: "responses",
+        apiVersion: "v1",
+      },
+    }))
+    expect(apiProviderConfigItemSchema.parse(DEFAULT_PROVIDER_CONFIG.azure)).toEqual(DEFAULT_PROVIDER_CONFIG.azure)
+  })
+
+  it("defines provider-specific Base URL placeholders", () => {
+    expect(PROVIDER_BASE_URL_PLACEHOLDERS.azure).toBe("https://<resource>.services.ai.azure.com/openai")
+    expect(PROVIDER_BASE_URL_PLACEHOLDERS.openai).toBe("https://api.openai.com/v1")
+    expect(PROVIDER_BASE_URL_PLACEHOLDERS["openai-compatible"]).toBe("https://api.example.com/v1")
+  })
+
+  it("places Azure immediately before Bedrock in provider pickers", () => {
+    expect(NON_CUSTOM_LLM_PROVIDER_TYPES.indexOf("azure")).toBe(NON_CUSTOM_LLM_PROVIDER_TYPES.indexOf("bedrock") - 1)
+    expect(API_PROVIDER_TYPES.indexOf("azure")).toBe(API_PROVIDER_TYPES.indexOf("bedrock") - 1)
+  })
+})

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -20,6 +20,7 @@ interface OpenAIGPT5ReasoningEffortPolicy {
 
 export const LLM_PROVIDER_MODELS = {
   "openai": ["gpt-5.5", "gpt-5.4-pro", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano", "gpt-5.3-chat-latest", "gpt-5.2-pro", "gpt-5.2-chat-latest", "gpt-5.2", "gpt-5.1-codex-mini", "gpt-5.1-codex", "gpt-5.1-chat-latest", "gpt-5.1", "gpt-5-pro", "gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-5-codex", "gpt-5-chat-latest", "gpt-4.1", "gpt-4.1-mini", "gpt-4.1-nano", "gpt-4o", "gpt-4o-mini"],
+  "azure": ["gpt-5.4-mini", "gpt-5.4", "gpt-5.4-pro", "gpt-5.4-nano", "gpt-5.3-chat", "gpt-5.2-chat", "gpt-5.1", "gpt-4.1", "gpt-4.1-mini", "gpt-4o", "gpt-4o-mini", "DeepSeek-V4-Flash", "DeepSeek-V4-Pro", "DeepSeek-V3.2", "DeepSeek-V3.1", "grok-4.3", "grok-4-20-non-reasoning", "grok-4-20-reasoning", "grok-4-1-fast-non-reasoning", "grok-4-1-fast-reasoning", "grok-4", "grok-code-fast-1"],
   "deepseek": ["deepseek-v4-flash", "deepseek-v4-pro", "deepseek-chat", "deepseek-reasoner"],
   "google": ["gemini-3.5-flash", "gemini-3.1-pro-preview", "gemini-3.1-flash-image-preview", "gemini-3.1-flash-lite-preview", "gemini-3-pro-preview", "gemini-3-pro-image-preview", "gemini-3-flash-preview", "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite", "gemini-2.5-flash-lite-preview-06-17", "gemini-2.0-flash"],
   "anthropic": ["claude-fable-5", "claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-sonnet-4-6", "claude-opus-4-5", "claude-haiku-4-5", "claude-sonnet-4-5", "claude-opus-4-1", "claude-opus-4-0", "claude-sonnet-4-0"],

--- a/src/utils/constants/providers.ts
+++ b/src/utils/constants/providers.ts
@@ -26,6 +26,11 @@ export const DEFAULT_LLM_PROVIDER_MODELS: LLMProviderModels = {
     isCustomModel: false,
     customModel: null,
   },
+  "azure": {
+    model: "gpt-5.4-mini",
+    isCustomModel: false,
+    customModel: null,
+  },
   "deepseek": {
     model: "deepseek-v4-flash",
     isCustomModel: false,
@@ -184,6 +189,11 @@ export const PROVIDER_ITEMS: Record<AllProviderTypes, { logo: (theme: Theme) => 
       logo: getLobeIconsCDNUrlFn("openai"),
       name: "OpenAI",
       website: "https://platform.openai.com",
+    },
+    "azure": {
+      logo: getLobeIconsCDNUrlFn("azure-color"),
+      name: "Azure",
+      website: "https://azure.microsoft.com/products/ai-services/openai-service",
     },
     "deepseek": {
       logo: getLobeIconsCDNUrlFn("deepseek-color"),
@@ -344,6 +354,18 @@ export const DEFAULT_PROVIDER_CONFIG = {
     enabled: true,
     provider: "openai",
     model: DEFAULT_LLM_PROVIDER_MODELS.openai,
+  },
+  "azure": {
+    id: "azure-default",
+    name: PROVIDER_ITEMS.azure.name,
+    description: i18n.t("options.apiProviders.providers.description.azure"),
+    enabled: true,
+    provider: "azure",
+    model: DEFAULT_LLM_PROVIDER_MODELS.azure,
+    providerSpecificSettings: {
+      apiMode: "responses",
+      apiVersion: "v1",
+    },
   },
   "deepseek": {
     id: "deepseek-default",
@@ -542,6 +564,37 @@ export const DEFAULT_PROVIDER_CONFIG = {
     model: DEFAULT_LLM_PROVIDER_MODELS.huggingface,
   },
 } as const satisfies Record<AllProviderTypes, ProviderConfig>
+
+export const PROVIDER_BASE_URL_PLACEHOLDERS: Partial<Record<APIProviderTypes, string>> = {
+  "siliconflow": DEFAULT_PROVIDER_CONFIG.siliconflow.baseURL,
+  "tensdaq": DEFAULT_PROVIDER_CONFIG.tensdaq.baseURL,
+  "openai-compatible": DEFAULT_PROVIDER_CONFIG["openai-compatible"].baseURL,
+  "openai": "https://api.openai.com/v1",
+  "azure": "https://<resource>.services.ai.azure.com/openai",
+  "deepseek": "https://api.deepseek.com",
+  "google": "https://generativelanguage.googleapis.com/v1beta",
+  "anthropic": "https://api.anthropic.com/v1",
+  "xai": "https://api.x.ai/v1",
+  "deeplx": DEFAULT_PROVIDER_CONFIG.deeplx.baseURL,
+  "bedrock": "https://bedrock-runtime.us-east-1.amazonaws.com",
+  "groq": "https://api.groq.com/openai/v1",
+  "deepinfra": "https://api.deepinfra.com/v1",
+  "mistral": "https://api.mistral.ai/v1",
+  "togetherai": "https://api.together.xyz/v1",
+  "cohere": "https://api.cohere.com/v2",
+  "fireworks": "https://api.fireworks.ai/inference/v1",
+  "cerebras": "https://api.cerebras.ai/v1",
+  "replicate": "https://api.replicate.com/v1",
+  "perplexity": "https://api.perplexity.ai",
+  "vercel": "https://api.v0.dev/v1",
+  "openrouter": "https://openrouter.ai/api/v1",
+  "ollama": DEFAULT_PROVIDER_CONFIG.ollama.baseURL,
+  "volcengine": DEFAULT_PROVIDER_CONFIG.volcengine.baseURL,
+  "minimax": DEFAULT_PROVIDER_CONFIG.minimax.baseURL,
+  "alibaba": DEFAULT_PROVIDER_CONFIG.alibaba.baseURL,
+  "moonshotai": "https://api.moonshot.ai/v1",
+  "huggingface": "https://router.huggingface.co/v1",
+}
 
 export const DEFAULT_PROVIDER_CONFIG_LIST: ProvidersConfig = [
   DEFAULT_PROVIDER_CONFIG["microsoft-translate"],

--- a/src/utils/providers/__tests__/model.test.ts
+++ b/src/utils/providers/__tests__/model.test.ts
@@ -6,17 +6,26 @@ let getStorageItemMock: ReturnType<typeof vi.fn>
 
 const {
   anthropicLanguageModelMock,
+  azureChatModelMock,
+  azureLanguageModelMock,
   openRouterLanguageModelMock,
   openAICompatibleLanguageModelMock,
   createAnthropicMock,
+  createAzureMock,
   createOpenRouterMock,
   createOpenAICompatibleMock,
 } = vi.hoisted(() => {
   const anthropicLanguageModelMock = vi.fn()
+  const azureChatModelMock = vi.fn()
+  const azureLanguageModelMock = vi.fn()
   const openRouterLanguageModelMock = vi.fn()
   const openAICompatibleLanguageModelMock = vi.fn()
   const createAnthropicMock = vi.fn((_options?: Record<string, unknown>) => ({
     languageModel: anthropicLanguageModelMock,
+  }))
+  const createAzureMock = vi.fn((_options?: Record<string, unknown>) => ({
+    chat: azureChatModelMock,
+    languageModel: azureLanguageModelMock,
   }))
   const createOpenRouterMock = vi.fn((_options?: Record<string, unknown>) => ({
     languageModel: openRouterLanguageModelMock,
@@ -27,9 +36,12 @@ const {
 
   return {
     anthropicLanguageModelMock,
+    azureChatModelMock,
+    azureLanguageModelMock,
     openRouterLanguageModelMock,
     openAICompatibleLanguageModelMock,
     createAnthropicMock,
+    createAzureMock,
     createOpenRouterMock,
     createOpenAICompatibleMock,
   }
@@ -37,6 +49,10 @@ const {
 
 vi.mock("@ai-sdk/anthropic", () => ({
   createAnthropic: createAnthropicMock,
+}))
+
+vi.mock("@ai-sdk/azure", () => ({
+  createAzure: createAzureMock,
 }))
 
 vi.mock("@openrouter/ai-sdk-provider", () => ({
@@ -83,6 +99,8 @@ describe("getModelById", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     anthropicLanguageModelMock.mockReturnValue("anthropic-model")
+    azureChatModelMock.mockReturnValue("azure-chat-model")
+    azureLanguageModelMock.mockReturnValue("azure-model")
     openRouterLanguageModelMock.mockReturnValue("openrouter-model")
     openAICompatibleLanguageModelMock.mockReturnValue("custom-model")
     getStorageItemMock = vi.fn()
@@ -119,6 +137,92 @@ describe("getModelById", () => {
       headers: DEFAULT_PROVIDER_HEADERS.openrouter,
     }))
     expect(openRouterLanguageModelMock).toHaveBeenCalledWith("x-ai/grok-4-fast:free")
+  })
+
+  it("passes Azure settings and resolves the deployment name with languageModel", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [
+        {
+          id: "azure-default",
+          name: "Azure OpenAI",
+          enabled: true,
+          provider: "azure",
+          apiKey: "azure-key",
+          baseURL: "https://proxy.example.test/openai",
+          model: {
+            model: "gpt-5.4-mini",
+            isCustomModel: true,
+            customModel: "read-frog-gpt-4o",
+          },
+          providerSpecificSettings: {
+            apiMode: "responses",
+            resourceName: "read-frog-openai",
+            apiVersion: "2025-04-01-preview",
+          },
+          headers: {
+            "X-Test": "1",
+          },
+        },
+      ],
+    })
+
+    const { getModelById } = await import("../model")
+    const result = await getModelById("azure-default")
+
+    expect(result).toBe("azure-model")
+    expect(createAzureMock).toHaveBeenCalledWith(expect.objectContaining({
+      resourceName: "read-frog-openai",
+      apiVersion: "2025-04-01-preview",
+      baseURL: "https://proxy.example.test/openai",
+      apiKey: "azure-key",
+      headers: {
+        "X-Test": "1",
+      },
+    }))
+    expect(createAzureMock.mock.calls[0]?.[0]).not.toHaveProperty("apiMode")
+    expect(createAzureMock.mock.calls[0]?.[0]).not.toHaveProperty("region")
+    expect(azureLanguageModelMock).toHaveBeenCalledWith("read-frog-gpt-4o")
+    expect(azureChatModelMock).not.toHaveBeenCalled()
+  })
+
+  it("uses Azure chat completions when API mode is chat", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [
+        {
+          id: "azure-default",
+          name: "Azure OpenAI",
+          enabled: true,
+          provider: "azure",
+          apiKey: "azure-key",
+          baseURL: "https://proxy.example.test/openai",
+          model: {
+            model: "gpt-5.4-mini",
+            isCustomModel: true,
+            customModel: "read-frog-gpt-4o",
+          },
+          providerSpecificSettings: {
+            apiMode: "chat",
+            resourceName: "read-frog-openai",
+            apiVersion: "2025-04-01-preview",
+          },
+        },
+      ],
+    })
+
+    const { getModelById } = await import("../model")
+    const result = await getModelById("azure-default")
+
+    expect(result).toBe("azure-chat-model")
+    expect(createAzureMock).toHaveBeenCalledWith(expect.objectContaining({
+      resourceName: "read-frog-openai",
+      apiVersion: "2025-04-01-preview",
+      baseURL: "https://proxy.example.test/openai",
+      apiKey: "azure-key",
+    }))
+    expect(createAzureMock.mock.calls[0]?.[0]).not.toHaveProperty("apiMode")
+    expect(createAzureMock.mock.calls[0]?.[0]).not.toHaveProperty("region")
+    expect(azureChatModelMock).toHaveBeenCalledWith("read-frog-gpt-4o")
+    expect(azureLanguageModelMock).not.toHaveBeenCalled()
   })
 
   it("uses user headers as a full override for Anthropic", async () => {

--- a/src/utils/providers/model.ts
+++ b/src/utils/providers/model.ts
@@ -1,7 +1,9 @@
 import type { Config } from "@/types/config/config"
+import type { AzureApiMode, LLMProviderConfig } from "@/types/config/provider"
 import { createAlibaba } from "@ai-sdk/alibaba"
 import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock"
 import { createAnthropic } from "@ai-sdk/anthropic"
+import { createAzure } from "@ai-sdk/azure"
 import { createCerebras } from "@ai-sdk/cerebras"
 import { createCohere } from "@ai-sdk/cohere"
 import { createDeepInfra } from "@ai-sdk/deepinfra"
@@ -23,7 +25,7 @@ import { createOpenRouter } from "@openrouter/ai-sdk-provider"
 import { createOllama } from "ollama-ai-provider-v2"
 import { createMinimax } from "vercel-minimax-ai-provider"
 import { storage } from "#imports"
-import { isCustomLLMProvider } from "@/types/config/provider"
+import { DEFAULT_AZURE_API_MODE, isCustomLLMProvider } from "@/types/config/provider"
 import { compactObject } from "@/types/utils"
 import { getLLMProvidersConfig, getProviderConfigById } from "../config/helpers"
 import { CONFIG_STORAGE_KEY } from "../constants/config"
@@ -37,6 +39,7 @@ const CREATE_AI_MAPPER = {
   "openrouter": createOpenRouter,
   "openai-compatible": createOpenAICompatible,
   "openai": createOpenAI,
+  "azure": createAzure,
   "deepseek": createDeepSeek,
   "google": createGoogleGenerativeAI,
   "anthropic": createAnthropic,
@@ -59,6 +62,28 @@ const CREATE_AI_MAPPER = {
   "huggingface": createHuggingFace,
 } as const
 
+function getProviderSpecificSettings(providerConfig: LLMProviderConfig) {
+  const settings = "providerSpecificSettings" in providerConfig
+    ? compactObject(providerConfig.providerSpecificSettings ?? {})
+    : {}
+
+  if (providerConfig.provider !== "azure") {
+    return settings
+  }
+
+  const { apiMode: _apiMode, ...azureSettings } = settings as Record<string, unknown>
+  return azureSettings
+}
+
+function getAzureApiMode(providerConfig: LLMProviderConfig): AzureApiMode {
+  if (providerConfig.provider !== "azure") {
+    return DEFAULT_AZURE_API_MODE
+  }
+
+  const apiMode = (providerConfig.providerSpecificSettings as { apiMode?: unknown } | undefined)?.apiMode
+  return apiMode === "chat" ? "chat" : DEFAULT_AZURE_API_MODE
+}
+
 async function getLanguageModelById(providerId: string) {
   const config = await storage.getItem<Config>(`local:${CONFIG_STORAGE_KEY}`)
   if (!config) {
@@ -72,9 +97,7 @@ async function getLanguageModelById(providerId: string) {
   }
 
   const headers = getProviderHeadersWithOverride(providerConfig.provider, providerConfig.headers)
-  const providerSpecificSettings = "providerSpecificSettings" in providerConfig
-    ? compactObject(providerConfig.providerSpecificSettings ?? {})
-    : {}
+  const providerSpecificSettings = getProviderSpecificSettings(providerConfig)
 
   const provider = isCustomLLMProvider(providerConfig.provider)
     ? CREATE_AI_MAPPER[providerConfig.provider]({
@@ -96,6 +119,10 @@ async function getLanguageModelById(providerId: string) {
 
   if (!modelId) {
     throw new Error("Model is undefined")
+  }
+
+  if (providerConfig.provider === "azure" && getAzureApiMode(providerConfig) === "chat") {
+    return (provider as ReturnType<typeof createAzure>).chat(modelId)
   }
 
   return provider.languageModel(modelId)


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [x] 🌐 Internationalization (i18n)
- [x] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Add Azure as a built-in AI SDK provider.

This wires `@ai-sdk/azure` into the provider factory, adds Azure to provider schemas and picker ordering, and uses the LobeHub `azure-color` icon. Azure is displayed as `Azure`, appears immediately before Amazon Bedrock, and defaults to non-custom `gpt-5.4-mini` with additional GPT, DeepSeek, and Grok shortcut model options available in the selector.

Azure-specific configuration now supports `apiMode`, optional `resourceName`, and optional `apiVersion` without adding a Bedrock-style `region`. `apiMode` defaults to the Responses API path and can switch to Chat Completions for Azure Foundry deployments that require it. The app strips `apiMode` before passing provider settings to `createAzure`.

The provider form also now shows provider-specific Base URL placeholders, including Azure's AI SDK base URL prefix format: `https://<resource>.services.ai.azure.com/openai`.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation run locally:

- `pnpm exec vitest run src/utils/constants/__tests__/providers.test.ts src/utils/constants/__tests__/model.test.ts src/utils/providers/__tests__/model.test.ts src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx src/entrypoints/options/pages/api-providers/__tests__/utils.test.ts`
- `SKIP_FREE_API=true pnpm test`
- `pnpm type-check`
- `pnpm exec eslint src/types/config/provider/constants.ts src/utils/constants/models.ts src/utils/constants/__tests__/model.test.ts src/utils/constants/__tests__/providers.test.ts src/utils/constants/providers.ts src/entrypoints/options/pages/api-providers/provider-config-form/base-url-field.tsx src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx src/utils/providers/model.ts src/utils/providers/__tests__/model.test.ts src/types/config/provider/provider-specific-settings.ts src/entrypoints/options/pages/api-providers/provider-config-form/provider-specific-settings-field.tsx src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/provider-specific-settings-field.test.tsx src/types/config/__tests__/provider-specific-settings.test.ts`
- `git diff --check`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Users should enter Azure Base URL overrides as the base prefix before `/v1`, for example `https://<resource>.services.ai.azure.com/openai`.
