### PR TITLE
feat(guide): track Dictionary Notebase completion

### DIFF
--- a/.changeset/guide-step3-localized-routes.md
+++ b/.changeset/guide-step3-localized-routes.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+Track Guide Step 3 Dictionary saves across direct and login-resumed Notebase flows.

--- a/src/entrypoints/background/__tests__/notebase-pending-save.test.ts
+++ b/src/entrypoints/background/__tests__/notebase-pending-save.test.ts
@@ -94,6 +94,7 @@ function createDeps({
     getSchema: vi.fn<(...args: any[]) => any>(),
     openNotebasePage: vi.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
     openActionOptions: vi.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
+    completeGuideDictionaryNotebase: vi.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
     now: () => 1_000,
     log: {
       info: vi.fn<(...args: any[]) => any>(),
@@ -209,6 +210,39 @@ describe("notebase pending save processor", () => {
     )
     expect(loggedInDeps.clearPendingNotebaseSave).toHaveBeenCalledTimes(1)
     expect(loggedInDeps.openNotebasePage).toHaveBeenCalledWith(pending.notebaseId)
+    expect(loggedInDeps.completeGuideDictionaryNotebase).not.toHaveBeenCalled()
+  })
+
+  it("completes the guide Dictionary Notebase flow after pending create resume when guide metadata is present", async () => {
+    const action = {
+      ...createAction(),
+      id: "default-dictionary",
+      name: "Dictionary",
+    }
+    const pending = createPendingNotebaseSave(action, { summary: "A short summary" }, 1_000, {
+      guideDictionaryNotebaseTracking: {
+        id: "tracking-1",
+        actionId: "default-dictionary",
+        sourceUrl: "https://readfrog.app/guide/step-3",
+        startedAt: 1_000,
+        expiresAt: 1_801_000,
+      },
+    })
+    const deps = createDeps({
+      pending,
+      config: createConfig(action),
+      authenticated: true,
+    })
+
+    await createNotebasePendingSaveProcessor(deps)("auth-cookie-change")
+
+    expect(deps.createNotebase).toHaveBeenCalledWith(buildNotebaseCreateInputFromPending(pending))
+    expect(deps.completeGuideDictionaryNotebase).toHaveBeenCalledWith({
+      trackingId: "tracking-1",
+      actionId: "default-dictionary",
+      notebaseId: pending.notebaseId,
+      sourceUrl: "https://readfrog.app/guide/step-3",
+    })
   })
 
   it("opens the notebase page after duplicate-create recovery succeeds", async () => {
@@ -257,6 +291,46 @@ describe("notebase pending save processor", () => {
     expect(deps.createNotebase).not.toHaveBeenCalled()
     expect(deps.clearPendingNotebaseSave).toHaveBeenCalledTimes(1)
     expect(deps.openNotebasePage).toHaveBeenCalledWith("notebase-1")
+    expect(deps.completeGuideDictionaryNotebase).not.toHaveBeenCalled()
+  })
+
+  it("completes the guide Dictionary Notebase flow after connected pending row resume when guide metadata is present", async () => {
+    const action = {
+      ...createConnectedAction(),
+      id: "default-dictionary",
+      name: "Dictionary",
+    }
+    const pending = createPendingConnectedNotebaseSave(
+      action,
+      action.notebaseConnection!,
+      { summary: "A short summary" },
+      1_000,
+      {
+        guideDictionaryNotebaseTracking: {
+          id: "tracking-1",
+          actionId: "default-dictionary",
+          sourceUrl: "https://readfrog.app/guide/step-3",
+          startedAt: 1_000,
+          expiresAt: 1_801_000,
+        },
+      },
+    )
+    const deps = createDeps({
+      pending,
+      config: createConfig(action),
+      authenticated: true,
+    })
+    deps.getSchema.mockResolvedValueOnce(createConnectedSchema())
+
+    await createNotebasePendingSaveProcessor(deps)("auth-cookie-change")
+
+    expect(deps.createRow).toHaveBeenCalledTimes(1)
+    expect(deps.completeGuideDictionaryNotebase).toHaveBeenCalledWith({
+      trackingId: "tracking-1",
+      actionId: "default-dictionary",
+      notebaseId: "notebase-1",
+      sourceUrl: "https://readfrog.app/guide/step-3",
+    })
   })
 
   it("creates a replacement Notebase for a connected pending save when the logged-in account differs", async () => {
@@ -294,5 +368,52 @@ describe("notebase pending save processor", () => {
       email: "other@example.com",
     })
     expect(deps.clearPendingNotebaseSave).toHaveBeenCalledTimes(1)
+    expect(deps.completeGuideDictionaryNotebase).not.toHaveBeenCalled()
+  })
+
+  it("carries guide metadata into connected pending replacement creates", async () => {
+    const action = {
+      ...createConnectedAction(),
+      id: "default-dictionary",
+      name: "Dictionary",
+    }
+    const pending = createPendingConnectedNotebaseSave(
+      action,
+      action.notebaseConnection!,
+      { summary: "A short summary" },
+      1_000,
+      {
+        guideDictionaryNotebaseTracking: {
+          id: "tracking-1",
+          actionId: "default-dictionary",
+          sourceUrl: "https://readfrog.app/guide/step-3",
+          startedAt: 1_000,
+          expiresAt: 1_801_000,
+        },
+      },
+    )
+    const deps = createDeps({
+      pending,
+      config: createConfig(action),
+      authenticated: true,
+    })
+    deps.getAuthenticatedAccount.mockResolvedValueOnce({
+      id: "user-2",
+      name: "Other Reader",
+      email: "other@example.com",
+      image: null,
+    })
+    deps.listNotebases.mockResolvedValueOnce([])
+
+    await createNotebasePendingSaveProcessor(deps)("auth-cookie-change")
+
+    expect(deps.createRow).not.toHaveBeenCalled()
+    expect(deps.createNotebase).toHaveBeenCalledTimes(1)
+    expect(deps.completeGuideDictionaryNotebase).toHaveBeenCalledWith({
+      trackingId: "tracking-1",
+      actionId: "default-dictionary",
+      notebaseId: expect.any(String),
+      sourceUrl: "https://readfrog.app/guide/step-3",
+    })
   })
 })

--- a/src/entrypoints/background/new-user-guide.ts
+++ b/src/entrypoints/background/new-user-guide.ts
@@ -1,11 +1,15 @@
+import type { GuideDictionaryNotebaseCompletionInput } from "@/utils/guide/dictionary-notebase"
 import { browser } from "#imports"
 import { env } from "@/env"
+import { markGuideDictionaryNotebaseCompleted } from "@/utils/guide/dictionary-notebase"
+import { logger } from "@/utils/logger"
 import { onMessage, sendMessage } from "@/utils/message"
 
 let lastIsPinned = false
 
 export function newUserGuide() {
   void guidePinExtension()
+  guideDictionaryNotebase()
 }
 
 export async function guidePinExtension() {
@@ -36,4 +40,34 @@ async function checkPinnedAndNotify() {
       }
     },
   )
+}
+
+export async function completeGuideDictionaryNotebaseAndNotify(
+  completion: GuideDictionaryNotebaseCompletionInput,
+) {
+  const state = await markGuideDictionaryNotebaseCompleted(completion)
+
+  await notifyGuideDictionaryNotebaseStateChanged(state)
+}
+
+function guideDictionaryNotebase() {
+  onMessage("completeGuideDictionaryNotebase", async (message) => {
+    await completeGuideDictionaryNotebaseAndNotify(message.data)
+  })
+}
+
+async function notifyGuideDictionaryNotebaseStateChanged(state: { completed: boolean }) {
+  const tabs = await browser.tabs.query({
+    url: env.WXT_OFFICIAL_SITE_ORIGINS.map((origin: string) => `${origin}/*`),
+  })
+
+  for (const tab of tabs) {
+    if (!tab.id) {
+      continue
+    }
+
+    void sendMessage("guideDictionaryNotebaseStateChanged", state, tab.id).catch((error) => {
+      logger.warn("[NewUserGuide] Failed to notify guide dictionary Notebase state", error)
+    })
+  }
 }

--- a/src/entrypoints/background/notebase-pending-save.ts
+++ b/src/entrypoints/background/notebase-pending-save.ts
@@ -6,6 +6,7 @@ import type {
 } from "@read-frog/api-contract"
 import type { Config } from "@/types/config/config"
 import type { SelectionToolbarCustomActionNotebaseAccount } from "@/types/config/selection-toolbar"
+import type { GuideDictionaryNotebaseCompletionInput } from "@/utils/guide/dictionary-notebase"
 import type {
   PendingConnectedNotebaseSave,
   PendingCreateNotebaseSave,
@@ -44,6 +45,7 @@ import {
   validateStillCanSavePendingCreateNotebaseSave,
 } from "@/utils/notebase/pending-save"
 import { backgroundOrpcClient } from "@/utils/orpc/background-client"
+import { completeGuideDictionaryNotebaseAndNotify } from "./new-user-guide"
 
 interface PendingNotebaseSaveProcessorDeps {
   getPendingNotebaseSave: () => Promise<PendingNotebaseSave | null>
@@ -57,6 +59,7 @@ interface PendingNotebaseSaveProcessorDeps {
   getSchema: (id: string) => Promise<NotebaseGetSchemaOutput>
   openNotebasePage: (notebaseId: string) => Promise<void>
   openActionOptions: (actionId: string) => Promise<void>
+  completeGuideDictionaryNotebase: (input: GuideDictionaryNotebaseCompletionInput) => Promise<void>
   now: () => number
   log: Pick<typeof logger, "info" | "warn" | "error">
 }
@@ -93,6 +96,28 @@ function shouldClearCreateError(error: unknown) {
   return isORPCForbiddenError(error) || isORPCValidationError(error)
 }
 
+async function completeGuideDictionaryNotebaseIfNeeded(
+  deps: PendingNotebaseSaveProcessorDeps,
+  pendingNotebaseSave: PendingNotebaseSave,
+  notebaseId: string,
+) {
+  const tracking = pendingNotebaseSave.guideDictionaryNotebaseTracking
+  if (!tracking || tracking.actionId !== pendingNotebaseSave.actionId) {
+    return
+  }
+
+  try {
+    await deps.completeGuideDictionaryNotebase({
+      trackingId: tracking.id,
+      actionId: tracking.actionId,
+      notebaseId,
+      sourceUrl: tracking.sourceUrl,
+    })
+  } catch (error) {
+    deps.log.warn("[NotebasePendingSave] Failed to complete guide Dictionary Notebase flow", error)
+  }
+}
+
 async function completePendingSave(
   deps: PendingNotebaseSaveProcessorDeps,
   pendingNotebaseSave: PendingCreateNotebaseSave,
@@ -118,6 +143,11 @@ async function completePendingSave(
 
   await deps.setConfig(applied.config)
   await deps.clearPendingNotebaseSave()
+  await completeGuideDictionaryNotebaseIfNeeded(
+    deps,
+    pendingNotebaseSave,
+    pendingNotebaseSave.notebaseId,
+  )
   deps.log.info("[NotebasePendingSave] Pending save completed", {
     pendingId: pendingNotebaseSave.id,
     actionId: pendingNotebaseSave.actionId,
@@ -236,6 +266,9 @@ async function createReplacementNotebaseFromConnectedPending(
     validation.action,
     pendingNotebaseSave.result,
     deps.now(),
+    {
+      guideDictionaryNotebaseTracking: pendingNotebaseSave.guideDictionaryNotebaseTracking,
+    },
   )
 
   try {
@@ -297,6 +330,11 @@ async function createReplacementNotebaseFromConnectedPending(
 
   await deps.setConfig(applied.config)
   await deps.clearPendingNotebaseSave()
+  await completeGuideDictionaryNotebaseIfNeeded(
+    deps,
+    replacementPendingNotebaseSave,
+    replacementPendingNotebaseSave.notebaseId,
+  )
   deps.log.info(
     "[NotebasePendingSave] Connected pending save completed with replacement Notebase",
     {
@@ -611,6 +649,11 @@ async function processConnectedPendingSave(
   }
 
   await deps.clearPendingNotebaseSave()
+  await completeGuideDictionaryNotebaseIfNeeded(
+    deps,
+    pendingNotebaseSave,
+    refreshedConnection.notebaseId,
+  )
   deps.log.info("[NotebasePendingSave] Connected pending row save completed", {
     pendingId: pendingNotebaseSave.id,
     actionId: pendingNotebaseSave.actionId,
@@ -665,6 +708,7 @@ export function setupNotebasePendingSaveProcessor() {
     createRow: (input) => backgroundOrpcClient.notebaseRow.create(input),
     listNotebases: () => backgroundOrpcClient.notebase.list({}),
     getSchema: (id) => backgroundOrpcClient.notebase.getSchema({ id }),
+    completeGuideDictionaryNotebase: completeGuideDictionaryNotebaseAndNotify,
     openNotebasePage: async (notebaseId) => {
       await browser.tabs.create({
         active: true,

--- a/src/entrypoints/guide.content/index.ts
+++ b/src/entrypoints/guide.content/index.ts
@@ -5,6 +5,10 @@ import { env } from "@/env"
 import { getLocalConfig } from "@/utils/config/storage"
 import { APP_NAME } from "@/utils/constants/app"
 import { CONFIG_STORAGE_KEY } from "@/utils/constants/config"
+import {
+  getGuideDictionaryNotebaseState,
+  startGuideDictionaryNotebaseTracking,
+} from "@/utils/guide/dictionary-notebase"
 import { onMessage, sendMessage } from "@/utils/message"
 
 export default defineContentScript({
@@ -14,38 +18,67 @@ export default defineContentScript({
       window.postMessage({ source: `${kebabCase(APP_NAME)}-ext`, ...msg }, "*")
     })
 
+    onMessage("guideDictionaryNotebaseStateChanged", (msg) => {
+      window.postMessage({ source: `${kebabCase(APP_NAME)}-ext`, ...msg }, "*")
+    })
+
     window.addEventListener("message", async (e) => {
-      const config = await getLocalConfig()
-      if (!config) return
       if (e.source !== window) return
       const { source, type } = e.data || {}
-      if (source === "read-frog-page" && type === "getPinState") {
+      if (source !== "read-frog-page") return
+
+      if (type === "getPinState") {
         const isPinned = await sendMessage("getPinState", undefined)
         window.postMessage(
           { source: `${kebabCase(APP_NAME)}-ext`, type: "getPinState", data: { isPinned } },
           "*",
         )
-      } else if (source === "read-frog-page" && type === "setTargetLanguage") {
-        const langCodeISO6393 = e.data.langCodeISO6393 ?? "eng"
-        // If we set storage too early, react of side content has not been mounted yet,
-        // so this set storage will not trigger the watch of storage adapter of atom in react of side content
-        // i.e. the side content will not be updated with the new config
-        // thus extract query will set the target language back to initial config when it call setLanguage
-        await new Promise((resolve) => setTimeout(resolve, 500))
-        await storage.setItem<Config>(`local:${CONFIG_STORAGE_KEY}`, {
-          ...config,
-          language: { ...config.language, targetCode: langCodeISO6393 },
-        })
-      } else if (source === "read-frog-page" && type === "getTargetLanguage") {
-        const targetLanguage = config.language.targetCode
+      } else if (type === "startGuideDictionaryNotebaseTracking") {
+        const state = await startGuideDictionaryNotebaseTracking(window.location.href)
         window.postMessage(
           {
             source: `${kebabCase(APP_NAME)}-ext`,
-            type: "getTargetLanguage",
-            data: { targetLanguage },
+            type: "getGuideDictionaryNotebaseState",
+            data: state,
           },
           "*",
         )
+      } else if (type === "getGuideDictionaryNotebaseState") {
+        const state = await getGuideDictionaryNotebaseState()
+        window.postMessage(
+          {
+            source: `${kebabCase(APP_NAME)}-ext`,
+            type: "getGuideDictionaryNotebaseState",
+            data: state,
+          },
+          "*",
+        )
+      } else {
+        const config = await getLocalConfig()
+        if (!config) return
+
+        if (type === "setTargetLanguage") {
+          const langCodeISO6393 = e.data.langCodeISO6393 ?? "eng"
+          // If we set storage too early, react of side content has not been mounted yet,
+          // so this set storage will not trigger the watch of storage adapter of atom in react of side content
+          // i.e. the side content will not be updated with the new config
+          // thus extract query will set the target language back to initial config when it call setLanguage
+          await new Promise((resolve) => setTimeout(resolve, 500))
+          await storage.setItem<Config>(`local:${CONFIG_STORAGE_KEY}`, {
+            ...config,
+            language: { ...config.language, targetCode: langCodeISO6393 },
+          })
+        } else if (type === "getTargetLanguage") {
+          const targetLanguage = config.language.targetCode
+          window.postMessage(
+            {
+              source: `${kebabCase(APP_NAME)}-ext`,
+              type: "getTargetLanguage",
+              data: { targetLanguage },
+            },
+            "*",
+          )
+        }
       }
     })
   },

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/save-to-notebase-button.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/save-to-notebase-button.test.tsx
@@ -33,6 +33,10 @@ const toastMock = vi.hoisted(() => ({
 }))
 
 const notebaseRowCreateMock = vi.hoisted(() => vi.fn<(...args: any[]) => any>())
+const guideTrackingMocks = vi.hoisted(() => ({
+  canUseGuideDictionaryNotebaseTracking: vi.fn<(...args: any[]) => any>(),
+  getActiveGuideDictionaryNotebaseTrackingForAction: vi.fn<(...args: any[]) => any>(),
+}))
 
 vi.mock("@/utils/auth/auth-client", () => ({
   authClient: {
@@ -46,6 +50,17 @@ vi.mock("@/utils/auth/auth-client", () => ({
 vi.mock("@/utils/message", () => ({
   sendMessage: vi.fn<(...args: any[]) => any>(),
 }))
+
+vi.mock("@/utils/guide/dictionary-notebase", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/guide/dictionary-notebase")>()
+
+  return {
+    ...actual,
+    canUseGuideDictionaryNotebaseTracking: guideTrackingMocks.canUseGuideDictionaryNotebaseTracking,
+    getActiveGuideDictionaryNotebaseTrackingForAction:
+      guideTrackingMocks.getActiveGuideDictionaryNotebaseTrackingForAction,
+  }
+})
 
 vi.mock("sonner", () => ({
   toast: toastMock,
@@ -128,6 +143,41 @@ function createConnectedAction(): SelectionToolbarCustomAction {
   }
 }
 
+function createDictionaryAction(): SelectionToolbarCustomAction {
+  const action = cloneConfig(DEFAULT_CONFIG).selectionToolbar.customActions.find(
+    (item) => item.id === "default-dictionary",
+  )
+  if (!action) {
+    throw new Error("Default Dictionary action is not configured")
+  }
+
+  return action
+}
+
+function createConnectedDictionaryAction(): SelectionToolbarCustomAction {
+  const action = createDictionaryAction()
+
+  return {
+    ...action,
+    notebaseConnection: {
+      notebaseId: "notebase-1",
+      notebaseNameSnapshot: "Dictionary Notes",
+      connectedAccount: {
+        id: "user-1",
+        name: "Reader",
+        email: "reader@example.com",
+        image: null,
+      },
+      mappings: action.outputSchema.map((field) => ({
+        id: `mapping-${field.id}`,
+        localFieldId: field.id,
+        notebaseColumnId: `column-${field.id}`,
+        notebaseColumnNameSnapshot: field.name,
+      })),
+    },
+  }
+}
+
 function createSchema(columnId = "column-summary"): NotebaseGetSchemaOutput {
   return {
     id: "notebase-1",
@@ -146,6 +196,28 @@ function createSchema(columnId = "column-summary"): NotebaseGetSchemaOutput {
         updatedAt: new Date(),
       },
     ],
+  }
+}
+
+function createSchemaForAction(action: SelectionToolbarCustomAction): NotebaseGetSchemaOutput {
+  return {
+    id: "notebase-1",
+    name: "Dictionary Notes",
+    updatedAt: new Date(),
+    notebaseColumns: action.outputSchema.map((field, index) => ({
+      id: `column-${field.id}`,
+      notebaseId: "notebase-1",
+      name: field.name,
+      config:
+        field.type === "number"
+          ? { type: "number", decimal: 0, format: "number" }
+          : { type: "string" },
+      position: index,
+      isPrimary: index === 0,
+      width: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })),
   }
 }
 
@@ -196,6 +268,8 @@ describe("saveToNotebaseButton notebase availability", () => {
     vi.mocked(orpcClient.notebase.getSchema).mockResolvedValue(createSchema())
     notebaseRowCreateMock.mockResolvedValue({ txid: 1 })
     vi.mocked(sendMessage).mockResolvedValue(undefined)
+    guideTrackingMocks.canUseGuideDictionaryNotebaseTracking.mockReturnValue(false)
+    guideTrackingMocks.getActiveGuideDictionaryNotebaseTrackingForAction.mockResolvedValue(null)
   })
 
   it("renders when beta experience is disabled", () => {
@@ -246,6 +320,38 @@ describe("saveToNotebaseButton notebase availability", () => {
       expect(sendMessage).toHaveBeenCalledWith("openPage", {
         url: expect.stringContaining(`/notebase/${encodeURIComponent(createInput!.id)}`),
         active: true,
+      })
+    })
+  })
+
+  it("marks guide Dictionary Notebase complete after direct create-and-save with guide tracking", async () => {
+    const config = cloneConfig(DEFAULT_CONFIG)
+    config.betaExperience.enabled = true
+    guideTrackingMocks.canUseGuideDictionaryNotebaseTracking.mockReturnValue(true)
+    guideTrackingMocks.getActiveGuideDictionaryNotebaseTrackingForAction.mockResolvedValue({
+      id: "tracking-1",
+      actionId: "default-dictionary",
+      sourceUrl: "https://readfrog.app/guide/step-3",
+      startedAt: 1_000,
+      expiresAt: 1_801_000,
+    })
+    const action = createDictionaryAction()
+    renderButton(config, action)
+
+    fireEvent.click(screen.getByRole("button", { name: i18n.t("action.saveToNotebase") }))
+    await waitFor(() => {
+      expect(screen.getByText(i18n.t("action.saveToNotebaseCreateTitle"))).toBeInTheDocument()
+    })
+    fireEvent.click(
+      screen.getByRole("button", { name: i18n.t("action.saveToNotebaseCreateAndSaveShort") }),
+    )
+
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith("completeGuideDictionaryNotebase", {
+        trackingId: "tracking-1",
+        actionId: "default-dictionary",
+        notebaseId: expect.any(String),
+        sourceUrl: "https://readfrog.app/guide/step-3",
       })
     })
   })
@@ -364,6 +470,72 @@ describe("saveToNotebaseButton notebase availability", () => {
       url: expect.stringContaining("/notebase/notebase-1"),
       active: true,
     })
+  })
+
+  it("marks guide Dictionary Notebase complete after direct connected row save with guide tracking", async () => {
+    const config = cloneConfig(DEFAULT_CONFIG)
+    config.betaExperience.enabled = true
+    guideTrackingMocks.canUseGuideDictionaryNotebaseTracking.mockReturnValue(true)
+    guideTrackingMocks.getActiveGuideDictionaryNotebaseTrackingForAction.mockResolvedValue({
+      id: "tracking-1",
+      actionId: "default-dictionary",
+      sourceUrl: "https://readfrog.app/guide/step-3",
+      startedAt: 1_000,
+      expiresAt: 1_801_000,
+    })
+    const action = createConnectedDictionaryAction()
+    vi.mocked(orpcClient.notebase.getSchema).mockResolvedValueOnce(createSchemaForAction(action))
+    renderButton(config, action)
+
+    fireEvent.click(screen.getByRole("button", { name: i18n.t("action.saveToNotebase") }))
+
+    await waitFor(() => {
+      expect(notebaseRowCreateMock).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(sendMessage).toHaveBeenCalledWith("completeGuideDictionaryNotebase", {
+        trackingId: "tracking-1",
+        actionId: "default-dictionary",
+        notebaseId: "notebase-1",
+        sourceUrl: "https://readfrog.app/guide/step-3",
+      })
+    })
+  })
+
+  it("does not mark guide complete for default Dictionary saves outside guide step 3", async () => {
+    const config = cloneConfig(DEFAULT_CONFIG)
+    config.betaExperience.enabled = true
+    guideTrackingMocks.canUseGuideDictionaryNotebaseTracking.mockReturnValue(false)
+    const action = createConnectedDictionaryAction()
+    vi.mocked(orpcClient.notebase.getSchema).mockResolvedValueOnce(createSchemaForAction(action))
+    renderButton(config, action)
+
+    fireEvent.click(screen.getByRole("button", { name: i18n.t("action.saveToNotebase") }))
+
+    await waitFor(() => {
+      expect(notebaseRowCreateMock).toHaveBeenCalledTimes(1)
+    })
+    expect(sendMessage).not.toHaveBeenCalledWith(
+      "completeGuideDictionaryNotebase",
+      expect.anything(),
+    )
+  })
+
+  it("does not mark guide complete for non-Dictionary custom actions", async () => {
+    const config = cloneConfig(DEFAULT_CONFIG)
+    config.betaExperience.enabled = true
+    guideTrackingMocks.canUseGuideDictionaryNotebaseTracking.mockReturnValue(false)
+    renderButton(config, createConnectedAction())
+
+    fireEvent.click(screen.getByRole("button", { name: i18n.t("action.saveToNotebase") }))
+
+    await waitFor(() => {
+      expect(notebaseRowCreateMock).toHaveBeenCalledTimes(1)
+    })
+    expect(sendMessage).not.toHaveBeenCalledWith(
+      "completeGuideDictionaryNotebase",
+      expect.anything(),
+    )
   })
 
   it("shows a Custom AI Actions toast action instead of disabling invalid mappings", async () => {

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/save-to-notebase-button.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/save-to-notebase-button.tsx
@@ -2,6 +2,7 @@ import type {
   SelectionToolbarCustomAction,
   SelectionToolbarCustomActionNotebaseAccount,
 } from "@/types/config/selection-toolbar"
+import type { GuideDictionaryNotebaseTracking } from "@/utils/guide/dictionary-notebase"
 import { useMutation } from "@tanstack/react-query"
 import { useAtom, useSetAtom } from "jotai"
 import { useRef, useState } from "react"
@@ -9,6 +10,10 @@ import { toast } from "sonner"
 import { Button } from "@/components/ui/base-ui/button"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { authClient } from "@/utils/auth/auth-client"
+import {
+  canUseGuideDictionaryNotebaseTracking,
+  getActiveGuideDictionaryNotebaseTrackingForAction,
+} from "@/utils/guide/dictionary-notebase"
 import { i18n } from "@/utils/i18n"
 import { sendMessage } from "@/utils/message"
 import {
@@ -56,6 +61,7 @@ export function SaveToNotebaseButton({
   const currentAccount = createNotebaseConnectedAccountSnapshot(session?.user)
   const [isPreparingSave, setIsPreparingSave] = useState(false)
   const savingNotebaseNameRef = useRef<string | undefined>(connection?.notebaseNameSnapshot)
+  const savingGuideTrackingRef = useRef<GuideDictionaryNotebaseTracking | null>(null)
 
   const openCustomActionOptions = () => {
     void sendMessage("openOptionsPage", {
@@ -72,6 +78,18 @@ export function SaveToNotebaseButton({
     })
   }
 
+  const completeGuideDictionaryNotebase = (
+    tracking: GuideDictionaryNotebaseTracking,
+    notebaseId: string,
+  ) => {
+    void sendMessage("completeGuideDictionaryNotebase", {
+      trackingId: tracking.id,
+      actionId: tracking.actionId,
+      notebaseId,
+      sourceUrl: tracking.sourceUrl,
+    }).catch(() => {})
+  }
+
   const saveMutation = useMutation(
     orpc.notebaseRow.create.mutationOptions({
       meta: {
@@ -79,6 +97,11 @@ export function SaveToNotebaseButton({
       },
       onSuccess: (_data, variables) => {
         const notebaseUrl = getNotebaseDetailUrl(variables.notebaseId)
+        const guideTracking = savingGuideTrackingRef.current
+        savingGuideTrackingRef.current = null
+        if (guideTracking) {
+          completeGuideDictionaryNotebase(guideTracking, variables.notebaseId)
+        }
         toast.success(i18n.t("action.saveToNotebaseSuccess"), {
           description: savingNotebaseNameRef.current ?? connection?.notebaseNameSnapshot,
           action: {
@@ -93,6 +116,7 @@ export function SaveToNotebaseButton({
         })
       },
       onError: (error: unknown) => {
+        savingGuideTrackingRef.current = null
         if (isORPCUnauthorizedError(error)) {
           toast.error(i18n.t("action.saveToNotebaseLoginRequired"))
           return
@@ -125,29 +149,52 @@ export function SaveToNotebaseButton({
     }),
   )
 
-  const openCreateOrConnectDialog = () => {
+  const getCurrentGuideDictionaryNotebaseUrl = () => {
+    const currentUrl = window.location.href
+    return canUseGuideDictionaryNotebaseTracking(action.id, currentUrl) ? currentUrl : null
+  }
+
+  const openCreateOrConnectDialog = async () => {
     if (!result) {
       return
     }
 
+    const guideDictionaryNotebaseUrl = getCurrentGuideDictionaryNotebaseUrl()
+    const guideDictionaryNotebaseTracking = guideDictionaryNotebaseUrl
+      ? await getActiveGuideDictionaryNotebaseTrackingForAction(
+          action.id,
+          guideDictionaryNotebaseUrl,
+        )
+      : null
     setSaveToNotebaseDialog({
       open: true,
       mode: "create_or_connect",
-      pendingNotebaseSave: createPendingNotebaseSave(action, result),
+      pendingNotebaseSave: createPendingNotebaseSave(action, result, Date.now(), {
+        guideDictionaryNotebaseTracking: guideDictionaryNotebaseTracking ?? undefined,
+      }),
     })
   }
 
-  const openForeignConnectionDialog = (
+  const openForeignConnectionDialog = async (
     connectedAccount: SelectionToolbarCustomActionNotebaseAccount,
   ) => {
     if (!result) {
       return
     }
 
+    const guideDictionaryNotebaseUrl = getCurrentGuideDictionaryNotebaseUrl()
+    const guideDictionaryNotebaseTracking = guideDictionaryNotebaseUrl
+      ? await getActiveGuideDictionaryNotebaseTrackingForAction(
+          action.id,
+          guideDictionaryNotebaseUrl,
+        )
+      : null
     setSaveToNotebaseDialog({
       open: true,
       mode: "foreign_connection",
-      pendingNotebaseSave: createPendingNotebaseSave(action, result),
+      pendingNotebaseSave: createPendingNotebaseSave(action, result, Date.now(), {
+        guideDictionaryNotebaseTracking: guideDictionaryNotebaseTracking ?? undefined,
+      }),
       connectedAccount,
     })
   }
@@ -161,7 +208,7 @@ export function SaveToNotebaseButton({
         variant="brand"
         size="sm"
         disabled={isUnconnectedDisabled}
-        onClick={openCreateOrConnectDialog}
+        onClick={() => void openCreateOrConnectDialog()}
       >
         {i18n.t("action.saveToNotebase")}
       </Button>
@@ -183,7 +230,22 @@ export function SaveToNotebaseButton({
     }
 
     if (!isAuthenticated) {
-      const pendingNotebaseSave = createPendingConnectedNotebaseSave(action, connection, result)
+      const guideDictionaryNotebaseUrl = getCurrentGuideDictionaryNotebaseUrl()
+      const guideDictionaryNotebaseTracking = guideDictionaryNotebaseUrl
+        ? await getActiveGuideDictionaryNotebaseTrackingForAction(
+            action.id,
+            guideDictionaryNotebaseUrl,
+          )
+        : null
+      const pendingNotebaseSave = createPendingConnectedNotebaseSave(
+        action,
+        connection,
+        result,
+        Date.now(),
+        {
+          guideDictionaryNotebaseTracking: guideDictionaryNotebaseTracking ?? undefined,
+        },
+      )
       setSaveToNotebaseDialog({
         open: true,
         mode: "connected_login_required",
@@ -208,12 +270,12 @@ export function SaveToNotebaseButton({
       })
 
       if (ownership.kind === "notebase_unavailable") {
-        openCreateOrConnectDialog()
+        await openCreateOrConnectDialog()
         return
       }
 
       if (ownership.kind === "foreign_account") {
-        openForeignConnectionDialog(connection.connectedAccount)
+        await openForeignConnectionDialog(connection.connectedAccount)
         return
       }
 
@@ -237,6 +299,13 @@ export function SaveToNotebaseButton({
 
       const { cells } = buildNotebaseRowCells(actionWithRefreshedConnection, schema, result)
       savingNotebaseNameRef.current = refreshedConnection.notebaseNameSnapshot
+      const guideDictionaryNotebaseUrl = getCurrentGuideDictionaryNotebaseUrl()
+      savingGuideTrackingRef.current = guideDictionaryNotebaseUrl
+        ? await getActiveGuideDictionaryNotebaseTrackingForAction(
+            action.id,
+            guideDictionaryNotebaseUrl,
+          )
+        : null
       saveMutation.mutate({
         notebaseId: refreshedConnection.notebaseId,
         data: {
@@ -255,7 +324,7 @@ export function SaveToNotebaseButton({
       }
 
       if (isORPCNotFoundError(error)) {
-        openCreateOrConnectDialog()
+        await openCreateOrConnectDialog()
         return
       }
 

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/save-to-notebase-dialog-host.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/save-to-notebase-dialog-host.tsx
@@ -70,6 +70,27 @@ function ConnectedAccountDisplay({
   )
 }
 
+async function completeGuideDictionaryNotebaseFromPending(pendingSave: PendingCreateNotebaseSave) {
+  const tracking = pendingSave.guideDictionaryNotebaseTracking
+  if (!tracking || tracking.actionId !== pendingSave.actionId) {
+    return
+  }
+
+  try {
+    await sendMessage("completeGuideDictionaryNotebase", {
+      trackingId: tracking.id,
+      actionId: tracking.actionId,
+      notebaseId: pendingSave.notebaseId,
+      sourceUrl: tracking.sourceUrl,
+    })
+  } catch (error) {
+    logger.warn(
+      "[SaveToNotebaseDialogHost] Failed to complete guide Dictionary Notebase flow",
+      error,
+    )
+  }
+}
+
 export function SaveToNotebaseDialogHost() {
   const [dialogState, setDialogState] = useAtom(saveToNotebaseDialogAtom)
   const [selectionToolbarConfig, setSelectionToolbarConfig] = useAtom(
@@ -117,6 +138,7 @@ export function SaveToNotebaseDialogHost() {
       toast.success(i18n.t("action.saveToNotebaseSuccess"), {
         description: createdPendingSave.actionName,
       })
+      await completeGuideDictionaryNotebaseFromPending(createdPendingSave)
 
       try {
         await sendMessage("openPage", {

--- a/src/utils/guide/__tests__/dictionary-notebase.test.ts
+++ b/src/utils/guide/__tests__/dictionary-notebase.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { storage } from "#imports"
+import {
+  getActiveGuideDictionaryNotebaseTrackingForAction,
+  getGuideDictionaryNotebaseState,
+  GUIDE_DICTIONARY_NOTEBASE_ACTION_ID,
+  GUIDE_DICTIONARY_NOTEBASE_COMPLETED_STORAGE_KEY,
+  GUIDE_DICTIONARY_NOTEBASE_SESSION_STORAGE_KEY,
+  isGuideDictionaryNotebaseGuideUrl,
+  markGuideDictionaryNotebaseCompleted,
+  startGuideDictionaryNotebaseTracking,
+} from "../dictionary-notebase"
+
+const GUIDE_URL = "https://readfrog.app/guide/step-3"
+
+function localKey(key: string) {
+  return `local:${key}`
+}
+
+describe("Dictionary Notebase guide tracking", () => {
+  const storageValues = new Map<string, unknown>()
+  let storageSetItemMock: ReturnType<typeof vi.fn<(...args: any[]) => any>>
+  let storageRemoveItemMock: ReturnType<typeof vi.fn<(...args: any[]) => any>>
+
+  beforeEach(() => {
+    storageValues.clear()
+    storage.getItem = vi.fn<(...args: any[]) => any>((key: string) =>
+      Promise.resolve(storageValues.get(key)),
+    )
+    storageSetItemMock = vi.fn<(...args: any[]) => any>((key: string, value: unknown) => {
+      storageValues.set(key, value)
+      return Promise.resolve()
+    })
+    storageRemoveItemMock = vi.fn<(...args: any[]) => any>((key: string) => {
+      storageValues.delete(key)
+      return Promise.resolve()
+    })
+    storage.setItem = storageSetItemMock
+    storage.removeItem = storageRemoveItemMock
+  })
+
+  it("recognizes official guide step 3 routes by pathname suffix", () => {
+    expect(isGuideDictionaryNotebaseGuideUrl(GUIDE_URL)).toBe(true)
+    expect(isGuideDictionaryNotebaseGuideUrl("https://readfrog.app/guide/step-3/")).toBe(true)
+    expect(isGuideDictionaryNotebaseGuideUrl("https://readfrog.app/en/guide/step-3")).toBe(true)
+    expect(isGuideDictionaryNotebaseGuideUrl("https://readfrog.app/zh-Hant/guide/step-3")).toBe(
+      true,
+    )
+    expect(
+      isGuideDictionaryNotebaseGuideUrl(
+        "https://readfrog.app/fr-CA/guide/step-3/?from=guide#dictionary",
+      ),
+    ).toBe(true)
+    expect(isGuideDictionaryNotebaseGuideUrl("https://readfrog.app/docs/guide/step-3")).toBe(true)
+    expect(isGuideDictionaryNotebaseGuideUrl("https://readfrog.app/guide/step-30")).toBe(false)
+    expect(isGuideDictionaryNotebaseGuideUrl("https://readfrog.app/guide/step-3/details")).toBe(
+      false,
+    )
+    expect(isGuideDictionaryNotebaseGuideUrl("https://example.com/guide/step-3")).toBe(false)
+  })
+
+  it("starts a short-lived tracking session only from guide step 3", async () => {
+    await expect(
+      startGuideDictionaryNotebaseTracking("https://readfrog.app/docs", 1_000),
+    ).resolves.toEqual({ completed: false })
+    expect(storageSetItemMock).not.toHaveBeenCalled()
+
+    await expect(startGuideDictionaryNotebaseTracking(GUIDE_URL, 2_000)).resolves.toEqual({
+      completed: false,
+    })
+
+    const tracking = storageValues.get(localKey(GUIDE_DICTIONARY_NOTEBASE_SESSION_STORAGE_KEY))
+    expect(tracking).toMatchObject({
+      actionId: GUIDE_DICTIONARY_NOTEBASE_ACTION_ID,
+      sourceUrl: GUIDE_URL,
+      startedAt: 2_000,
+      expiresAt: 1_802_000,
+    })
+  })
+
+  it("returns active tracking only for the default Dictionary action on guide step 3", async () => {
+    await startGuideDictionaryNotebaseTracking(GUIDE_URL, 1_000)
+
+    await expect(
+      getActiveGuideDictionaryNotebaseTrackingForAction(
+        GUIDE_DICTIONARY_NOTEBASE_ACTION_ID,
+        GUIDE_URL,
+        2_000,
+      ),
+    ).resolves.toMatchObject({
+      actionId: GUIDE_DICTIONARY_NOTEBASE_ACTION_ID,
+      sourceUrl: GUIDE_URL,
+    })
+
+    await expect(
+      getActiveGuideDictionaryNotebaseTrackingForAction("custom-action", GUIDE_URL, 2_000),
+    ).resolves.toBeNull()
+    await expect(
+      getActiveGuideDictionaryNotebaseTrackingForAction(
+        GUIDE_DICTIONARY_NOTEBASE_ACTION_ID,
+        "https://readfrog.app/docs",
+        2_000,
+      ),
+    ).resolves.toBeNull()
+  })
+
+  it("marks the guide complete and clears the active tracking session", async () => {
+    await startGuideDictionaryNotebaseTracking(GUIDE_URL, 1_000)
+
+    await expect(
+      markGuideDictionaryNotebaseCompleted(
+        {
+          trackingId: "tracking-1",
+          actionId: GUIDE_DICTIONARY_NOTEBASE_ACTION_ID,
+          notebaseId: "notebase-1",
+          sourceUrl: GUIDE_URL,
+        },
+        3_000,
+      ),
+    ).resolves.toEqual({ completed: true })
+
+    expect(
+      storageValues.get(localKey(GUIDE_DICTIONARY_NOTEBASE_COMPLETED_STORAGE_KEY)),
+    ).toMatchObject({
+      completed: true,
+      completedAt: 3_000,
+      trackingId: "tracking-1",
+      actionId: GUIDE_DICTIONARY_NOTEBASE_ACTION_ID,
+      notebaseId: "notebase-1",
+      sourceUrl: GUIDE_URL,
+    })
+    expect(storageRemoveItemMock).toHaveBeenCalledWith(
+      localKey(GUIDE_DICTIONARY_NOTEBASE_SESSION_STORAGE_KEY),
+    )
+    await expect(getGuideDictionaryNotebaseState()).resolves.toEqual({ completed: true })
+  })
+})

--- a/src/utils/guide/dictionary-notebase.ts
+++ b/src/utils/guide/dictionary-notebase.ts
@@ -1,0 +1,145 @@
+import { z } from "zod"
+import { storage } from "#imports"
+import { env } from "@/env"
+import { getRandomUUID } from "@/utils/crypto-polyfill"
+
+export const GUIDE_DICTIONARY_NOTEBASE_ACTION_ID = "default-dictionary"
+export const GUIDE_DICTIONARY_NOTEBASE_COMPLETED_STORAGE_KEY = "guideDictionaryNotebaseCompleted"
+export const GUIDE_DICTIONARY_NOTEBASE_SESSION_STORAGE_KEY = "guideDictionaryNotebaseSession"
+export const GUIDE_DICTIONARY_NOTEBASE_SESSION_TTL_MS = 30 * 60 * 1000
+const GUIDE_DICTIONARY_NOTEBASE_ROUTE_PATH_SUFFIX = "/guide/step-3"
+
+export const guideDictionaryNotebaseTrackingSchema = z.object({
+  id: z.string().nonempty(),
+  actionId: z.literal(GUIDE_DICTIONARY_NOTEBASE_ACTION_ID),
+  sourceUrl: z.url(),
+  startedAt: z.number(),
+  expiresAt: z.number(),
+})
+
+export type GuideDictionaryNotebaseTracking = z.infer<typeof guideDictionaryNotebaseTrackingSchema>
+
+export const guideDictionaryNotebaseCompletionInputSchema = z.object({
+  trackingId: z.string().nonempty(),
+  actionId: z.literal(GUIDE_DICTIONARY_NOTEBASE_ACTION_ID),
+  notebaseId: z.string().nonempty(),
+  sourceUrl: z.url(),
+})
+
+export type GuideDictionaryNotebaseCompletionInput = z.infer<
+  typeof guideDictionaryNotebaseCompletionInputSchema
+>
+
+const guideDictionaryNotebaseCompletionSchema = guideDictionaryNotebaseCompletionInputSchema.extend(
+  {
+    completed: z.literal(true),
+    completedAt: z.number(),
+  },
+)
+
+export type GuideDictionaryNotebaseState = {
+  completed: boolean
+}
+
+function getLocalStorageKey(key: string): `local:${string}` {
+  return `local:${key}`
+}
+
+export function isGuideDictionaryNotebaseGuideUrl(rawUrl: string) {
+  try {
+    const url = new URL(rawUrl)
+    const isOfficialOrigin = env.WXT_OFFICIAL_SITE_ORIGINS.includes(url.origin)
+    const normalizedPathname = url.pathname.replace(/\/$/, "")
+
+    return (
+      isOfficialOrigin && normalizedPathname.endsWith(GUIDE_DICTIONARY_NOTEBASE_ROUTE_PATH_SUFFIX)
+    )
+  } catch {
+    return false
+  }
+}
+
+export function canUseGuideDictionaryNotebaseTracking(actionId: string, currentUrl: string) {
+  return (
+    actionId === GUIDE_DICTIONARY_NOTEBASE_ACTION_ID &&
+    isGuideDictionaryNotebaseGuideUrl(currentUrl)
+  )
+}
+
+export async function getGuideDictionaryNotebaseState(): Promise<GuideDictionaryNotebaseState> {
+  const value = await storage.getItem<unknown>(
+    getLocalStorageKey(GUIDE_DICTIONARY_NOTEBASE_COMPLETED_STORAGE_KEY),
+  )
+  const parsed = guideDictionaryNotebaseCompletionSchema.safeParse(value)
+
+  return { completed: parsed.success }
+}
+
+export async function startGuideDictionaryNotebaseTracking(sourceUrl: string, now = Date.now()) {
+  const state = await getGuideDictionaryNotebaseState()
+  if (state.completed || !isGuideDictionaryNotebaseGuideUrl(sourceUrl)) {
+    return state
+  }
+
+  const tracking: GuideDictionaryNotebaseTracking = {
+    id: getRandomUUID(),
+    actionId: GUIDE_DICTIONARY_NOTEBASE_ACTION_ID,
+    sourceUrl,
+    startedAt: now,
+    expiresAt: now + GUIDE_DICTIONARY_NOTEBASE_SESSION_TTL_MS,
+  }
+
+  await storage.setItem(getLocalStorageKey(GUIDE_DICTIONARY_NOTEBASE_SESSION_STORAGE_KEY), tracking)
+
+  return { completed: false }
+}
+
+export async function getActiveGuideDictionaryNotebaseTrackingForAction(
+  actionId: string,
+  currentUrl: string,
+  now = Date.now(),
+) {
+  if (!canUseGuideDictionaryNotebaseTracking(actionId, currentUrl)) {
+    return null
+  }
+
+  const state = await getGuideDictionaryNotebaseState()
+  if (state.completed) {
+    return null
+  }
+
+  const value = await storage.getItem<unknown>(
+    getLocalStorageKey(GUIDE_DICTIONARY_NOTEBASE_SESSION_STORAGE_KEY),
+  )
+  const parsed = guideDictionaryNotebaseTrackingSchema.safeParse(value)
+  if (!parsed.success) {
+    return null
+  }
+
+  if (parsed.data.expiresAt <= now) {
+    await storage.removeItem(getLocalStorageKey(GUIDE_DICTIONARY_NOTEBASE_SESSION_STORAGE_KEY))
+    return null
+  }
+
+  if (!isGuideDictionaryNotebaseGuideUrl(parsed.data.sourceUrl)) {
+    return null
+  }
+
+  return parsed.data
+}
+
+export async function markGuideDictionaryNotebaseCompleted(
+  input: GuideDictionaryNotebaseCompletionInput,
+  now = Date.now(),
+) {
+  const completionInput = guideDictionaryNotebaseCompletionInputSchema.parse(input)
+
+  await storage.setItem(getLocalStorageKey(GUIDE_DICTIONARY_NOTEBASE_COMPLETED_STORAGE_KEY), {
+    ...completionInput,
+    completed: true,
+    completedAt: now,
+  })
+  await storage.removeItem(getLocalStorageKey(GUIDE_DICTIONARY_NOTEBASE_SESSION_STORAGE_KEY))
+
+  return { completed: true }
+}

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -1,4 +1,5 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
+import type { GuideDictionaryNotebaseCompletionInput } from "./guide/dictionary-notebase"
 import type { FeatureUsageContext, FeatureUsedEventProperties } from "@/types/analytics"
 import type {
   BackgroundGenerateTextPayload,
@@ -81,6 +82,8 @@ interface ProtocolMap {
   pinStateChanged: (data: { isPinned: boolean }) => void
   getPinState: () => boolean
   returnPinState: (data: { isPinned: boolean }) => void
+  guideDictionaryNotebaseStateChanged: (data: { completed: boolean }) => void
+  completeGuideDictionaryNotebase: (data: GuideDictionaryNotebaseCompletionInput) => void
   // request
   enqueueTranslateRequest: (data: {
     text: string

--- a/src/utils/notebase/pending-save.ts
+++ b/src/utils/notebase/pending-save.ts
@@ -12,6 +12,7 @@ import { storage } from "#imports"
 import { env } from "@/env"
 import { selectionToolbarCustomActionNotebaseConnectionSchema } from "@/types/config/selection-toolbar"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
+import { guideDictionaryNotebaseTrackingSchema } from "@/utils/guide/dictionary-notebase"
 import { buildNotebaseRowCells } from "./mapping"
 
 export const NOTEBASE_PENDING_SAVE_STORAGE_KEY = "notebasePendingSave"
@@ -32,6 +33,7 @@ const pendingNotebaseSaveBaseSchema = zod.object({
   actionId: zod.string().nonempty(),
   actionName: zod.string().min(1),
   outputSchemaFingerprint: zod.string(),
+  guideDictionaryNotebaseTracking: guideDictionaryNotebaseTrackingSchema.optional(),
 })
 
 export const pendingCreateNotebaseSaveSchema = pendingNotebaseSaveBaseSchema.extend({
@@ -56,6 +58,10 @@ export const pendingNotebaseSaveSchema = zod.union([
 export type PendingNotebaseSave = z.infer<typeof pendingNotebaseSaveSchema>
 export type PendingCreateNotebaseSave = z.infer<typeof pendingCreateNotebaseSaveSchema>
 export type PendingConnectedNotebaseSave = z.infer<typeof pendingConnectedNotebaseSaveSchema>
+
+interface PendingNotebaseSaveOptions {
+  guideDictionaryNotebaseTracking?: PendingNotebaseSave["guideDictionaryNotebaseTracking"]
+}
 
 export type PendingNotebaseSaveActionStatus =
   | "valid"
@@ -87,6 +93,7 @@ export function createPendingNotebaseSave(
   action: SelectionToolbarCustomAction,
   result: Record<string, unknown>,
   now = Date.now(),
+  options?: PendingNotebaseSaveOptions,
 ): PendingCreateNotebaseSave {
   const columns = action.outputSchema.map((field) => ({
     localFieldId: field.id,
@@ -104,6 +111,9 @@ export function createPendingNotebaseSave(
     actionId: action.id,
     actionName: action.name.trim() || action.name,
     outputSchemaFingerprint: getOutputSchemaFingerprint(action.outputSchema),
+    ...(options?.guideDictionaryNotebaseTracking
+      ? { guideDictionaryNotebaseTracking: options.guideDictionaryNotebaseTracking }
+      : {}),
     notebaseId: getRandomUUID(),
     rowId: getRandomUUID(),
     columns,
@@ -118,6 +128,7 @@ export function createPendingConnectedNotebaseSave(
   connection: SelectionToolbarCustomActionNotebaseConnection,
   result: Record<string, unknown>,
   now = Date.now(),
+  options?: PendingNotebaseSaveOptions,
 ): PendingConnectedNotebaseSave {
   return {
     kind: "save_to_connected_notebase",
@@ -127,6 +138,9 @@ export function createPendingConnectedNotebaseSave(
     actionId: action.id,
     actionName: action.name.trim() || action.name,
     outputSchemaFingerprint: getOutputSchemaFingerprint(action.outputSchema),
+    ...(options?.guideDictionaryNotebaseTracking
+      ? { guideDictionaryNotebaseTracking: options.guideDictionaryNotebaseTracking }
+      : {}),
     connectionSnapshot: connection,
     result,
   }


### PR DESCRIPTION
## Summary

- start a short-lived Guide Step 3 tracking session only on official guide routes
- attribute completion only to the default Dictionary Save to Notebase action
- carry tracking through direct create, connected row saves, and login-resumed pending saves
- persist completion in extension local storage and notify open guide tabs
- add focused coverage for direct and pending save paths plus a patch changeset

## Rollout

The extension behavior remains inert until the web Guide Step 3 rollout flag is enabled.

## Validation

- pnpm type-check
- pnpm fmt:check
- targeted Vitest suite: 27 tests passed
- pre-push full extension suite: 176 test files, 1514 tests passed