### PR TITLE
fix(popup): hide disabled custom AI actions from the provider selecto…

### DIFF
--- a/.changeset/hide-disabled-custom-actions.md
+++ b/.changeset/hide-disabled-custom-actions.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(popup): hide disabled custom AI actions from the provider selector list

--- a/src/components/llm-providers/__tests__/feature-provider-selector-list.test.tsx
+++ b/src/components/llm-providers/__tests__/feature-provider-selector-list.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import type { Config } from "@/types/config/config"
+import { render, screen } from "@testing-library/react"
+import { createStore, Provider } from "jotai"
+import { describe, expect, it, vi } from "vitest"
+import { FeatureProviderSelectorList } from "@/components/llm-providers/feature-provider-selector-list"
+import { configAtom } from "@/utils/atoms/config"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+
+// Keep the render shallow — we only care about which custom-action rows appear,
+// not the provider dropdown internals.
+vi.mock("@/components/llm-providers/provider-selector", () => ({
+  default: () => <div>ProviderSelector</div>,
+}))
+
+type CustomAction = Config["selectionToolbar"]["customActions"][number]
+
+function cloneConfig(config: Config): Config {
+  return JSON.parse(JSON.stringify(config)) as Config
+}
+
+function makeAction(
+  action: Pick<CustomAction, "id" | "name" | "providerId"> & Partial<CustomAction>,
+): CustomAction {
+  return {
+    icon: "tabler:sparkles",
+    systemPrompt: "You are helpful.",
+    prompt: "Do something.",
+    outputSchema: [],
+    ...action,
+  }
+}
+
+function renderWithConfig(config: Config) {
+  const store = createStore()
+  store.set(configAtom, config)
+  render(
+    <Provider store={store}>
+      <FeatureProviderSelectorList />
+    </Provider>,
+  )
+}
+
+describe("featureProviderSelectorList custom action filtering", () => {
+  it("only renders provider rows for enabled custom actions", () => {
+    const config = cloneConfig(DEFAULT_CONFIG)
+    const providerId = config.providersConfig[0]!.id
+
+    config.selectionToolbar.customActions = [
+      makeAction({ id: "enabled-action", name: "Enabled Action", providerId, enabled: true }),
+      makeAction({ id: "disabled-action", name: "Disabled Action", providerId, enabled: false }),
+    ]
+
+    renderWithConfig(config)
+
+    expect(screen.getByText("Enabled Action")).toBeInTheDocument()
+    expect(screen.queryByText("Disabled Action")).not.toBeInTheDocument()
+  })
+
+  it("treats actions without an explicit enabled flag as enabled", () => {
+    const config = cloneConfig(DEFAULT_CONFIG)
+    const providerId = config.providersConfig[0]!.id
+
+    config.selectionToolbar.customActions = [
+      makeAction({ id: "implicit-action", name: "Implicit Action", providerId }),
+    ]
+
+    renderWithConfig(config)
+
+    expect(screen.getByText("Implicit Action")).toBeInTheDocument()
+  })
+
+  it("hides the custom actions section when every action is disabled", () => {
+    const config = cloneConfig(DEFAULT_CONFIG)
+    const providerId = config.providersConfig[0]!.id
+
+    config.selectionToolbar.customActions = [
+      makeAction({ id: "disabled-action", name: "Disabled Action", providerId, enabled: false }),
+    ]
+
+    renderWithConfig(config)
+
+    expect(screen.queryByText("Disabled Action")).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("options.general.featureProviders.customActions"),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/components/llm-providers/feature-provider-selector-list.tsx
+++ b/src/components/llm-providers/feature-provider-selector-list.tsx
@@ -87,7 +87,9 @@ function CustomActionProviderFields({
     [providersConfig],
   )
 
-  const customActions = config.selectionToolbar.customActions
+  const customActions = config.selectionToolbar.customActions.filter(
+    action => action.enabled !== false,
+  )
 
   if (customActions.length === 0) {
     return null

--- a/src/entrypoints/popup/components/providers-field.tsx
+++ b/src/entrypoints/popup/components/providers-field.tsx
@@ -36,6 +36,9 @@ function getSelectedProviderOptions(config: Config, providersConfig: ProvidersCo
   }
 
   for (const action of config.selectionToolbar.customActions) {
+    if (action.enabled === false) {
+      continue
+    }
     addProvider("selectionToolbar.customAction", action.providerId)
   }
 


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

The extension popup's provider section ("自定义 AI 指令" / Custom AI Actions) rendered a provider dropdown for **every** custom AI action, ignoring each action's `enabled` flag. As a result, disabled or old test actions still cluttered the list even when the user had only enabled a few actions.

The `enabled !== false` convention (an action counts as enabled unless explicitly disabled) is already used everywhere else in the codebase — e.g. the context menu (`context-menu.ts`) and the selection toolbar buttons (`custom-action-button/index.tsx`) — but the provider selector list was the one place missing it.

This PR filters disabled custom actions out of the provider selector list:

- **`feature-provider-selector-list.tsx`** — `CustomActionProviderFields` now filters `config.selectionToolbar.customActions` by `enabled !== false`. This component is shared, so the fix applies to **both** the popup provider drawer and the options → General "Feature Providers" section, keeping the two mirrored surfaces consistent. When no enabled actions remain, the existing empty-check also hides the "Custom AI Actions" section header.
- **`providers-field.tsx`** — the popup's collapsed provider avatar summary skips disabled actions too, so its count matches the drawer contents.

No functionality is lost: each action's provider stays editable per-action on the Custom AI Actions page.

## Related Issue

Closes #1802

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Added `feature-provider-selector-list.test.tsx` (jsdom + jotai) covering: enabled actions render / disabled actions are hidden, actions with no explicit `enabled` flag are treated as enabled, and the custom-actions section header is hidden when every action is disabled.

- New tests: 3/3 pass
- Full suite: 175 files, 1503 tests pass
- `pnpm type-check`: clean
- `pnpm lint` on touched files: clean

## Screenshots

<!--- Before: the popup provider list showed disabled actions (e.g. 词典) alongside enabled ones. After: only enabled custom actions appear. -->

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The shared `FeatureProviderSelectorList` component was introduced in #1743 specifically to mirror the popup drawer and the options General page, so filtering in the shared component (rather than the popup only) is the consistent fix.
