### PR TITLE
fix(options): show test connection feedback inside button

### DIFF
--- a/.changeset/connection-test-button-feedback.md
+++ b/.changeset/connection-test-button-feedback.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(options): show test connection feedback inside button

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/connection-button.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/connection-button.tsx
@@ -1,7 +1,7 @@
 import type { APIProviderConfig } from "@/types/config/provider"
-import { Icon } from "@iconify/react"
+import { IconCheck, IconHourglassLow, IconX } from "@tabler/icons-react"
 import { useMutation } from "@tanstack/react-query"
-import { useEffect } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { i18n } from "#imports"
 import LoadingDots from "@/components/loading-dots"
 import { Button } from "@/components/ui/base-ui/button"
@@ -10,31 +10,69 @@ import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { executeTranslate } from "@/utils/host/translate/execute-translate"
 import { getTranslatePrompt } from "@/utils/prompts/translate"
 
-function ConnectionSuccessIcon() {
-  return (
-    <div className="flex items-center justify-center size-5 rounded-full bg-green-200 dark:bg-green-800/50">
-      <Icon
-        icon="tabler:check"
-        className="size-3.5 text-green-700 dark:text-green-300 stroke-[2.5]"
-      />
-    </div>
-  )
+const SLOW_CONNECTION_THRESHOLD_MS = 3_000
+const CONNECTION_TEST_FEEDBACK_DURATION_MS = 5_000
+
+type ConnectionTestFeedback = "success" | "failed" | "slow"
+
+interface ConnectionTestFeedbackState {
+  status: ConnectionTestFeedback
+  requestId: number
+  provider: APIProviderConfig["provider"]
+  apiKey: string | undefined
+  baseURL: string | undefined
+  providerSpecificSettings: unknown
 }
 
-function ConnectionErrorIcon() {
-  return (
-    <div className="flex items-center justify-center size-5 rounded-full bg-red-200 dark:bg-red-800/50">
-      <Icon
-        icon="tabler:x"
-        className="size-3.5 text-red-700 dark:text-red-300 stroke-[2.5]"
-      />
-    </div>
-  )
+interface ConnectionTestVariables {
+  requestId: number
+  startedAt: number
 }
 
-const ConnectionTestResultIconMap = {
-  success: <ConnectionSuccessIcon />,
-  error: <ConnectionErrorIcon />,
+const connectionTestFeedbackIconConfig = {
+  success: {
+    Icon: IconCheck,
+    containerClassName: "flex size-4 items-center justify-center rounded-full bg-green-200 dark:bg-green-800/50",
+    iconClassName: "size-3 text-green-700 dark:text-green-300 stroke-[2.5]",
+  },
+  failed: {
+    Icon: IconX,
+    containerClassName: "flex size-4 items-center justify-center rounded-full bg-red-200 dark:bg-red-800/50",
+    iconClassName: "size-3 text-red-700 dark:text-red-300 stroke-[2.5]",
+  },
+  slow: {
+    Icon: IconHourglassLow,
+    containerClassName: "flex size-4 items-center justify-center rounded-full bg-yellow-200 dark:bg-yellow-800/50",
+    iconClassName: "size-3 text-yellow-700 dark:text-yellow-300 stroke-[2.5]",
+  },
+} satisfies Record<ConnectionTestFeedback, {
+  Icon: typeof IconCheck
+  containerClassName: string
+  iconClassName: string
+}>
+
+const connectionTestFeedbackLabelKey = {
+  success: "options.apiProviders.testConnection.success",
+  failed: "options.apiProviders.testConnection.failed",
+  slow: "options.apiProviders.testConnection.slow",
+} as const
+
+function getConnectionTestFeedback(startedAt: number): ConnectionTestFeedback {
+  return Date.now() - startedAt > SLOW_CONNECTION_THRESHOLD_MS ? "slow" : "success"
+}
+
+function ConnectionFeedbackIcon({ feedback }: { feedback: ConnectionTestFeedback }) {
+  const {
+    Icon: FeedbackIcon,
+    containerClassName,
+    iconClassName,
+  } = connectionTestFeedbackIconConfig[feedback]
+
+  return (
+    <div aria-hidden="true" className={containerClassName}>
+      <FeedbackIcon className={iconClassName} strokeWidth={2.5} />
+    </div>
+  )
 }
 
 export function ConnectionTestButton({ providerConfig }: { providerConfig: APIProviderConfig }) {
@@ -43,51 +81,119 @@ export function ConnectionTestButton({ providerConfig }: { providerConfig: APIPr
   const providerSpecificSettings = "providerSpecificSettings" in providerConfig
     ? providerConfig.providerSpecificSettings
     : undefined
+  const [feedback, setFeedback] = useState<ConnectionTestFeedbackState | null>(null)
+  const latestRequestIdRef = useRef(0)
+  const feedbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const mutation = useMutation({
     // for safety, we should not include apiKey in the mutationKey
     mutationKey: ["apiConnection", getObjectWithoutAPIKeys(providerConfig)],
-    mutationFn: async () => {
+    mutationFn: async (_variables: ConnectionTestVariables) => {
       return await executeTranslate("Hi", DEFAULT_CONFIG.language, providerConfig, getTranslatePrompt)
     },
   })
 
+  const clearFeedbackTimeout = useCallback(() => {
+    if (feedbackTimeoutRef.current !== null) {
+      clearTimeout(feedbackTimeoutRef.current)
+      feedbackTimeoutRef.current = null
+    }
+  }, [])
+
+  const showFeedback = useCallback((nextFeedback: ConnectionTestFeedback, requestId: number) => {
+    if (requestId !== latestRequestIdRef.current) {
+      return
+    }
+
+    clearFeedbackTimeout()
+    setFeedback({
+      status: nextFeedback,
+      requestId,
+      provider,
+      apiKey,
+      baseURL,
+      providerSpecificSettings,
+    })
+    feedbackTimeoutRef.current = setTimeout(() => {
+      if (requestId === latestRequestIdRef.current) {
+        setFeedback(currentFeedback => currentFeedback?.requestId === requestId ? null : currentFeedback)
+      }
+      feedbackTimeoutRef.current = null
+    }, CONNECTION_TEST_FEEDBACK_DURATION_MS)
+  }, [apiKey, baseURL, clearFeedbackTimeout, provider, providerSpecificSettings])
+
   const handleTestConnection = () => {
-    mutation.mutate()
+    clearFeedbackTimeout()
+    setFeedback(null)
+
+    const requestId = latestRequestIdRef.current + 1
+    latestRequestIdRef.current = requestId
+    const startedAt = Date.now()
+
+    mutation.mutate({ requestId, startedAt }, {
+      onSuccess: (_data, variables) => {
+        showFeedback(getConnectionTestFeedback(variables.startedAt), variables.requestId)
+      },
+      onError: (_error, variables) => {
+        showFeedback("failed", variables.requestId)
+      },
+    })
   }
 
   useEffect(() => {
+    latestRequestIdRef.current += 1
+    clearFeedbackTimeout()
     mutation.reset()
   // eslint-disable-next-line react/exhaustive-deps
-  }, [provider, apiKey, baseURL, providerSpecificSettings])
+  }, [provider, apiKey, baseURL, providerSpecificSettings, clearFeedbackTimeout])
 
-  const testResult = mutation.isSuccess ? "success" : mutation.isError ? "error" : null
-  const ConnectionTestResultIcon = testResult ? ConnectionTestResultIconMap[testResult] : null
+  useEffect(() => {
+    return () => {
+      latestRequestIdRef.current += 1
+      clearFeedbackTimeout()
+    }
+  }, [clearFeedbackTimeout])
+
+  const visibleFeedback = feedback
+    && feedback.requestId === latestRequestIdRef.current
+    && feedback.provider === provider
+    && feedback.apiKey === apiKey
+    && feedback.baseURL === baseURL
+    && feedback.providerSpecificSettings === providerSpecificSettings
+    ? feedback.status
+    : null
 
   return (
-    <div className="flex items-center gap-2">
-      {ConnectionTestResultIcon}
-      <Button
-        size="xs"
-        variant="outline"
-        onClick={handleTestConnection}
-        disabled={mutation.isPending || (!apiKey && provider !== "deeplx" && provider !== "ollama")}
-      >
-        {mutation.isPending
+    <Button
+      size="xs"
+      variant="outline"
+      className="gap-2"
+      onClick={handleTestConnection}
+      disabled={mutation.isPending || (!apiKey && provider !== "deeplx" && provider !== "ollama")}
+    >
+      {mutation.isPending
+        ? (
+            <>
+              <LoadingDots className="scale-75" />
+              <span className="text-xs">
+                {i18n.t("options.apiProviders.testConnection.testing")}
+              </span>
+            </>
+          )
+        : visibleFeedback
           ? (
-              <div className="flex items-center gap-2">
-                <LoadingDots className="scale-75" />
+              <>
+                <ConnectionFeedbackIcon feedback={visibleFeedback} />
                 <span className="text-xs">
-                  {i18n.t("options.apiProviders.testConnection.testing")}
+                  {i18n.t(connectionTestFeedbackLabelKey[visibleFeedback])}
                 </span>
-              </div>
+              </>
             )
           : (
               <span className="text-xs">
                 {i18n.t("options.apiProviders.testConnection.button")}
               </span>
             )}
-      </Button>
-    </div>
+    </Button>
   )
 }

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -201,6 +201,9 @@ options:
     testConnection:
       button: Test Connection
       testing: Testing...
+      success: Success
+      failed: Failed
+      slow: Slow (try adjusting thinking mode)
   general:
     title: General
     appearance:

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -201,6 +201,9 @@ options:
     testConnection:
       button: Probar conexión
       testing: Probando...
+      success: Correcto
+      failed: Falló
+      slow: Lento (se recomienda ajustar el modo de razonamiento)
   general:
     title: General
     appearance:

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -200,6 +200,9 @@ options:
     testConnection:
       button: 接続テスト
       testing: テスト中...
+      success: 成功
+      failed: 失敗
+      slow: 低速（思考モードの調整を推奨）
   general:
     title: 一般
     appearance:

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -200,6 +200,9 @@ options:
     testConnection:
       button: 연결 테스트
       testing: 테스트 중...
+      success: 성공
+      failed: 실패
+      slow: 느림(사고 모드 조정 권장)
   general:
     title: 일반
     appearance:

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -200,6 +200,9 @@ options:
     testConnection:
       button: Проверить соединение
       testing: Тестирование...
+      success: Успешно
+      failed: Ошибка
+      slow: Медленно (рекомендуется настроить режим рассуждения)
   general:
     title: Общие
     appearance:

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -200,6 +200,9 @@ options:
     testConnection:
       button: Bağlantıyı Test Et
       testing: Test ediliyor...
+      success: Başarılı
+      failed: Başarısız
+      slow: Yavaş (düşünme modunu ayarlamanız önerilir)
   general:
     title: Genel
     appearance:

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -200,6 +200,9 @@ options:
     testConnection:
       button: Kiểm tra kết nối
       testing: Đang kiểm tra...
+      success: Thành công
+      failed: Thất bại
+      slow: Chậm (nên điều chỉnh chế độ suy nghĩ)
   general:
     title: Chung
     appearance:

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -201,6 +201,9 @@ options:
     testConnection:
       button: 测试连接
       testing: 测试中...
+      success: 成功
+      failed: 失败
+      slow: 缓慢（建议调节思考模式）
   general:
     title: 通用
     appearance:

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -201,6 +201,9 @@ options:
     testConnection:
       button: 測試連線
       testing: 測試中…
+      success: 成功
+      failed: 失敗
+      slow: 緩慢（建議調整思考模式）
   general:
     title: 通用
     appearance:


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [x] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [x] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Updates the API provider test connection button so result feedback appears inside the button instead of as a separate icon beside it.

- Shows inline success, failure, and slow-success states with matching icons and localized labels.
- Detects slow successful responses after more than 3 seconds and shows a yellow hourglass state.
- Clears stale feedback when provider configuration changes and ignores outdated test responses.
- Adds localized feedback labels for all existing locale files.

## Related Issue


## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

Validated locally with:

- `SKIP_FREE_API=true pnpm type-check`
- `pnpm eslint src/entrypoints/options/pages/api-providers/provider-config-form/components/connection-button.tsx`
- Pre-push hook: `nx run @read-frog/extension:lint`
- Pre-push hook: `nx run @read-frog/extension:type-check`
- Pre-push hook: `nx run @read-frog/extension:test` (162 files, 1369 tests passed)

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

No unit tests were added per request.
