### PR TITLE
fix(translation): treat display contents as block

### DIFF
--- a/.changeset/steam-display-contents-block.md
+++ b/.changeset/steam-display-contents-block.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): treat display contents wrappers as block containers

--- a/src/utils/host/dom/__tests__/filter.test.ts
+++ b/src/utils/host/dom/__tests__/filter.test.ts
@@ -96,6 +96,16 @@ describe("inline/block display detection", () => {
     expect(isShallowInlineHTMLElement(element)).toBe(false)
     expect(isShallowBlockHTMLElement(element)).toBe(true)
   })
+
+  it("should treat display contents as block", () => {
+    const element = document.createElement("a")
+    element.textContent = "Market item"
+    element.style.display = "contents"
+
+    expect(window.getComputedStyle(element).display).toBe("contents")
+    expect(isShallowInlineHTMLElement(element)).toBe(false)
+    expect(isShallowBlockHTMLElement(element)).toBe(true)
+  })
 })
 
 function createConfig(range: "main" | "all"): Config {

--- a/src/utils/host/dom/filter.ts
+++ b/src/utils/host/dom/filter.ts
@@ -45,10 +45,6 @@ function isInlineDisplay(display: string): boolean {
     return false
   }
 
-  if (normalizedDisplay === "contents") {
-    return true
-  }
-
   if (normalizedDisplay.startsWith("inline")) {
     return true
   }


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Treat `display: contents` elements as block containers during page translation inline/block classification.

Steam Community Market item cards use `display: contents` anchor wrappers around grid card content. The previous classification treated those transparent wrappers as inline, which could cause the walker to group card-grid children as inline content instead of descending into and translating the individual card fields.

This removes the special-case inline classification for `display: contents`, adds coverage for the new classification, and includes a patch changeset for `@read-frog/extension`.

## Related Issue


## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Commands run:

```bash
pnpm vitest run src/utils/host/dom/__tests__/filter.test.ts
SKIP_FREE_API=true pnpm vitest run src/utils/host/__tests__/translate.integration.test.tsx
WXT_SKIP_ENV_VALIDATION=true pnpm build:edge
git diff --check
git push -u origin codex/fix-display-contents-translation
```

The push hook also passed:

```bash
nx run @read-frog/extension:lint
nx run @read-frog/extension:type-check
nx run @read-frog/extension:test
```

Manual verification:

- Built the Edge extension and loaded it in a real Edge browser.
- Re-tested Steam Community Market at https://steamcommunity.com/market/search?appid=3678970.
- Confirmed the target `display: contents` anchor is classified as block, not inline.
- Confirmed target item card text receives translation wrappers, including `供品`, `王国50周年纪念币`, `待售数量...`, and price text.

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This is the minimal implementation requested for this issue: `display: contents` is no longer treated as inline, so it falls through to the existing block classification path.
