### PR TITLE
fix(page-translation): allow site rules to control aria-hidden content

### DIFF
--- a/.changeset/aria-hidden-site-rules.md
+++ b/.changeset/aria-hidden-site-rules.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(page-translation): allow site rules to control aria-hidden exclusions

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -157,7 +157,7 @@ function deepQueryTopLevelSelectorImpl(
 
 function isBlockedForTraversal(element: HTMLElement): boolean {
   return Boolean(element.hidden)
-    || element.getAttribute("aria-hidden") === "true"
+    || element.matches("[data-site-rule-blocked][aria-hidden='true']")
     || element.classList.contains("closed")
 }
 
@@ -245,9 +245,9 @@ describe("pageTranslationManager mutation re-walk", () => {
     manager.stop()
   })
 
-  it("observes and translates aria-hidden accordion content after it becomes visible", async () => {
+  it("observes and translates aria-hidden content after a site-rule block becomes walkable", async () => {
     document.body.innerHTML = `
-      <section id="accordion" aria-hidden="true">
+      <section id="accordion" data-site-rule-blocked aria-hidden="true">
         <p id="panel">Accordion body</p>
       </section>
     `

--- a/src/utils/host/dom/__tests__/filter.test.ts
+++ b/src/utils/host/dom/__tests__/filter.test.ts
@@ -141,10 +141,32 @@ describe("isDontWalkIntoAndDontTranslateAsChildElement", () => {
     expect(isDontWalkIntoAndDontTranslateAsChildElement(element, DEFAULT_CONFIG)).toBe(true)
   })
 
-  it("should return true for aria-hidden=\"true\"", () => {
+  it("should not block aria-hidden=\"true\" by default", () => {
+    setHost("non-configured-example.org")
     const element = document.createElement("div")
     element.setAttribute("aria-hidden", "true")
+    expect(isDontWalkIntoAndDontTranslateAsChildElement(element, DEFAULT_CONFIG)).toBe(false)
+  })
+
+  it("should still block aria-hidden=\"true\" on WhatsApp through the built-in site rule", () => {
+    setHost("web.whatsapp.com")
+    const element = document.createElement("div")
+    element.setAttribute("aria-hidden", "true")
+
     expect(isDontWalkIntoAndDontTranslateAsChildElement(element, DEFAULT_CONFIG)).toBe(true)
+  })
+
+  it("should still block Twitch aria-hidden chat decorations through the built-in site rule", () => {
+    setHost("www.twitch.tv")
+    const container = document.createElement("div")
+    container.className = "chat-line__no-background"
+    const element = document.createElement("span")
+    element.setAttribute("aria-hidden", "true")
+    container.appendChild(element)
+    document.body.appendChild(container)
+
+    expect(isDontWalkIntoAndDontTranslateAsChildElement(element, DEFAULT_CONFIG)).toBe(true)
+    document.body.removeChild(container)
   })
 
   it("should return true for SCRIPT tag", () => {

--- a/src/utils/host/dom/filter.ts
+++ b/src/utils/host/dom/filter.ts
@@ -190,12 +190,11 @@ export function isDontWalkIntoAndDontTranslateAsChildElement(element: HTMLElemen
     = window.getComputedStyle(element).display === "none"
       || window.getComputedStyle(element).visibility === "hidden"
   const dontWalkHidden = element.hidden
-  const dontWalkAriaHidden = element.getAttribute("aria-hidden") === "true"
   const dontWalkVisuallyHidden = ["sr-only", "visually-hidden"].some(cls =>
     element.classList.contains(cls),
   )
 
-  if (dontWalkCustomElement || dontWalkContent || dontWalkInvalidTag || dontWalkCSS || dontWalkHidden || dontWalkAriaHidden || dontWalkVisuallyHidden) {
+  if (dontWalkCustomElement || dontWalkContent || dontWalkInvalidTag || dontWalkCSS || dontWalkHidden || dontWalkVisuallyHidden) {
     return true
   }
 


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

- Removes the global aria-hidden traversal block so page translation can follow site-rule exclusions.
- Keeps hidden, CSS-hidden, and screen-reader-only elements blocked.
- Adds regression coverage for default aria-hidden content plus WhatsApp and Twitch site-rule exclusions.

## Related Issue

Closes #1473

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Commands run:

- `SKIP_FREE_API=true pnpm vitest run src/utils/host/dom src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts`
- Pre-push checks: `pnpm lint`, `pnpm type-check`, `pnpm test`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

A patch changeset is included for `@read-frog/extension`.