### PR TITLE
feat(context-menu): add tts option for selected text

### DIFF
--- a/.changeset/deep-rabbits-allow.md
+++ b/.changeset/deep-rabbits-allow.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(context menu): add read-aloud option in right-click menu for selected text

--- a/src/entrypoints/background/__tests__/context-menu.test.ts
+++ b/src/entrypoints/background/__tests__/context-menu.test.ts
@@ -49,7 +49,7 @@ describe("background context menu", () => {
     i18n.t = vi.fn((key: string) => ({
       "contextMenu.translate": "Translate",
       "contextMenu.translateSelection": "Translate \"%s\"",
-      "contextMenu.readAloudSelection": "Read Aloud \"%s\"",
+      "contextMenu.readAloudSelection": "Read aloud \"%s\"",
       "contextMenu.showOriginal": "Show Original",
     })[key] ?? key) as typeof i18n.t
   })
@@ -74,7 +74,7 @@ describe("background context menu", () => {
     })
     expect(browser.contextMenus.create).toHaveBeenNthCalledWith(3, {
       id: MENU_ID_SELECTION_READ_ALOUD,
-      title: "Read Aloud \"%s\"",
+      title: "Read aloud \"%s\"",
       contexts: ["selection"],
     })
     expect(browser.contextMenus.update).toHaveBeenCalledWith(MENU_ID_TRANSLATE, {

--- a/src/entrypoints/background/__tests__/context-menu.test.ts
+++ b/src/entrypoints/background/__tests__/context-menu.test.ts
@@ -49,6 +49,7 @@ describe("background context menu", () => {
     i18n.t = vi.fn((key: string) => ({
       "contextMenu.translate": "Translate",
       "contextMenu.translateSelection": "Translate \"%s\"",
+      "contextMenu.readAloudSelection": "Read Aloud \"%s\"",
       "contextMenu.showOriginal": "Show Original",
     })[key] ?? key) as typeof i18n.t
   })
@@ -56,7 +57,7 @@ describe("background context menu", () => {
   it("creates page and selection menu items when the context menu is enabled", async () => {
     ensureInitializedConfigMock.mockResolvedValue(createConfig(true))
 
-    const { initializeContextMenu, MENU_ID_SELECTION_TRANSLATE, MENU_ID_TRANSLATE } = await import("../context-menu")
+    const { initializeContextMenu, MENU_ID_SELECTION_TRANSLATE, MENU_ID_TRANSLATE, MENU_ID_SELECTION_READ_ALOUD } = await import("../context-menu")
 
     await initializeContextMenu()
 
@@ -69,6 +70,11 @@ describe("background context menu", () => {
     expect(browser.contextMenus.create).toHaveBeenNthCalledWith(2, {
       id: MENU_ID_SELECTION_TRANSLATE,
       title: "Translate \"%s\"",
+      contexts: ["selection"],
+    })
+    expect(browser.contextMenus.create).toHaveBeenNthCalledWith(3, {
+      id: MENU_ID_SELECTION_READ_ALOUD,
+      title: "Read Aloud \"%s\"",
       contexts: ["selection"],
     })
     expect(browser.contextMenus.update).toHaveBeenCalledWith(MENU_ID_TRANSLATE, {
@@ -92,12 +98,12 @@ describe("background context menu", () => {
 
     await initializeContextMenu()
 
-    expect(browser.contextMenus.create).toHaveBeenNthCalledWith(3, {
+    expect(browser.contextMenus.create).toHaveBeenNthCalledWith(4, {
       id: `${MENU_ID_SELECTION_CUSTOM_ACTION_PREFIX}dictionary`,
       title: "Dictionary",
       contexts: ["selection"],
     })
-    expect(browser.contextMenus.create).toHaveBeenNthCalledWith(4, {
+    expect(browser.contextMenus.create).toHaveBeenNthCalledWith(5, {
       id: `${MENU_ID_SELECTION_CUSTOM_ACTION_PREFIX}rewrite`,
       title: "Rewrite",
       contexts: ["selection"],
@@ -138,6 +144,31 @@ describe("background context menu", () => {
       "openSelectionTranslationFromContextMenu",
       { selectionText: "Selected text" },
       { tabId: 5, frameId: 7 },
+    )
+  })
+
+  it("routes read aloud menu clicks to the matching tab and frame", async () => {
+    const { MENU_ID_SELECTION_READ_ALOUD, registerContextMenuListeners } = await import("../context-menu")
+
+    registerContextMenuListeners()
+
+    const clickHandler = contextMenuClickListeners[0]
+    if (!clickHandler) {
+      throw new Error("Context menu click listener was not registered")
+    }
+
+    await clickHandler({
+      menuItemId: MENU_ID_SELECTION_READ_ALOUD,
+      selectionText: "Selected text",
+      frameId: 4,
+    }, {
+      id: 2,
+    })
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      "readAloudSelectionFromContextMenu",
+      { selectionText: "Selected text" },
+      { tabId: 2, frameId: 4 },
     )
   })
 

--- a/src/entrypoints/background/context-menu.ts
+++ b/src/entrypoints/background/context-menu.ts
@@ -11,6 +11,7 @@ import { getPageTranslationEnabled, setPageTranslationEnabled } from "./page-tra
 
 export const MENU_ID_TRANSLATE = "read-frog-translate"
 export const MENU_ID_SELECTION_TRANSLATE = "read-frog-selection-translate"
+export const MENU_ID_SELECTION_READ_ALOUD = "read-frog-selection-read-aloud"
 export const MENU_ID_SELECTION_CUSTOM_ACTION_PREFIX = "read-frog-selection-custom-action:"
 
 function getSelectionCustomActionMenuId(actionId: string) {
@@ -108,6 +109,12 @@ async function updateContextMenuItems(config: Config) {
       contexts: ["selection"],
     })
 
+    browser.contextMenus.create({
+      id: MENU_ID_SELECTION_READ_ALOUD,
+      title: i18n.t("contextMenu.readAloudSelection"),
+      contexts: ["selection"],
+    })
+
     if (enabledCustomActions.length > 0) {
       enabledCustomActions.forEach((action) => {
         browser.contextMenus.create({
@@ -181,6 +188,11 @@ async function handleContextMenuClick(
     return
   }
 
+  if (info.menuItemId === MENU_ID_SELECTION_READ_ALOUD) {
+    await handleSelectionReadAloudClick(info, tab.id)
+    return
+  }
+
   if (typeof info.menuItemId === "string" && info.menuItemId.startsWith(MENU_ID_SELECTION_CUSTOM_ACTION_PREFIX)) {
     const actionId = info.menuItemId.slice(MENU_ID_SELECTION_CUSTOM_ACTION_PREFIX.length)
     if (!actionId) {
@@ -231,6 +243,22 @@ async function handleSelectionTranslateClick(
   void sendMessage("openSelectionTranslationFromContextMenu", {
     selectionText,
   }, target)
+}
+
+async function handleSelectionReadAloudClick(
+  info: Browser.contextMenus.OnClickData,
+  tabId: number,
+) {
+  const selectionText = info.selectionText?.trim()
+  if (!selectionText) {
+    return
+  }
+
+  const target = typeof info.frameId === "number"
+    ? { tabId, frameId: info.frameId }
+    : tabId
+
+  void sendMessage("readAloudSelectionFromContextMenu", { selectionText }, target)
 }
 
 async function handleSelectionCustomActionClick(

--- a/src/entrypoints/selection.content/app.tsx
+++ b/src/entrypoints/selection.content/app.tsx
@@ -10,6 +10,7 @@ import {
 import { SelectionToolbar } from "./selection-toolbar"
 import { SelectionCustomActionProvider } from "./selection-toolbar/custom-action-button/provider"
 import { SelectionTranslationProvider } from "./selection-toolbar/translate-button/provider"
+import { useContextMenuReadAloud } from "./use-context-menu-read-aloud"
 
 export default function App({
   uiContainer,
@@ -17,6 +18,7 @@ export default function App({
   uiContainer: HTMLElement
 }) {
   useInputTranslation()
+  useContextMenuReadAloud()
   const opacity = useAtomValue(configFieldsAtomMap.selectionToolbar).opacity / 100
 
   useEffect(() => {

--- a/src/entrypoints/selection.content/use-context-menu-read-aloud.ts
+++ b/src/entrypoints/selection.content/use-context-menu-read-aloud.ts
@@ -1,5 +1,5 @@
 import { useAtomValue } from "jotai"
-import { useEffect, useRef } from "react"
+import { useEffect, useEffectEvent } from "react"
 import { useTextToSpeech } from "@/hooks/use-text-to-speech"
 import { ANALYTICS_SURFACE } from "@/types/analytics"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
@@ -9,12 +9,13 @@ export function useContextMenuReadAloud() {
   const ttsConfig = useAtomValue(configFieldsAtomMap.tts)
   const { play } = useTextToSpeech(ANALYTICS_SURFACE.CONTEXT_MENU)
 
-  const callbackRef = useRef({ play, ttsConfig })
-  callbackRef.current = { play, ttsConfig }
+  const handleReadAloud = useEffectEvent((selectionText: string) => {
+    void play(selectionText, ttsConfig)
+  })
 
   useEffect(() => {
     return onMessage("readAloudSelectionFromContextMenu", (message) => {
-      void callbackRef.current.play(message.data.selectionText, callbackRef.current.ttsConfig)
+      handleReadAloud(message.data.selectionText)
     })
   }, [])
 }

--- a/src/entrypoints/selection.content/use-context-menu-read-aloud.ts
+++ b/src/entrypoints/selection.content/use-context-menu-read-aloud.ts
@@ -1,0 +1,20 @@
+import { useAtomValue } from "jotai"
+import { useEffect, useRef } from "react"
+import { useTextToSpeech } from "@/hooks/use-text-to-speech"
+import { ANALYTICS_SURFACE } from "@/types/analytics"
+import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { onMessage } from "@/utils/message"
+
+export function useContextMenuReadAloud() {
+  const ttsConfig = useAtomValue(configFieldsAtomMap.tts)
+  const { play } = useTextToSpeech(ANALYTICS_SURFACE.CONTEXT_MENU)
+
+  const callbackRef = useRef({ play, ttsConfig })
+  callbackRef.current = { play, ttsConfig }
+
+  useEffect(() => {
+    return onMessage("readAloudSelectionFromContextMenu", (message) => {
+      void callbackRef.current.play(message.data.selectionText, callbackRef.current.ttsConfig)
+    })
+  }, [])
+}

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -8,7 +8,7 @@ dataTypes:
 contextMenu:
   translate: Translate
   translateSelection: Translate "%s"
-  readAloudSelection: Read Aloud "%s"
+  readAloudSelection: Read aloud "%s"
   showOriginal: Show Original
 sidePanel:
   firefoxUserActionHint: In Firefox, open Read Frog from the browser sidebar.

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -8,6 +8,7 @@ dataTypes:
 contextMenu:
   translate: Translate
   translateSelection: Translate "%s"
+  readAloudSelection: Read Aloud "%s"
   showOriginal: Show Original
 sidePanel:
   firefoxUserActionHint: In Firefox, open Read Frog from the browser sidebar.

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -8,6 +8,7 @@ dataTypes:
 contextMenu:
   translate: Traducir
   translateSelection: Traducir "%s"
+  readAloudSelection: Leer en voz alta "%s"
   showOriginal: Mostrar original
 sidePanel:
   firefoxUserActionHint: En Firefox, abre Read Frog desde la barra lateral del navegador.

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -8,6 +8,7 @@ dataTypes:
 contextMenu:
   translate: 翻訳
   translateSelection: 「%s」を翻訳
+  readAloudSelection: 「%s」を読み上げ
   showOriginal: 原文を表示
 sidePanel:
   firefoxUserActionHint: Firefox では、ブラウザーのサイドバーから Read Frog を開いてください。

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -8,6 +8,7 @@ dataTypes:
 contextMenu:
   translate: 번역
   translateSelection: '"%s" 번역'
+  readAloudSelection: '"%s" 읽어주기'
   showOriginal: 원문 보기
 sidePanel:
   firefoxUserActionHint: Firefox에서는 브라우저 사이드바에서 Read Frog를 열어 주세요.

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -8,6 +8,7 @@ dataTypes:
 contextMenu:
   translate: Перевести
   translateSelection: Перевести "%s"
+  readAloudSelection: Прочитать вслух "%s"
   showOriginal: Показать оригинал
 sidePanel:
   firefoxUserActionHint: В Firefox откройте Read Frog из боковой панели браузера.

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -8,7 +8,7 @@ dataTypes:
 contextMenu:
   translate: Çevir
   translateSelection: '"%s" Çevir'
-  readAloudSelection: '"%s" Sesli Oku'
+  readAloudSelection: '"%s" Sesli oku'
   showOriginal: Orijinali Göster
 sidePanel:
   firefoxUserActionHint: Firefox'ta Read Frog'u tarayıcının kenar çubuğundan açın.

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -8,6 +8,7 @@ dataTypes:
 contextMenu:
   translate: Çevir
   translateSelection: '"%s" Çevir'
+  readAloudSelection: '"%s" Sesli Oku'
   showOriginal: Orijinali Göster
 sidePanel:
   firefoxUserActionHint: Firefox'ta Read Frog'u tarayıcının kenar çubuğundan açın.

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -8,6 +8,7 @@ dataTypes:
 contextMenu:
   translate: Dịch
   translateSelection: Dịch "%s"
+  readAloudSelection: Đọc to "%s"
   showOriginal: Hiển thị bản gốc
 sidePanel:
   firefoxUserActionHint: Trong Firefox, hãy mở Read Frog từ thanh bên của trình duyệt.

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -7,7 +7,8 @@ dataTypes:
   number: 数字
 contextMenu:
   translate: 翻译
-  translateSelection: 翻译“%s”
+  translateSelection: 翻译”%s”
+  readAloudSelection: 朗读”%s”
   showOriginal: 显示原文
 sidePanel:
   firefoxUserActionHint: 在 Firefox 中，请从浏览器侧边栏打开陪读蛙。

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -8,6 +8,7 @@ dataTypes:
 contextMenu:
   translate: 翻譯
   translateSelection: 翻譯「%s」
+  readAloudSelection: 朗讀「%s」
   showOriginal: 顯示原文
 sidePanel:
   firefoxUserActionHint: 在 Firefox 中，請從瀏覽器側邊欄開啟陪讀蛙。

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -45,6 +45,7 @@ interface ProtocolMap {
   askManagerToTogglePageTranslation: (data: { enabled: boolean, analyticsContext?: FeatureUsageContext }) => void
   openSelectionTranslationFromContextMenu: (data: { selectionText: string }) => void
   openSelectionCustomActionFromContextMenu: (data: { actionId: string, selectionText: string }) => void
+  readAloudSelectionFromContextMenu: (data: { selectionText: string }) => void
   // analytics
   trackFeatureUsedEvent: (data: FeatureUsedEventProperties) => void
   // user guide


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Adds a "Read Aloud" option to the browser right-click context menu when text is selected. Clicking it routes the selected text through the existing TTS flow, matching the behavior of the speak button in the selection toolbar.

Since all existing read-aloud entry points are selection-based, no page-level read-aloud is included. The item only appears when text is selected; right-clicking on a page without a selection leaves the menu unchanged.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #1409

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [x] Added unit tests
- [x] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->
<img width="1253" height="667" alt="right_click_read_aloud" src="https://github.com/user-attachments/assets/6b211c4f-6e3c-446a-826f-b84bd6979467" />


## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->
A page-level fallback was considered but not implemented. Since there is no existing page-level TTS entry point, reading the full page body would be a new feature beyond this scope.

