### PR TITLE
fix(providers): populate default provider descriptions

### DIFF
--- a/.changeset/fresh-provider-descriptions.md
+++ b/.changeset/fresh-provider-descriptions.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(providers): populate descriptions for providers seeded on fresh installs

--- a/src/entrypoints/options/pages/api-providers/__tests__/utils.test.ts
+++ b/src/entrypoints/options/pages/api-providers/__tests__/utils.test.ts
@@ -1,11 +1,29 @@
 import type { Config } from "@/types/config/config"
 import type { APIProviderConfig } from "@/types/config/provider"
 import { describe, expect, it, vi } from "vitest"
-import { duplicateProvider } from "../utils"
+import { initI18n } from "@/utils/i18n"
+import { addProvider, duplicateProvider } from "../utils"
 
 type AlibabaProviderConfig = Extract<APIProviderConfig, { provider: "alibaba" }>
 
 describe("api provider utils", () => {
+  it("adds the OpenAI-compatible provider with its localized default description", async () => {
+    await initI18n("en")
+    let updatedProviders: Config["providersConfig"] | undefined
+    const setProvidersConfig = vi.fn<(...args: any[]) => any>(async (config) => {
+      updatedProviders = config as Config["providersConfig"]
+    })
+
+    await addProvider("openai-compatible", [], setProvidersConfig)
+
+    expect(updatedProviders?.[0]).toEqual(
+      expect.objectContaining({
+        provider: "openai-compatible",
+        description: "options.apiProviders.providers.description.openaiCompatible",
+      }),
+    )
+  })
+
   it("duplicates an existing provider config with a fresh id and unique name", async () => {
     const sourceProvider: AlibabaProviderConfig = {
       id: "alibaba-original",

--- a/src/entrypoints/options/pages/api-providers/utils.ts
+++ b/src/entrypoints/options/pages/api-providers/utils.ts
@@ -1,20 +1,12 @@
 import type { Config } from "@/types/config/config"
 import type { APIProviderConfig, APIProviderTypes } from "@/types/config/provider"
-import { API_PROVIDER_ITEMS, DEFAULT_PROVIDER_CONFIG } from "@/utils/constants/providers"
+import {
+  API_PROVIDER_ITEMS,
+  DEFAULT_PROVIDER_CONFIG,
+  getDefaultProviderDescription,
+} from "@/utils/constants/providers"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
-import { i18n } from "@/utils/i18n"
 import { getUniqueName } from "@/utils/name"
-
-/**
- * Resolve a provider's default description in the current interface language at creation
- * time (it is no longer baked into DEFAULT_PROVIDER_CONFIG at module-import, which would
- * freeze the string). Returns undefined for provider types without a description key
- * (the facade returns "" for a missing key).
- */
-function getDefaultProviderDescription(providerType: APIProviderTypes): string | undefined {
-  const description = i18n.t(`options.apiProviders.providers.description.${providerType}` as never)
-  return description || undefined
-}
 
 export async function addProvider(
   providerType: APIProviderTypes,

--- a/src/utils/config/__tests__/init.test.ts
+++ b/src/utils/config/__tests__/init.test.ts
@@ -95,6 +95,12 @@ describe("initializeConfig", () => {
 
     expect(setItemMock).toHaveBeenCalledTimes(1)
     expect(setItemMock).toHaveBeenCalledWith("local:config", expect.any(Object))
+    const freshConfig = setItemMock.mock.calls[0]?.[1] as Config
+    for (const providerId of ["openai-default", "deepseek-default", "atlascloud-default"]) {
+      expect(freshConfig.providersConfig.find((provider) => provider.id === providerId)).toEqual(
+        expect.objectContaining({ description: expect.any(String) }),
+      )
+    }
     expect(setMetaMock).toHaveBeenCalledTimes(1)
     expect(setMetaMock).toHaveBeenCalledWith(
       "local:config",

--- a/src/utils/config/init.ts
+++ b/src/utils/config/init.ts
@@ -10,6 +10,7 @@ import {
   CONFIG_STORAGE_KEY,
   DEFAULT_CONFIG,
 } from "../constants/config"
+import { buildDefaultProviderConfigList } from "../constants/providers"
 import { logger } from "../logger"
 import { runMigration } from "./migration"
 
@@ -21,6 +22,7 @@ import { runMigration } from "./migration"
 function buildFreshDefaultConfig(): Config {
   return {
     ...DEFAULT_CONFIG,
+    providersConfig: buildDefaultProviderConfigList(),
     selectionToolbar: {
       ...DEFAULT_CONFIG.selectionToolbar,
       customActions: buildDefaultCustomActions(),

--- a/src/utils/constants/providers.ts
+++ b/src/utils/constants/providers.ts
@@ -7,6 +7,7 @@ import type {
   ProviderSponsorConfig,
 } from "@/types/config/provider"
 import type { Theme } from "@/types/config/theme"
+import { camelCase } from "case-anything"
 import customProviderLogo from "@/assets/providers/custom-provider.svg?url&no-inline"
 import deeplxLogoDark from "@/assets/providers/deeplx-dark.svg?url&no-inline"
 import deeplxLogoLight from "@/assets/providers/deeplx-light.svg?url&no-inline"
@@ -21,8 +22,10 @@ import {
   PURE_API_PROVIDER_TYPES,
   PURE_TRANSLATE_PROVIDERS,
   TRANSLATE_PROVIDER_TYPES,
+  isAPIProviderConfig,
 } from "@/types/config/provider"
 import { omit, pick } from "@/types/utils"
+import { i18n } from "@/utils/i18n"
 import { getLobeIconsCDNUrlFn } from "../logo"
 
 export const DEFAULT_LLM_PROVIDER_MODELS: LLMProviderModels = {
@@ -622,6 +625,30 @@ export const DEFAULT_PROVIDER_CONFIG_LIST: ProvidersConfig = [
   DEFAULT_PROVIDER_CONFIG.deepseek,
   DEFAULT_PROVIDER_CONFIG.atlascloud,
 ]
+
+/** Resolve a provider's default description in the active interface language. */
+export function getDefaultProviderDescription(providerType: APIProviderTypes): string | undefined {
+  const descriptionKey = camelCase(providerType)
+  const description = i18n.t(
+    `options.apiProviders.providers.description.${descriptionKey}` as never,
+  )
+  return description || undefined
+}
+
+/**
+ * Build providers for a fresh config after i18n has initialized, so descriptions are
+ * persisted in the same interface language as providers created from the options page.
+ */
+export function buildDefaultProviderConfigList(): ProvidersConfig {
+  return structuredClone(DEFAULT_PROVIDER_CONFIG_LIST).map((providerConfig) => {
+    if (!isAPIProviderConfig(providerConfig)) {
+      return providerConfig
+    }
+
+    const description = getDefaultProviderDescription(providerConfig.provider)
+    return description ? { ...providerConfig, description } : providerConfig
+  })
+}
 
 export const NON_API_TRANSLATE_PROVIDER_ITEMS = pick(PROVIDER_ITEMS, NON_API_TRANSLATE_PROVIDERS)
 


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Populate localized descriptions for API providers seeded into a fresh installation.

Fresh installs previously copied `DEFAULT_PROVIDER_CONFIG_LIST` directly after provider descriptions were removed from module-scope defaults. Providers created later from the options page resolved their descriptions at creation time, leaving the two initialization paths inconsistent.

This change:

- resolves default provider descriptions after i18n initialization
- shares the description resolver between fresh-install defaults and manually added providers
- converts provider identifiers such as `openai-compatible` to camelCase translation keys with `case-anything`
- keeps module-scope provider defaults free of language-frozen strings
- adds regression coverage for fresh config initialization and OpenAI-compatible provider creation

## Related Issue

None.

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Validation performed:

- `SKIP_FREE_API=true pnpm test` — 176 test files passed, 1 intentionally skipped; 1522 tests passed, 4 skipped
- `pnpm lint`
- `pnpm type-check`
- pre-push format, lint, and test hooks

## Screenshots

Not applicable.

## Checklist

- [x] I have tested these changes locally
- [x] Documentation is not required for this bug fix
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

A patch changeset is included for `@read-frog/extension`.
