### PR TITLE
style(format): enable oxfmt tailwind sorting

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -22,6 +22,10 @@
     "pnpm-lock.yaml",
     "**/*.svg"
   ],
+  "sortTailwindcss": {
+    "stylesheet": "./src/assets/styles/theme.css",
+    "functions": ["clsx", "cn", "cva"]
+  },
   "sortImports": {
     "groups": [
       "setup",

--- a/src/components/container.tsx
+++ b/src/components/container.tsx
@@ -9,7 +9,7 @@ function Container({
   return (
     <div
       ref={ref}
-      className={cn("max-w-7xl mx-auto w-full px-6 md:px-8 lg:px-14", className)}
+      className={cn("mx-auto w-full max-w-7xl px-6 md:px-8 lg:px-14", className)}
       {...props}
     >
       {children}

--- a/src/components/form/input-field-auto-save.tsx
+++ b/src/components/form/input-field-auto-save.tsx
@@ -39,7 +39,7 @@ export function InputFieldAutoSave({
 
   return (
     <Field invalid={hasError}>
-      <div className="flex items-end justify-between w-full">
+      <div className="flex w-full items-end justify-between">
         <FieldLabel nativeLabel={false} render={<div />}>
           {label}
         </FieldLabel>

--- a/src/components/form/input-field.tsx
+++ b/src/components/form/input-field.tsx
@@ -35,7 +35,7 @@ export function InputField({
 
   return (
     <Field invalid={hasError}>
-      <div className="flex items-end justify-between w-full">
+      <div className="flex w-full items-end justify-between">
         <FieldLabel nativeLabel={false} render={<div />}>
           {label}
         </FieldLabel>

--- a/src/components/form/select-field-auto-save.tsx
+++ b/src/components/form/select-field-auto-save.tsx
@@ -32,7 +32,7 @@ export function SelectFieldAutoSave({
 
   return (
     <Field invalid={hasError}>
-      <div className="flex items-end justify-between w-full">
+      <div className="flex w-full items-end justify-between">
         <FieldLabel nativeLabel={false} render={<div />}>
           {label}
         </FieldLabel>

--- a/src/components/frog-toast/index.tsx
+++ b/src/components/frog-toast/index.tsx
@@ -43,7 +43,7 @@ function FrogToast({
           .filter(Boolean)
           .join(" "),
       }}
-      className="z-[2147483647] notranslate"
+      className="notranslate z-[2147483647]"
     />
   )
 }

--- a/src/components/gradient-background.tsx
+++ b/src/components/gradient-background.tsx
@@ -24,7 +24,7 @@ export function GradientBackground({ children, className }: GradientBackgroundPr
 
   return (
     <div
-      className={cn("w-full py-8 flex items-center justify-center rounded-xl my-8", className)}
+      className={cn("my-8 flex w-full items-center justify-center rounded-xl py-8", className)}
       style={{
         backgroundImage: [
           "radial-gradient(circle at 70% 10%, rgba(7 240 139 / 0.15), transparent)",

--- a/src/components/help-tooltip.tsx
+++ b/src/components/help-tooltip.tsx
@@ -13,7 +13,7 @@ export function HelpTooltip({
   return (
     <Tooltip>
       <TooltipTrigger render={<span className="inline-flex items-center" />}>
-        <Icon icon="tabler:help" className="size-3 text-muted-foreground cursor-help" />
+        <Icon icon="tabler:help" className="size-3 cursor-help text-muted-foreground" />
       </TooltipTrigger>
       <TooltipContent className={cn("max-w-64", contentClassName)}>
         <p>{children}</p>

--- a/src/components/llm-status-indicator.tsx
+++ b/src/components/llm-status-indicator.tsx
@@ -7,7 +7,7 @@ interface LLMStatusIndicatorProps {
 
 export function LLMStatusIndicator({ hasLLMProvider, featureName }: LLMStatusIndicatorProps) {
   return (
-    <div className="flex items-center gap-1.5 mt-2">
+    <div className="mt-2 flex items-center gap-1.5">
       <div className={`size-2 rounded-full ${hasLLMProvider ? "bg-green-500" : "bg-orange-400"}`} />
       <span className="text-xs">
         {hasLLMProvider

--- a/src/components/markdown-renderer.tsx
+++ b/src/components/markdown-renderer.tsx
@@ -7,54 +7,54 @@ interface MarkdownRendererProps {
 
 const MARKDOWN_COMPONENTS: Components = {
   h1: ({ children }) => (
-    <h1 className="text-lg font-bold text-slate-800 dark:text-slate-100 mb-4 mt-6 first:mt-0 pb-2 border-b border-slate-200 dark:border-slate-700 flex items-center">
-      <span className="w-2 h-2 bg-blue-500 rounded-full mr-3"></span>
+    <h1 className="mt-6 mb-4 flex items-center border-b border-slate-200 pb-2 text-lg font-bold text-slate-800 first:mt-0 dark:border-slate-700 dark:text-slate-100">
+      <span className="mr-3 h-2 w-2 rounded-full bg-blue-500"></span>
       {children}
     </h1>
   ),
   h2: ({ children }) => (
-    <h2 className="text-base font-semibold text-slate-800 dark:text-slate-100 mb-3 mt-5 first:mt-0 flex items-center">
-      <span className="w-1.5 h-1.5 bg-green-500 rounded-full mr-2"></span>
+    <h2 className="mt-5 mb-3 flex items-center text-base font-semibold text-slate-800 first:mt-0 dark:text-slate-100">
+      <span className="mr-2 h-1.5 w-1.5 rounded-full bg-green-500"></span>
       {children}
     </h2>
   ),
   h3: ({ children }) => (
-    <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100 mb-2 mt-4 first:mt-0 flex items-center">
-      <span className="w-1 h-1 bg-orange-500 rounded-full mr-2"></span>
+    <h3 className="mt-4 mb-2 flex items-center text-sm font-semibold text-slate-800 first:mt-0 dark:text-slate-100">
+      <span className="mr-2 h-1 w-1 rounded-full bg-orange-500"></span>
       {children}
     </h3>
   ),
   h4: ({ children }) => (
-    <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-100 mb-2 mt-4 first:mt-0 flex items-center">
-      <span className="w-1 h-1 bg-purple-500 rounded-full mr-2"></span>
+    <h4 className="mt-4 mb-2 flex items-center text-sm font-semibold text-slate-800 first:mt-0 dark:text-slate-100">
+      <span className="mr-2 h-1 w-1 rounded-full bg-purple-500"></span>
       {children}
     </h4>
   ),
   p: ({ children }) => (
-    <p className="text-sm text-slate-700 dark:text-slate-300 mb-3 mt-3 first:mt-0 leading-relaxed">
+    <p className="mt-3 mb-3 text-sm leading-relaxed text-slate-700 first:mt-0 dark:text-slate-300">
       {children}
     </p>
   ),
-  ul: ({ children }) => <ul className="mb-3 mt-3 first:mt-0 space-y-2">{children}</ul>,
-  ol: ({ children }) => <ol className="mb-3 mt-3 first:mt-0 space-y-2">{children}</ol>,
+  ul: ({ children }) => <ul className="mt-3 mb-3 space-y-2 first:mt-0">{children}</ul>,
+  ol: ({ children }) => <ol className="mt-3 mb-3 space-y-2 first:mt-0">{children}</ol>,
   li: ({ children }) => (
-    <li className="text-sm text-slate-700 dark:text-slate-300 flex items-start">
-      <span className="w-1.5 h-1.5 bg-slate-400 dark:bg-slate-500 rounded-full mt-2 mr-3 flex-shrink-0"></span>
+    <li className="flex items-start text-sm text-slate-700 dark:text-slate-300">
+      <span className="mt-2 mr-3 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-slate-400 dark:bg-slate-500"></span>
       <span className="flex-1">{children}</span>
     </li>
   ),
   strong: ({ children }) => (
-    <strong className="font-semibold text-emerald-800 dark:text-emerald-200 bg-emerald-50 dark:bg-emerald-900/30 px-1.5 py-0.5 rounded">
+    <strong className="rounded bg-emerald-50 px-1.5 py-0.5 font-semibold text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-200">
       {children}
     </strong>
   ),
   em: ({ children }) => (
-    <em className="italic text-slate-600 dark:text-slate-400 bg-slate-50 dark:bg-slate-800/50 px-1 py-0.5 rounded">
+    <em className="rounded bg-slate-50 px-1 py-0.5 text-slate-600 italic dark:bg-slate-800/50 dark:text-slate-400">
       {children}
     </em>
   ),
   blockquote: ({ children }) => (
-    <blockquote className="border-l-4 border-blue-500 bg-blue-50 dark:bg-blue-900/20 pl-4 py-2 mb-3 mt-3 first:mt-0 italic text-slate-700 dark:text-slate-300 rounded-r">
+    <blockquote className="mt-3 mb-3 rounded-r border-l-4 border-blue-500 bg-blue-50 py-2 pl-4 text-slate-700 italic first:mt-0 dark:bg-blue-900/20 dark:text-slate-300">
       {children}
     </blockquote>
   ),

--- a/src/components/prompt-configurator/configure-prompt.tsx
+++ b/src/components/prompt-configurator/configure-prompt.tsx
@@ -128,7 +128,7 @@ export function ConfigurePrompt({
             </FieldLabel>
             <QuickInsertableTextarea
               value={prompt.systemPrompt}
-              className="min-h-40 max-h-80"
+              className="max-h-80 min-h-40"
               disabled={isDefault}
               onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
                 setPrompt({ ...prompt, systemPrompt: e.target.value })

--- a/src/components/prompt-configurator/prompt-grid.tsx
+++ b/src/components/prompt-configurator/prompt-grid.tsx
@@ -68,7 +68,7 @@ export function PromptGrid({
   return (
     <div
       aria-label={i18n.t("options.translation.personalizedPrompts.title")}
-      className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 max-h-96 overflow-auto p-2 select-none"
+      className="grid max-h-96 grid-cols-1 gap-4 overflow-auto p-2 select-none md:grid-cols-2 lg:grid-cols-4"
     >
       {allPrompts.map((pattern) => {
         const isDefault = pattern.id === DEFAULT_TRANSLATE_PROMPT_ID
@@ -77,7 +77,7 @@ export function PromptGrid({
         return (
           <Card
             className={cn(
-              "h-full gap-0 pb-2 py-0 cursor-pointer hover:scale-[1.02] transition-transform duration-30 ease-in-out",
+              "h-full cursor-pointer gap-0 py-0 pb-2 transition-transform duration-30 ease-in-out hover:scale-[1.02]",
               // for highlight checked card in export mode
               isExportMode
                 ? "has-aria-checked:border-primary has-aria-checked:bg-primary/5 dark:has-aria-checked:border-primary/70 dark:has-aria-checked:bg-primary/10"
@@ -86,11 +86,11 @@ export function PromptGrid({
             key={pattern.id}
           >
             <CardHeader
-              className="grid-rows-1 pt-4 px-4 mb-3"
+              className="mb-3 grid-rows-1 px-4 pt-4"
               onClick={() => handleCardClick(pattern)}
             >
               <CardTitle className="w-full min-w-0">
-                <div className="leading-relaxed gap-3 flex items-center w-full h-5">
+                <div className="flex h-5 w-full items-center gap-3 leading-relaxed">
                   {/* Checkbox: only show in export mode for custom prompts (not default) */}
                   <Activity mode={isExportMode && !isDefault ? "visible" : "hidden"}>
                     <Checkbox
@@ -108,7 +108,7 @@ export function PromptGrid({
                   </Activity>
                   <Label
                     htmlFor={`${checkboxBaseId}-check-${pattern.id}`}
-                    className="flex-1 min-w-0 block truncate cursor-pointer"
+                    className="block min-w-0 flex-1 cursor-pointer truncate"
                     title={pattern.name}
                   >
                     {pattern.name}
@@ -122,17 +122,17 @@ export function PromptGrid({
               </CardTitle>
             </CardHeader>
             <CardContent
-              className="flex flex-col gap-4 h-16 flex-1 px-4 mb-3"
+              className="mb-3 flex h-16 flex-1 flex-col gap-4 px-4"
               onClick={() => handleCardClick(pattern)}
             >
-              <p className="text-sm text-ellipsis whitespace-pre-wrap line-clamp-3">
+              <p className="line-clamp-3 text-sm text-ellipsis whitespace-pre-wrap">
                 {pattern.systemPrompt && pattern.prompt
                   ? `${pattern.systemPrompt}\n---\n${pattern.prompt}`
                   : pattern.systemPrompt || pattern.prompt}
               </p>
             </CardContent>
             <Separator className="my-0" />
-            <CardFooter className="w-full flex justify-between px-4 items-center py-2 cursor-default">
+            <CardFooter className="flex w-full cursor-default items-center justify-between px-4 py-2">
               <Activity mode={isDefault ? "visible" : "hidden"}>
                 <CardAction>
                   <ConfigurePrompt originPrompt={pattern} />

--- a/src/components/prompt-configurator/prompt-list.tsx
+++ b/src/components/prompt-configurator/prompt-list.tsx
@@ -27,7 +27,7 @@ export function PromptList() {
 
   return (
     <section className="w-full">
-      <div className="w-full text-end mb-4 gap-3 flex justify-end">
+      <div className="mb-4 flex w-full justify-end gap-3 text-end">
         <Activity mode={isExportMode ? "visible" : "hidden"}>
           <Button
             variant="outline"

--- a/src/components/provider-icon.tsx
+++ b/src/components/provider-icon.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/utils/content-script/background-asset-url"
 import { cn } from "@/utils/styles/utils"
 
-const providerIconVariants = cva("flex items-center min-w-0", {
+const providerIconVariants = cva("flex min-w-0 items-center", {
   variants: {
     size: {
       sm: "gap-1.5",
@@ -24,7 +24,7 @@ const providerIconVariants = cva("flex items-center min-w-0", {
 })
 
 const iconContainerVariants = cva(
-  "rounded-full bg-white dark:bg-muted border border-border flex items-center justify-center flex-shrink-0",
+  "flex flex-shrink-0 items-center justify-center rounded-full border border-border bg-white dark:bg-muted",
   {
     variants: {
       size: {

--- a/src/components/recovery/recovery-fallback.tsx
+++ b/src/components/recovery/recovery-fallback.tsx
@@ -49,8 +49,8 @@ export function RecoveryFallback({ error, onRecovered }: RecoveryFallbackProps) 
   }
 
   return (
-    <div className="w-full min-h-full p-4 md:p-6">
-      <div className="mx-auto max-w-xl rounded-xl border bg-card p-4 md:p-6 space-y-4">
+    <div className="min-h-full w-full p-4 md:p-6">
+      <div className="mx-auto max-w-xl space-y-4 rounded-xl border bg-card p-4 md:p-6">
         <div className="space-y-2">
           <h2 className="text-lg font-semibold">{i18n.t("errorRecovery.title")}</h2>
           <p className="text-sm text-muted-foreground">{i18n.t("errorRecovery.description")}</p>

--- a/src/components/sortable-list.tsx
+++ b/src/components/sortable-list.tsx
@@ -120,7 +120,7 @@ function SortableItemWrapper({ id, children }: { id: string; children: React.Rea
       data-sortable-id={id}
       style={style}
       className={cn(
-        "cursor-grab active:cursor-grabbing rounded-xl transition-all duration-200",
+        "cursor-grab rounded-xl transition-all duration-200 active:cursor-grabbing",
         isDragging && "opacity-50",
       )}
       {...attributes}

--- a/src/components/thinking.tsx
+++ b/src/components/thinking.tsx
@@ -110,7 +110,7 @@ export function Thinking({ status, content, defaultExpanded = false, className }
         className="max-h-32 overflow-y-auto px-3 pb-2.5"
         onScroll={handleContentScroll}
       >
-        <p className="text-xs whitespace-pre-wrap break-words [overflow-wrap:anywhere] text-muted-foreground">
+        <p className="text-xs [overflow-wrap:anywhere] break-words whitespace-pre-wrap text-muted-foreground">
           {trimmedContent}
         </p>
       </CollapsibleContent>

--- a/src/components/translation/error/error-button.tsx
+++ b/src/components/translation/error/error-button.tsx
@@ -14,10 +14,10 @@ export function ErrorButton({ error }: { error: APICallError }) {
         delay={0}
         closeDelay={0}
         render={
-          <IconAlertCircle className="size-4 text-destructive hover:text-destructive/90 cursor-pointer" />
+          <IconAlertCircle className="size-4 cursor-pointer text-destructive hover:text-destructive/90" />
         }
       />
-      <HoverCardContent container={shadowWrapper} className="w-64 notranslate" render={<Alert />}>
+      <HoverCardContent container={shadowWrapper} className="notranslate w-64" render={<Alert />}>
         <IconAlertCircle className="size-4 text-red-500!" />
         <AlertTitle>Translation Error</AlertTitle>
         <AlertDescription className="break-all">
@@ -49,8 +49,8 @@ function StatusCode({ statusCode }: { statusCode: number }) {
   }
 
   return (
-    <div className="flex items-center gap-2 mb-2">
-      <div className={`w-2 h-2 rounded-full ${getStatusCodeColor(statusCode)}`} />
+    <div className="mb-2 flex items-center gap-2">
+      <div className={`h-2 w-2 rounded-full ${getStatusCodeColor(statusCode)}`} />
       <span className="text-sm font-medium">
         Status Code:
         {statusCode}

--- a/src/components/ui/base-ui/alert-dialog.tsx
+++ b/src/components/ui/base-ui/alert-dialog.tsx
@@ -23,7 +23,7 @@ function AlertDialogOverlay({ className, ...props }: AlertDialogPrimitive.Backdr
     <AlertDialogPrimitive.Backdrop
       data-slot="alert-dialog-overlay"
       className={cn(
-        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50",
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         SHARED_POPUP_CLOSED_STATE_CLASS,
         className,
       )}
@@ -48,7 +48,7 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 bg-background ring-foreground/10 gap-4 rounded-xl p-4 ring-1 duration-100 data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           SHARED_POPUP_CLOSED_STATE_CLASS,
           className,
         )}
@@ -76,7 +76,7 @@ function AlertDialogFooter({ className, ...props }: React.ComponentProps<"div">)
     <div
       data-slot="alert-dialog-footer"
       className={cn(
-        "bg-muted/50 -mx-4 -mb-4 rounded-b-xl border-t p-4 flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
         className,
       )}
       {...props}
@@ -89,7 +89,7 @@ function AlertDialogMedia({ className, ...props }: React.ComponentProps<"div">) 
     <div
       data-slot="alert-dialog-media"
       className={cn(
-        "bg-muted mb-2 inline-flex size-10 items-center justify-center rounded-md sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
+        "mb-2 inline-flex size-10 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-6",
         className,
       )}
       {...props}
@@ -121,7 +121,7 @@ function AlertDialogDescription({
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
       className={cn(
-        "text-muted-foreground *:[a]:hover:text-foreground text-sm text-balance md:text-pretty *:[a]:underline *:[a]:underline-offset-3",
+        "text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/alert.tsx
+++ b/src/components/ui/base-ui/alert.tsx
@@ -4,13 +4,13 @@ import * as React from "react"
 import { cn } from "@/utils/styles/utils"
 
 const alertVariants = cva(
-  "grid gap-0.5 rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4 w-full relative group/alert",
+  "group/alert relative grid w-full gap-0.5 rounded-lg border px-4 py-3 text-left text-sm has-data-[slot=alert-action]:relative has-data-[slot=alert-action]:pr-18 has-[>svg]:grid-cols-[auto_1fr] has-[>svg]:gap-x-2.5 *:[svg]:row-span-2 *:[svg]:translate-y-0.5 *:[svg]:text-current *:[svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
         default: "bg-card text-card-foreground",
         destructive:
-          "text-destructive border-destructive bg-destructive/5 *:data-[slot=alert-description]:text-card-foreground *:[svg]:text-current",
+          "border-destructive bg-destructive/5 text-destructive *:data-[slot=alert-description]:text-card-foreground *:[svg]:text-current",
       },
     },
     defaultVariants: {
@@ -39,7 +39,7 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="alert-title"
       className={cn(
-        "[&_a]:hover:text-foreground font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3",
+        "font-medium group-has-[>svg]/alert:col-start-2 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground",
         className,
       )}
       {...props}
@@ -52,7 +52,7 @@ function AlertDescription({ className, ...props }: React.ComponentProps<"div">) 
     <div
       data-slot="alert-description"
       className={cn(
-        "text-muted-foreground min-w-0 text-sm text-balance break-words [overflow-wrap:anywhere] md:text-pretty [&_a]:hover:text-foreground [&_a]:underline [&_a]:underline-offset-3 [&_p:not(:last-child)]:mb-4",
+        "min-w-0 text-sm text-balance [overflow-wrap:anywhere] break-words text-muted-foreground md:text-pretty [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/badge.tsx
+++ b/src/components/ui/base-ui/badge.tsx
@@ -5,14 +5,14 @@ import { cva } from "class-variance-authority"
 import { cn } from "@/utils/styles/utils"
 
 const badgeVariants = cva(
-  "gap-1 rounded-4xl border border-transparent font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 inline-flex items-center justify-center w-fit whitespace-nowrap shrink-0 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive overflow-hidden group/badge",
+  "group/badge inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none",
   {
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
         secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
-          "bg-destructive/10 [a]:hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 text-destructive dark:bg-destructive/20",
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
         outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
         ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline",

--- a/src/components/ui/base-ui/button-group.tsx
+++ b/src/components/ui/base-ui/button-group.tsx
@@ -6,14 +6,14 @@ import { Separator } from "@/components/ui/base-ui/separator"
 import { cn } from "@/utils/styles/utils"
 
 const buttonGroupVariants = cva(
-  'has-[>[data-slot=button-group]]:gap-2 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md flex w-fit items-stretch [&>*]:focus-visible:z-10 [&>*]:focus-visible:relative [&>[data-slot=select-trigger]:not([class*="w-"])]:w-fit [&>input]:flex-1',
+  'flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md [&>[data-slot=select-trigger]:not([class*="w-"])]:w-fit [&>input]:flex-1',
   {
     variants: {
       orientation: {
         horizontal:
-          "[&>[data-slot]:not(:has(~[data-slot]))]:rounded-r-md! [&>[data-slot]~[data-slot]]:rounded-l-none [&>[data-slot]~[data-slot]]:border-l-0 [&>[data-slot]]:rounded-r-none",
+          "[&>[data-slot]]:rounded-r-none [&>[data-slot]:not(:has(~[data-slot]))]:rounded-r-md! [&>[data-slot]~[data-slot]]:rounded-l-none [&>[data-slot]~[data-slot]]:border-l-0",
         vertical:
-          "[&>[data-slot]:not(:has(~[data-slot]))]:rounded-b-md! flex-col [&>[data-slot]~[data-slot]]:rounded-t-none [&>[data-slot]~[data-slot]]:border-t-0 [&>[data-slot]]:rounded-b-none",
+          "flex-col [&>[data-slot]]:rounded-b-none [&>[data-slot]:not(:has(~[data-slot]))]:rounded-b-md! [&>[data-slot]~[data-slot]]:rounded-t-none [&>[data-slot]~[data-slot]]:border-t-0",
       },
     },
     defaultVariants: {
@@ -44,7 +44,7 @@ function ButtonGroupText({ className, render, ...props }: useRender.ComponentPro
     props: mergeProps<"div">(
       {
         className: cn(
-          "bg-muted gap-2 rounded-md border px-2.5 text-sm font-medium shadow-xs [&_svg:not([class*='size-'])]:size-4 flex items-center [&_svg]:pointer-events-none",
+          "flex items-center gap-2 rounded-md border bg-muted px-2.5 text-sm font-medium shadow-xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
           className,
         ),
       },
@@ -67,7 +67,7 @@ function ButtonGroupSeparator({
       data-slot="button-group-separator"
       orientation={orientation}
       className={cn(
-        "bg-input relative self-stretch data-[orientation=horizontal]:mx-px data-[orientation=horizontal]:w-auto data-[orientation=vertical]:my-px data-[orientation=vertical]:h-auto",
+        "relative self-stretch bg-input data-[orientation=horizontal]:mx-px data-[orientation=horizontal]:w-auto data-[orientation=vertical]:my-px data-[orientation=vertical]:h-auto",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/card.tsx
+++ b/src/components/ui/base-ui/card.tsx
@@ -11,7 +11,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-xl py-4 text-sm ring-1 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col",
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
         className,
       )}
       {...props}
@@ -23,7 +23,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]",
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
         className,
       )}
       {...props}
@@ -46,7 +46,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
   )
@@ -74,7 +74,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-footer"
       className={cn(
-        "bg-muted/50 rounded-b-xl border-t p-4 group-data-[size=sm]/card:p-3 flex items-center",
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/chart.tsx
+++ b/src/components/ui/base-ui/chart.tsx
@@ -145,7 +145,7 @@ function ChartTooltipContent({
   return (
     <div
       className={cn(
-        "border-border/50 bg-background gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl grid min-w-32 items-start",
+        "grid min-w-32 items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
         className,
       )}
     >

--- a/src/components/ui/base-ui/checkbox.tsx
+++ b/src/components/ui/base-ui/checkbox.tsx
@@ -23,7 +23,7 @@ function Checkbox({ className, onCheckedChange, ...props }: CheckboxProps) {
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "border-input dark:bg-input/30 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary aria-invalid:aria-checked:border-primary aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 flex size-4 items-center justify-center rounded-[4px] border shadow-xs transition-shadow group-has-disabled/field:opacity-50 focus-visible:ring-[3px] aria-invalid:ring-[3px] peer relative shrink-0 outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input shadow-xs transition-shadow outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
         className,
       )}
       onCheckedChange={handleCheckedChange}
@@ -31,7 +31,7 @@ function Checkbox({ className, onCheckedChange, ...props }: CheckboxProps) {
     >
       <CheckboxPrimitive.Indicator
         data-slot="checkbox-indicator"
-        className="[&>svg]:size-3.5 grid place-content-center text-current transition-none"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
       >
         <IconCheck />
       </CheckboxPrimitive.Indicator>

--- a/src/components/ui/base-ui/combobox.tsx
+++ b/src/components/ui/base-ui/combobox.tsx
@@ -25,7 +25,7 @@ function ComboboxTrigger({ className, children, ...props }: ComboboxPrimitive.Tr
       {...props}
     >
       {children}
-      <IconChevronDown className="text-muted-foreground size-4 pointer-events-none" />
+      <IconChevronDown className="pointer-events-none size-4 text-muted-foreground" />
     </ComboboxPrimitive.Trigger>
   )
 }
@@ -108,7 +108,7 @@ function ComboboxContent({
           data-slot="combobox-content"
           data-chips={!!anchor}
           className={cn(
-            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 ring-foreground/10 *:data-[slot=input-group]:bg-input/30 *:data-[slot=input-group]:border-input/30 overflow-hidden rounded-lg shadow-md ring-1 duration-100 *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-8 *:data-[slot=input-group]:shadow-none group/combobox-content relative max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) data-[chips=true]:min-w-(--anchor-width)",
+            "group/combobox-content relative max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) overflow-hidden rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[chips=true]:min-w-(--anchor-width) data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-8 *:data-[slot=input-group]:border-input/30 *:data-[slot=input-group]:bg-input/30 *:data-[slot=input-group]:shadow-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
             SHARED_POPUP_CLOSED_STATE_CLASS,
             className,
           )}
@@ -124,7 +124,7 @@ function ComboboxList({ className, ...props }: ComboboxPrimitive.List.Props) {
     <ComboboxPrimitive.List
       data-slot="combobox-list"
       className={cn(
-        "no-scrollbar max-h-[min(calc(--spacing(72)---spacing(9)),calc(var(--available-height)---spacing(9)))] scroll-py-1 overflow-y-auto p-1 data-empty:p-0 overscroll-contain",
+        "no-scrollbar max-h-[min(calc(--spacing(72)---spacing(9)),calc(var(--available-height)---spacing(9)))] scroll-py-1 overflow-y-auto overscroll-contain p-1 data-empty:p-0",
         className,
       )}
       {...props}
@@ -137,7 +137,7 @@ function ComboboxItem({ className, children, ...props }: ComboboxPrimitive.Item.
     <ComboboxPrimitive.Item
       data-slot="combobox-item"
       className={cn(
-        "data-highlighted:bg-accent data-highlighted:text-accent-foreground not-data-[variant=destructive]:data-highlighted:**:text-accent-foreground gap-2 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 relative flex w-full cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "relative flex w-full cursor-default items-center gap-2 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground not-data-[variant=destructive]:data-highlighted:**:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -165,7 +165,7 @@ function ComboboxLabel({ className, ...props }: ComboboxPrimitive.GroupLabel.Pro
   return (
     <ComboboxPrimitive.GroupLabel
       data-slot="combobox-label"
-      className={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+      className={cn("px-2 py-1.5 text-xs text-muted-foreground", className)}
       {...props}
     />
   )
@@ -180,7 +180,7 @@ function ComboboxEmpty({ className, ...props }: ComboboxPrimitive.Empty.Props) {
     <ComboboxPrimitive.Empty
       data-slot="combobox-empty"
       className={cn(
-        "text-muted-foreground hidden w-full justify-center py-2 text-center text-sm group-data-empty/combobox-content:flex",
+        "hidden w-full justify-center py-2 text-center text-sm text-muted-foreground group-data-empty/combobox-content:flex",
         className,
       )}
       {...props}
@@ -192,7 +192,7 @@ function ComboboxSeparator({ className, ...props }: ComboboxPrimitive.Separator.
   return (
     <ComboboxPrimitive.Separator
       data-slot="combobox-separator"
-      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
       {...props}
     />
   )
@@ -206,7 +206,7 @@ function ComboboxChips({
     <ComboboxPrimitive.Chips
       data-slot="combobox-chips"
       className={cn(
-        "dark:bg-input/30 border-input focus-within:border-ring focus-within:ring-ring/50 has-aria-invalid:ring-destructive/20 dark:has-aria-invalid:ring-destructive/40 has-aria-invalid:border-destructive dark:has-aria-invalid:border-destructive/50 flex min-h-8 flex-wrap items-center gap-1 rounded-lg border bg-transparent bg-clip-padding px-2.5 py-1 text-sm transition-colors focus-within:ring-3 has-aria-invalid:ring-3 has-data-[slot=combobox-chip]:px-1",
+        "flex min-h-8 flex-wrap items-center gap-1 rounded-lg border border-input bg-transparent bg-clip-padding px-2.5 py-1 text-sm transition-colors focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50 has-aria-invalid:border-destructive has-aria-invalid:ring-3 has-aria-invalid:ring-destructive/20 has-data-[slot=combobox-chip]:px-1 dark:bg-input/30 dark:has-aria-invalid:border-destructive/50 dark:has-aria-invalid:ring-destructive/40",
         className,
       )}
       {...props}
@@ -226,7 +226,7 @@ function ComboboxChip({
     <ComboboxPrimitive.Chip
       data-slot="combobox-chip"
       className={cn(
-        "bg-muted text-foreground flex h-[calc(--spacing(5.25))] w-fit items-center justify-center gap-1 rounded-sm px-1.5 text-xs font-medium whitespace-nowrap has-data-[slot=combobox-chip-remove]:pr-0 has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50",
+        "flex h-[calc(--spacing(5.25))] w-fit items-center justify-center gap-1 rounded-sm bg-muted px-1.5 text-xs font-medium whitespace-nowrap text-foreground has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50 has-data-[slot=combobox-chip-remove]:pr-0",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/command.tsx
+++ b/src/components/ui/base-ui/command.tsx
@@ -18,7 +18,7 @@ function Command({ className, ...props }: React.ComponentProps<typeof CommandPri
     <CommandPrimitive
       data-slot="command"
       className={cn(
-        "bg-popover text-popover-foreground rounded-xl! p-1 flex size-full flex-col overflow-hidden",
+        "flex size-full flex-col overflow-hidden rounded-xl! bg-popover p-1 text-popover-foreground",
         className,
       )}
       {...props}
@@ -46,7 +46,7 @@ function CommandDialog({
         <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
       <DialogContent
-        className={cn("rounded-xl! top-1/3 translate-y-0 overflow-hidden p-0", className)}
+        className={cn("top-1/3 translate-y-0 overflow-hidden rounded-xl! p-0", className)}
         showCloseButton={showCloseButton}
       >
         {children}
@@ -60,7 +60,7 @@ function CommandInput({
 }: React.ComponentProps<typeof CommandPrimitive.Input>) {
   return (
     <div data-slot="command-input-wrapper" className="p-1 pb-0">
-      <InputGroup className="bg-input/30 border-input/30 h-8! rounded-lg! shadow-none! *:data-[slot=input-group-addon]:pl-2!">
+      <InputGroup className="h-8! rounded-lg! border-input/30 bg-input/30 shadow-none! *:data-[slot=input-group-addon]:pl-2!">
         <CommandPrimitive.Input
           data-slot="command-input"
           className={cn(
@@ -81,7 +81,7 @@ function CommandList({ className, ...props }: React.ComponentProps<typeof Comman
     <CommandPrimitive.List
       data-slot="command-list"
       className={cn(
-        "no-scrollbar max-h-72 scroll-py-1 outline-none overflow-x-hidden overflow-y-auto",
+        "no-scrollbar max-h-72 scroll-py-1 overflow-x-hidden overflow-y-auto outline-none",
         className,
       )}
       {...props}
@@ -108,7 +108,7 @@ function CommandGroup({
     <CommandPrimitive.Group
       data-slot="command-group"
       className={cn(
-        "text-foreground **:[[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium",
+        "overflow-hidden p-1 text-foreground **:[[cmdk-group-heading]]:px-2 **:[[cmdk-group-heading]]:py-1.5 **:[[cmdk-group-heading]]:text-xs **:[[cmdk-group-heading]]:font-medium **:[[cmdk-group-heading]]:text-muted-foreground",
         className,
       )}
       {...props}
@@ -122,7 +122,7 @@ function CommandSeparator({
   return (
     <CommandPrimitive.Separator
       data-slot="command-separator"
-      className={cn("bg-border -mx-1 h-px", className)}
+      className={cn("-mx-1 h-px bg-border", className)}
       {...props}
     />
   )
@@ -136,7 +136,7 @@ function CommandItem({
     <CommandPrimitive.Item
       data-slot="command-item"
       className={cn(
-        "data-[selected=true]:bg-muted data-[selected=true]:text-foreground data-[selected=true]:*:[svg]:text-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! [&_svg:not([class*='size-'])]:size-4 group/command-item data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "group/command-item relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none in-data-[slot=dialog-content]:rounded-lg! data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-muted data-[selected=true]:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[selected=true]:*:[svg]:text-foreground",
         className,
       )}
       {...props}
@@ -151,7 +151,7 @@ function CommandShortcut({ className, ...props }: React.ComponentProps<"span">) 
     <span
       data-slot="command-shortcut"
       className={cn(
-        "text-muted-foreground group-data-[selected=true]/command-item:text-foreground ml-auto text-xs tracking-widest",
+        "ml-auto text-xs tracking-widest text-muted-foreground group-data-[selected=true]/command-item:text-foreground",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/dialog.tsx
+++ b/src/components/ui/base-ui/dialog.tsx
@@ -26,7 +26,7 @@ function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) 
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50",
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         SHARED_POPUP_CLOSED_STATE_CLASS,
         className,
       )}
@@ -55,7 +55,7 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "bg-background data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           SHARED_POPUP_CLOSED_STATE_CLASS,
           className,
         )}
@@ -80,7 +80,7 @@ function DialogContent({
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div data-slot="dialog-header" className={cn("gap-2 flex flex-col", className)} {...props} />
+    <div data-slot="dialog-header" className={cn("flex flex-col gap-2", className)} {...props} />
   )
 }
 
@@ -96,7 +96,7 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "bg-muted/50 -mx-4 -mb-4 rounded-b-xl border-t p-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
         className,
       )}
       {...props}
@@ -124,7 +124,7 @@ function DialogDescription({ className, ...props }: DialogPrimitive.Description.
     <DialogPrimitive.Description
       data-slot="dialog-description"
       className={cn(
-        "text-muted-foreground *:[a]:hover:text-foreground text-sm *:[a]:underline *:[a]:underline-offset-3",
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/drawer.tsx
+++ b/src/components/ui/base-ui/drawer.tsx
@@ -26,7 +26,7 @@ function DrawerOverlay({ className, ...props }: DrawerPrimitive.Backdrop.Props) 
     <DrawerPrimitive.Backdrop
       data-slot="drawer-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/10 opacity-[calc(1-var(--drawer-swipe-progress))] transition-opacity duration-[500ms] ease-[cubic-bezier(0.32,0.72,0,1)] supports-backdrop-filter:backdrop-blur-xs data-starting-style:opacity-0 data-ending-style:opacity-0 data-ending-style:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-swiping:duration-0",
+        "fixed inset-0 z-50 bg-black/10 opacity-[calc(1-var(--drawer-swipe-progress))] transition-opacity duration-[500ms] ease-[cubic-bezier(0.32,0.72,0,1)] data-ending-style:opacity-0 data-ending-style:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-starting-style:opacity-0 data-swiping:duration-0 supports-backdrop-filter:backdrop-blur-xs",
         SHARED_POPUP_CLOSED_STATE_CLASS,
         className,
       )}
@@ -58,17 +58,17 @@ function DrawerContent({
         <DrawerPrimitive.Popup
           data-slot="drawer-content"
           className={cn(
-            "group/drawer-content fixed z-50 flex h-auto touch-none flex-col bg-popover text-sm text-popover-foreground outline-none transition-[transform,opacity] duration-[500ms] ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform data-ending-style:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-swiping:duration-0",
+            "group/drawer-content fixed z-50 flex h-auto touch-none flex-col bg-popover text-sm text-popover-foreground transition-[transform,opacity] duration-[500ms] ease-[cubic-bezier(0.32,0.72,0,1)] will-change-transform outline-none data-ending-style:duration-[calc(var(--drawer-swipe-strength)*400ms)] data-swiping:duration-0",
             "data-[swipe-direction=down]:inset-x-0 data-[swipe-direction=down]:bottom-0 data-[swipe-direction=down]:mt-24 data-[swipe-direction=down]:max-h-[80vh] data-[swipe-direction=down]:rounded-t-xl data-[swipe-direction=down]:border-t",
             "data-[swipe-direction=up]:inset-x-0 data-[swipe-direction=up]:top-0 data-[swipe-direction=up]:mb-24 data-[swipe-direction=up]:max-h-[80vh] data-[swipe-direction=up]:rounded-b-xl data-[swipe-direction=up]:border-b",
             "data-[swipe-direction=left]:inset-y-0 data-[swipe-direction=left]:left-0 data-[swipe-direction=left]:w-3/4 data-[swipe-direction=left]:rounded-r-xl data-[swipe-direction=left]:border-r data-[swipe-direction=left]:sm:max-w-sm",
             "data-[swipe-direction=right]:inset-y-0 data-[swipe-direction=right]:right-0 data-[swipe-direction=right]:w-3/4 data-[swipe-direction=right]:rounded-l-xl data-[swipe-direction=right]:border-l data-[swipe-direction=right]:sm:max-w-sm",
             "data-[swipe-direction=down]:[transform:translate3d(0,calc(var(--drawer-snap-point-offset)+var(--drawer-swipe-movement-y)),0)] data-[swipe-direction=up]:[transform:translate3d(0,calc(var(--drawer-snap-point-offset)+var(--drawer-swipe-movement-y)),0)]",
             "data-[swipe-direction=left]:[transform:translate3d(var(--drawer-swipe-movement-x),0,0)] data-[swipe-direction=right]:[transform:translate3d(var(--drawer-swipe-movement-x),0,0)]",
-            "data-starting-style:data-[swipe-direction=down]:[transform:translate3d(0,100%,0)] data-ending-style:data-[swipe-direction=down]:[transform:translate3d(0,100%,0)]",
-            "data-starting-style:data-[swipe-direction=up]:[transform:translate3d(0,-100%,0)] data-ending-style:data-[swipe-direction=up]:[transform:translate3d(0,-100%,0)]",
-            "data-starting-style:data-[swipe-direction=left]:[transform:translate3d(-100%,0,0)] data-ending-style:data-[swipe-direction=left]:[transform:translate3d(-100%,0,0)]",
-            "data-starting-style:data-[swipe-direction=right]:[transform:translate3d(100%,0,0)] data-ending-style:data-[swipe-direction=right]:[transform:translate3d(100%,0,0)]",
+            "data-ending-style:data-[swipe-direction=down]:[transform:translate3d(0,100%,0)] data-starting-style:data-[swipe-direction=down]:[transform:translate3d(0,100%,0)]",
+            "data-ending-style:data-[swipe-direction=up]:[transform:translate3d(0,-100%,0)] data-starting-style:data-[swipe-direction=up]:[transform:translate3d(0,-100%,0)]",
+            "data-ending-style:data-[swipe-direction=left]:[transform:translate3d(-100%,0,0)] data-starting-style:data-[swipe-direction=left]:[transform:translate3d(-100%,0,0)]",
+            "data-ending-style:data-[swipe-direction=right]:[transform:translate3d(100%,0,0)] data-starting-style:data-[swipe-direction=right]:[transform:translate3d(100%,0,0)]",
             "after:pointer-events-none after:absolute after:bg-inherit after:content-[''] data-[swipe-direction=down]:after:inset-x-0 data-[swipe-direction=down]:after:top-full data-[swipe-direction=down]:after:h-[200%]",
             "data-[swipe-direction=up]:after:inset-x-0 data-[swipe-direction=up]:after:bottom-full data-[swipe-direction=up]:after:h-[200%]",
             "data-[swipe-direction=left]:after:inset-y-0 data-[swipe-direction=left]:after:right-full data-[swipe-direction=left]:after:w-[200%]",
@@ -90,7 +90,7 @@ function DrawerBody({ className, ...props }: DrawerPrimitive.Content.Props) {
   return (
     <DrawerPrimitive.Content
       data-slot="drawer-body"
-      className={cn("min-h-0 flex-1 overflow-y-auto overscroll-contain touch-auto", className)}
+      className={cn("min-h-0 flex-1 touch-auto overflow-y-auto overscroll-contain", className)}
       {...props}
     />
   )

--- a/src/components/ui/base-ui/dropdown-menu.tsx
+++ b/src/components/ui/base-ui/dropdown-menu.tsx
@@ -41,7 +41,7 @@ function DropdownMenuContent({
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
           className={cn(
-            "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-32 rounded-lg p-1 shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 max-h-(--available-height) w-(--anchor-width) origin-(--transform-origin) overflow-x-hidden overflow-y-auto outline-none data-closed:overflow-hidden",
+            "z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95",
             SHARED_POPUP_CLOSED_STATE_CLASS,
             className,
           )}
@@ -66,7 +66,7 @@ function DropdownMenuLabel({
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(
-        "text-muted-foreground px-1.5 py-1 text-xs font-medium data-inset:pl-7",
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
         className,
       )}
       {...props}
@@ -88,7 +88,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 dark:data-[variant=destructive]:focus:bg-destructive/20 data-[variant=destructive]:focus:text-destructive data-[variant=destructive]:*:[svg]:text-destructive not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 group/dropdown-menu-item relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
         className,
       )}
       {...props}
@@ -111,7 +111,7 @@ function DropdownMenuSubTrigger({
       data-slot="dropdown-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md px-1.5 py-1 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 data-popup-open:bg-accent data-popup-open:text-accent-foreground flex cursor-default items-center outline-hidden select-none [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -134,7 +134,7 @@ function DropdownMenuSubContent({
     <DropdownMenuContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground min-w-[96px] rounded-lg p-1 shadow-lg ring-1 duration-100 w-auto",
+        "w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
         className,
       )}
       align={align}
@@ -160,14 +160,14 @@ function DropdownMenuCheckboxItem({
       data-slot="dropdown-menu-checkbox-item"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       checked={checked}
       {...props}
     >
       <span
-        className="absolute right-2 flex items-center justify-center pointer-events-none"
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
         data-slot="dropdown-menu-checkbox-item-indicator"
       >
         <MenuPrimitive.CheckboxItemIndicator>
@@ -194,13 +194,13 @@ function DropdownMenuRadioItem({
       data-slot="dropdown-menu-radio-item"
       data-inset={inset}
       className={cn(
-        "focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm data-inset:pl-7 [&_svg:not([class*='size-'])]:size-4 relative flex cursor-default items-center outline-hidden select-none data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
     >
       <span
-        className="absolute right-2 flex items-center justify-center pointer-events-none"
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
         data-slot="dropdown-menu-radio-item-indicator"
       >
         <MenuPrimitive.RadioItemIndicator>
@@ -215,7 +215,7 @@ function DropdownMenuSeparator({ className, ...props }: MenuPrimitive.Separator.
   return (
     <MenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
-      className={cn("bg-border -mx-1 my-1 h-px", className)}
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
       {...props}
     />
   )
@@ -225,7 +225,7 @@ function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"spa
     <span
       data-slot="dropdown-menu-shortcut"
       className={cn(
-        "text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground ml-auto text-xs tracking-widest",
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/empty.tsx
+++ b/src/components/ui/base-ui/empty.tsx
@@ -26,12 +26,12 @@ function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 const emptyMediaVariants = cva(
-  "flex shrink-0 items-center justify-center mb-2 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default: "bg-transparent",
-        icon: "bg-muted text-foreground flex size-10 shrink-0 items-center justify-center rounded-lg [&_svg:not([class*='size-'])]:size-6",
+        icon: "flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6",
       },
     },
     defaultVariants: {
@@ -70,7 +70,7 @@ function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
     <div
       data-slot="empty-description"
       className={cn(
-        "text-muted-foreground [&>a:hover]:text-primary text-sm/relaxed [&>a]:underline [&>a]:underline-offset-4",
+        "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/field.tsx
+++ b/src/components/ui/base-ui/field.tsx
@@ -62,12 +62,12 @@ const fieldVariants = cva("group/field flex w-full gap-2 data-[invalid]:text-des
         "has-[>[data-slot=field-content]]:items-start has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
       ],
       responsive: [
-        "flex-col [&>*]:w-full [&>.sr-only]:w-auto @md/field-group:flex-row @md/field-group:items-center @md/field-group:[&>*]:w-auto",
+        "flex-col @md/field-group:flex-row @md/field-group:items-center [&>*]:w-full @md/field-group:[&>*]:w-auto [&>.sr-only]:w-auto",
         "@md/field-group:[&>[data-slot=field-label]]:flex-auto",
         "@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
       ],
       "responsive-compact": [
-        "flex-col [&>*]:w-full [&>.sr-only]:w-auto @xs/field-group:flex-row @xs/field-group:items-center @xs/field-group:[&>*]:w-auto",
+        "flex-col @xs/field-group:flex-row @xs/field-group:items-center [&>*]:w-full @xs/field-group:[&>*]:w-auto [&>.sr-only]:w-auto",
         "@xs/field-group:[&>[data-slot=field-label]]:flex-auto",
         "@xs/field-group:has-[>[data-slot=field-content]]:items-start @xs/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
       ],
@@ -108,11 +108,11 @@ function FieldLabel({ className, ...props }: FieldPrimitive.Label.Props) {
     <FieldPrimitive.Label
       data-slot="field-label"
       className={cn(
-        "group/field-label peer/field-label flex w-fit gap-2 text-sm font-medium leading-snug text-foreground",
+        "group/field-label peer/field-label flex w-fit gap-2 text-sm leading-snug font-medium text-foreground",
         "group-data-[disabled]/field:opacity-50",
         // Nested field support
         "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4",
-        "has-data-[state=checked]:bg-primary/5 has-data-[state=checked]:border-primary dark:has-data-[state=checked]:bg-primary/10",
+        "has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5 dark:has-data-[state=checked]:bg-primary/10",
         className,
       )}
       {...props}
@@ -125,7 +125,7 @@ function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="field-label"
       className={cn(
-        "flex w-fit items-center gap-2 text-sm font-medium leading-snug",
+        "flex w-fit items-center gap-2 text-sm leading-snug font-medium",
         "group-data-[disabled]/field:opacity-50",
         className,
       )}
@@ -139,12 +139,12 @@ function FieldDescription({ className, ...props }: FieldPrimitive.Description.Pr
     <FieldPrimitive.Description
       data-slot="field-description"
       className={cn(
-        "text-sm font-normal leading-normal text-muted-foreground",
+        "text-sm leading-normal font-normal text-muted-foreground",
         "group-has-[[data-orientation=horizontal]]/field:text-balance",
         // Spacing adjustments
         "last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5",
         // Link styling
-        "[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
         className,
       )}
       {...props}
@@ -163,7 +163,7 @@ function FieldControl({
       data-slot="field-control"
       className={cn(
         "h-8 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground",
-        "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+        "focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/hover-card.tsx
+++ b/src/components/ui/base-ui/hover-card.tsx
@@ -33,7 +33,7 @@ function HoverCardContent({
         <PreviewCardPrimitive.Popup
           data-slot="hover-card-content"
           className={cn(
-            "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 bg-popover text-popover-foreground w-64 rounded-lg p-4 text-sm shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 origin-(--transform-origin) outline-hidden",
+            "z-50 w-64 origin-(--transform-origin) rounded-lg bg-popover p-4 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
             SHARED_POPUP_CLOSED_STATE_CLASS,
             className,
           )}

--- a/src/components/ui/base-ui/input-group.tsx
+++ b/src/components/ui/base-ui/input-group.tsx
@@ -14,7 +14,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="input-group"
       role="group"
       className={cn(
-        "border-input dark:bg-input/30 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 h-8 rounded-md border shadow-xs transition-[color,box-shadow] has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot][aria-invalid=true]]:ring-[3px] has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5 [[data-slot=combobox-content]_&]:focus-within:border-inherit [[data-slot=combobox-content]_&]:focus-within:ring-0 group/input-group relative flex w-full min-w-0 items-center outline-none has-[>textarea]:h-auto",
+        "group/input-group relative flex h-8 w-full min-w-0 items-center rounded-md border border-input shadow-xs transition-[color,box-shadow] outline-none has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-[3px] has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:bg-input/30 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5 [[data-slot=combobox-content]_&]:focus-within:border-inherit [[data-slot=combobox-content]_&]:focus-within:ring-0",
         className,
       )}
       {...props}
@@ -23,16 +23,16 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 const inputGroupAddonVariants = cva(
-  "text-muted-foreground h-auto gap-2 py-1.5 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4 flex cursor-text items-center justify-center select-none",
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
   {
     variants: {
       align: {
-        "inline-start": "pl-2 has-[>button]:ml-[-0.25rem] has-[>kbd]:ml-[-0.15rem] order-first",
-        "inline-end": "pr-2 has-[>button]:mr-[-0.25rem] has-[>kbd]:mr-[-0.15rem] order-last",
+        "inline-start": "order-first pl-2 has-[>button]:ml-[-0.25rem] has-[>kbd]:ml-[-0.15rem]",
+        "inline-end": "order-last pr-2 has-[>button]:mr-[-0.25rem] has-[>kbd]:mr-[-0.15rem]",
         "block-start":
-          "px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2 order-first w-full justify-start",
+          "order-first w-full justify-start px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2",
         "block-end":
-          "px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2 order-last w-full justify-start",
+          "order-last w-full justify-start px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2",
       },
     },
     defaultVariants: {
@@ -63,7 +63,7 @@ function InputGroupAddon({
   )
 }
 
-const inputGroupButtonVariants = cva("gap-2 text-sm shadow-none flex items-center", {
+const inputGroupButtonVariants = cva("flex items-center gap-2 text-sm shadow-none", {
   variants: {
     size: {
       xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
@@ -102,7 +102,7 @@ function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
       className={cn(
-        "text-muted-foreground gap-2 text-sm [&_svg:not([class*='size-'])]:size-4 flex items-center [&_svg]:pointer-events-none",
+        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}
@@ -115,7 +115,7 @@ function InputGroupInput({ className, ...props }: React.ComponentProps<"input">)
     <Input
       data-slot="input-group-control"
       className={cn(
-        "rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1",
+        "flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
         className,
       )}
       {...props}
@@ -128,7 +128,7 @@ function InputGroupTextarea({ className, ...props }: React.ComponentProps<"texta
     <Textarea
       data-slot="input-group-control"
       className={cn(
-        "rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent flex-1 resize-none",
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 aria-invalid:ring-0 dark:bg-transparent",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/input.tsx
+++ b/src/components/ui/base-ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 h-8 rounded-md border bg-transparent px-2.5 py-1 text-sm shadow-xs transition-[color,box-shadow] file:h-7 file:text-sm file:font-medium focus-visible:ring-[3px] aria-invalid:ring-[3px] file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        "h-8 w-full min-w-0 rounded-md border border-input bg-transparent px-2.5 py-1 text-sm shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/item.tsx
+++ b/src/components/ui/base-ui/item.tsx
@@ -27,7 +27,7 @@ function ItemSeparator({ className, ...props }: React.ComponentProps<typeof Sepa
 }
 
 const itemVariants = cva(
-  "group/item flex items-center border border-transparent text-sm rounded-md transition-colors [a]:hover:bg-ghost/50 [a]:transition-colors duration-100 flex-wrap outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+  "group/item [a]:hover:bg-ghost/50 flex flex-wrap items-center rounded-md border border-transparent text-sm transition-colors duration-100 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 [a]:transition-colors",
   {
     variants: {
       variant: {
@@ -36,8 +36,8 @@ const itemVariants = cva(
         muted: "bg-muted/50",
       },
       size: {
-        default: "p-4 gap-4 ",
-        sm: "py-3 px-4 gap-2.5",
+        default: "gap-4 p-4",
+        sm: "gap-2.5 px-4 py-3",
       },
     },
     defaultVariants: {
@@ -65,13 +65,13 @@ function Item({
 }
 
 const itemMediaVariants = cva(
-  "flex shrink-0 items-center justify-center gap-2 group-has-[[data-slot=item-description]]/item:self-start [&_svg]:pointer-events-none group-has-[[data-slot=item-description]]/item:translate-y-0.5",
+  "flex shrink-0 items-center justify-center gap-2 group-has-[[data-slot=item-description]]/item:translate-y-0.5 group-has-[[data-slot=item-description]]/item:self-start [&_svg]:pointer-events-none",
   {
     variants: {
       variant: {
         default: "bg-transparent",
-        icon: "size-8 border rounded-sm bg-muted [&_svg:not([class*='size-'])]:size-4",
-        image: "size-10 rounded-sm overflow-hidden [&_img]:size-full [&_img]:object-cover",
+        icon: "size-8 rounded-sm border bg-muted [&_svg:not([class*='size-'])]:size-4",
+        image: "size-10 overflow-hidden rounded-sm [&_img]:size-full [&_img]:object-cover",
       },
     },
     defaultVariants: {
@@ -120,8 +120,8 @@ function ItemDescription({ className, ...props }: React.ComponentProps<"p">) {
     <p
       data-slot="item-description"
       className={cn(
-        "text-muted-foreground line-clamp-2 text-sm leading-normal font-normal text-balance",
-        "[&>a:hover]:text-primary [&>a]:underline [&>a]:underline-offset-4",
+        "line-clamp-2 text-sm leading-normal font-normal text-balance text-muted-foreground",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/kbd.tsx
+++ b/src/components/ui/base-ui/kbd.tsx
@@ -5,7 +5,7 @@ function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
     <kbd
       data-slot="kbd"
       className={cn(
-        "bg-muted text-muted-foreground in-data-[slot=tooltip-content]:bg-background/20 in-data-[slot=tooltip-content]:text-background dark:in-data-[slot=tooltip-content]:bg-background/10 h-5 w-fit min-w-5 gap-1 rounded-sm px-1 font-sans text-xs font-medium [&_svg:not([class*='size-'])]:size-3 pointer-events-none inline-flex items-center justify-center select-none",
+        "pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm bg-muted px-1 font-sans text-xs font-medium text-muted-foreground select-none in-data-[slot=tooltip-content]:bg-background/20 in-data-[slot=tooltip-content]:text-background dark:in-data-[slot=tooltip-content]:bg-background/10 [&_svg:not([class*='size-'])]:size-3",
         className,
       )}
       {...props}
@@ -16,7 +16,7 @@ function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <kbd
       data-slot="kbd-group"
-      className={cn("gap-1 inline-flex items-center", className)}
+      className={cn("inline-flex items-center gap-1", className)}
       {...props}
     />
   )

--- a/src/components/ui/base-ui/label.tsx
+++ b/src/components/ui/base-ui/label.tsx
@@ -8,7 +8,7 @@ function Label({ className, ...props }: React.ComponentProps<"label">) {
     <label
       data-slot="label"
       className={cn(
-        "gap-2 text-sm leading-none font-medium group-data-[disabled=true]:opacity-50 peer-disabled:opacity-50 flex items-center select-none group-data-[disabled=true]:pointer-events-none peer-disabled:cursor-not-allowed",
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/popover.tsx
+++ b/src/components/ui/base-ui/popover.tsx
@@ -38,7 +38,7 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            "bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 flex flex-col gap-2.5 rounded-lg p-2.5 text-sm shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 z-50 w-72 origin-(--transform-origin) outline-hidden",
+            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
             SHARED_POPUP_CLOSED_STATE_CLASS,
             className,
           )}

--- a/src/components/ui/base-ui/progress.tsx
+++ b/src/components/ui/base-ui/progress.tsx
@@ -21,7 +21,7 @@ function ProgressTrack({ className, ...props }: ProgressPrimitive.Track.Props) {
   return (
     <ProgressPrimitive.Track
       className={cn(
-        "bg-muted h-1.5 rounded-full relative flex w-full items-center overflow-x-hidden",
+        "relative flex h-1.5 w-full items-center overflow-x-hidden rounded-full bg-muted",
         className,
       )}
       data-slot="progress-track"
@@ -34,7 +34,7 @@ function ProgressIndicator({ className, ...props }: ProgressPrimitive.Indicator.
   return (
     <ProgressPrimitive.Indicator
       data-slot="progress-indicator"
-      className={cn("bg-primary h-full transition-all", className)}
+      className={cn("h-full bg-primary transition-all", className)}
       {...props}
     />
   )
@@ -53,7 +53,7 @@ function ProgressLabel({ className, ...props }: ProgressPrimitive.Label.Props) {
 function ProgressValue({ className, ...props }: ProgressPrimitive.Value.Props) {
   return (
     <ProgressPrimitive.Value
-      className={cn("text-muted-foreground ml-auto text-sm tabular-nums", className)}
+      className={cn("ml-auto text-sm text-muted-foreground tabular-nums", className)}
       data-slot="progress-value"
       {...props}
     />

--- a/src/components/ui/base-ui/radio-group.tsx
+++ b/src/components/ui/base-ui/radio-group.tsx
@@ -6,7 +6,7 @@ function RadioGroup({ className, ...props }: RadioGroupPrimitive.Props) {
   return (
     <RadioGroupPrimitive
       data-slot="radio-group"
-      className={cn("grid gap-3 w-full", className)}
+      className={cn("grid w-full gap-3", className)}
       {...props}
     />
   )
@@ -17,7 +17,7 @@ function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props) {
     <RadioPrimitive.Root
       data-slot="radio-group-item"
       className={cn(
-        "border-input dark:bg-input/30 data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary data-checked:border-primary aria-invalid:aria-checked:border-primary aria-invalid:border-destructive focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 dark:aria-invalid:border-destructive/50 flex size-4 rounded-full focus-visible:ring-3 aria-invalid:ring-3 group/radio-group-item peer relative aspect-square shrink-0 border outline-none after:absolute after:-inset-x-3 after:-inset-y-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-full border border-input outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
         className,
       )}
       {...props}
@@ -26,7 +26,7 @@ function RadioGroupItem({ className, ...props }: RadioPrimitive.Root.Props) {
         data-slot="radio-group-indicator"
         className="flex size-4 items-center justify-center"
       >
-        <span className="bg-primary-foreground absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full" />
+        <span className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-foreground" />
       </RadioPrimitive.Indicator>
     </RadioPrimitive.Root>
   )

--- a/src/components/ui/base-ui/scroll-area.tsx
+++ b/src/components/ui/base-ui/scroll-area.tsx
@@ -13,7 +13,7 @@ function ScrollArea({ className, children, ...props }: ScrollAreaPrimitive.Root.
     >
       <ScrollAreaPrimitive.Viewport
         data-slot="scroll-area-viewport"
-        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >
         {children}
       </ScrollAreaPrimitive.Viewport>
@@ -34,14 +34,14 @@ function ScrollBar({
       data-orientation={orientation}
       orientation={orientation}
       className={cn(
-        "data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent flex touch-none p-px transition-colors select-none",
+        "flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-l data-vertical:border-l-transparent",
         className,
       )}
       {...props}
     >
       <ScrollAreaPrimitive.Thumb
         data-slot="scroll-area-thumb"
-        className="rounded-full bg-border relative flex-1"
+        className="relative flex-1 rounded-full bg-border"
       />
     </ScrollAreaPrimitive.Scrollbar>
   )

--- a/src/components/ui/base-ui/select.tsx
+++ b/src/components/ui/base-ui/select.tsx
@@ -47,7 +47,7 @@ function SelectTrigger({
       {children}
       <SelectPrimitive.Icon
         data-slot="select-icon"
-        render={<IconChevronDown className="size-4 pointer-events-none" />}
+        render={<IconChevronDown className="pointer-events-none size-4" />}
       />
     </SelectPrimitive.Trigger>
   )

--- a/src/components/ui/base-ui/separator.tsx
+++ b/src/components/ui/base-ui/separator.tsx
@@ -7,7 +7,7 @@ function Separator({ className, orientation = "horizontal", ...props }: Separato
       data-slot="separator"
       orientation={orientation}
       className={cn(
-        "bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch",
+        "shrink-0 bg-border data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px data-[orientation=vertical]:self-stretch",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/sheet.tsx
+++ b/src/components/ui/base-ui/sheet.tsx
@@ -28,7 +28,7 @@ function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
     <SheetPrimitive.Backdrop
       data-slot="sheet-overlay"
       className={cn(
-        "data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 z-50",
+        "fixed inset-0 z-50 bg-black/10 duration-100 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         SHARED_POPUP_CLOSED_STATE_CLASS,
         className,
       )}
@@ -56,7 +56,7 @@ function SheetContent({
         data-slot="sheet-content"
         data-side={side}
         className={cn(
-          "bg-background data-open:animate-in data-closed:animate-out data-[side=right]:data-closed:slide-out-to-right-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=top]:data-closed:slide-out-to-top-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:fade-out-0 data-open:fade-in-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=bottom]:data-open:slide-in-from-bottom-10 fixed z-50 flex flex-col gap-4 bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm",
+          "fixed z-50 flex flex-col gap-4 bg-background bg-clip-padding text-sm shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
           SHARED_POPUP_CLOSED_STATE_CLASS,
           className,
         )}
@@ -81,7 +81,7 @@ function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="sheet-header"
-      className={cn("gap-1.5 p-4 flex flex-col", className)}
+      className={cn("flex flex-col gap-1.5 p-4", className)}
       {...props}
     />
   )
@@ -91,7 +91,7 @@ function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="sheet-footer"
-      className={cn("gap-2 p-4 mt-auto flex flex-col", className)}
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
       {...props}
     />
   )
@@ -101,7 +101,7 @@ function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn("text-foreground font-medium", className)}
+      className={cn("font-medium text-foreground", className)}
       {...props}
     />
   )
@@ -111,7 +111,7 @@ function SheetDescription({ className, ...props }: SheetPrimitive.Description.Pr
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
   )

--- a/src/components/ui/base-ui/sidebar.tsx
+++ b/src/components/ui/base-ui/sidebar.tsx
@@ -132,7 +132,7 @@ function SidebarProvider({
           } as React.CSSProperties
         }
         className={cn(
-          "group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full",
+          "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
           className,
         )}
         {...props}
@@ -162,7 +162,7 @@ function Sidebar({
       <div
         data-slot="sidebar"
         className={cn(
-          "bg-sidebar text-sidebar-foreground flex h-full w-(--sidebar-width) flex-col",
+          "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
           className,
         )}
         {...props}
@@ -179,7 +179,7 @@ function Sidebar({
           data-sidebar="sidebar"
           data-slot="sidebar"
           data-mobile="true"
-          className="bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden"
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
           style={
             {
               "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
@@ -199,7 +199,7 @@ function Sidebar({
 
   return (
     <div
-      className="group peer text-sidebar-foreground hidden md:block"
+      className="group peer hidden text-sidebar-foreground md:block"
       data-state={state}
       data-collapsible={state === "collapsed" ? collapsible : ""}
       data-variant={variant}
@@ -210,7 +210,7 @@ function Sidebar({
       <div
         data-slot="sidebar-gap"
         className={cn(
-          "transition-[width] duration-200 ease-linear relative w-(--sidebar-width) bg-transparent",
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
           "group-data-[collapsible=offcanvas]:w-0",
           "group-data-[side=right]:rotate-180",
           variant === "floating" || variant === "inset"
@@ -236,7 +236,7 @@ function Sidebar({
         <div
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
-          className="bg-sidebar group-data-[variant=floating]:ring-sidebar-border group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1 flex size-full flex-col"
+          className="flex size-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1 group-data-[variant=floating]:ring-sidebar-border"
         >
           {children}
         </div>
@@ -280,10 +280,10 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
+        "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
         "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
-        "hover:group-data-[collapsible=offcanvas]:bg-sidebar group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full",
+        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
         "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
         "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
         className,
@@ -298,7 +298,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 relative flex w-full flex-1 flex-col",
+        "relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className,
       )}
       {...props}
@@ -311,7 +311,7 @@ function SidebarInput({ className, ...props }: React.ComponentProps<typeof Input
     <Input
       data-slot="sidebar-input"
       data-sidebar="input"
-      className={cn("bg-background h-8 w-full shadow-none", className)}
+      className={cn("h-8 w-full bg-background shadow-none", className)}
       {...props}
     />
   )
@@ -322,7 +322,7 @@ function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="sidebar-header"
       data-sidebar="header"
-      className={cn("gap-2 p-2 flex flex-col", className)}
+      className={cn("flex flex-col gap-2 p-2", className)}
       {...props}
     />
   )
@@ -333,7 +333,7 @@ function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="sidebar-footer"
       data-sidebar="footer"
-      className={cn("gap-2 p-2 flex flex-col", className)}
+      className={cn("flex flex-col gap-2 p-2", className)}
       {...props}
     />
   )
@@ -344,7 +344,7 @@ function SidebarSeparator({ className, ...props }: React.ComponentProps<typeof S
     <Separator
       data-slot="sidebar-separator"
       data-sidebar="separator"
-      className={cn("bg-sidebar-border mx-2 w-auto", className)}
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
       {...props}
     />
   )
@@ -356,7 +356,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        "no-scrollbar gap-2 flex min-h-0 flex-1 flex-col overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        "no-scrollbar flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
         className,
       )}
       {...props}
@@ -369,7 +369,7 @@ function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="sidebar-group"
       data-sidebar="group"
-      className={cn("p-2 relative flex w-full min-w-0 flex-col", className)}
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
       {...props}
     />
   )
@@ -385,7 +385,7 @@ function SidebarGroupLabel({
     props: mergeProps<"div">(
       {
         className: cn(
-          "text-sidebar-foreground/70 ring-sidebar-ring h-8 rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 flex shrink-0 items-center outline-hidden [&>svg]:shrink-0",
+          "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
           className,
         ),
       },
@@ -409,7 +409,7 @@ function SidebarGroupAction({
     props: mergeProps<"button">(
       {
         className: cn(
-          "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 w-5 rounded-md p-0 focus-visible:ring-2 [&>svg]:size-4 flex aspect-square items-center justify-center outline-hidden transition-transform [&>svg]:shrink-0 after:absolute after:-inset-2 md:after:hidden group-data-[collapsible=icon]:hidden",
+          "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
           className,
         ),
       },
@@ -428,7 +428,7 @@ function SidebarGroupContent({ className, ...props }: React.ComponentProps<"div"
     <div
       data-slot="sidebar-group-content"
       data-sidebar="group-content"
-      className={cn("text-sm w-full", className)}
+      className={cn("w-full text-sm", className)}
       {...props}
     />
   )
@@ -439,7 +439,7 @@ function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
     <ul
       data-slot="sidebar-menu"
       data-sidebar="menu"
-      className={cn("gap-1 flex w-full min-w-0 flex-col", className)}
+      className={cn("flex w-full min-w-0 flex-col gap-1", className)}
       {...props}
     />
   )
@@ -457,13 +457,13 @@ function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
 }
 
 const sidebarMenuButtonVariants = cva(
-  "ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground gap-2 rounded-md p-2 text-left text-sm transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! focus-visible:ring-2 data-active:font-medium peer/menu-button flex w-full items-center overflow-hidden outline-hidden group/menu-button disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&_svg]:size-4 [&_svg]:shrink-0",
+  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
   {
     variants: {
       variant: {
         default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
         outline:
-          "bg-background hover:bg-sidebar-accent hover:text-sidebar-accent-foreground shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
       },
       size: {
         default: "h-8 text-sm",
@@ -546,9 +546,9 @@ function SidebarMenuAction({
     props: mergeProps<"button">(
       {
         className: cn(
-          "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 aspect-square w-5 rounded-md p-0 peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 focus-visible:ring-2 [&>svg]:size-4 flex items-center justify-center outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 md:after:hidden [&>svg]:shrink-0",
+          "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
           showOnHover &&
-            "peer-data-active/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-open:opacity-100 md:opacity-0",
+            "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-active/menu-button:text-sidebar-accent-foreground md:opacity-0 data-open:opacity-100",
           className,
         ),
       },
@@ -568,7 +568,7 @@ function SidebarMenuBadge({ className, ...props }: React.ComponentProps<"div">) 
       data-slot="sidebar-menu-badge"
       data-sidebar="menu-badge"
       className={cn(
-        "text-sidebar-foreground peer-hover/menu-button:text-sidebar-accent-foreground peer-data-active/menu-button:text-sidebar-accent-foreground pointer-events-none absolute right-1 h-5 min-w-5 rounded-md px-1 text-xs font-medium peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 flex items-center justify-center tabular-nums select-none group-data-[collapsible=icon]:hidden",
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 peer-data-active/menu-button:text-sidebar-accent-foreground",
         className,
       )}
       {...props}
@@ -592,7 +592,7 @@ function SidebarMenuSkeleton({
     <div
       data-slot="sidebar-menu-skeleton"
       data-sidebar="menu-skeleton"
-      className={cn("h-8 gap-2 rounded-md px-2 flex items-center", className)}
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
       {...props}
     >
       {showIcon && <Skeleton className="size-4 rounded-md" data-sidebar="menu-skeleton-icon" />}
@@ -615,7 +615,7 @@ function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
       data-slot="sidebar-menu-sub"
       data-sidebar="menu-sub"
       className={cn(
-        "border-sidebar-border mx-3.5 translate-x-px gap-1 border-l px-2.5 py-0.5 group-data-[collapsible=icon]:hidden flex min-w-0 flex-col",
+        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5 group-data-[collapsible=icon]:hidden",
         className,
       )}
       {...props}
@@ -650,7 +650,7 @@ function SidebarMenuSubButton({
     props: mergeProps<"a">(
       {
         className: cn(
-          "text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground active:bg-sidebar-accent active:text-sidebar-accent-foreground [&>svg]:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground h-7 gap-2 rounded-md px-2 focus-visible:ring-2 data-[size=md]:text-sm data-[size=sm]:text-xs [&>svg]:size-4 flex min-w-0 -translate-x-px items-center overflow-hidden outline-hidden group-data-[collapsible=icon]:hidden disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:shrink-0",
+          "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
           className,
         ),
       },

--- a/src/components/ui/base-ui/skeleton.tsx
+++ b/src/components/ui/base-ui/skeleton.tsx
@@ -4,7 +4,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("bg-muted rounded-md animate-pulse", className)}
+      className={cn("animate-pulse rounded-md bg-muted", className)}
       {...props}
     />
   )

--- a/src/components/ui/base-ui/slider.tsx
+++ b/src/components/ui/base-ui/slider.tsx
@@ -28,10 +28,10 @@ function Slider({
       thumbAlignment="edge"
       {...props}
     >
-      <SliderPrimitive.Control className="data-vertical:min-h-40 relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:w-auto data-vertical:flex-col">
+      <SliderPrimitive.Control className="relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:min-h-40 data-vertical:w-auto data-vertical:flex-col">
         <SliderPrimitive.Track
           data-slot="slider-track"
-          className="bg-muted rounded-full data-horizontal:h-1 data-horizontal:w-full data-vertical:h-full data-vertical:w-1 relative grow overflow-hidden select-none"
+          className="relative grow overflow-hidden rounded-full bg-muted select-none data-horizontal:h-1 data-horizontal:w-full data-vertical:h-full data-vertical:w-1"
         >
           <SliderPrimitive.Indicator
             data-slot="slider-range"
@@ -42,7 +42,7 @@ function Slider({
           <SliderPrimitive.Thumb
             data-slot="slider-thumb"
             key={index}
-            className="border-ring ring-ring/50 relative size-3 rounded-full border bg-white transition-[color,box-shadow] after:absolute after:-inset-2 hover:ring-3 focus-visible:ring-3 focus-visible:outline-hidden active:ring-3 block shrink-0 select-none disabled:pointer-events-none disabled:opacity-50"
+            className="relative block size-3 shrink-0 rounded-full border border-ring bg-white ring-ring/50 transition-[color,box-shadow] select-none after:absolute after:-inset-2 hover:ring-3 focus-visible:ring-3 focus-visible:outline-hidden active:ring-3 disabled:pointer-events-none disabled:opacity-50"
           />
         ))}
       </SliderPrimitive.Control>

--- a/src/components/ui/base-ui/switch.tsx
+++ b/src/components/ui/base-ui/switch.tsx
@@ -26,7 +26,7 @@ function Switch({ className, size = "default", onCheckedChange, ...props }: Swit
       data-slot="switch"
       data-size={size}
       className={cn(
-        "data-checked:bg-primary data-unchecked:bg-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 dark:data-unchecked:bg-input/80 shrink-0 rounded-full border border-transparent shadow-xs focus-visible:ring-[3px] aria-invalid:ring-[3px] data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] peer group/switch relative inline-flex items-center transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className,
       )}
       onCheckedChange={handleCheckedChange}
@@ -34,7 +34,7 @@ function Switch({ className, size = "default", onCheckedChange, ...props }: Swit
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
-        className="bg-background dark:data-unchecked:bg-foreground dark:data-checked:bg-primary-foreground rounded-full group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 pointer-events-none block ring-0 transition-transform"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
       />
     </SwitchPrimitive.Root>
   )

--- a/src/components/ui/base-ui/table.tsx
+++ b/src/components/ui/base-ui/table.tsx
@@ -31,7 +31,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
   return (
     <tfoot
       data-slot="table-footer"
-      className={cn("bg-muted/50 border-t font-medium [&>tr]:last:border-b-0", className)}
+      className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
       {...props}
     />
   )
@@ -42,7 +42,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
         className,
       )}
       {...props}
@@ -55,7 +55,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0",
+        "h-10 px-2 text-left align-middle font-medium whitespace-nowrap text-foreground [&:has([role=checkbox])]:pr-0",
         className,
       )}
       {...props}
@@ -77,7 +77,7 @@ function TableCaption({ className, ...props }: React.ComponentProps<"caption">) 
   return (
     <caption
       data-slot="table-caption"
-      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
       {...props}
     />
   )

--- a/src/components/ui/base-ui/tabs.tsx
+++ b/src/components/ui/base-ui/tabs.tsx
@@ -24,7 +24,7 @@ function Tabs({ className, orientation = "horizontal", onValueChange, ...props }
     <TabsPrimitive.Root
       data-slot="tabs"
       data-orientation={orientation}
-      className={cn("gap-2 group/tabs flex data-[orientation=horizontal]:flex-col", className)}
+      className={cn("group/tabs flex gap-2 data-[orientation=horizontal]:flex-col", className)}
       onValueChange={handleValueChange}
       {...props}
     />
@@ -32,7 +32,7 @@ function Tabs({ className, orientation = "horizontal", onValueChange, ...props }
 }
 
 const tabsListVariants = cva(
-  "rounded-lg p-[3px] group-data-horizontal/tabs:h-8 data-[variant=line]:rounded-none group/tabs-list text-muted-foreground inline-flex w-fit items-center justify-center group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col",
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col group-data-horizontal/tabs:h-8 data-[variant=line]:rounded-none",
   {
     variants: {
       variant: {
@@ -66,10 +66,10 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
     <TabsPrimitive.Tab
       data-slot="tabs-trigger"
       className={cn(
-        "gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg:not([class*='size-'])]:size-4 focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring text-foreground/60 hover:text-foreground dark:text-muted-foreground dark:hover:text-foreground relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center whitespace-nowrap transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
-        "data-active:bg-background dark:data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 data-active:text-foreground",
-        "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
         className,
       )}
       {...props}
@@ -81,7 +81,7 @@ function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
   return (
     <TabsPrimitive.Panel
       data-slot="tabs-content"
-      className={cn("text-sm flex-1 outline-none", className)}
+      className={cn("flex-1 text-sm outline-none", className)}
       {...props}
     />
   )

--- a/src/components/ui/base-ui/textarea.tsx
+++ b/src/components/ui/base-ui/textarea.tsx
@@ -6,7 +6,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input dark:bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-md border bg-transparent px-2.5 py-2 shadow-xs transition-[color,box-shadow] focus-visible:ring-[3px] aria-invalid:ring-[3px] text-sm placeholder:text-muted-foreground flex field-sizing-content min-h-16 w-full outline-none disabled:cursor-not-allowed disabled:opacity-50",
+        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-2.5 py-2 text-sm shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-[3px] aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
         className,
       )}
       {...props}

--- a/src/components/ui/base-ui/tooltip.tsx
+++ b/src/components/ui/base-ui/tooltip.tsx
@@ -40,14 +40,14 @@ function TooltipContent({
         <TooltipPrimitive.Popup
           data-slot="tooltip-content"
           className={cn(
-            "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 rounded-md px-3 py-1.5 text-xs data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 bg-foreground text-background z-50 w-fit max-w-xs origin-(--transform-origin)",
+            "z-50 w-fit max-w-xs origin-(--transform-origin) rounded-md bg-foreground px-3 py-1.5 text-xs text-background data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
             SHARED_POPUP_CLOSED_STATE_CLASS,
             className,
           )}
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 bg-foreground fill-foreground z-50 data-[side=bottom]:top-1 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>

--- a/src/components/ui/css-code-editor.tsx
+++ b/src/components/ui/css-code-editor.tsx
@@ -48,10 +48,10 @@ export function CSSCodeEditor({
       }}
       className={cn(
         "overflow-hidden rounded-md border",
-        "focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]",
+        "focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50",
         hasError &&
           "border-destructive focus-within:border-destructive focus-within:ring-destructive/50",
-        !editable && "opacity-50 cursor-not-allowed",
+        !editable && "cursor-not-allowed opacity-50",
         className,
       )}
       style={{

--- a/src/components/ui/insertable-textarea.tsx
+++ b/src/components/ui/insertable-textarea.tsx
@@ -83,7 +83,7 @@ function QuickInsertableTextarea({
   }
 
   return (
-    <div className={cn("space-y-2 w-full min-w-0", containerClassName)}>
+    <div className={cn("w-full min-w-0 space-y-2", containerClassName)}>
       <InsertableTextarea ref={textareaRef} className={className} {...props} />
       <div className={cn("flex flex-wrap gap-2", cellsClassName)}>
         {insertCells.map((cell) => (

--- a/src/components/ui/json-code-editor.tsx
+++ b/src/components/ui/json-code-editor.tsx
@@ -49,10 +49,10 @@ export function JSONCodeEditor({
       }}
       className={cn(
         "overflow-hidden rounded-md border",
-        "focus-within:border-ring focus-within:ring-ring/50 focus-within:ring-[3px]",
+        "focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/50",
         hasError &&
           "border-destructive focus-within:border-destructive focus-within:ring-destructive/50",
-        !editable && "opacity-50 cursor-not-allowed",
+        !editable && "cursor-not-allowed opacity-50",
         className,
       )}
       style={{

--- a/src/components/ui/selection-popover/index.tsx
+++ b/src/components/ui/selection-popover/index.tsx
@@ -234,7 +234,7 @@ function SelectionPopoverTrigger({
       {
         type: "button",
         className: cn(
-          "px-2 h-7 shrink-0 flex items-center justify-center hover:bg-accent cursor-pointer",
+          "flex h-7 shrink-0 cursor-pointer items-center justify-center px-2 hover:bg-accent",
           className,
         ),
         children,
@@ -407,7 +407,7 @@ function SelectionPopoverContent({
     defaultTagName: "div",
     props: mergeProps<"div">(
       {
-        className: cn("flex min-h-0 h-full flex-1 flex-col", className),
+        className: cn("flex h-full min-h-0 flex-1 flex-col", className),
         children: (
           <SelectionPopoverContentContext value={contentContextValue}>
             {children}
@@ -434,7 +434,7 @@ function SelectionPopoverContent({
     <DialogPrimitive.Portal container={container}>
       <DialogPrimitive.Popup
         className={cn(
-          "fixed inset-0 pointer-events-none focus:outline-none",
+          "pointer-events-none fixed inset-0 focus:outline-none",
           SELECTION_CONTENT_OVERLAY_LAYERS.popover,
         )}
         finalFocus={resolvedFinalFocus}
@@ -472,14 +472,14 @@ function SelectionPopoverHeader({
     props: mergeProps<"div">(
       {
         className: cn(
-          `${SELECTION_POPOVER_DRAG_HANDLE_CLASS} group relative flex items-center justify-between gap-3 py-2 px-4 select-none hover:cursor-grab active:cursor-grabbing`,
+          `${SELECTION_POPOVER_DRAG_HANDLE_CLASS} group relative flex items-center justify-between gap-3 px-4 py-2 select-none hover:cursor-grab active:cursor-grabbing`,
           className,
         ),
         children: (
           <>
             <div
               className={cn(
-                "absolute left-1/2 top-0 -translate-x-1/2 p-1 transition-all duration-200",
+                "absolute top-0 left-1/2 -translate-x-1/2 p-1 transition-all duration-200",
                 isDragging ? "opacity-100" : "opacity-0 group-hover:opacity-100",
               )}
             >
@@ -527,7 +527,7 @@ function SelectionPopoverBody({
 }
 
 function SelectionPopoverFooter({ className, ...props }: React.ComponentProps<"div">) {
-  return <div className={cn("flex items-center gap-2 py-2 px-4", className)} {...props} />
+  return <div className={cn("flex items-center gap-2 px-4 py-2", className)} {...props} />
 }
 
 function SelectionPopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {

--- a/src/components/ui/tree.tsx
+++ b/src/components/ui/tree.tsx
@@ -155,7 +155,7 @@ function TreeItemLabel<T = any>({
     <span
       data-slot="tree-item-label"
       className={cn(
-        "in-focus-visible:ring-ring/50 bg-background hover:bg-accent in-data-[selected=true]:bg-accent in-data-[selected=true]:text-accent-foreground in-data-[drag-target=true]:bg-accent flex items-center gap-1 rounded-sm px-2 py-1.5 text-sm transition-colors not-in-data-[folder=true]:ps-7 in-focus-visible:ring-[3px] in-data-[search-match=true]:bg-blue-50! [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "flex items-center gap-1 rounded-sm bg-background px-2 py-1.5 text-sm transition-colors not-in-data-[folder=true]:ps-7 hover:bg-accent in-focus-visible:ring-[3px] in-focus-visible:ring-ring/50 in-data-[drag-target=true]:bg-accent in-data-[search-match=true]:bg-blue-50! in-data-[selected=true]:bg-accent in-data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
       {...props}
@@ -164,19 +164,19 @@ function TreeItemLabel<T = any>({
         (toggleIconType === "plus-minus" ? (
           item.isExpanded() ? (
             <IconSquareMinus
-              className="text-muted-foreground size-3.5"
+              className="size-3.5 text-muted-foreground"
               stroke="currentColor"
               strokeWidth="1"
             />
           ) : (
             <IconSquarePlus
-              className="text-muted-foreground size-3.5"
+              className="size-3.5 text-muted-foreground"
               stroke="currentColor"
               strokeWidth="1"
             />
           )
         ) : (
-          <IconChevronDown className="text-muted-foreground size-4 in-aria-[expanded=false]:-rotate-90" />
+          <IconChevronDown className="size-4 text-muted-foreground in-aria-[expanded=false]:-rotate-90" />
         ))}
       {children || (typeof item.getItemName === "function" ? item.getItemName() : null)}
     </span>
@@ -203,7 +203,7 @@ function TreeDragLine({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
     <div
       style={dragLine}
       className={cn(
-        "bg-primary before:bg-background before:border-primary absolute z-30 -mt-px h-0.5 w-[unset] before:absolute before:-top-[3px] before:left-0 before:size-2 before:rounded-full before:border-2",
+        "absolute z-30 -mt-px h-0.5 w-[unset] bg-primary before:absolute before:-top-[3px] before:left-0 before:size-2 before:rounded-full before:border-2 before:border-primary before:bg-background",
         className,
       )}
       {...props}

--- a/src/components/user-account-menu/popup.tsx
+++ b/src/components/user-account-menu/popup.tsx
@@ -33,7 +33,7 @@ export function UserAccountMenuPopup() {
           render={
             <button
               type="button"
-              className="group/account flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 transition-colors hover:bg-accent active:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring data-[popup-open]:bg-accent"
+              className="group/account flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none active:bg-accent/70 data-[popup-open]:bg-accent"
             />
           }
         >

--- a/src/entrypoints/options/app-sidebar/animated-indicator.tsx
+++ b/src/entrypoints/options/app-sidebar/animated-indicator.tsx
@@ -6,7 +6,7 @@ export function AnimatedIndicator({ show }: AnimatedIndicatorProps) {
   if (!show) return null
 
   return (
-    <span className="absolute top-1/2 right-2 flex items-center justify-center size-2.5 -translate-y-1/2">
+    <span className="absolute top-1/2 right-2 flex size-2.5 -translate-y-1/2 items-center justify-center">
       <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-brand opacity-75"></span>
       <span className="relative inline-flex size-2 rounded-full bg-brand"></span>
     </span>

--- a/src/entrypoints/options/app-sidebar/index.tsx
+++ b/src/entrypoints/options/app-sidebar/index.tsx
@@ -22,7 +22,7 @@ export function AppSidebar() {
 
   return (
     <Sidebar collapsible="icon">
-      <SidebarHeader className="group-data-[state=expanded]:px-5 group-data-[state=expanded]:pt-4 transition-all">
+      <SidebarHeader className="transition-all group-data-[state=expanded]:px-5 group-data-[state=expanded]:pt-4">
         <UserAccountMenuSidebar />
         <InputGroup onClick={() => setCommandPaletteOpen(true)} className="bg-background">
           <InputGroupInput
@@ -38,11 +38,11 @@ export function AppSidebar() {
           </InputGroupAddon>
         </InputGroup>
       </SidebarHeader>
-      <SidebarContent className="group-data-[state=expanded]:px-2 transition-all">
+      <SidebarContent className="transition-all group-data-[state=expanded]:px-2">
         <SettingsNav />
         <ToolsNav />
       </SidebarContent>
-      <SidebarFooter className="group-data-[state=expanded]:px-2 transition-all">
+      <SidebarFooter className="transition-all group-data-[state=expanded]:px-2">
         <WhatsNewFooter />
       </SidebarFooter>
     </Sidebar>

--- a/src/entrypoints/options/components/config-card.tsx
+++ b/src/entrypoints/options/components/config-card.tsx
@@ -19,15 +19,15 @@ export function ConfigCard({
     <section
       id={id}
       className={cn(
-        "py-6 flex lg:flex-row flex-col lg:gap-x-[50px] xl:gap-x-[100px] gap-y-6",
+        "flex flex-col gap-y-6 py-6 lg:flex-row lg:gap-x-[50px] xl:gap-x-[100px]",
         className,
       )}
     >
-      <div className="lg:basis-2/5 shrink-0">
-        <h2 className={cn("text-lg font-bold mb-1", titleClassName)}>{title}</h2>
+      <div className="shrink-0 lg:basis-2/5">
+        <h2 className={cn("mb-1 text-lg font-bold", titleClassName)}>{title}</h2>
         <div className="text-sm text-muted-foreground">{description}</div>
       </div>
-      <div className="lg:basis-3/5 min-w-0">{children}</div>
+      <div className="min-w-0 lg:basis-3/5">{children}</div>
     </section>
   )
 }

--- a/src/entrypoints/options/components/entity-editor-layout.tsx
+++ b/src/entrypoints/options/components/entity-editor-layout.tsx
@@ -15,8 +15,8 @@ export function EntityEditorLayout({
 }: EntityEditorLayoutProps) {
   return (
     <div className={cn("flex gap-4", className)}>
-      <div className={cn("w-40 lg:w-52 flex flex-col gap-4", listClassName)}>{list}</div>
-      <div className="flex-1 min-w-0">{editor}</div>
+      <div className={cn("flex w-40 flex-col gap-4 lg:w-52", listClassName)}>{list}</div>
+      <div className="min-w-0 flex-1">{editor}</div>
     </div>
   )
 }

--- a/src/entrypoints/options/components/entity-list-rail.tsx
+++ b/src/entrypoints/options/components/entity-list-rail.tsx
@@ -74,25 +74,25 @@ export function EntityListRail({ children, className, containerClassName }: Enti
   return (
     <div className={cn("relative", className)}>
       {canScroll && !isScrolledToTop && (
-        <div className="absolute top-0 left-0 right-0 h-8 bg-linear-to-b from-background to-transparent flex items-center justify-center z-10 pointer-events-none">
-          <Icon icon="tabler:chevron-up" className="size-4 text-muted-foreground animate-bounce" />
+        <div className="pointer-events-none absolute top-0 right-0 left-0 z-10 flex h-8 items-center justify-center bg-linear-to-b from-background to-transparent">
+          <Icon icon="tabler:chevron-up" className="size-4 animate-bounce text-muted-foreground" />
         </div>
       )}
       <div
         ref={scrollContainerRef}
         style={{ overflowAnchor: "none" }}
         className={cn(
-          "overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] max-h-[720px]",
+          "max-h-[720px] [scrollbar-width:none] overflow-y-auto [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden",
           containerClassName,
         )}
       >
         {children}
       </div>
       {canScroll && !isScrolledToBottom && (
-        <div className="absolute bottom-0 left-0 right-0 h-8 bg-linear-to-t from-background to-transparent flex items-center justify-center pointer-events-none">
+        <div className="pointer-events-none absolute right-0 bottom-0 left-0 flex h-8 items-center justify-center bg-linear-to-t from-background to-transparent">
           <Icon
             icon="tabler:chevron-down"
-            className="size-4 text-muted-foreground animate-bounce"
+            className="size-4 animate-bounce text-muted-foreground"
           />
         </div>
       )}

--- a/src/entrypoints/options/components/metric-card.tsx
+++ b/src/entrypoints/options/components/metric-card.tsx
@@ -20,16 +20,16 @@ export function MetricCard({
   comparison?: number
 }) {
   return (
-    <Card className="flex flex-row hover:scale-[1.01] hover:-translate-y-1/12 transition-all duration-200 shadow-xs">
-      <CardContent className="flex gap-4 w-full">
-        <div className="h-full flex items-center">
-          <div className="size-10 flex items-center justify-center rounded-xl bg-zinc-200 text-black dark:bg-zinc-800 dark:text-white">
+    <Card className="flex flex-row shadow-xs transition-all duration-200 hover:-translate-y-1/12 hover:scale-[1.01]">
+      <CardContent className="flex w-full gap-4">
+        <div className="flex h-full items-center">
+          <div className="flex size-10 items-center justify-center rounded-xl bg-zinc-200 text-black dark:bg-zinc-800 dark:text-white">
             <Icon icon={icon} className="size-5" />
           </div>
         </div>
-        <div className="h-full flex flex-col gap-3 w-full items-start">
-          <div className="leading-none text-muted-foreground text-sm">{title}</div>
-          <div className="leading-none text-lg font-semibold tabular-nums flex flex-wrap gap-x-3 items-center">
+        <div className="flex h-full w-full flex-col items-start gap-3">
+          <div className="text-sm leading-none text-muted-foreground">{title}</div>
+          <div className="flex flex-wrap items-center gap-x-3 text-lg leading-none font-semibold tabular-nums">
             {addThousandsSeparator(metric)}
             <Comparison comparison={comparison} />
           </div>
@@ -47,18 +47,18 @@ function Comparison({ comparison }: { comparison?: number }) {
   return (
     <>
       <Activity mode={comparison > 0 ? "visible" : "hidden"}>
-        <div className="h-full text-base flex items-center gap-1 text-primary-strong">
+        <div className="text-primary-strong flex h-full items-center gap-1 text-base">
           <IconCircleArrowUpRightFilled className="size-5" />
           {comparisonText}
         </div>
       </Activity>
       <Activity mode={comparison === 0 ? "visible" : "hidden"}>
-        <div className="h-full text-base flex items-center gap-1 text-foreground">
+        <div className="flex h-full items-center gap-1 text-base text-foreground">
           <IconMinus className="size-5" />
         </div>
       </Activity>
       <Activity mode={comparison < 0 ? "visible" : "hidden"}>
-        <div className="h-full text-base flex items-center gap-1 text-destructive">
+        <div className="flex h-full items-center gap-1 text-base text-destructive">
           <IconCircleArrowDownRightFilled className="size-5" />
           {comparisonText}
         </div>

--- a/src/entrypoints/options/components/page-layout.tsx
+++ b/src/entrypoints/options/components/page-layout.tsx
@@ -18,9 +18,9 @@ export function PageLayout({
     <div className={cn("w-full pb-8", className)}>
       <div className="border-b">
         <Container>
-          <header className="flex h-14 -ml-1.5 shrink-0 items-center gap-2">
+          <header className="-ml-1.5 flex h-14 shrink-0 items-center gap-2">
             <SidebarTrigger />
-            <Separator orientation="vertical" className="mr-1.5 h-4! my-auto" />
+            <Separator orientation="vertical" className="my-auto mr-1.5 h-4!" />
             <h1>{title}</h1>
           </header>
         </Container>

--- a/src/entrypoints/options/components/set-api-key-warning.tsx
+++ b/src/entrypoints/options/components/set-api-key-warning.tsx
@@ -3,7 +3,7 @@ import { i18n } from "@/utils/i18n"
 
 export function SetApiKeyWarning() {
   return (
-    <div className="text-xs bg-warning px-2 rounded-md flex items-center gap-1 border border-warning-border">
+    <div className="border-warning-border flex items-center gap-1 rounded-md border bg-warning px-2 text-xs">
       {i18n.t("options.setAPIKeyWarning.please")}{" "}
       <Link to="/api-providers" className="text-blue-500 hover:underline">
         {i18n.t("options.apiProviders.title")}

--- a/src/entrypoints/options/pages/api-providers/add-provider-dialog.tsx
+++ b/src/entrypoints/options/pages/api-providers/add-provider-dialog.tsx
@@ -20,7 +20,7 @@ export default function AddProviderDialog({ onClose }: { onClose: () => void }) 
   }
 
   return (
-    <DialogContent className="md:max-w-2xl lg:max-w-4xl xl:max-w-5xl max-h-[90vh] overflow-y-auto">
+    <DialogContent className="max-h-[90vh] overflow-y-auto md:max-w-2xl lg:max-w-4xl xl:max-w-5xl">
       <DialogHeader>
         <DialogTitle>{i18n.t("options.apiProviders.dialog.title")}</DialogTitle>
       </DialogHeader>
@@ -54,13 +54,13 @@ function ProviderButtonGroup({
 }) {
   return (
     <div className="my-2.5">
-      <h3 className="text-base font-base text-input-foreground text-center sm:text-left">
+      <h3 className="font-base text-input-foreground text-center text-base sm:text-left">
         {groupTitle}
       </h3>
-      <p className="text-sm text-muted-foreground mt-1 mb-2 text-center sm:text-left">
+      <p className="mt-1 mb-2 text-center text-sm text-muted-foreground sm:text-left">
         {groupDescription}
       </p>
-      <div className="grid grid-cols-4 sm:grid-cols-5 md:grid-cols-7 lg:grid-cols-9 xl:grid-cols-11 gap-1.5 py-2">
+      <div className="grid grid-cols-4 gap-1.5 py-2 sm:grid-cols-5 md:grid-cols-7 lg:grid-cols-9 xl:grid-cols-11">
         {providerTypes.map((providerType) => (
           <ProviderButton
             key={providerType}
@@ -86,14 +86,14 @@ function ProviderButton({
     <button
       type="button"
       key={providerType}
-      className="relative h-auto p-2 flex flex-col items-center space-y-1.5 hover:bg-muted/70 rounded-lg"
+      className="relative flex h-auto flex-col items-center space-y-1.5 rounded-lg p-2 hover:bg-muted/70"
       onClick={() => handleAddProvider(providerType)}
     >
       {sponsor?.sponsoring && (
         <SponsorBadge className="absolute top-0 left-1/2 -translate-x-1/2 -translate-y-[65%]" />
       )}
       <ProviderIcon logo={API_PROVIDER_ITEMS[providerType].logo(theme)} size="md" />
-      <span className="text-xs font-light w-full line-clamp-2 flex-1 flex items-center justify-center">
+      <span className="line-clamp-2 flex w-full flex-1 items-center justify-center text-xs font-light">
         {API_PROVIDER_ITEMS[providerType].name}
       </span>
     </button>

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/advanced-options-section.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/advanced-options-section.tsx
@@ -19,7 +19,7 @@ export function AdvancedOptionsSection({ children }: AdvancedOptionsSectionProps
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <CollapsibleTrigger className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground cursor-pointer">
+      <CollapsibleTrigger className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground hover:text-foreground">
         <Icon
           icon="tabler:chevron-right"
           className={cn("size-4 transition-transform duration-200", isOpen && "rotate-90")}

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/provider-options-recommendation-trigger.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/provider-options-recommendation-trigger.tsx
@@ -132,7 +132,7 @@ export function ProviderOptionsRecommendationTrigger({
             size="icon-xs"
             aria-label={i18n.t("options.apiProviders.form.providerOptionsRecommendationTrigger")}
             className={cn(
-              "text-muted-foreground hover:text-foreground transition-colors duration-700 ease-in-out",
+              "text-muted-foreground transition-colors duration-700 ease-in-out hover:text-foreground",
               isFlashing && "text-primary",
             )}
           />

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/feature-provider-section.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/feature-provider-section.tsx
@@ -53,7 +53,7 @@ export const FeatureProviderSection = withForm({
 
     return (
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <CollapsibleTrigger className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground cursor-pointer py-2">
+        <CollapsibleTrigger className="flex cursor-pointer items-center gap-2 py-2 text-sm text-muted-foreground hover:text-foreground">
           <Icon
             icon="tabler:chevron-right"
             className={cn("size-4 transition-transform duration-200", isOpen && "rotate-90")}

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/index.tsx
@@ -167,7 +167,7 @@ export function ProviderConfigForm() {
     <form.AppForm>
       <div
         className={cn(
-          "flex-1 bg-card rounded-xl p-4 border flex flex-col justify-between",
+          "flex flex-1 flex-col justify-between rounded-xl border bg-card p-4",
           selectedProviderId !== providerConfig.id && "hidden",
         )}
       >
@@ -221,7 +221,7 @@ export function ProviderConfigForm() {
             </AdvancedOptionsSection>
           )}
         </div>
-        <div className="flex justify-between mt-8">
+        <div className="mt-8 flex justify-between">
           <Button type="button" variant="outline" onClick={handleDuplicate}>
             {i18n.t("options.apiProviders.form.duplicate")}
           </Button>

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/provider-options-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/provider-options-field.tsx
@@ -65,7 +65,7 @@ export const ProviderOptionsField = withForm({
         editorAriaLabel="provider-options-editor"
         placeholder={placeholderText}
         label={
-          <div className="flex items-center justify-between w-full">
+          <div className="flex w-full items-center justify-between">
             <div className="flex items-center gap-1.5">
               <span>{i18n.t("options.apiProviders.form.providerOptions")}</span>
               <HelpTooltip>{i18n.t("options.apiProviders.form.providerOptionsHint")}</HelpTooltip>

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
@@ -136,7 +136,7 @@ export const TranslateModelSelector = withForm({
                 />
                 <label
                   htmlFor="isCustomModel-translate"
-                  className="text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70 cursor-pointer"
+                  className="cursor-pointer text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
                 >
                   {i18n.t("options.general.translationConfig.model.enterCustomModel")}
                 </label>

--- a/src/entrypoints/options/pages/api-providers/providers-config.tsx
+++ b/src/entrypoints/options/pages/api-providers/providers-config.tsx
@@ -107,12 +107,12 @@ function ProviderCardList() {
           render={
             <Button
               variant="outline"
-              className="h-auto p-3 border-dashed rounded-xl"
+              className="h-auto rounded-xl border-dashed p-3"
               onClick={() => setIsAddDialogOpen(true)}
             />
           }
         >
-          <div className="flex items-center justify-center gap-2 w-full">
+          <div className="flex w-full items-center justify-center gap-2">
             <Icon icon="tabler:plus" className="size-4" />
             <span className="text-sm">{i18n.t("options.apiProviders.addProvider")}</span>
           </div>
@@ -199,11 +199,11 @@ function FeatureCountBadge({ count, children }: { count: number; children: React
   return (
     <div className="absolute -top-2 right-2 flex items-center justify-center gap-1">
       <Tooltip>
-        <TooltipTrigger render={<Badge className="bg-blue-500 cursor-default" size="sm" />}>
+        <TooltipTrigger render={<Badge className="cursor-default bg-blue-500" size="sm" />}>
           {i18n.t("options.apiProviders.badges.featureCount", [count])}
         </TooltipTrigger>
         <TooltipContent>
-          <ul className="list-disc list-inside marker:text-green-500">{children}</ul>
+          <ul className="list-inside list-disc marker:text-green-500">{children}</ul>
         </TooltipContent>
       </Tooltip>
     </div>
@@ -237,7 +237,7 @@ function ProviderListCell({
     <div
       data-provider-id={providerId}
       className={cn(
-        "rounded-xl p-3 border bg-card relative cursor-pointer",
+        "relative cursor-pointer rounded-xl border bg-card p-3",
         selected && "border-primary",
       )}
       onClick={onSelect}
@@ -297,7 +297,7 @@ function BuiltInProviderPanel() {
   const atlasCloudUrl = atlasCloudProvider.sponsor?.referUrl ?? atlasCloudProvider.website
 
   return (
-    <div className="flex-1 bg-card rounded-xl p-4 border">
+    <div className="flex-1 rounded-xl border bg-card p-4">
       <div className="flex flex-col gap-6">
         <div className="flex flex-col gap-4">
           <ProviderIcon
@@ -307,7 +307,7 @@ function BuiltInProviderPanel() {
             textClassName="font-medium"
           />
           <div className="flex flex-col items-start gap-3">
-            <p className="text-sm text-muted-foreground leading-6">
+            <p className="text-sm leading-6 text-muted-foreground">
               {i18n.t("options.apiProviders.providers.attribution.freeAi" as never)}
             </p>
             <Button
@@ -336,7 +336,7 @@ function BuiltInFeatureProviderSection() {
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <CollapsibleTrigger className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground cursor-pointer py-2">
+      <CollapsibleTrigger className="flex cursor-pointer items-center gap-2 py-2 text-sm text-muted-foreground hover:text-foreground">
         <Icon
           icon="tabler:chevron-right"
           className={cn("size-4 transition-transform duration-200", isOpen && "rotate-90")}

--- a/src/entrypoints/options/pages/config/beta-experience.tsx
+++ b/src/entrypoints/options/pages/config/beta-experience.tsx
@@ -15,7 +15,7 @@ export function BetaExperienceConfig() {
       title={i18n.t("options.betaExperience.title")}
       description={i18n.t("options.betaExperience.description")}
     >
-      <div className="w-full flex justify-end">
+      <div className="flex w-full justify-end">
         <Switch
           checked={betaExperienceConfig.enabled}
           onCheckedChange={(checked) => {

--- a/src/entrypoints/options/pages/config/components/view-config.tsx
+++ b/src/entrypoints/options/pages/config/components/view-config.tsx
@@ -20,7 +20,7 @@ export function ViewConfig({
   const [isExpanded, setIsExpanded] = useState(false)
 
   return (
-    <div className="w-full flex flex-col justify-end">
+    <div className="flex w-full flex-col justify-end">
       <Button variant="outline" size={size} onClick={() => setIsExpanded(!isExpanded)}>
         <Icon icon={isExpanded ? "tabler:chevron-up" : "tabler:chevron-down"} />
         {isExpanded
@@ -29,8 +29,8 @@ export function ViewConfig({
       </Button>
 
       {isExpanded && (
-        <ScrollArea className="h-96 w-full rounded-lg border bg-muted mt-3">
-          <pre className="text-xs p-4 whitespace-pre-wrap break-all overflow-wrap-anywhere">
+        <ScrollArea className="mt-3 h-96 w-full rounded-lg border bg-muted">
+          <pre className="overflow-wrap-anywhere p-4 text-xs break-all whitespace-pre-wrap">
             {JSON.stringify(
               {
                 schemaVersion: configSchemaVersion ?? CONFIG_SCHEMA_VERSION,

--- a/src/entrypoints/options/pages/config/config-backup/components/backup-config-item.tsx
+++ b/src/entrypoints/options/pages/config/config-backup/components/backup-config-item.tsx
@@ -57,7 +57,7 @@ export function BackupConfigItem({ backupId, backupMetadata, backup }: BackupCon
     <Item variant="muted">
       <ItemContent>
         <ItemTitle>{formatDate(backupMetadata.createdAt)}</ItemTitle>
-        <ItemDescription className="text-xs flex flex-wrap items-center gap-x-4">
+        <ItemDescription className="flex flex-wrap items-center gap-x-4 text-xs">
           <span>
             {i18n.t("options.config.backup.item.extensionVersion")}{" "}
             {backupMetadata.extensionVersion}

--- a/src/entrypoints/options/pages/config/config-backup/index.tsx
+++ b/src/entrypoints/options/pages/config/config-backup/index.tsx
@@ -34,7 +34,7 @@ export function ConfigBackup() {
     >
       <div className="space-y-4">
         {isPending && (
-          <div className="text-center text-muted-foreground py-8">
+          <div className="py-8 text-center text-muted-foreground">
             {i18n.t("options.config.backup.loading")}
           </div>
         )}

--- a/src/entrypoints/options/pages/config/google-drive-sync/components/field-option-row.tsx
+++ b/src/entrypoints/options/pages/config/google-drive-sync/components/field-option-row.tsx
@@ -61,22 +61,22 @@ export function FieldOptionRow({
       onClick={onClick}
     >
       <div className="flex items-center">
-        <span className={cn("px-2 py-0.5 rounded mr-2 shrink-0", text, badge)}>
+        <span className={cn("mr-2 shrink-0 rounded px-2 py-0.5", text, badge)}>
           {i18n.t(label)}
         </span>
         {showFieldKey && (
           <>
             <span className={text}>"{fieldKey}"</span>
-            <span className="text-slate-500 mx-1">:</span>
+            <span className="mx-1 text-slate-500">:</span>
           </>
         )}
         {!isComplexValue && (
           <span className="text-slate-700 dark:text-slate-300">{formatValue(value)}</span>
         )}
-        {isSelected && <Icon icon="mdi:check-circle" className={cn("size-4 ml-2", text)} />}
+        {isSelected && <Icon icon="mdi:check-circle" className={cn("ml-2 size-4", text)} />}
       </div>
       {isComplexValue && (
-        <pre className="text-slate-700 dark:text-slate-300 ml-4 max-h-40 overflow-auto whitespace-pre-wrap break-all">
+        <pre className="ml-4 max-h-40 overflow-auto break-all whitespace-pre-wrap text-slate-700 dark:text-slate-300">
           {formatValue(value)}
         </pre>
       )}

--- a/src/entrypoints/options/pages/config/google-drive-sync/components/json-tree-view.tsx
+++ b/src/entrypoints/options/pages/config/google-drive-sync/components/json-tree-view.tsx
@@ -108,9 +108,9 @@ export function JsonTreeView({ resolvedConfig }: { resolvedConfig: Config }) {
     return (
       <div key={item.getId()}>
         <TreeItem item={item}>
-          <TreeItemLabel className="font-mono text-xs bg-transparent hover:bg-transparent">
+          <TreeItemLabel className="bg-transparent font-mono text-xs hover:bg-transparent">
             {!isArrayItem && <span className="text-blue-600 dark:text-blue-400">{key}</span>}
-            {!isArrayItem && <span className="text-slate-500 mx-1">:</span>}
+            {!isArrayItem && <span className="mx-1 text-slate-500">:</span>}
             <span className="text-slate-700 dark:text-slate-300">
               {isFolder
                 ? formatFolderLabel(value, item.getChildren().length ?? 0)

--- a/src/entrypoints/options/pages/config/google-drive-sync/components/unresolved-dialog.tsx
+++ b/src/entrypoints/options/pages/config/google-drive-sync/components/unresolved-dialog.tsx
@@ -87,7 +87,7 @@ function DialogContent({ onResolved, onCancelled }: DialogContentProps) {
   const canConfirm = status.isValid && !isConfirming
 
   return (
-    <AlertDialogContent className="data-[size=default]:max-w-[calc(100vw-2rem)] data-[size=default]:md:max-w-2xl data-[size=default]:lg:max-w-4xl data-[size=default]:xl:max-w-5xl max-h-[90vh] flex flex-col overflow-hidden">
+    <AlertDialogContent className="flex max-h-[90vh] flex-col overflow-hidden data-[size=default]:max-w-[calc(100vw-2rem)] data-[size=default]:md:max-w-2xl data-[size=default]:lg:max-w-4xl data-[size=default]:xl:max-w-5xl">
       <AlertDialogHeader>
         <AlertDialogTitle className="flex items-center gap-2">
           <Icon icon="mdi:alert" className="size-5 text-yellow-500" />
@@ -99,7 +99,7 @@ function DialogContent({ onResolved, onCancelled }: DialogContentProps) {
       </AlertDialogHeader>
 
       {/* Status bar */}
-      <div className="flex items-center justify-between flex-wrap gap-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-4 text-xs">
           {status.allResolved ? (
             !status.isValid ? (
@@ -127,7 +127,7 @@ function DialogContent({ onResolved, onCancelled }: DialogContentProps) {
             onClick={() => selectAllLocal()}
             disabled={isConfirming}
           >
-            <Icon icon="mdi:check-all" className="size-4 mr-1 text-green-600 dark:text-green-400" />
+            <Icon icon="mdi:check-all" className="mr-1 size-4 text-green-600 dark:text-green-400" />
             {i18n.t("options.config.sync.googleDrive.unresolved.useAllLocal")}
           </Button>
           <Button
@@ -136,7 +136,7 @@ function DialogContent({ onResolved, onCancelled }: DialogContentProps) {
             onClick={() => selectAllRemote()}
             disabled={isConfirming}
           >
-            <Icon icon="mdi:check-all" className="size-4 mr-1 text-blue-600 dark:text-blue-400" />
+            <Icon icon="mdi:check-all" className="mr-1 size-4 text-blue-600 dark:text-blue-400" />
             {i18n.t("options.config.sync.googleDrive.unresolved.useAllRemote")}
           </Button>
         </div>
@@ -153,7 +153,7 @@ function DialogContent({ onResolved, onCancelled }: DialogContentProps) {
             <p>
               {i18n.t("options.config.sync.googleDrive.unresolved.validationAlert.description")}
             </p>
-            <ul className="list-disc list-inside text-xs">
+            <ul className="list-inside list-disc text-xs">
               {status.validationError.issues.slice(0, 5).map((issue) => (
                 <li key={`${issue.path.join(".")}-${issue.message}`}>
                   <code className="text-xs">{issue.path.join(".")}</code>
@@ -173,7 +173,7 @@ function DialogContent({ onResolved, onCancelled }: DialogContentProps) {
         </Alert>
       )}
 
-      <div className="flex-1 min-h-0 flex flex-col">
+      <div className="flex min-h-0 flex-1 flex-col">
         <Activity mode={resolvedConfigResult?.config ? "visible" : "hidden"}>
           <MergeConfigView />
         </Activity>
@@ -206,8 +206,8 @@ function MergeConfigView() {
   if (!resolvedConfig) return null
 
   return (
-    <div className="h-full rounded-lg overflow-hidden flex flex-col bg-muted">
-      <div className="px-4 py-2 flex items-center gap-4 text-xs border-b bg-muted">
+    <div className="flex h-full flex-col overflow-hidden rounded-lg bg-muted">
+      <div className="flex items-center gap-4 border-b bg-muted px-4 py-2 text-xs">
         {status.conflictCount > 0 && (
           <span className="text-zinc-700 dark:text-zinc-300">
             {i18n.t("options.config.sync.googleDrive.unresolved.progress", [
@@ -216,18 +216,18 @@ function MergeConfigView() {
             ])}
           </span>
         )}
-        <div className="flex items-center gap-4 ml-auto text-zinc-600 dark:text-zinc-400">
+        <div className="ml-auto flex items-center gap-4 text-zinc-600 dark:text-zinc-400">
           <div className="flex items-center gap-2">
-            <div className="w-2 h-2 rounded-full bg-green-500" />
+            <div className="h-2 w-2 rounded-full bg-green-500" />
             <span>{i18n.t("options.config.sync.googleDrive.unresolved.localValue")}</span>
           </div>
           <div className="flex items-center gap-2">
-            <div className="w-2 h-2 rounded-full bg-blue-500" />
+            <div className="h-2 w-2 rounded-full bg-blue-500" />
             <span>{i18n.t("options.config.sync.googleDrive.unresolved.remoteValue")}</span>
           </div>
         </div>
       </div>
-      <div className="flex-1 overflow-auto min-h-0">
+      <div className="min-h-0 flex-1 overflow-auto">
         <JsonTreeView resolvedConfig={resolvedConfig} />
       </div>
     </div>

--- a/src/entrypoints/options/pages/config/google-drive-sync/components/unresolved-field.tsx
+++ b/src/entrypoints/options/pages/config/google-drive-sync/components/unresolved-field.tsx
@@ -57,20 +57,20 @@ export function ConflictField({ pathKey, indent }: ConflictFieldProps) {
 
   return (
     <div
-      className={cn("border-l-4 my-1", containerStyle.bg, containerStyle.border)}
+      className={cn("my-1 border-l-4", containerStyle.bg, containerStyle.border)}
       style={{ "--indent": `${indent}px` } as CSSProperties}
     >
-      <div className="flex items-center py-1 ps-(--indent) h-8">
-        <Icon icon={icon} className={cn("size-4 shrink-0 mr-2", iconClass)} />
+      <div className="flex h-8 items-center py-1 ps-(--indent)">
+        <Icon icon={icon} className={cn("mr-2 size-4 shrink-0", iconClass)} />
         <span className={cn("text-xs", labelClass)}>{label}</span>
         {resolution && (
           <Button
             size="sm"
             variant="ghost"
-            className="h-6 text-xs text-slate-600 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 ml-2"
+            className="ml-2 h-6 text-xs text-slate-600 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200"
             onClick={reset}
           >
-            <Icon icon="mdi:undo" className="size-3 mr-1" />
+            <Icon icon="mdi:undo" className="mr-1 size-3" />
             {i18n.t("options.config.sync.googleDrive.unresolved.reset")}
           </Button>
         )}

--- a/src/entrypoints/options/pages/config/google-drive-sync/index.tsx
+++ b/src/entrypoints/options/pages/config/google-drive-sync/index.tsx
@@ -84,7 +84,7 @@ export function GoogleDriveSyncCard() {
                   <img
                     src={authData.userInfo.picture}
                     alt="Google Account"
-                    className="size-5 border rounded-full"
+                    className="size-5 rounded-full border"
                   />
                 )}
                 <span className="text-sm text-muted-foreground">{authData?.userInfo?.email}</span>
@@ -93,8 +93,8 @@ export function GoogleDriveSyncCard() {
           </div>
         }
       >
-        <div className="w-full flex flex-col items-end gap-4">
-          <div className="flex flex-col gap-2 items-end">
+        <div className="flex w-full flex-col items-end gap-4">
+          <div className="flex flex-col items-end gap-2">
             <div className="flex gap-2">
               <Button onClick={handleSync} disabled={isSyncing}>
                 <Icon icon="logos:google-drive" className="size-4" />

--- a/src/entrypoints/options/pages/config/manual-config-sync.tsx
+++ b/src/entrypoints/options/pages/config/manual-config-sync.tsx
@@ -37,7 +37,7 @@ export function ManualConfigSync() {
       description={i18n.t("options.config.sync.description")}
     >
       <div className="w-full space-y-4">
-        <div className="text-end gap-3 flex justify-end">
+        <div className="flex justify-end gap-3 text-end">
           <ImportConfig />
           <ExportConfig />
         </div>

--- a/src/entrypoints/options/pages/config/reset-config.tsx
+++ b/src/entrypoints/options/pages/config/reset-config.tsx
@@ -33,7 +33,7 @@ export function ResetConfig() {
       description={i18n.t("options.config.resetConfig.description")}
     >
       <AlertDialog open={open} onOpenChange={setOpen}>
-        <div className="w-full flex justify-end">
+        <div className="flex w-full justify-end">
           <AlertDialogTrigger render={<Button variant="destructive" />}>
             <IconRefresh className="size-4" />
             {i18n.t("options.config.resetConfig.dialog.trigger")}

--- a/src/entrypoints/options/pages/context-menu/context-menu-translate-toggle.tsx
+++ b/src/entrypoints/options/pages/context-menu/context-menu-translate-toggle.tsx
@@ -13,7 +13,7 @@ export function ContextMenuTranslateToggle() {
       title={i18n.t("options.floatingButtonAndToolbar.contextMenu.translate.title")}
       description={i18n.t("options.floatingButtonAndToolbar.contextMenu.translate.description")}
     >
-      <div className="w-full flex justify-end">
+      <div className="flex w-full justify-end">
         <Switch
           checked={contextMenu.enabled}
           onCheckedChange={(checked) => {

--- a/src/entrypoints/options/pages/context-menu/index.tsx
+++ b/src/entrypoints/options/pages/context-menu/index.tsx
@@ -11,7 +11,7 @@ export function ContextMenuPage() {
         <img
           src={contextMenuDemoImage}
           alt={i18n.t("options.floatingButtonAndToolbar.selectionToolbarDemoImageAlt")}
-          className="w-100 h-auto"
+          className="h-auto w-100"
         />
       </GradientBackground>
       <div className="*:border-b [&>*:last-child]:border-b-0">

--- a/src/entrypoints/options/pages/custom-actions/action-config-form/index.tsx
+++ b/src/entrypoints/options/pages/custom-actions/action-config-form/index.tsx
@@ -39,7 +39,7 @@ export function CustomActionConfigForm() {
 
   if (!selectedAction) {
     return (
-      <div className="flex-1 bg-card rounded-xl p-4 border min-h-[420px] flex items-center justify-center text-sm text-muted-foreground">
+      <div className="flex min-h-[420px] flex-1 items-center justify-center rounded-xl border bg-card p-4 text-sm text-muted-foreground">
         {customActions.length === 0
           ? i18n.t("options.floatingButtonAndToolbar.selectionToolbar.customActions.empty")
           : i18n.t("options.floatingButtonAndToolbar.selectionToolbar.customActions.edit")}
@@ -111,7 +111,7 @@ function CustomActionConfigEditor({
 
   return (
     <form.AppForm>
-      <div className={cn("flex-1 bg-card rounded-xl p-4 border flex flex-col justify-between")}>
+      <div className={cn("flex flex-1 flex-col justify-between rounded-xl border bg-card p-4")}>
         <div className="flex flex-col gap-4">
           <NameField form={form} />
 
@@ -126,7 +126,7 @@ function CustomActionConfigEditor({
                 label={i18n.t(
                   "options.floatingButtonAndToolbar.selectionToolbar.customActions.form.systemPrompt",
                 )}
-                className="min-h-36 max-h-80"
+                className="max-h-80 min-h-36"
                 insertCells={customActionInsertCells}
               />
             )}
@@ -139,7 +139,7 @@ function CustomActionConfigEditor({
                 label={i18n.t(
                   "options.floatingButtonAndToolbar.selectionToolbar.customActions.form.prompt",
                 )}
-                className="min-h-28 max-h-80"
+                className="max-h-80 min-h-28"
                 insertCells={customActionInsertCells}
               />
             )}
@@ -149,7 +149,7 @@ function CustomActionConfigEditor({
 
           <NotebaseConnectionField form={form} />
         </div>
-        <div className="flex justify-end mt-8">
+        <div className="mt-8 flex justify-end">
           <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
             <AlertDialogTrigger render={<Button type="button" variant="destructive" />}>
               {i18n.t(

--- a/src/entrypoints/options/pages/custom-actions/action-config-form/notebase-connection-field.tsx
+++ b/src/entrypoints/options/pages/custom-actions/action-config-form/notebase-connection-field.tsx
@@ -403,7 +403,7 @@ export const NotebaseConnectionField = withForm({
     }
 
     return (
-      <Field className="rounded-xl border border-dashed bg-muted/10 p-4 gap-4">
+      <Field className="gap-4 rounded-xl border border-dashed bg-muted/10 p-4">
         <div className="space-y-1">
           <FieldLabel nativeLabel={false} render={<div />}>
             {t("title")}
@@ -625,7 +625,7 @@ export const NotebaseConnectionField = withForm({
                   )}
 
                   <div className="space-y-2">
-                    <div className="hidden md:grid md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)_auto] md:items-center gap-2 px-1 text-xs font-medium text-muted-foreground">
+                    <div className="hidden gap-2 px-1 text-xs font-medium text-muted-foreground md:grid md:grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)_auto] md:items-center">
                       <span>{t("localFieldLabel")}</span>
                       <span />
                       <span>{t("remoteFieldLabel")}</span>
@@ -689,7 +689,7 @@ export const NotebaseConnectionField = withForm({
                               </SelectContent>
                             </Select>
 
-                            <div className="hidden md:flex items-center justify-center text-muted-foreground">
+                            <div className="hidden items-center justify-center text-muted-foreground md:flex">
                               <IconChevronsRight className="size-4" />
                             </div>
 

--- a/src/entrypoints/options/pages/custom-actions/action-config-form/output-schema-field.tsx
+++ b/src/entrypoints/options/pages/custom-actions/action-config-form/output-schema-field.tsx
@@ -327,16 +327,16 @@ export const OutputSchemaField = withForm({
                   <div className="flex items-center gap-2 rounded-lg border bg-card p-2">
                     <Icon
                       icon="tabler:grip-vertical"
-                      className="size-4 text-muted-foreground shrink-0"
+                      className="size-4 shrink-0 text-muted-foreground"
                     />
-                    <span className="text-sm font-medium shrink-0">{outputField.name}</span>
+                    <span className="shrink-0 text-sm font-medium">{outputField.name}</span>
                     <Badge variant="secondary" className="shrink-0">
                       {i18n.t(`dataTypes.${outputField.type}`)}
                     </Badge>
-                    <span className="text-sm text-muted-foreground truncate min-w-0 flex-1">
+                    <span className="min-w-0 flex-1 truncate text-sm text-muted-foreground">
                       {outputField.description || "—"}
                     </span>
-                    <div className="flex gap-1 shrink-0">
+                    <div className="flex shrink-0 gap-1">
                       <Button
                         type="button"
                         variant="outline"

--- a/src/entrypoints/options/pages/custom-actions/components/action-card-list.tsx
+++ b/src/entrypoints/options/pages/custom-actions/components/action-card-list.tsx
@@ -81,10 +81,10 @@ export function CustomActionCardList() {
           render={
             <Button
               variant="outline"
-              className="h-auto p-3 border-dashed rounded-xl"
+              className="h-auto rounded-xl border-dashed p-3"
               disabled={customActionProviders.length === 0}
             >
-              <div className="flex items-center justify-center gap-2 w-full">
+              <div className="flex w-full items-center justify-center gap-2">
                 <Icon icon="tabler:plus" className="size-4" />
                 <span className="text-sm">
                   {i18n.t("options.floatingButtonAndToolbar.selectionToolbar.customActions.add")}
@@ -128,18 +128,18 @@ function CustomActionCard({ action }: { action: SelectionToolbarCustomAction }) 
   return (
     <div
       className={cn(
-        "rounded-xl border p-3 bg-card transition-colors cursor-pointer",
+        "cursor-pointer rounded-xl border bg-card p-3 transition-colors",
         selectedCustomActionId === action.id && "border-primary",
         action.enabled === false && "opacity-70",
       )}
       onClick={() => setSelectedCustomActionId(action.id)}
     >
       <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2 min-w-0">
+        <div className="flex min-w-0 items-center gap-2">
           <div className="size-4">
-            <Icon icon={action.icon} className="size-4 text-zinc-600 dark:text-zinc-300 shrink-0" />
+            <Icon icon={action.icon} className="size-4 shrink-0 text-zinc-600 dark:text-zinc-300" />
           </div>
-          <span className="text-sm font-medium truncate">{action.name}</span>
+          <span className="truncate text-sm font-medium">{action.name}</span>
         </div>
         <Switch
           checked={action.enabled !== false}

--- a/src/entrypoints/options/pages/floating-button/floating-button-click-action.tsx
+++ b/src/entrypoints/options/pages/floating-button/floating-button-click-action.tsx
@@ -36,7 +36,7 @@ export function FloatingButtonClickAction() {
         "options.floatingButtonAndToolbar.floatingButton.clickAction.description",
       )}
     >
-      <div className="w-full flex justify-end">
+      <div className="flex w-full justify-end">
         <Select
           items={items}
           value={floatingButton.clickAction}

--- a/src/entrypoints/options/pages/floating-button/floating-button-global-toggle.tsx
+++ b/src/entrypoints/options/pages/floating-button/floating-button-global-toggle.tsx
@@ -15,7 +15,7 @@ export function FloatingButtonGlobalToggle() {
         "options.floatingButtonAndToolbar.floatingButton.globalToggle.description",
       )}
     >
-      <div className="w-full flex justify-end">
+      <div className="flex w-full justify-end">
         <Switch
           checked={floatingButton.enabled}
           onCheckedChange={(checked) => {

--- a/src/entrypoints/options/pages/floating-button/floating-button-side.tsx
+++ b/src/entrypoints/options/pages/floating-button/floating-button-side.tsx
@@ -28,7 +28,7 @@ export function FloatingButtonSide() {
       title={i18n.t("options.floatingButtonAndToolbar.floatingButton.side.title")}
       description={i18n.t("options.floatingButtonAndToolbar.floatingButton.side.description")}
     >
-      <div className="w-full flex justify-end">
+      <div className="flex w-full justify-end">
         <Select
           items={items}
           value={floatingButton.side}

--- a/src/entrypoints/options/pages/floating-button/index.tsx
+++ b/src/entrypoints/options/pages/floating-button/index.tsx
@@ -14,7 +14,7 @@ export function FloatingButtonPage() {
         <img
           src={floatingButtonDemoImage}
           alt={i18n.t("options.floatingButtonAndToolbar.floatingButtonDemoImageAlt")}
-          className="w-100 h-auto"
+          className="h-auto w-100"
         />
       </GradientBackground>
       <div className="*:border-b [&>*:last-child]:border-b-0">

--- a/src/entrypoints/options/pages/general/appearance-settings.tsx
+++ b/src/entrypoints/options/pages/general/appearance-settings.tsx
@@ -34,7 +34,7 @@ export default function AppearanceSettings() {
       title={i18n.t("options.general.appearance.title")}
       description={i18n.t("options.general.appearance.theme")}
     >
-      <div className="w-full flex justify-start md:justify-end">
+      <div className="flex w-full justify-start md:justify-end">
         <Select value={themeMode} onValueChange={(value) => setThemeMode(value as ThemeMode)}>
           <SelectTrigger className="w-full">
             <SelectValue render={<span />}>

--- a/src/entrypoints/options/pages/general/language-detection-config.tsx
+++ b/src/entrypoints/options/pages/general/language-detection-config.tsx
@@ -50,7 +50,7 @@ export default function LanguageDetectionConfig() {
       description={
         <>
           {i18n.t("options.general.languageDetection.description")}
-          <div className="flex items-center gap-1.5 mt-2">
+          <div className="mt-2 flex items-center gap-1.5">
             <div className={`size-2 rounded-full ${statusIndicator.color}`} />
             <span className="text-xs">{statusIndicator.text}</span>
           </div>

--- a/src/entrypoints/options/pages/general/ui-language-selector.tsx
+++ b/src/entrypoints/options/pages/general/ui-language-selector.tsx
@@ -55,7 +55,7 @@ export default function UiLanguageSelector() {
       title={i18n.t("options.general.interfaceLanguage.title")}
       description={i18n.t("options.general.interfaceLanguage.description")}
     >
-      <div className="w-full flex justify-start md:justify-end">
+      <div className="flex w-full justify-start md:justify-end">
         <Select
           value={uiLanguage}
           onValueChange={(value) => void setUiLanguage(value as UiLanguage)}

--- a/src/entrypoints/options/pages/input-translation/input-translation-languages.tsx
+++ b/src/entrypoints/options/pages/input-translation/input-translation-languages.tsx
@@ -27,8 +27,8 @@ interface LangSelectProps {
 function LangSelect({ value, onValueChange, getDisplayLabel }: LangSelectProps) {
   return (
     <Select value={value} onValueChange={(v) => onValueChange(v as InputTranslationLang)}>
-      <SelectTrigger className="w-full max-h-52 min-w-0">
-        <SelectValue render={<span className="flex-1 min-w-0" />}>
+      <SelectTrigger className="max-h-52 w-full min-w-0">
+        <SelectValue render={<span className="min-w-0 flex-1" />}>
           <span className="block min-w-0 truncate">{getDisplayLabel(value)}</span>
         </SelectValue>
       </SelectTrigger>
@@ -84,15 +84,15 @@ export function InputTranslationLanguages() {
       title={i18n.t("options.inputTranslation.languages.title")}
       description={i18n.t("options.inputTranslation.languages.description")}
     >
-      <div className="flex flex-col gap-4 min-w-0 w-full">
-        <div className="flex flex-col items-end gap-1 min-w-0 w-full">
+      <div className="flex w-full min-w-0 flex-col gap-4">
+        <div className="flex w-full min-w-0 flex-col items-end gap-1">
           <LangSelect
             value={inputTranslation.fromLang}
             onValueChange={handleFromLangChange}
             getDisplayLabel={getDisplayLabel}
           />
 
-          <div className="relative size-5 shrink-0 mx-auto my-2">
+          <div className="relative mx-auto my-2 size-5 shrink-0">
             <Activity mode={inputTranslation.enableCycle ? "visible" : "hidden"}>
               <Icon
                 icon="fluent:arrow-sort-24-filled"
@@ -120,7 +120,7 @@ export function InputTranslationLanguages() {
             checked={inputTranslation.enableCycle}
             onCheckedChange={handleEnableCycleChange}
           />
-          <Label htmlFor="enable-cycle" className="text-sm font-normal cursor-pointer">
+          <Label htmlFor="enable-cycle" className="cursor-pointer text-sm font-normal">
             {i18n.t("options.inputTranslation.languages.enableCycle")}
           </Label>
         </div>

--- a/src/entrypoints/options/pages/input-translation/input-translation-toggle.tsx
+++ b/src/entrypoints/options/pages/input-translation/input-translation-toggle.tsx
@@ -13,7 +13,7 @@ export function InputTranslationToggle() {
       title={i18n.t("options.inputTranslation.toggle.title")}
       description={i18n.t("options.inputTranslation.toggle.description")}
     >
-      <div className="w-full flex justify-end">
+      <div className="flex w-full justify-end">
         <Switch
           checked={inputTranslation.enabled}
           onCheckedChange={(checked) => {

--- a/src/entrypoints/options/pages/selection-toolbar/index.tsx
+++ b/src/entrypoints/options/pages/selection-toolbar/index.tsx
@@ -15,7 +15,7 @@ export function SelectionToolbarPage() {
         <img
           src={selectionToolbarDemoImage}
           alt={i18n.t("options.floatingButtonAndToolbar.selectionToolbarDemoImageAlt")}
-          className="w-100 h-auto"
+          className="h-auto w-100"
         />
       </GradientBackground>
       <div className="*:border-b [&>*:last-child]:border-b-0">

--- a/src/entrypoints/options/pages/selection-toolbar/selection-toolbar-feature-toggles.tsx
+++ b/src/entrypoints/options/pages/selection-toolbar/selection-toolbar-feature-toggles.tsx
@@ -29,7 +29,7 @@ export function SelectionToolbarFeatureToggles() {
         "options.floatingButtonAndToolbar.selectionToolbar.featureToggles.description",
       )}
     >
-      <div className="w-full flex flex-col gap-3">
+      <div className="flex w-full flex-col gap-3">
         <div className="flex items-center justify-between">
           <span className="flex items-center gap-2 text-sm">
             <RiTranslate className="size-4 text-muted-foreground" />

--- a/src/entrypoints/options/pages/selection-toolbar/selection-toolbar-global-toggle.tsx
+++ b/src/entrypoints/options/pages/selection-toolbar/selection-toolbar-global-toggle.tsx
@@ -15,7 +15,7 @@ export function SelectionToolbarGlobalToggle() {
         "options.floatingButtonAndToolbar.selectionToolbar.globalToggle.description",
       )}
     >
-      <div className="w-full flex justify-end">
+      <div className="flex w-full justify-end">
         <Switch
           checked={selectionToolbar.enabled}
           onCheckedChange={(checked) => {

--- a/src/entrypoints/options/pages/selection-toolbar/selection-toolbar-opacity.tsx
+++ b/src/entrypoints/options/pages/selection-toolbar/selection-toolbar-opacity.tsx
@@ -24,7 +24,7 @@ export function SelectionToolbarOpacity() {
       title={i18n.t("options.floatingButtonAndToolbar.selectionToolbar.opacity.title")}
       description={i18n.t("options.floatingButtonAndToolbar.selectionToolbar.opacity.description")}
     >
-      <div className="w-full flex items-center gap-2">
+      <div className="flex w-full items-center gap-2">
         <Slider
           min={MIN_SELECTION_OVERLAY_OPACITY}
           max={MAX_SELECTION_OVERLAY_OPACITY}
@@ -38,7 +38,7 @@ export function SelectionToolbarOpacity() {
           }}
           className="flex-1"
         />
-        <span className="w-10 text-sm text-right">{draftOpacity}%</span>
+        <span className="w-10 text-right text-sm">{draftOpacity}%</span>
       </div>
     </ConfigCard>
   )

--- a/src/entrypoints/options/pages/site-rules/built-in-rule-row.tsx
+++ b/src/entrypoints/options/pages/site-rules/built-in-rule-row.tsx
@@ -47,16 +47,16 @@ export function BuiltInRuleRow({ rule }: { rule: SiteRule }) {
   return (
     <Collapsible className="group/site-rule">
       <div className="flex items-center gap-2 px-3 py-2">
-        <CollapsibleTrigger className="flex flex-1 items-center gap-2 min-w-0 text-left cursor-pointer">
+        <CollapsibleTrigger className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left">
           <Icon
             icon="tabler:chevron-right"
             className="size-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]/site-rule:rotate-90"
           />
-          <code className="text-xs shrink-0">{rule.id}</code>
+          <code className="shrink-0 text-xs">{rule.id}</code>
           {rule.description && (
-            <span className="text-xs text-muted-foreground truncate">{rule.description}</span>
+            <span className="truncate text-xs text-muted-foreground">{rule.description}</span>
           )}
-          <span className="ml-auto flex items-center gap-1 shrink-0">
+          <span className="ml-auto flex shrink-0 items-center gap-1">
             {matches.slice(0, VISIBLE_MATCH_BADGES).map((pattern) => (
               <Badge key={pattern} variant="secondary">
                 <span className="max-w-40 truncate">{pattern}</span>
@@ -87,7 +87,7 @@ export function BuiltInRuleRow({ rule }: { rule: SiteRule }) {
         />
       </div>
       <CollapsibleContent>
-        <pre className="text-xs overflow-x-auto rounded-md bg-muted p-3 mx-3 mb-3">
+        <pre className="mx-3 mb-3 overflow-x-auto rounded-md bg-muted p-3 text-xs">
           {JSON.stringify(rule, null, 2)}
         </pre>
       </CollapsibleContent>

--- a/src/entrypoints/options/pages/site-rules/user-rules-editor.tsx
+++ b/src/entrypoints/options/pages/site-rules/user-rules-editor.tsx
@@ -86,14 +86,14 @@ export function UserRulesEditor() {
           value={jsonInput}
           onChange={setJsonInput}
           hasError={!validation.ok}
-          className="min-h-[200px] max-h-[400px] overflow-y-auto"
+          className="max-h-[400px] min-h-[200px] overflow-y-auto"
         />
         {!validation.ok && (
           <Alert variant="destructive">
             <Icon icon="tabler:alert-circle-filled" className="size-4" />
             <AlertTitle>{i18n.t(VALIDATION_ERROR_MESSAGE_KEYS[validation.kind])}</AlertTitle>
             <AlertDescription>
-              <ul className="list-disc list-inside text-xs">
+              <ul className="list-inside list-disc text-xs">
                 {validation.issues.slice(0, MAX_VISIBLE_ISSUES).map((issue) => (
                   <li key={`${issue.path}-${issue.message}`}>
                     <code className="text-xs">{issue.path}</code>
@@ -112,7 +112,7 @@ export function UserRulesEditor() {
             </AlertDescription>
           </Alert>
         )}
-        <div className="flex items-center gap-2 justify-between">
+        <div className="flex items-center justify-between gap-2">
           <div
             className={cn(
               "text-sm text-green-500",

--- a/src/entrypoints/options/pages/statistics/charts/batch-request-record/aside.tsx
+++ b/src/entrypoints/options/pages/statistics/charts/batch-request-record/aside.tsx
@@ -16,25 +16,25 @@ export default function Aside() {
   const averageSavePercentage = calculateAverageSavePercentage(currentPeriodRecords)
 
   return (
-    <aside className="w-80 flex flex-col py-4 gap-y-4">
+    <aside className="flex w-80 flex-col gap-y-4 py-4">
       <div className="flex flex-col items-start justify-between gap-2">
-        <h2 className="items-center leading-relax text-xl font-medium">
+        <h2 className="leading-relax items-center text-xl font-medium">
           {i18n.t("options.statistics.batchRequest.title")}
         </h2>
-        <span className="items-center leading-relax text-base text-muted-foreground">
+        <span className="leading-relax items-center text-base text-muted-foreground">
           {i18n.t("options.statistics.batchRequest.description")}
         </span>
       </div>
-      <div className="w-full flex-1 flex items-center justify-start">
-        <span className="text-4xl font-bold leading-none">{averageSavePercentage}</span>
+      <div className="flex w-full flex-1 items-center justify-start">
+        <span className="text-4xl leading-none font-bold">{averageSavePercentage}</span>
       </div>
-      <Tabs className="w-full flex" defaultValue={recentDay} onValueChange={setRecentDay}>
+      <Tabs className="flex w-full" defaultValue={recentDay} onValueChange={setRecentDay}>
         <TabsList className="w-full bg-background">
           {recentDays.map((recentDayOption) => (
             <TabsTrigger
               key={recentDayOption}
               value={recentDayOption}
-              className="transition-none data-[state=active]:bg-primary-weak! data-[state=active]:shadow-none"
+              className="data-[state=active]:bg-primary-weak! transition-none data-[state=active]:shadow-none"
             >
               {recentDayOption}D
             </TabsTrigger>

--- a/src/entrypoints/options/pages/statistics/charts/batch-request-record/metrics.tsx
+++ b/src/entrypoints/options/pages/statistics/charts/batch-request-record/metrics.tsx
@@ -14,7 +14,7 @@ export default function Metrics() {
   const metrics = transformRecordsToMetrics(currentPeriodRecords, previousPeriodRecords)
 
   return (
-    <div className="h-fit w-full grid gap-4 grid-cols-1 @xl:grid-cols-2 @4xl:grid-cols-3 @6xl:grid-cols-4">
+    <div className="grid h-fit w-full grid-cols-1 gap-4 @xl:grid-cols-2 @4xl:grid-cols-3 @6xl:grid-cols-4">
       {Object.entries(metrics).map(([key, metric]) => (
         <MetricCard key={key} {...metric} />
       ))}

--- a/src/entrypoints/options/pages/text-to-speech/tts-config.tsx
+++ b/src/entrypoints/options/pages/text-to-speech/tts-config.tsx
@@ -78,7 +78,7 @@ function getTTSVoiceGenderBadgeClass(gender: TTSVoiceItem["gender"]): string | u
 }
 
 function TTSVoiceSelectValue({ voice }: { voice: TTSVoice }) {
-  return <span className="block min-w-0 max-w-full truncate">{voice}</span>
+  return <span className="block max-w-full min-w-0 truncate">{voice}</span>
 }
 
 function getTTSVoiceSearchValue(item: TTSVoiceItem): string {
@@ -94,13 +94,13 @@ function TTSVoiceComboboxItem({ item }: { item: TTSVoiceItem }) {
     <ComboboxItem key={item.voice} value={item} className="overflow-hidden py-1.5">
       <Item
         size="sm"
-        className="w-full min-w-0 max-w-[calc(var(--anchor-width)_-_2.5rem)] flex-nowrap gap-2 overflow-hidden p-0"
+        className="w-full max-w-[calc(var(--anchor-width)_-_2.5rem)] min-w-0 flex-nowrap gap-2 overflow-hidden p-0"
       >
         <ItemContent className="min-w-0 gap-1 overflow-hidden">
-          <ItemTitle className="w-full min-w-0 max-w-full overflow-hidden font-mono text-xs">
+          <ItemTitle className="w-full max-w-full min-w-0 overflow-hidden font-mono text-xs">
             <span className="block min-w-0 truncate">{item.voice}</span>
           </ItemTitle>
-          <ItemDescription className="m-0 flex min-w-0 max-w-full flex-wrap items-center gap-1.5 overflow-hidden">
+          <ItemDescription className="m-0 flex max-w-full min-w-0 flex-wrap items-center gap-1.5 overflow-hidden">
             <Badge variant="secondary" size="sm">
               {item.type}
             </Badge>

--- a/src/entrypoints/options/pages/translation/auto-translate-languages.tsx
+++ b/src/entrypoints/options/pages/translation/auto-translate-languages.tsx
@@ -10,7 +10,7 @@ import { ConfigCard } from "../../components/config-card"
 
 export function AutoTranslateLanguages() {
   return (
-    <div className="py-6 flex flex-col gap-y-4">
+    <div className="flex flex-col gap-y-4 py-6">
       <ConfigCard
         id="auto-translate-languages"
         title={i18n.t("options.translation.autoTranslateLanguages.title")}
@@ -29,7 +29,7 @@ function AutoTranslateLanguagesSelector() {
   const selectedLanguages = translateConfig.page.autoTranslateLanguages
 
   return (
-    <div className="w-full flex justify-start md:justify-end">
+    <div className="flex w-full justify-start md:justify-end">
       <MultiLanguageCombobox
         selectedLanguages={selectedLanguages}
         onLanguagesChange={(languages) =>
@@ -74,7 +74,7 @@ function SelectedLanguageCells() {
           <Button
             variant="ghost"
             size="icon"
-            className="h-4 w-4 p-0 hover:bg-input hover:text-input-foreground"
+            className="hover:text-input-foreground h-4 w-4 p-0 hover:bg-input"
             onClick={() => removeLanguage(language)}
           >
             <Icon icon="tabler:x" className="h-3 w-3" />

--- a/src/entrypoints/options/pages/translation/clear-cache-config.tsx
+++ b/src/entrypoints/options/pages/translation/clear-cache-config.tsx
@@ -39,7 +39,7 @@ export function ClearCacheConfig() {
       description={i18n.t("options.general.clearCache.description")}
     >
       <AlertDialog open={open} onOpenChange={setOpen}>
-        <div className="w-full flex justify-end">
+        <div className="flex w-full justify-end">
           <AlertDialogTrigger render={<Button variant="destructive" disabled={isClearing} />}>
             <IconTrash className="size-4" />
             {isClearing

--- a/src/entrypoints/options/pages/translation/custom-translation-style/css-editor.tsx
+++ b/src/entrypoints/options/pages/translation/custom-translation-style/css-editor.tsx
@@ -81,7 +81,7 @@ export function CSSEditor() {
           onChange={setCssInput}
           hasError={hasSyntaxError || hasLengthError}
           placeholder={i18n.t("options.translation.translationStyle.customCSS.editor.placeholder")}
-          className="min-h-[200px] max-h-[400px] overflow-y-auto"
+          className="max-h-[400px] min-h-[200px] overflow-y-auto"
         />
         {/* Show syntax errors */}
         {/* <Activity mode={hasSyntaxError ? 'visible' : 'hidden'}>
@@ -113,7 +113,7 @@ export function CSSEditor() {
             </AlertDescription>
           </Alert>
         </Activity> */}
-        <div className="flex items-center gap-2 justify-between">
+        <div className="flex items-center justify-between gap-2">
           <div
             className={cn(
               "text-sm text-green-500",

--- a/src/entrypoints/options/pages/translation/custom-translation-style/style-preview.tsx
+++ b/src/entrypoints/options/pages/translation/custom-translation-style/style-preview.tsx
@@ -96,7 +96,7 @@ export function StylePreview() {
 
       <Field>
         <FieldLabel>{i18n.t("options.translation.translationStyle.preview")}</FieldLabel>
-        <div id="style-preview" className="w-full flex flex-col gap-2 p-4 border rounded-md">
+        <div id="style-preview" className="flex w-full flex-col gap-2 rounded-md border p-4">
           <span className={CONTENT_WRAPPER_CLASS} lang={language} dir={dir}>
             <span className={`text-sm ${BLOCK_CONTENT_CLASS}`} ref={blockContentRef}>
               {translatedText}

--- a/src/entrypoints/options/pages/translation/node-translation-hotkey.tsx
+++ b/src/entrypoints/options/pages/translation/node-translation-hotkey.tsx
@@ -48,7 +48,7 @@ export function NodeTranslationHotkey() {
           disabled={!translateConfig.node.enabled}
         >
           <SelectTrigger
-            className={`w-full ${!translateConfig.node.enabled ? "opacity-50 pointer-events-none" : ""}`}
+            className={`w-full ${!translateConfig.node.enabled ? "pointer-events-none opacity-50" : ""}`}
           >
             <SelectValue render={<span />}>
               {HOTKEY_ICONS[translateConfig.node.hotkey]}{" "}

--- a/src/entrypoints/options/pages/translation/request-batch.tsx
+++ b/src/entrypoints/options/pages/translation/request-batch.tsx
@@ -44,12 +44,12 @@ function StatisticsLink() {
 
   return (
     <Link
-      className="text-primary hover:opacity-80 cursor-pointer transition-opacity"
+      className="cursor-pointer text-primary transition-opacity hover:opacity-80"
       to="/statistics"
       target="_blank"
     >
       {i18n.t("options.translation.batchQueueConfig.statisticsLink", [averageSavePercentage])}{" "}
-      <Icon icon="tabler:external-link" className="inline w-3.5 h-3.5" />
+      <Icon icon="tabler:external-link" className="inline h-3.5 w-3.5" />
     </Link>
   )
 }

--- a/src/entrypoints/options/pages/translation/skip-languages.tsx
+++ b/src/entrypoints/options/pages/translation/skip-languages.tsx
@@ -13,7 +13,7 @@ import { ConfigCard } from "../../components/config-card"
 
 export function SkipLanguages() {
   return (
-    <div className="py-6 flex flex-col gap-y-4">
+    <div className="flex flex-col gap-y-4 py-6">
       <ConfigCard
         id="skip-languages"
         title={i18n.t("options.translation.skipLanguages.title")}
@@ -64,7 +64,7 @@ function SkipLanguagesSelector() {
   const selectedLanguages = translateConfig.page.skipLanguages
 
   return (
-    <div className="w-full flex justify-start md:justify-end">
+    <div className="flex w-full justify-start md:justify-end">
       <MultiLanguageCombobox
         selectedLanguages={selectedLanguages}
         onLanguagesChange={(languages) =>
@@ -109,7 +109,7 @@ function SelectedSkipLanguageCells() {
           <Button
             variant="ghost"
             size="icon"
-            className="h-4 w-4 p-0 hover:bg-input hover:text-input-foreground"
+            className="hover:text-input-foreground h-4 w-4 p-0 hover:bg-input"
             onClick={() => removeLanguage(language)}
           >
             <Icon icon="tabler:x" className="h-3 w-3" />

--- a/src/entrypoints/options/pages/translation/translation-mode.tsx
+++ b/src/entrypoints/options/pages/translation/translation-mode.tsx
@@ -37,7 +37,7 @@ function TranslationModeSelector() {
   }
 
   return (
-    <div className="w-full flex justify-start md:justify-end">
+    <div className="flex w-full justify-start md:justify-end">
       <Select value={currentMode} onValueChange={handleModeChange}>
         <SelectTrigger className="w-40">
           <SelectValue render={<span />}>

--- a/src/entrypoints/options/pages/video-subtitles/clear-ai-segmentation-cache.tsx
+++ b/src/entrypoints/options/pages/video-subtitles/clear-ai-segmentation-cache.tsx
@@ -39,7 +39,7 @@ export function ClearAiSegmentationCache() {
       description={i18n.t("options.videoSubtitles.aiSegmentation.clearCacheDialog.description")}
     >
       <AlertDialog open={open} onOpenChange={setOpen}>
-        <div className="w-full flex justify-end">
+        <div className="flex w-full justify-end">
           <AlertDialogTrigger render={<Button variant="destructive" disabled={isClearing} />}>
             <IconTrash className="size-4" />
             {isClearing

--- a/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/general-settings.tsx
+++ b/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/general-settings.tsx
@@ -167,7 +167,7 @@ export function GeneralSettings() {
                   }
                   className="flex-1"
                 />
-                <span className="w-10 text-sm text-right">{draftBackgroundOpacity}%</span>
+                <span className="w-10 text-right text-sm">{draftBackgroundOpacity}%</span>
               </div>
             </div>
           </div>

--- a/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/subtitles-preview.tsx
+++ b/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/subtitles-preview.tsx
@@ -32,9 +32,9 @@ export function SubtitlesPreview() {
         {i18n.t("options.videoSubtitles.style.preview")}
       </Label>
       <GradientBackground>
-        <div className="relative w-fit min-w-full h-fit min-h-32 rounded-lg overflow-hidden flex items-center justify-center p-4">
+        <div className="relative flex h-fit min-h-32 w-fit min-w-full items-center justify-center overflow-hidden rounded-lg p-4">
           <div
-            className="flex flex-col gap-2 px-3 py-2 rounded text-center text-white max-w-[90%]"
+            className="flex max-w-[90%] flex-col gap-2 rounded px-3 py-2 text-center text-white"
             style={containerStyle}
           >
             <Activity mode={showMain ? "visible" : "hidden"}>

--- a/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/subtitles-text-style-form.tsx
+++ b/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/components/subtitles-text-style-form.tsx
@@ -107,7 +107,7 @@ export function SubtitlesTextStyleForm({ type }: SubtitlesTextStyleFormProps) {
               onValueCommitted={(value) => handleChange({ fontScale: value as number })}
               className="flex-1"
             />
-            <span className="w-10 text-sm text-right">{draftFontScale}%</span>
+            <span className="w-10 text-right text-sm">{draftFontScale}%</span>
           </div>
         </div>
       </Field>
@@ -127,7 +127,7 @@ export function SubtitlesTextStyleForm({ type }: SubtitlesTextStyleFormProps) {
               onValueCommitted={(value) => handleChange({ fontWeight: value as number })}
               className="flex-1"
             />
-            <span className="w-10 text-sm text-right">{draftFontWeight}</span>
+            <span className="w-10 text-right text-sm">{draftFontWeight}</span>
           </div>
         </div>
       </Field>
@@ -142,7 +142,7 @@ export function SubtitlesTextStyleForm({ type }: SubtitlesTextStyleFormProps) {
               type="color"
               value={textStyle.color}
               onChange={(e) => handleChange({ color: e.target.value })}
-              className="!w-8 h-8 p-0.5 rounded border border-input cursor-pointer"
+              className="h-8 !w-8 cursor-pointer rounded border border-input p-0.5"
             />
           </div>
         </div>

--- a/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/index.tsx
+++ b/src/entrypoints/options/pages/video-subtitles/subtitles-style-settings/index.tsx
@@ -15,7 +15,7 @@ export function SubtitlesStyleSettings() {
     >
       <SubtitlesPreview />
 
-      <div className="mt-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
         <GeneralSettings />
         <MainSubtitlesStyle />
         <TranslationSubtitlesStyle />

--- a/src/entrypoints/popup/app.tsx
+++ b/src/entrypoints/popup/app.tsx
@@ -20,7 +20,7 @@ import TranslationModeSelector from "./components/translation-mode-selector"
 function App() {
   return (
     <>
-      <div className="bg-background flex flex-col gap-4 px-6 pt-5 pb-4">
+      <div className="flex flex-col gap-4 bg-background px-6 pt-5 pb-4">
         <div className="flex items-center justify-between">
           <UserAccountMenuPopup />
           <div className="flex items-center">

--- a/src/entrypoints/popup/components/blog-notification.tsx
+++ b/src/entrypoints/popup/components/blog-notification.tsx
@@ -49,7 +49,7 @@ export default function BlogNotification() {
       >
         <Icon icon="tabler:bell-filled" />
         {showIndicator && (
-          <span className="absolute top-1.5 right-1.5 flex items-center justify-center size-2">
+          <span className="absolute top-1.5 right-1.5 flex size-2 items-center justify-center">
             <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-brand opacity-75"></span>
             <span className="relative inline-flex size-1.5 rounded-full bg-brand"></span>
           </span>

--- a/src/entrypoints/popup/components/language-options-selector.tsx
+++ b/src/entrypoints/popup/components/language-options-selector.tsx
@@ -56,7 +56,7 @@ function LanguageComboboxTrigger({
       }
     >
       <div className={langSelectorContentClasses}>
-        <span className="truncate w-full text-left">{label}</span>
+        <span className="w-full truncate text-left">{label}</span>
         <span className="text-sm text-neutral-500">{subtitle}</span>
       </div>
       <IconChevronDown className="size-4 text-muted-foreground" />
@@ -127,7 +127,7 @@ export default function LanguageOptionsSelector() {
           }
           ariaLabel={i18n.t("popup.sourceLang")}
         />
-        <ComboboxContent className="rounded-lg shadow-md w-72">
+        <ComboboxContent className="w-72 rounded-lg shadow-md">
           <ComboboxInput
             showTrigger={false}
             placeholder={i18n.t("translationHub.searchLanguages")}
@@ -156,7 +156,7 @@ export default function LanguageOptionsSelector() {
           subtitle={i18n.t("popup.targetLang")}
           ariaLabel={i18n.t("popup.targetLang")}
         />
-        <ComboboxContent className="rounded-lg shadow-md w-72">
+        <ComboboxContent className="w-72 rounded-lg shadow-md">
           <ComboboxInput
             showTrigger={false}
             placeholder={i18n.t("translationHub.searchLanguages")}
@@ -177,7 +177,7 @@ export default function LanguageOptionsSelector() {
 
 function AutoLangCell() {
   return (
-    <span className="rounded-full bg-neutral-200 px-1 text-xs dark:bg-neutral-800 flex items-center">
+    <span className="flex items-center rounded-full bg-neutral-200 px-1 text-xs dark:bg-neutral-800">
       auto
     </span>
   )

--- a/src/entrypoints/popup/components/node-translation-hotkey-selector.tsx
+++ b/src/entrypoints/popup/components/node-translation-hotkey-selector.tsx
@@ -49,7 +49,7 @@ export default function NodeTranslationHotkeySelector() {
       >
         <SelectTrigger
           size="sm"
-          className="pt-3.5 -mt-3.5 pb-4 -mb-4 px-2 -ml-2 h-5! ring-none cursor-pointer truncate border-none text-[13px] font-medium shadow-none focus-visible:border-none focus-visible:ring-0 bg-transparent! rounded-md"
+          className="ring-none -mt-3.5 -mb-4 -ml-2 h-5! cursor-pointer truncate rounded-md border-none bg-transparent! px-2 pt-3.5 pb-4 text-[13px] font-medium shadow-none focus-visible:border-none focus-visible:ring-0"
         >
           <div className="truncate">
             <HotkeyDisplay hotkey={translateConfig.node.hotkey} />

--- a/src/entrypoints/popup/components/translate-prompt-selector.tsx
+++ b/src/entrypoints/popup/components/translate-prompt-selector.tsx
@@ -34,7 +34,7 @@ export default function TranslatePromptSelector() {
 
   return (
     <div className="flex items-center justify-between gap-2">
-      <span className="text-[13px] font-medium flex items-center gap-1.5">
+      <span className="flex items-center gap-1.5 text-[13px] font-medium">
         {i18n.t("translatePrompt.title")}
         <HelpTooltip>{i18n.t("translatePrompt.description")}</HelpTooltip>
       </span>

--- a/src/entrypoints/selection.content/components/selection-source-content.tsx
+++ b/src/entrypoints/selection.content/components/selection-source-content.tsx
@@ -30,7 +30,7 @@ export function SelectionSourceContent({
           <ScrollArea className={cn("min-w-0 flex-1", actionsExpanded && "h-18 overflow-hidden")}>
             <p
               className={cn(
-                "text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere] text-zinc-600 dark:text-zinc-400",
+                "text-sm [overflow-wrap:anywhere] break-words whitespace-pre-wrap text-zinc-600 dark:text-zinc-400",
                 !actionsExpanded && "line-clamp-3",
               )}
             >

--- a/src/entrypoints/selection.content/components/selection-toolbar-footer-content.tsx
+++ b/src/entrypoints/selection.content/components/selection-toolbar-footer-content.tsx
@@ -31,7 +31,7 @@ function PreviewField({
         <div
           data-slot="selection-toolbar-footer-preview-value"
           data-field={field}
-          className="max-h-36 overflow-y-auto rounded-md border bg-muted/40 px-2 py-1 text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere] text-muted-foreground"
+          className="max-h-36 overflow-y-auto rounded-md border bg-muted/40 px-2 py-1 text-sm [overflow-wrap:anywhere] break-words whitespace-pre-wrap text-muted-foreground"
         >
           {displayValue}
         </div>
@@ -171,7 +171,7 @@ export function SelectionToolbarFooterContent({
 
   return (
     <SelectionPopover.Footer className={cn("justify-between gap-3 border-t", className)}>
-      <div className="min-w-0 max-w-52 flex-1">
+      <div className="max-w-52 min-w-0 flex-1">
         <ProviderSelector
           providers={providers}
           value={value}

--- a/src/entrypoints/selection.content/components/selection-toolbar-title-content.tsx
+++ b/src/entrypoints/selection.content/components/selection-toolbar-title-content.tsx
@@ -13,7 +13,7 @@ export function SelectionToolbarTitleContent({
   title: ReactNode
 }) {
   return (
-    <div className={cn("flex items-center gap-2 min-w-0", className)}>
+    <div className={cn("flex min-w-0 items-center gap-2", className)}>
       <Icon icon={icon} strokeWidth={0.8} className="size-4.5 shrink-0 text-muted-foreground" />
       <SelectionPopover.Title className="truncate">{title}</SelectionPopover.Title>
     </div>

--- a/src/entrypoints/selection.content/components/selection-tooltip.tsx
+++ b/src/entrypoints/selection.content/components/selection-tooltip.tsx
@@ -81,7 +81,7 @@ function SelectionTooltip({
         // This path keeps the popup mouse-transparent while open so
         // hover-leave cannot land on the tooltip itself and contaminate the
         // hover chain.
-        className={cn("pointer-events-none whitespace-nowrap leading-5", className)}
+        className={cn("pointer-events-none leading-5 whitespace-nowrap", className)}
         container={container}
         // The positioner is a separate overlay box around the popup. Making the
         // popup itself transparent is not enough if the pointer can still land

--- a/src/entrypoints/selection.content/selection-toolbar/close-button.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/close-button.tsx
@@ -36,7 +36,7 @@ export function CloseButton() {
           <button
             type="button"
             title="Close selection toolbar"
-            className={`border-border absolute -top-1 -right-1 cursor-pointer rounded-full border bg-neutral-100 dark:bg-neutral-900 ${isDropdownOpen ? "block" : "hidden group-hover:block"}`}
+            className={`absolute -top-1 -right-1 cursor-pointer rounded-full border border-border bg-neutral-100 dark:bg-neutral-900 ${isDropdownOpen ? "block" : "hidden group-hover:block"}`}
             onMouseDown={handleMouseDown}
           />
         }

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/custom-action-trigger.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/custom-action-trigger.tsx
@@ -27,7 +27,7 @@ export function SelectionToolbarCustomActionTrigger({
         <button
           type="button"
           aria-label={action.name}
-          className="px-2 h-7 shrink-0 flex items-center justify-center hover:bg-accent cursor-pointer"
+          className="flex h-7 shrink-0 cursor-pointer items-center justify-center px-2 hover:bg-accent"
           onClick={handleClick}
         />
       }

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/structured-object-renderer.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/structured-object-renderer.tsx
@@ -123,14 +123,14 @@ const { registry: STRUCTURED_OBJECT_REGISTRY } = defineRegistry(structuredObject
 
       return (
         <div className="" data-slot="custom-action-field-row" data-field-name={label}>
-          <div className="flex items-center gap-0.5 h-6">
+          <div className="flex h-6 items-center gap-0.5">
             <div className="inline-flex min-w-0 items-center gap-0.5 text-xs font-medium text-muted-foreground">
               {getFieldTypeIcon(type)}
               <span className="truncate">{label}</span>
             </div>
             {speakingEnabled && <FieldSpeakButton text={value} disabled={speakButtonDisabled} />}
           </div>
-          <div className="text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+          <div className="text-sm [overflow-wrap:anywhere] break-words whitespace-pre-wrap">
             {pending ? "…" : value || "—"}
           </div>
         </div>

--- a/src/entrypoints/selection.content/selection-toolbar/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/index.tsx
@@ -469,10 +469,10 @@ export function SelectionToolbar() {
         >
           <div
             data-slot="selection-toolbar-surface"
-            className="bg-popover rounded-sm shadow-floating border border-border/50 flex items-center"
+            className="flex items-center rounded-sm border border-border/50 bg-popover shadow-floating"
             style={{ opacity: "var(--rf-selection-opacity, 1)" }}
           >
-            <div className="flex items-center overflow-x-auto overflow-y-hidden rounded-sm max-w-105 no-scrollbar">
+            <div className="no-scrollbar flex max-w-105 items-center overflow-x-auto overflow-y-hidden rounded-sm">
               {features.translate.enabled && <TranslateButton />}
               {features.speak.enabled && <SpeakButton />}
               <SelectionToolbarCustomActionButtons />

--- a/src/entrypoints/selection.content/selection-toolbar/speak-button.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/speak-button.tsx
@@ -50,7 +50,7 @@ export function SpeakButton() {
       render={
         <button
           type="button"
-          className="px-2 h-7 flex items-center justify-center hover:bg-accent cursor-pointer"
+          className="flex h-7 cursor-pointer items-center justify-center px-2 hover:bg-accent"
           onClick={handleClick}
           aria-label={tooltipText}
         />

--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/translation-content.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/translation-content.tsx
@@ -26,7 +26,7 @@ export function TranslationContent({
       <SelectionSourceContent text={selectionContent} separatorClassName="mb-3" />
       <div className="space-y-2">
         {thinking && <Thinking status={thinking.status} content={thinking.text} />}
-        <p className="text-sm whitespace-pre-wrap break-words [overflow-wrap:anywhere]">
+        <p className="text-sm [overflow-wrap:anywhere] break-words whitespace-pre-wrap">
           {showLoadingIndicator && (
             <IconLoader2 className="inline size-4 animate-spin" strokeWidth={1.6} />
           )}

--- a/src/entrypoints/side.content/components/floating-button/components/hidden-button.tsx
+++ b/src/entrypoints/side.content/components/floating-button/components/hidden-button.tsx
@@ -20,7 +20,7 @@ export default function HiddenButton({
     <button
       type="button"
       className={cn(
-        "border-border cursor-pointer rounded-full border bg-white shadow-lg p-1.5 text-neutral-600 dark:text-neutral-400 transition-transform duration-300 hover:bg-neutral-100 dark:bg-neutral-900 dark:hover:bg-neutral-800",
+        "cursor-pointer rounded-full border border-border bg-white p-1.5 text-neutral-600 shadow-lg transition-transform duration-300 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-400 dark:hover:bg-neutral-800",
         side === "right" ? "mr-2" : "ml-2",
         expanded ? "translate-x-0" : side === "right" ? "translate-x-12" : "-translate-x-12",
         className,

--- a/src/entrypoints/side.content/components/floating-button/index.tsx
+++ b/src/entrypoints/side.content/components/floating-button/index.tsx
@@ -51,7 +51,7 @@ interface PendingDragState {
 }
 
 const floatingButtonControlClassName = cn(
-  "absolute invisible cursor-pointer pointer-events-none flex size-6 items-center justify-center",
+  "pointer-events-none invisible absolute flex size-6 cursor-pointer items-center justify-center",
   "text-neutral-300 transition-[color,left,right,transform] duration-300 hover:scale-110 hover:text-neutral-500 active:scale-90 active:text-neutral-500",
   "dark:text-neutral-700 dark:hover:text-neutral-500 dark:active:text-neutral-500",
 )
@@ -356,9 +356,9 @@ export default function FloatingButton() {
           ref={mainButtonRef}
           data-testid="floating-main-button"
           className={cn(
-            "border-border relative flex h-10 items-center bg-white shadow-lg transition-transform duration-300 dark:bg-neutral-900",
+            "relative flex h-10 items-center border-border bg-white shadow-lg transition-transform duration-300 dark:bg-neutral-900",
             isDraggingButton
-              ? "w-10 touch-none justify-center rounded-full border cursor-grabbing opacity-100"
+              ? "w-10 cursor-grabbing touch-none justify-center rounded-full border opacity-100"
               : floatingButtonSide === "right"
                 ? "w-11 justify-start rounded-l-full border border-r-0"
                 : "w-11 justify-end rounded-r-full border border-l-0",
@@ -463,8 +463,8 @@ function FloatingButtonCloseMenu({
               floatingButtonControlClassName,
               "-top-1",
               controlOffsetClassName,
-              expanded && "visible pointer-events-auto",
-              open && "visible pointer-events-auto",
+              expanded && "pointer-events-auto visible",
+              open && "pointer-events-auto visible",
             )}
           />
         }
@@ -513,7 +513,7 @@ function FloatingButtonLockControl({ expanded, side }: FloatingButtonLockControl
         floatingButtonControlClassName,
         "-bottom-1",
         controlOffsetClassName,
-        expanded && "visible pointer-events-auto",
+        expanded && "pointer-events-auto visible",
       )}
       onClick={handleToggleLocked}
     >

--- a/src/entrypoints/sidepanel/main.tsx
+++ b/src/entrypoints/sidepanel/main.tsx
@@ -24,12 +24,12 @@ function HydrateAtoms({
 
 function SidePanelShell() {
   return (
-    <main className="bg-background text-foreground flex min-h-screen flex-col px-5 py-6">
+    <main className="flex min-h-screen flex-col bg-background px-5 py-6 text-foreground">
       <section className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
         <img src={readFrogLogo} alt={APP_NAME} className="size-16 rounded-full" />
         <div className="space-y-2">
           <h1 className="text-xl font-semibold tracking-tight">{APP_NAME}</h1>
-          <p className="text-muted-foreground text-sm">Side Panel is coming soon.</p>
+          <p className="text-sm text-muted-foreground">Side Panel is coming soon.</p>
         </div>
       </section>
     </main>

--- a/src/entrypoints/subtitles.content/ui/state-message.tsx
+++ b/src/entrypoints/subtitles.content/ui/state-message.tsx
@@ -32,14 +32,14 @@ export function StateMessage({ state, message }: StateMessageProps) {
 
   return (
     <div
-      className={`${STATE_MESSAGE_CLASS} absolute left-4 bottom-18 pointer-events-auto`}
+      className={`${STATE_MESSAGE_CLASS} pointer-events-auto absolute bottom-18 left-4`}
       style={{
         fontFamily:
           'Roboto, "Arial Unicode Ms", Arial, Helvetica, Verdana, "PT Sans Caption", sans-serif',
       }}
     >
       <div
-        className="flex items-center justify-center px-3 py-2 rounded-md text-base font-medium whitespace-nowrap leading-tight backdrop-blur-sm bg-black/50 shadow-[0_4px_16px_rgba(0,0,0,0.35)]"
+        className="flex items-center justify-center rounded-md bg-black/50 px-3 py-2 text-base leading-tight font-medium whitespace-nowrap shadow-[0_4px_16px_rgba(0,0,0,0.35)] backdrop-blur-sm"
         style={{ color }}
       >
         {text}

--- a/src/entrypoints/subtitles.content/ui/subtitle-lines.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitle-lines.tsx
@@ -27,7 +27,7 @@ export function MainSubtitle({ content, className }: SubtitleLineProps) {
 
   return (
     <div
-      className={cn("subtitles-main leading-tight text-xl", className)}
+      className={cn("subtitles-main text-xl leading-tight", className)}
       style={getTextStyles(style.main)}
     >
       {text}
@@ -44,7 +44,7 @@ export function TranslationSubtitle({ content, className }: SubtitleLineProps) {
 
   return (
     <div
-      className={cn("subtitles-translation leading-tight text-xl", className)}
+      className={cn("subtitles-translation text-xl leading-tight", className)}
       style={getTextStyles(style.translation)}
       dir={dir}
       lang={lang}

--- a/src/entrypoints/subtitles.content/ui/subtitles-container.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-container.tsx
@@ -13,7 +13,7 @@ export function SubtitlesContainer() {
   const ui = use(SubtitlesUIContext)
 
   return (
-    <div className="absolute inset-0 pointer-events-none overflow-visible">
+    <div className="pointer-events-none absolute inset-0 overflow-visible">
       <div className="absolute inset-0 z-10 overflow-visible">
         {isVisible && (
           <>

--- a/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/components/subpage-menu-entry.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/components/subpage-menu-entry.tsx
@@ -18,12 +18,12 @@ export function SubpageMenuEntry({ icon, label, onClick }: SubpageMenuEntryProps
       className={cn("h-auto w-full justify-start rounded-[14px] px-2 py-2 text-left")}
     >
       <div className="flex items-center gap-3">
-        <div className="text-muted-foreground flex size-5 shrink-0 items-center justify-center">
+        <div className="flex size-5 shrink-0 items-center justify-center text-muted-foreground">
           {icon}
         </div>
 
         <div className="min-w-0 flex-1">
-          <Label className="font-light! cursor-pointer text-left text-[13px] leading-5">
+          <Label className="cursor-pointer text-left text-[13px] leading-5 font-light!">
             {label}
           </Label>
         </div>

--- a/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/components/subtitles-settings-item.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/components/subtitles-settings-item.tsx
@@ -14,12 +14,12 @@ export function SubtitlesSettingsItem({
   children,
 }: SubtitlesSettingsItemProps) {
   return (
-    <div className="hover:bg-muted/50 flex items-center gap-3 rounded-[14px] px-2 py-2 transition-colors">
+    <div className="flex items-center gap-3 rounded-[14px] px-2 py-2 transition-colors hover:bg-muted/50">
       <Label
         htmlFor={labelFor}
-        className="font-light! flex min-w-0 flex-1 cursor-pointer items-center gap-3 rounded-md py-0.5 text-left text-[13px] leading-5 transition-colors"
+        className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 rounded-md py-0.5 text-left text-[13px] leading-5 font-light! transition-colors"
       >
-        <div className="text-muted-foreground flex size-5 shrink-0 items-center justify-center">
+        <div className="flex size-5 shrink-0 items-center justify-center text-muted-foreground">
           {icon}
         </div>
         <div className="min-w-0 flex-1">{label}</div>

--- a/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/panel-shell.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/panel-shell.tsx
@@ -30,7 +30,7 @@ function TransitionContent({
       key={transitionKey}
       data-direction={direction}
       className={cn(
-        "duration-200 ease-out animate-in fade-in-0",
+        "animate-in duration-200 ease-out fade-in-0",
         direction === "forward" ? "slide-in-from-right-3" : "slide-in-from-left-3",
       )}
     >
@@ -56,11 +56,11 @@ function PanelContent({
     <div
       ref={panelRef}
       data-slot="subtitles-settings-panel"
-      className="bg-popover text-popover-foreground border-border pointer-events-auto relative isolate z-40 flex w-[min(19rem,calc(100vw-2rem))] flex-col overflow-hidden rounded-[20px] border shadow-floating backdrop-blur-2xl"
+      className="pointer-events-auto relative isolate z-40 flex w-[min(19rem,calc(100vw-2rem))] flex-col overflow-hidden rounded-[20px] border border-border bg-popover text-popover-foreground shadow-floating backdrop-blur-2xl"
       style={{ maxHeight }}
     >
       <Activity mode={header ? "visible" : "hidden"}>
-        <div className="border-border flex items-center gap-3 border-b px-4 pt-3 pb-3">
+        <div className="flex items-center gap-3 border-b border-border px-4 pt-3 pb-3">
           <Button
             type="button"
             variant="ghost-secondary"
@@ -114,7 +114,7 @@ export function PanelShell({ children, open, onClose, header, transition }: Pane
 
   const positionClassName = cn(
     "absolute z-40 transition-[bottom,top,opacity,transform] duration-200 ease-out",
-    buttonRelative ? "bottom-full right-0" : "right-4",
+    buttonRelative ? "right-0 bottom-full" : "right-4",
     open ? "translate-y-0 opacity-100" : "translate-y-2 opacity-0",
   )
 

--- a/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/views/style.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-settings-panel/views/style.tsx
@@ -62,7 +62,7 @@ function SettingsGroup({
   return (
     <div className="mb-4">
       <div className="mb-1.5 flex items-center justify-between px-0.5">
-        <div className="text-popover-foreground flex items-center gap-1.5 text-[13px] font-medium">
+        <div className="flex items-center gap-1.5 text-[13px] font-medium text-popover-foreground">
           {icon}
           {title}
         </div>
@@ -71,12 +71,12 @@ function SettingsGroup({
           variant="ghost"
           size="icon-sm"
           onClick={onReset}
-          className="text-muted-foreground hover:bg-accent/60 hover:text-popover-foreground cursor-pointer"
+          className="cursor-pointer text-muted-foreground hover:bg-accent/60 hover:text-popover-foreground"
         >
           <IconRefresh className="size-3.5" />
         </Button>
       </div>
-      <div className="bg-muted/50 divide-border rounded-xl border divide-y">{children}</div>
+      <div className="divide-y divide-border rounded-xl border bg-muted/50">{children}</div>
     </div>
   )
 }
@@ -84,7 +84,7 @@ function SettingsGroup({
 function SettingRow({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex items-center justify-between px-3 py-2.5">
-      <span className="text-popover-foreground text-[13px]">{label}</span>
+      <span className="text-[13px] text-popover-foreground">{label}</span>
       {children}
     </div>
   )
@@ -110,8 +110,8 @@ function SliderRow({
   return (
     <div className="px-3 py-2.5">
       <div className="mb-3.5 flex items-center justify-between">
-        <span className="text-popover-foreground text-[13px]">{label}</span>
-        <span className="text-muted-foreground text-[12px]">{display}</span>
+        <span className="text-[13px] text-popover-foreground">{label}</span>
+        <span className="text-[12px] text-muted-foreground">{display}</span>
       </div>
       <Slider
         min={min}
@@ -157,7 +157,7 @@ function TextStyleGroup({
           type="color"
           value={textStyle.color}
           onChange={(e) => onChange({ color: e.target.value })}
-          className="border-input bg-background h-6 w-6 cursor-pointer rounded border p-0.5"
+          className="h-6 w-6 cursor-pointer rounded border border-input bg-background p-0.5"
         />
       </SettingRow>
 
@@ -211,7 +211,7 @@ export function StyleView() {
   }
 
   return (
-    <div className="min-h-[calc(100cqh-6rem)] px-3 pb-4 pt-3">
+    <div className="min-h-[calc(100cqh-6rem)] px-3 pt-3 pb-4">
       <SettingsGroup
         icon={<IconSettings className="size-3.5" />}
         title={i18n.t("options.videoSubtitles.style.generalSettings")}

--- a/src/entrypoints/subtitles.content/ui/subtitles-translate-button.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-translate-button.tsx
@@ -26,7 +26,7 @@ export function SubtitlesTranslateButton() {
         setPanelOpen((prev) => !prev)
       }}
       className={cn(
-        `${TRANSLATE_BUTTON_CLASS} w-12 h-full flex items-center justify-center relative border-none p-0 m-0 cursor-pointer rounded-[14px] transition-all duration-200`,
+        `${TRANSLATE_BUTTON_CLASS} relative m-0 flex h-full w-12 cursor-pointer items-center justify-center rounded-[14px] border-none p-0 transition-all duration-200`,
         panelOpen ? "bg-accent shadow-inner" : "bg-transparent",
       )}
     >
@@ -34,14 +34,14 @@ export function SubtitlesTranslateButton() {
         src={logo}
         alt="Subtitle Toggle"
         className={cn(
-          "w-8 h-8 transition-all duration-200 object-contain block",
+          "block h-8 w-8 object-contain transition-all duration-200",
           isVisible ? "opacity-100 saturate-110" : "opacity-75 saturate-90",
           panelOpen && "scale-[1.02]",
         )}
       />
       <div
         className={cn(
-          "absolute bottom-1 right-0 min-w-7 px-1 py-0.5 rounded-md text-[8px] font-semibold leading-none tracking-[0.08em] text-center transition-colors duration-200",
+          "absolute right-0 bottom-1 min-w-7 rounded-md px-1 py-0.5 text-center text-[8px] leading-none font-semibold tracking-[0.08em] transition-colors duration-200",
           isVisible
             ? "bg-primary text-primary-foreground shadow-sm"
             : "bg-secondary text-secondary-foreground",

--- a/src/entrypoints/subtitles.content/ui/subtitles-view.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-view.tsx
@@ -29,10 +29,10 @@ function SubtitlesContent() {
 
   return (
     <div
-      className={`${SUBTITLES_VIEW_CLASS} flex w-full flex-col items-center justify-end pb-3 pointer-events-none`}
+      className={`${SUBTITLES_VIEW_CLASS} pointer-events-none flex w-full flex-col items-center justify-end pb-3`}
     >
       <div
-        className="flex flex-col gap-2 w-fit max-w-[90%] mx-auto px-2 py-1.5 rounded text-center text-white pointer-events-auto select-text cursor-text"
+        className="pointer-events-auto mx-auto flex w-fit max-w-[90%] cursor-text flex-col gap-2 rounded px-2 py-1.5 text-center text-white select-text"
         style={containerStyle}
       >
         <Activity mode={showMain ? "visible" : "hidden"}>
@@ -67,7 +67,7 @@ export function SubtitlesView({ showContent }: SubtitlesViewProps) {
       <div
         ref={refs.container}
         className={cn(
-          "group flex flex-col items-center absolute w-full left-0 right-0",
+          "group absolute right-0 left-0 flex w-full flex-col items-center",
           !isDragging && "transition-[top,bottom] duration-200",
           !showContent && "invisible",
         )}
@@ -76,7 +76,7 @@ export function SubtitlesView({ showContent }: SubtitlesViewProps) {
         <div className="pointer-events-auto">
           <div
             ref={refs.handle}
-            className="mb-0.5 px-2 py-1 rounded cursor-grab active:cursor-grabbing bg-black/75 opacity-0 group-hover:opacity-100 active:opacity-100 transition-opacity duration-200"
+            className="mb-0.5 cursor-grab rounded bg-black/75 px-2 py-1 opacity-0 transition-opacity duration-200 group-hover:opacity-100 active:cursor-grabbing active:opacity-100"
           >
             <IconGripHorizontal className="size-4 text-white" />
           </div>

--- a/src/entrypoints/translation-hub/app.tsx
+++ b/src/entrypoints/translation-hub/app.tsx
@@ -9,7 +9,7 @@ import { TranslationServiceDropdown } from "./components/translation-service-dro
 export default function App() {
   return (
     <div className="min-h-screen">
-      <div className="max-w-6xl mx-auto">
+      <div className="mx-auto max-w-6xl">
         <header className="px-6 py-4">
           <h1 className="text-2xl font-semibold text-foreground">
             {i18n.t("translationHub.title")}
@@ -17,12 +17,12 @@ export default function App() {
         </header>
 
         <main className="p-6">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
             {/* Row 1: Controls */}
             <div className="order-1">
               <LanguageControlPanel />
             </div>
-            <div className="order-3 lg:order-2 flex justify-end lg:items-end lg:h-full">
+            <div className="order-3 flex justify-end lg:order-2 lg:h-full lg:items-end">
               <div className="flex items-center gap-2">
                 <PromptSelector />
                 <TranslationServiceDropdown />

--- a/src/entrypoints/translation-hub/components/language-control-panel.tsx
+++ b/src/entrypoints/translation-hub/components/language-control-panel.tsx
@@ -45,9 +45,9 @@ export function LanguageControlPanel() {
   const detectedLangCode = detectedSourceLangCode ?? "eng"
 
   return (
-    <div className="flex items-center gap-3 w-full">
+    <div className="flex w-full items-center gap-3">
       <SearchableLanguageSelector
-        className="flex-1 min-w-0"
+        className="min-w-0 flex-1"
         value={sourceLangCode}
         onValueChange={setSourceLangCode}
         detectedLangCode={detectedLangCode}
@@ -67,7 +67,7 @@ export function LanguageControlPanel() {
       </div>
 
       <SearchableLanguageSelector
-        className="flex-1 min-w-0"
+        className="min-w-0 flex-1"
         value={targetLangCode}
         onValueChange={(value) => {
           if (value !== "auto") setTargetLangCode(value)

--- a/src/entrypoints/translation-hub/components/text-input.tsx
+++ b/src/entrypoints/translation-hub/components/text-input.tsx
@@ -47,7 +47,7 @@ export function TextInput() {
         onClick={handleTranslate}
         disabled={!value.trim()}
         size="sm"
-        className="absolute bottom-3 right-3"
+        className="absolute right-3 bottom-3"
       >
         {i18n.t("translationHub.translate")}
         <span className="ml-1.5 text-xs">⌘↵</span>

--- a/src/entrypoints/translation-hub/components/translation-card.tsx
+++ b/src/entrypoints/translation-hub/components/translation-card.tsx
@@ -116,7 +116,7 @@ export function TranslationCard({
   const hasContent = mutation.isError || (mutation.data !== undefined && mutation.data !== "")
 
   return (
-    <div className="border rounded-lg bg-card">
+    <div className="rounded-lg border bg-card">
       <div
         className={cn(
           "flex items-center justify-between px-3 py-2",
@@ -127,7 +127,7 @@ export function TranslationCard({
           {providerItem ? (
             <ProviderIcon logo={providerItem.logo(theme)} name={provider.name} size="sm" />
           ) : (
-            <div className="w-5 h-5 bg-muted rounded flex items-center justify-center text-xs text-muted-foreground">
+            <div className="flex h-5 w-5 items-center justify-center rounded bg-muted text-xs text-muted-foreground">
               ?
             </div>
           )}
@@ -194,7 +194,7 @@ export function TranslationCard({
         <div className="p-3">
           {mutation.isError ? (
             <div>
-              <div className="flex items-center space-x-2 text-destructive mb-1">
+              <div className="mb-1 flex items-center space-x-2 text-destructive">
                 <Icon icon="tabler:alert-circle" className="h-4 w-4" />
                 <span className="text-sm font-medium">
                   {i18n.t("translationHub.translationFailed")}
@@ -209,7 +209,7 @@ export function TranslationCard({
           ) : (
             <div
               key={mutation.data}
-              className="text-base leading-relaxed whitespace-pre-wrap animate-in fade-in duration-300"
+              className="animate-in text-base leading-relaxed whitespace-pre-wrap duration-300 fade-in"
             >
               {mutation.data}
             </div>

--- a/src/entrypoints/translation-hub/components/translation-service-dropdown.tsx
+++ b/src/entrypoints/translation-hub/components/translation-service-dropdown.tsx
@@ -54,7 +54,7 @@ export function TranslationServiceDropdown() {
             {selectedIds.length > 0 ? (
               <div className="flex items-center gap-2">
                 <span>{i18n.t("translateService.translationProviders")}</span>
-                <span className="text-xs bg-primary text-primary-foreground px-1.5 py-0.5 rounded-full">
+                <span className="rounded-full bg-primary px-1.5 py-0.5 text-xs text-primary-foreground">
                   {selectedIds.length}
                 </span>
               </div>


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [x] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Enable Oxfmt's Tailwind CSS class sorting for the extension.

- Configures `sortTailwindcss` in `.oxfmtrc.json`.
- Points Oxfmt at the Tailwind v4 stylesheet `src/assets/styles/theme.css`.
- Registers the project's class composition helpers: `clsx`, `cn`, and `cva`.
- Applies the formatter once so existing Tailwind class strings are consistently ordered.

No changeset is included because this is formatter/tooling behavior and does not change extension runtime behavior.

## Related Issue


## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

Commands run:

- `pnpm fmt`
- `pnpm fmt:check`
- `pnpm lint`
- `git diff --check`
- `git push -u origin codex/enable-oxfmt-tailwind-sort` pre-push checks:
  - `nx run @read-frog/extension:"fmt:check"`
  - `nx run @read-frog/extension:lint`
  - `nx run @read-frog/extension:test`

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This PR intentionally creates a broad formatting diff because enabling Tailwind sorting changes the canonical order of existing class strings.
