### PR TITLE
fix(selection): resolve subtitle shadow selections

### DIFF
--- a/.changeset/fix-youtube-subtitle-selection-context.md
+++ b/.changeset/fix-youtube-subtitle-selection-context.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection): resolve Read Frog subtitle selections inside the subtitles shadow root

--- a/src/entrypoints/selection.content/__tests__/utils.test.ts
+++ b/src/entrypoints/selection.content/__tests__/utils.test.ts
@@ -266,6 +266,71 @@ describe("readSelectionSnapshot", () => {
     })
   })
 
+  it("passes the Read Frog subtitles shadow root when selection boundaries expose only the host", () => {
+    document.body.innerHTML = `
+      <div id="read-frog-subtitles-ui-host"></div>
+      <main><span id="fallback">against</span></main>
+    `
+
+    const subtitlesHost = document.getElementById("read-frog-subtitles-ui-host")
+    const fallbackNode = document.getElementById("fallback")?.firstChild
+    if (!subtitlesHost || !fallbackNode) {
+      throw new Error("Selection fixtures not found")
+    }
+
+    const subtitlesShadowRoot = subtitlesHost.attachShadow({ mode: "open" })
+    const subtitleLine = document.createElement("div")
+    subtitleLine.className = "subtitles-main"
+    subtitleLine.textContent = "fears that anti-immigration protests could descend into widespread violence against foreigners."
+    subtitlesShadowRoot.appendChild(subtitleLine)
+
+    const subtitleNode = subtitleLine.firstChild
+    if (!subtitleNode) {
+      throw new Error("Subtitle text node not found")
+    }
+
+    const selectedWordStart = subtitleNode.textContent?.indexOf("against") ?? -1
+    if (selectedWordStart < 0) {
+      throw new Error("Selected word not found in subtitle")
+    }
+
+    const subtitleRange = document.createRange()
+    subtitleRange.setStart(subtitleNode, selectedWordStart)
+    subtitleRange.setEnd(subtitleNode, selectedWordStart + "against".length)
+
+    const fallbackRange = document.createRange()
+    fallbackRange.setStart(fallbackNode, 0)
+    fallbackRange.setEnd(fallbackNode, fallbackNode.textContent?.length ?? 0)
+
+    const getComposedRanges = vi.fn((options?: { shadowRoots?: ShadowRoot[] }) =>
+      options?.shadowRoots?.includes(subtitlesShadowRoot) ? [subtitleRange] : [],
+    )
+    const selection = {
+      toString: () => "against",
+      anchorNode: subtitlesHost,
+      focusNode: subtitlesHost,
+      rangeCount: 1,
+      getRangeAt: () => fallbackRange,
+      getComposedRanges,
+    } as unknown as Selection
+
+    const snapshot = readSelectionSnapshot(selection)
+
+    expect(getComposedRanges).toHaveBeenCalledWith({
+      shadowRoots: [subtitlesShadowRoot],
+    })
+    expect(snapshot?.ranges[0]).toMatchObject({
+      startContainer: subtitleNode,
+      startOffset: selectedWordStart,
+      endContainer: subtitleNode,
+      endOffset: selectedWordStart + "against".length,
+    })
+    expect(buildContextSnapshot(snapshot)).toEqual({
+      text: "fears that anti-immigration protests could descend into widespread violence against foreigners.",
+      paragraphs: ["fears that anti-immigration protests could descend into widespread violence against foreigners."],
+    })
+  })
+
   it("falls back to getRangeAt when getComposedRanges returns no ranges", () => {
     document.body.innerHTML = `<div id="selection">Beta</div>`
 

--- a/src/entrypoints/selection.content/utils.ts
+++ b/src/entrypoints/selection.content/utils.ts
@@ -1,3 +1,5 @@
+import { READ_FROG_SUBTITLES_UI_HOST_ID } from "@/utils/constants/subtitles"
+
 export interface SelectionRangeSnapshot {
   startContainer: Node
   startOffset: number
@@ -143,6 +145,12 @@ function collectSelectionBoundaryNodes(selection: Selection) {
   return [...boundaryNodes]
 }
 
+function getReadFrogSubtitleShadowRoot() {
+  const subtitlesHost = document.getElementById(READ_FROG_SUBTITLES_UI_HOST_ID)
+  const subtitlesRoot = subtitlesHost?.shadowRoot
+  return subtitlesRoot ?? null
+}
+
 function collectSelectionShadowRoots(selection: Selection) {
   const shadowRoots = new Set<ShadowRoot>()
 
@@ -158,6 +166,11 @@ function collectSelectionShadowRoots(selection: Selection) {
       shadowRoots.add(root)
       current = root.host
     }
+  }
+
+  const subtitleShadowRoot = getReadFrogSubtitleShadowRoot()
+  if (subtitleShadowRoot) {
+    shadowRoots.add(subtitleShadowRoot)
   }
 
   return [...shadowRoots]

--- a/src/entrypoints/subtitles.content/renderer/mount-subtitles-ui.tsx
+++ b/src/entrypoints/subtitles.content/renderer/mount-subtitles-ui.tsx
@@ -3,7 +3,7 @@ import type { PlatformConfig } from "@/entrypoints/subtitles.content/platforms"
 import ReactDOM from "react-dom/client"
 import themeCSS from "@/assets/styles/theme.css?inline"
 import { REACT_SHADOW_HOST_CLASS } from "@/utils/constants/dom-labels"
-import { SUBTITLES_THEME } from "@/utils/constants/subtitles"
+import { READ_FROG_SUBTITLES_UI_HOST_ID, SUBTITLES_THEME } from "@/utils/constants/subtitles"
 import { waitForElement } from "@/utils/dom/wait-for-element"
 import { ShadowWrapperContext } from "@/utils/react-shadow-host/create-shadow-host"
 import { ShadowHostBuilder } from "@/utils/react-shadow-host/shadow-host-builder"
@@ -11,8 +11,6 @@ import { applyTheme } from "@/utils/theme"
 import { SubtitlesContainer } from "../ui/subtitles-container"
 import { SubtitlesProviders } from "../ui/subtitles-ui-context"
 import { mountSubtitlesToast } from "./mount-subtitles-toast"
-
-const SUBTITLES_UI_HOST_ID = "read-frog-subtitles-ui-host"
 
 interface MountSubtitlesUIOptions {
   adapter: SubtitlesProvidersAdapter
@@ -33,7 +31,7 @@ export async function mountSubtitlesUI(
     parentEl.style.position = "relative"
   }
 
-  const existingHost = document.getElementById(SUBTITLES_UI_HOST_ID) as HTMLDivElement | null
+  const existingHost = document.getElementById(READ_FROG_SUBTITLES_UI_HOST_ID) as HTMLDivElement | null
   if (existingHost) {
     if (existingHost.parentElement === parentEl) {
       return
@@ -44,7 +42,7 @@ export async function mountSubtitlesUI(
   }
 
   const shadowHost = document.createElement("div")
-  shadowHost.id = SUBTITLES_UI_HOST_ID
+  shadowHost.id = READ_FROG_SUBTITLES_UI_HOST_ID
   shadowHost.classList.add(REACT_SHADOW_HOST_CLASS)
   shadowHost.style.cssText = `
     position: absolute;

--- a/src/utils/constants/subtitles.ts
+++ b/src/utils/constants/subtitles.ts
@@ -16,6 +16,7 @@ export const TRANSLATE_LOOK_AHEAD_MS = 30_000
 export const PROCESS_LOOK_AHEAD_MS = 60_000
 
 // DOM IDs
+export const READ_FROG_SUBTITLES_UI_HOST_ID = "read-frog-subtitles-ui-host"
 export const TRANSLATE_BUTTON_CONTAINER_ID = "read-frog-subtitles-translate-button-container"
 export const HIDE_NATIVE_CAPTIONS_STYLE_ID = "read-frog-hide-native-captions"
 


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fixes paragraph context extraction for selections inside Read Frog-rendered YouTube subtitles.

The subtitle UI is mounted inside an open shadow root. When browser selection boundaries are retargeted to the shadow host, the selection toolbar could fall back to page-level ranges and collect unrelated YouTube page text as `Paragraphs`. This change reuses the shared subtitles host id and passes the subtitles shadow root to `Selection.getComposedRanges()`, allowing the existing paragraph owner logic to resolve the real subtitle text node.

This intentionally keeps the fix minimal: it does not add subtitle-line selector special cases or change user-facing subtitle behavior.

## Related Issue

Closes #1680

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Commands run:

- `SKIP_FREE_API=true pnpm exec vitest run src/entrypoints/selection.content/__tests__/utils.test.ts`
- `pnpm exec eslint src/entrypoints/selection.content/utils.ts src/entrypoints/selection.content/__tests__/utils.test.ts src/entrypoints/subtitles.content/renderer/mount-subtitles-ui.tsx src/utils/constants/subtitles.ts`
- `git diff --check`
- pre-push hook: `@read-frog/extension:lint`
- pre-push hook: `@read-frog/extension:type-check`
- pre-push hook: `@read-frog/extension:test` (164 files, 1409 tests)

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Includes a patch changeset for `@read-frog/extension`.