### PR TITLE
ci(contributor-trust): exclude config migrations from line count

### DIFF
--- a/.github/scripts/contributor-trust/comment-template.js
+++ b/.github/scripts/contributor-trust/comment-template.js
@@ -33,6 +33,26 @@ function summarizeTopRepositories(repositories) {
   }
 }
 
+function getChangedLineSignal(pullRequest, plan) {
+  const additions = Number(plan.changedLineAdditions ?? pullRequest.additions) || 0
+  const deletions = Number(plan.changedLineDeletions ?? pullRequest.deletions) || 0
+  const changedLines = Number(plan.changedLines ?? additions + deletions) || 0
+  const excludedAdditions = Number(plan.excludedChangedLineAdditions) || 0
+  const excludedDeletions = Number(plan.excludedChangedLineDeletions) || 0
+  const excludedChangedLines = Number(plan.excludedChangedLines) || 0
+  const lines = [
+    `- PR counted changed lines: ${changedLines} (+${additions} / -${deletions})`,
+  ]
+
+  if (excludedChangedLines > 0) {
+    lines.push(
+      `- Migration-related changed lines excluded: ${excludedChangedLines} (+${excludedAdditions} / -${excludedDeletions})`,
+    )
+  }
+
+  return lines
+}
+
 function buildContent({ owner, repo, pullRequest, author, metrics, score, plan }) {
   const bucketTitle = BUCKET_TITLES[score.bucket]
   const trustLabel = plan.targetTrustLabel ?? "none"
@@ -67,7 +87,7 @@ function buildContent({ owner, repo, pullRequest, author, metrics, score, plan }
     `- Repo commits: ${metrics.commitsInRepo} (author commits reachable from the repository default branch)`,
     `- Repo PR history: merged ${metrics.mergedPrs}, open ${metrics.openPrs}, closed-unmerged ${metrics.closedPrs}`,
     `- Repo reviews: ${metrics.reviews}`,
-    `- PR changed lines: ${(Number(pullRequest.additions) || 0) + (Number(pullRequest.deletions) || 0)} (+${Number(pullRequest.additions) || 0} / -${Number(pullRequest.deletions) || 0})`,
+    ...getChangedLineSignal(pullRequest, plan),
     `- Repo permission: ${metrics.repoPermission ?? "none"}`,
     `- Followers: ${metrics.followers}`,
     `- Account age: ${formatMonths(metrics.accountCreated)}`,
@@ -75,7 +95,8 @@ function buildContent({ owner, repo, pullRequest, author, metrics, score, plan }
     "",
     "**Policy**",
     `- Low-score review threshold: < ${POLICY.lowScoreThreshold}`,
-    `- Auto-close: score < ${POLICY.autoCloseBelowScore} and changed lines > ${POLICY.autoCloseAboveChangedLines}`,
+    `- Auto-close: score < ${POLICY.autoCloseBelowScore} and counted changed lines > ${POLICY.autoCloseAboveChangedLines}`,
+    "- Migration-related files are excluded from the auto-close line count",
     `- Policy version: \`${POLICY.version}\``,
     "",
     `_${pullRequest.state === "closed" ? "Manually re-evaluated on a closed PR." : "Updated automatically when the PR changes or when a maintainer reruns the workflow."}_`,

--- a/.github/scripts/contributor-trust/comment-template.test.js
+++ b/.github/scripts/contributor-trust/comment-template.test.js
@@ -31,6 +31,12 @@ describe("buildTrustComment", () => {
       },
       owner: "mengxi-ream",
       plan: {
+        changedLineAdditions: 820,
+        changedLineDeletions: 245,
+        changedLines: 1065,
+        excludedChangedLineAdditions: 1662,
+        excludedChangedLineDeletions: 0,
+        excludedChangedLines: 1662,
         needsMaintainerReview: false,
         targetTrustLabel: "contrib-trust:trusted",
       },
@@ -55,9 +61,11 @@ describe("buildTrustComment", () => {
 
     expect(comment.body).toContain("stars on owned non-fork repositories")
     expect(comment.body).toContain("Repo commits: 14")
-    expect(comment.body).toContain("PR changed lines: 1065 (+820 / -245)")
+    expect(comment.body).toContain("PR counted changed lines: 1065 (+820 / -245)")
+    expect(comment.body).toContain("Migration-related changed lines excluded: 1662 (+1662 / -0)")
     expect(comment.body).toContain("Repo permission: write")
-    expect(comment.body).toContain("Auto-close: score < 20 and changed lines > 1000")
+    expect(comment.body).toContain("Auto-close: score < 20 and counted changed lines > 1000")
+    expect(comment.body).toContain("Migration-related files are excluded from the auto-close line count")
     expect(comment.body).toContain("Owned non-fork repos considered: max 42, total 42 (kilidoc/browser-tools (42))")
     expect(comment.body).not.toContain("Fork repos excluded from OSS influence")
     expect(comment.body).not.toContain("Public repos:")

--- a/.github/scripts/contributor-trust/config.js
+++ b/.github/scripts/contributor-trust/config.js
@@ -5,7 +5,7 @@ export const MANAGED_COMMENT_AUTHOR = "github-actions[bot]"
 export const TRUST_LABEL_PREFIX = "contrib-trust:"
 
 export const POLICY = Object.freeze({
-  version: "v1.1",
+  version: "v1.2",
   lowScoreThreshold: 30,
   autoCloseBelowScore: 20,
   autoCloseAboveChangedLines: 1000,

--- a/.github/scripts/contributor-trust/github-api.js
+++ b/.github/scripts/contributor-trust/github-api.js
@@ -121,6 +121,10 @@ export async function getPullRequest(token, owner, repo, pullNumber) {
   return apiRequest(token, `/repos/${owner}/${repo}/pulls/${pullNumber}`)
 }
 
+export async function listPullRequestFiles(token, owner, repo, pullNumber) {
+  return paginate(token, `/repos/${owner}/${repo}/pulls/${pullNumber}/files`)
+}
+
 export async function listIssueLabels(token, owner, repo, issueNumber) {
   const labels = await apiRequest(token, `/repos/${owner}/${repo}/issues/${issueNumber}/labels?per_page=100`)
   return labels.map(label => label.name)

--- a/.github/scripts/contributor-trust/github-api.test.js
+++ b/.github/scripts/contributor-trust/github-api.test.js
@@ -5,6 +5,7 @@ import {
   countReviewsOnOthersPullRequestsInRepo,
   createContributorMetrics,
   createPullRequestStateList,
+  listPullRequestFiles,
   selectOwnedNonForkRepositories,
 } from "./github-api.js"
 
@@ -151,6 +152,50 @@ describe("countAuthorCommitsInRepo", () => {
       )
 
       expect(count).toBe(1)
+    }
+    finally {
+      globalThis.fetch = originalFetch
+    }
+  })
+})
+
+describe("listPullRequestFiles", () => {
+  it("lists changed pull request files through the paginated files API", async () => {
+    const originalFetch = globalThis.fetch
+    const requests = []
+    globalThis.fetch = async (input) => {
+      requests.push(String(input))
+
+      return new Response(JSON.stringify([
+        {
+          additions: 20,
+          deletions: 5,
+          filename: "src/index.ts",
+        },
+      ]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    }
+
+    try {
+      const files = await listPullRequestFiles(
+        "token",
+        "mengxi-ream",
+        "read-frog",
+        1735,
+      )
+
+      expect(files).toEqual([
+        {
+          additions: 20,
+          deletions: 5,
+          filename: "src/index.ts",
+        },
+      ])
+      expect(requests).toEqual([
+        "https://api.github.com/repos/mengxi-ream/read-frog/pulls/1735/files?per_page=100&page=1",
+      ])
     }
     finally {
       globalThis.fetch = originalFetch

--- a/.github/scripts/contributor-trust/plan-actions.js
+++ b/.github/scripts/contributor-trust/plan-actions.js
@@ -1,16 +1,90 @@
 import { bucketToLabel, MANAGED_TRUST_LABELS, POLICY } from "./config.js"
 
+const CONFIG_MIGRATION_CHANGED_LINE_PATH_PATTERNS = Object.freeze([
+  /^src\/utils\/config\/migration-scripts\/v\d+-to-v\d+\.ts$/,
+  /^src\/utils\/config\/__tests__\/migration-scripts\/v\d+-to-v\d+\.test\.ts$/,
+  /^src\/utils\/config\/__tests__\/example\/v\d+\.ts$/,
+])
+
 function uniqueSorted(values) {
   return [...new Set(values)].sort((left, right) => left.localeCompare(right))
 }
 
-function getPullRequestChangedLines(pullRequest) {
-  const additions = Number(pullRequest?.additions) || 0
-  const deletions = Number(pullRequest?.deletions) || 0
-  return additions + deletions
+function toChangedLineCount(value) {
+  return Number(value) || 0
 }
 
-export function planTrustActions({ currentLabels = [], pullRequest = null, score }) {
+function getPullRequestFilePath(file) {
+  return String(file?.filename ?? file?.path ?? "")
+}
+
+export function isMigrationChangedLineFile(filePath) {
+  const normalizedPath = String(filePath).replaceAll("\\", "/")
+  return CONFIG_MIGRATION_CHANGED_LINE_PATH_PATTERNS.some(pattern => pattern.test(normalizedPath))
+}
+
+function getFallbackChangedLineDetails(pullRequest) {
+  const additions = Number(pullRequest?.additions) || 0
+  const deletions = Number(pullRequest?.deletions) || 0
+
+  return {
+    additions,
+    changedLines: additions + deletions,
+    deletions,
+    excludedAdditions: 0,
+    excludedChangedLines: 0,
+    excludedDeletions: 0,
+    excludedFiles: [],
+    hasFileBreakdown: false,
+  }
+}
+
+function getPullRequestChangedLineDetails(pullRequest, pullRequestFiles) {
+  if (!Array.isArray(pullRequestFiles))
+    return getFallbackChangedLineDetails(pullRequest)
+
+  const details = {
+    additions: 0,
+    changedLines: 0,
+    deletions: 0,
+    excludedAdditions: 0,
+    excludedChangedLines: 0,
+    excludedDeletions: 0,
+    excludedFiles: [],
+    hasFileBreakdown: true,
+  }
+
+  for (const file of pullRequestFiles) {
+    const additions = toChangedLineCount(file?.additions)
+    const deletions = toChangedLineCount(file?.deletions)
+    const changedLines = additions + deletions
+    const filePath = getPullRequestFilePath(file)
+
+    if (isMigrationChangedLineFile(filePath)) {
+      details.excludedAdditions += additions
+      details.excludedChangedLines += changedLines
+      details.excludedDeletions += deletions
+      details.excludedFiles.push(filePath)
+      continue
+    }
+
+    details.additions += additions
+    details.changedLines += changedLines
+    details.deletions += deletions
+  }
+
+  return details
+}
+
+function formatChangedLineThresholdReason(score, changedLineDetails) {
+  const changedLineDescription = changedLineDetails.excludedChangedLines > 0
+    ? `${changedLineDetails.changedLines} counted lines after excluding ${changedLineDetails.excludedChangedLines} migration-related lines`
+    : `${changedLineDetails.changedLines} lines`
+
+  return `Score ${score.total} is below ${POLICY.autoCloseBelowScore} and the PR changes ${changedLineDescription}, exceeding ${POLICY.autoCloseAboveChangedLines}.`
+}
+
+export function planTrustActions({ currentLabels = [], pullRequest = null, pullRequestFiles, score }) {
   const labelSet = new Set(currentLabels)
 
   if (labelSet.has(POLICY.overrideLabel)) {
@@ -30,7 +104,7 @@ export function planTrustActions({ currentLabels = [], pullRequest = null, score
 
   const targetTrustLabel = bucketToLabel(score.bucket)
   const needsMaintainerReview = score.total < POLICY.lowScoreThreshold
-  const changedLines = getPullRequestChangedLines(pullRequest)
+  const changedLineDetails = getPullRequestChangedLineDetails(pullRequest, pullRequestFiles)
 
   const labelsToAdd = []
   const labelsToRemove = []
@@ -53,7 +127,7 @@ export function planTrustActions({ currentLabels = [], pullRequest = null, score
 
   const shouldClosePr = POLICY.autoCloseBelowScore !== null
     && score.total < POLICY.autoCloseBelowScore
-    && changedLines > POLICY.autoCloseAboveChangedLines
+    && changedLineDetails.changedLines > POLICY.autoCloseAboveChangedLines
 
   return {
     skipAutomation: false,
@@ -62,10 +136,17 @@ export function planTrustActions({ currentLabels = [], pullRequest = null, score
     labelsToAdd: uniqueSorted(labelsToAdd),
     labelsToRemove: uniqueSorted(labelsToRemove),
     needsMaintainerReview,
-    changedLines,
+    changedLineAdditions: changedLineDetails.additions,
+    changedLineDeletions: changedLineDetails.deletions,
+    changedLines: changedLineDetails.changedLines,
+    excludedChangedLineAdditions: changedLineDetails.excludedAdditions,
+    excludedChangedLineDeletions: changedLineDetails.excludedDeletions,
+    excludedChangedLineFiles: changedLineDetails.excludedFiles,
+    excludedChangedLines: changedLineDetails.excludedChangedLines,
+    hasFileBreakdown: changedLineDetails.hasFileBreakdown,
     shouldClosePr,
     closeReason: shouldClosePr
-      ? `Score ${score.total} is below ${POLICY.autoCloseBelowScore} and the PR changes ${changedLines} lines, exceeding ${POLICY.autoCloseAboveChangedLines}.`
+      ? formatChangedLineThresholdReason(score, changedLineDetails)
       : null,
   }
 }

--- a/.github/scripts/contributor-trust/plan-actions.test.js
+++ b/.github/scripts/contributor-trust/plan-actions.test.js
@@ -1,7 +1,21 @@
 import { describe, expect, it } from "vitest"
 
 import { POLICY } from "./config.js"
-import { planTrustActions } from "./plan-actions.js"
+import { isMigrationChangedLineFile, planTrustActions } from "./plan-actions.js"
+
+describe("isMigrationChangedLineFile", () => {
+  it("matches read-frog config migration scripts, tests, and generated fixtures", () => {
+    expect(isMigrationChangedLineFile("src/utils/config/migration-scripts/v080-to-v081.ts")).toBe(true)
+    expect(isMigrationChangedLineFile("src/utils/config/__tests__/migration-scripts/v079-to-v080.test.ts")).toBe(true)
+    expect(isMigrationChangedLineFile("src/utils/config/__tests__/example/v081.ts")).toBe(true)
+    expect(isMigrationChangedLineFile(".agents/skills/migration-scripts/SKILL.md")).toBe(false)
+    expect(isMigrationChangedLineFile("src/utils/config/migration.ts")).toBe(false)
+    expect(isMigrationChangedLineFile("src/utils/config/migration-scripts/types.ts")).toBe(false)
+    expect(isMigrationChangedLineFile("src/utils/config/__tests__/migration-scripts/all-migrations.test.ts")).toBe(false)
+    expect(isMigrationChangedLineFile("src/utils/config/__tests__/example/types.ts")).toBe(false)
+    expect(isMigrationChangedLineFile("src/entrypoints/host.content/runtime.ts")).toBe(false)
+  })
+})
 
 describe("planTrustActions", () => {
   it("assigns the low-trust labels for new contributors", () => {
@@ -108,6 +122,55 @@ describe("planTrustActions", () => {
     expect(plan.closeReason).toContain("Score 19 is below 20")
     expect(plan.closeReason).toContain("1065 lines")
     expect(plan.closeReason).toContain("exceeding 1000")
+  })
+
+  it("excludes migration-related files from the changed-line threshold", () => {
+    const plan = planTrustActions({
+      currentLabels: [],
+      pullRequest: { additions: 1699, deletions: 2 },
+      pullRequestFiles: [
+        {
+          additions: 1662,
+          deletions: 0,
+          filename: "src/utils/config/__tests__/example/v081.ts",
+        },
+        {
+          additions: 30,
+          deletions: 0,
+          filename: "src/utils/config/migration-scripts/v080-to-v081.ts",
+        },
+        {
+          additions: 4,
+          deletions: 0,
+          filename: "src/entrypoints/host.content/runtime.ts",
+        },
+        {
+          additions: 3,
+          deletions: 2,
+          filename: "src/utils/constants/config.ts",
+        },
+      ],
+      score: {
+        bucket: "new",
+        exemptReason: null,
+        total: 19,
+      },
+    })
+
+    expect(plan).toMatchObject({
+      changedLineAdditions: 7,
+      changedLineDeletions: 2,
+      changedLines: 9,
+      excludedChangedLineAdditions: 1692,
+      excludedChangedLineDeletions: 0,
+      excludedChangedLines: 1692,
+      shouldClosePr: false,
+    })
+    expect(plan.excludedChangedLineFiles).toEqual([
+      "src/utils/config/__tests__/example/v081.ts",
+      "src/utils/config/migration-scripts/v080-to-v081.ts",
+    ])
+    expect(plan.closeReason).toBeNull()
   })
 
   it("does not auto-close a low-score PR when it is still under the line threshold", () => {

--- a/.github/scripts/contributor-trust/run.js
+++ b/.github/scripts/contributor-trust/run.js
@@ -17,6 +17,7 @@ import {
   getPullRequest,
   listIssueComments,
   listIssueLabels,
+  listPullRequestFiles,
   removeLabelFromIssue,
   updateIssueComment,
 } from "./github-api.js"
@@ -199,8 +200,11 @@ export async function main() {
     return
   }
 
-  const permission = await getCollaboratorPermission(token, owner, repo, pullRequest.user.login)
-  const authorMetrics = await getAuthorMetrics(token, owner, repo, pullRequest.user.login)
+  const [pullRequestFiles, permission, authorMetrics] = await Promise.all([
+    listPullRequestFiles(token, owner, repo, pullRequest.number),
+    getCollaboratorPermission(token, owner, repo, pullRequest.user.login),
+    getAuthorMetrics(token, owner, repo, pullRequest.user.login),
+  ])
   const scoreInput = createContributorMetrics({
     author: authorMetrics.author,
     permission,
@@ -208,7 +212,7 @@ export async function main() {
   })
 
   const score = computeContributorScore(scoreInput)
-  const plan = planTrustActions({ currentLabels, pullRequest, score })
+  const plan = planTrustActions({ currentLabels, pullRequest, pullRequestFiles, score })
   const comment = buildTrustComment({
     author: {
       login: authorMetrics.author.login,
@@ -259,7 +263,9 @@ export async function main() {
   logScoreBreakdown(score)
 
   summaryLines.push(`- Trust score: **${score.total}/100**`)
-  summaryLines.push(`- PR changed lines: ${plan.changedLines}`)
+  summaryLines.push(`- PR counted changed lines: ${plan.changedLines}`)
+  if (plan.excludedChangedLines > 0)
+    summaryLines.push(`- Migration-related changed lines excluded: ${plan.excludedChangedLines}`)
   summaryLines.push(`- Bucket: \`${score.bucket}\``)
   summaryLines.push(`- Target label: \`${plan.targetTrustLabel}\``)
   summaryLines.push(`- Maintainer review: ${plan.needsMaintainerReview ? "required" : "not required"}`)

--- a/.github/scripts/contributor-trust/run.test.js
+++ b/.github/scripts/contributor-trust/run.test.js
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   getAuthorMetrics: vi.fn(),
   getCollaboratorPermission: vi.fn(),
   getPullRequest: vi.fn(),
+  listPullRequestFiles: vi.fn(),
   listIssueComments: vi.fn(),
   listIssueLabels: vi.fn(),
   removeLabelFromIssue: vi.fn(),
@@ -36,6 +37,7 @@ vi.mock("./github-api.js", () => ({
   getAuthorMetrics: mocks.getAuthorMetrics,
   getCollaboratorPermission: mocks.getCollaboratorPermission,
   getPullRequest: mocks.getPullRequest,
+  listPullRequestFiles: mocks.listPullRequestFiles,
   listIssueComments: mocks.listIssueComments,
   listIssueLabels: mocks.listIssueLabels,
   removeLabelFromIssue: mocks.removeLabelFromIssue,
@@ -109,6 +111,7 @@ describe("main", () => {
 
     expect(mocks.ensureRepositoryLabels).not.toHaveBeenCalled()
     expect(mocks.listIssueLabels).not.toHaveBeenCalled()
+    expect(mocks.listPullRequestFiles).not.toHaveBeenCalled()
     expect(mocks.getCollaboratorPermission).not.toHaveBeenCalled()
     expect(mocks.getAuthorMetrics).not.toHaveBeenCalled()
 
@@ -118,7 +121,7 @@ describe("main", () => {
 
   it("continues to process human-authored pull requests", async () => {
     mocks.getPullRequest.mockResolvedValue({
-      additions: 20,
+      additions: 1520,
       deletions: 5,
       draft: false,
       number: 42,
@@ -131,6 +134,18 @@ describe("main", () => {
     })
     mocks.ensureRepositoryLabels.mockResolvedValue(undefined)
     mocks.listIssueLabels.mockResolvedValue([])
+    mocks.listPullRequestFiles.mockResolvedValue([
+      {
+        additions: 1500,
+        deletions: 0,
+        filename: "src/utils/config/__tests__/example/v081.ts",
+      },
+      {
+        additions: 20,
+        deletions: 5,
+        filename: "src/entrypoints/options/pages/translation/index.tsx",
+      },
+    ])
     mocks.getCollaboratorPermission.mockResolvedValue("write")
     mocks.getAuthorMetrics.mockResolvedValue({
       author: {
@@ -200,9 +215,23 @@ describe("main", () => {
       "mengxi-ream",
     )
     expect(mocks.getAuthorMetrics).toHaveBeenCalledTimes(1)
+    expect(mocks.listPullRequestFiles).toHaveBeenCalledWith(
+      "test-token",
+      "read-frog",
+      "read-frog",
+      42,
+    )
+    expect(mocks.buildTrustComment).toHaveBeenCalledWith(expect.objectContaining({
+      plan: expect.objectContaining({
+        changedLines: 25,
+        excludedChangedLines: 1500,
+      }),
+    }))
     expect(mocks.createIssueComment).toHaveBeenCalledTimes(1)
 
     const summary = await readFile(process.env.GITHUB_STEP_SUMMARY, "utf8")
     expect(summary).toContain("- Trust score: **78/100**")
+    expect(summary).toContain("- PR counted changed lines: 25")
+    expect(summary).toContain("- Migration-related changed lines excluded: 1500")
   })
 })


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [x] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Updates contributor trust automation so the auto-close line-count threshold uses PR file-level additions and deletions instead of only the PR-level total. This lets the workflow exclude read-frog's versioned config migration artifacts from the size threshold while still counting ordinary source changes.

The excluded paths are intentionally scoped to the repository's existing config migration layout:

- `src/utils/config/migration-scripts/vNNN-to-vMMM.ts`
- `src/utils/config/__tests__/migration-scripts/vNNN-to-vMMM.test.ts`
- `src/utils/config/__tests__/example/vNNN.ts`

The trust comment and job summary now report counted changed lines and the number of migration-related lines excluded, so maintainers can see why a PR did or did not exceed the auto-close threshold.

For PR #1735, this policy counts 138 changed lines and excludes 1692 migration-related lines.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Commands run:

- `git diff --check`
- `pnpm exec eslint .github/scripts/contributor-trust/comment-template.js .github/scripts/contributor-trust/comment-template.test.js .github/scripts/contributor-trust/config.js .github/scripts/contributor-trust/github-api.js .github/scripts/contributor-trust/github-api.test.js .github/scripts/contributor-trust/plan-actions.js .github/scripts/contributor-trust/plan-actions.test.js .github/scripts/contributor-trust/run.js .github/scripts/contributor-trust/run.test.js`
- `pnpm exec vitest run .github/scripts/contributor-trust/plan-actions.test.js .github/scripts/contributor-trust/comment-template.test.js .github/scripts/contributor-trust/run.test.js .github/scripts/contributor-trust/github-api.test.js`
- Pre-push hook: `nx run @read-frog/extension:lint`
- Pre-push hook: `nx run @read-frog/extension:type-check`
- Pre-push hook: `nx run @read-frog/extension:test`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

No changeset is included because this only changes repository automation and does not affect the published extension package.
