### PR TITLE
fix(notebase): add an upgrade action to note-limit toasts

### DIFF
--- a/.changeset/bright-frogs-upgrade.md
+++ b/.changeset/bright-frogs-upgrade.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(notebase): add an upgrade action to note-limit toasts

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/save-to-notebase-button.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/__tests__/save-to-notebase-button.test.tsx
@@ -7,6 +7,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { createStore, Provider } from "jotai"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { env } from "@/env"
 import { configAtom } from "@/utils/atoms/config"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { i18n } from "@/utils/i18n"
@@ -324,6 +325,42 @@ describe("saveToNotebaseButton notebase availability", () => {
     })
   })
 
+  it("shows an upgrade action when creating a Notebase exceeds the note limit", async () => {
+    const config = cloneConfig(DEFAULT_CONFIG)
+    config.betaExperience.enabled = true
+    vi.mocked(orpcClient.notebase.create).mockRejectedValueOnce(
+      new ORPCError("NOTE_LIMIT_EXCEEDED", { status: 403 }),
+    )
+    renderButton(config, createAction())
+
+    fireEvent.click(screen.getByRole("button", { name: i18n.t("action.saveToNotebase") }))
+    fireEvent.click(
+      screen.getByRole("button", { name: i18n.t("action.saveToNotebaseCreateAndSaveShort") }),
+    )
+
+    await waitFor(() => {
+      expect(toastMock.error).toHaveBeenCalledWith(
+        i18n.t("action.saveToNotebaseLimitExceeded"),
+        expect.objectContaining({
+          action: expect.objectContaining({
+            label: i18n.t("action.upgrade"),
+            onClick: expect.any(Function),
+          }),
+        }),
+      )
+    })
+
+    const toastOptions = toastMock.error.mock.calls[0]?.[1] as
+      | { action?: { onClick?: () => void } }
+      | undefined
+    toastOptions?.action?.onClick?.()
+
+    expect(sendMessage).toHaveBeenCalledWith("openPage", {
+      url: new URL("/pricing", env.WXT_WEBSITE_URL).toString(),
+      active: true,
+    })
+  })
+
   it("marks guide Dictionary Notebase complete after direct create-and-save with guide tracking", async () => {
     const config = cloneConfig(DEFAULT_CONFIG)
     config.betaExperience.enabled = true
@@ -583,7 +620,7 @@ describe("saveToNotebaseButton notebase availability", () => {
     })
   })
 
-  it("shows a note limit toast when the backend rejects the save for quota", async () => {
+  it("shows an upgrade action when the backend rejects the save for quota", async () => {
     const config = cloneConfig(DEFAULT_CONFIG)
     config.betaExperience.enabled = false
     notebaseRowCreateMock.mockRejectedValueOnce(
@@ -594,7 +631,25 @@ describe("saveToNotebaseButton notebase availability", () => {
     fireEvent.click(screen.getByRole("button", { name: i18n.t("action.saveToNotebase") }))
 
     await waitFor(() => {
-      expect(toastMock.error).toHaveBeenCalledWith(i18n.t("action.saveToNotebaseLimitExceeded"))
+      expect(toastMock.error).toHaveBeenCalledWith(
+        i18n.t("action.saveToNotebaseLimitExceeded"),
+        expect.objectContaining({
+          action: expect.objectContaining({
+            label: i18n.t("action.upgrade"),
+            onClick: expect.any(Function),
+          }),
+        }),
+      )
+    })
+
+    const toastOptions = toastMock.error.mock.calls[0]?.[1] as
+      | { action?: { onClick?: () => void } }
+      | undefined
+    toastOptions?.action?.onClick?.()
+
+    expect(sendMessage).toHaveBeenCalledWith("openPage", {
+      url: new URL("/pricing", env.WXT_WEBSITE_URL).toString(),
+      active: true,
     })
   })
 

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/notebase-limit-toast.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/notebase-limit-toast.ts
@@ -1,0 +1,18 @@
+import { toast } from "sonner"
+import { env } from "@/env"
+import { i18n } from "@/utils/i18n"
+import { sendMessage } from "@/utils/message"
+
+export function showNotebaseLimitExceededToast() {
+  toast.error(i18n.t("action.saveToNotebaseLimitExceeded"), {
+    action: {
+      label: i18n.t("action.upgrade"),
+      onClick: () => {
+        void sendMessage("openPage", {
+          url: new URL("/pricing", env.WXT_WEBSITE_URL).toString(),
+          active: true,
+        })
+      },
+    },
+  })
+}

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/save-to-notebase-button.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/save-to-notebase-button.tsx
@@ -37,6 +37,7 @@ import {
   getNotebaseDetailUrl,
 } from "@/utils/notebase/pending-save"
 import { orpc, orpcClient } from "@/utils/orpc/client"
+import { showNotebaseLimitExceededToast } from "./notebase-limit-toast"
 import { saveToNotebaseDialogAtom } from "./save-to-notebase-dialog-atom"
 
 export function SaveToNotebaseButton({
@@ -123,7 +124,7 @@ export function SaveToNotebaseButton({
         }
 
         if (isORPCNoteLimitExceededError(error)) {
-          toast.error(i18n.t("action.saveToNotebaseLimitExceeded"))
+          showNotebaseLimitExceededToast()
           return
         }
 

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/save-to-notebase-dialog-host.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/save-to-notebase-dialog-host.tsx
@@ -39,6 +39,7 @@ import {
   setPendingNotebaseSave,
 } from "@/utils/notebase/pending-save"
 import { orpcClient } from "@/utils/orpc/client"
+import { showNotebaseLimitExceededToast } from "./notebase-limit-toast"
 import { saveToNotebaseDialogAtom } from "./save-to-notebase-dialog-atom"
 
 function getAccountFallback(account: SelectionToolbarCustomActionNotebaseAccount | undefined) {
@@ -156,7 +157,7 @@ export function SaveToNotebaseDialogHost() {
       }
 
       if (isORPCNoteLimitExceededError(error)) {
-        toast.error(i18n.t("action.saveToNotebaseLimitExceeded"))
+        showNotebaseLimitExceededToast()
         return
       }
 

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1101,6 +1101,7 @@ action:
   saveToNotebasePendingLogin: Log in to finish saving
   saveToNotebasePendingLoginDescription: After login, Read Frog will create the Notebase and save this result automatically.
   saveToNotebasePendingConnectedLoginDescription: After login, Read Frog will save to the connected Notebase when possible. If this account cannot use it, Read Frog will create a new Notebase and save this result.
+  upgrade: Upgrade
   openCustomActions: Open Custom AI Actions
   openNotebase: Open Notebase
   contextDetailsTitleLabel: Title

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -1101,6 +1101,7 @@ action:
   saveToNotebasePendingLogin: Inicia sesión para terminar de guardar
   saveToNotebasePendingLoginDescription: Después de iniciar sesión, Read Frog creará la Notebase y guardará este resultado automáticamente.
   saveToNotebasePendingConnectedLoginDescription: Después de iniciar sesión, Read Frog guardará en la Notebase conectada si es posible. Si esta cuenta no puede usarla, creará una nueva Notebase y guardará este resultado.
+  upgrade: Mejorar plan
   openCustomActions: Abrir Custom AI Actions
   openNotebase: Abrir Notebase
   contextDetailsTitleLabel: Título

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -986,6 +986,7 @@ action:
   saveToNotebasePendingLogin: ログイン後に保存を完了
   saveToNotebasePendingLoginDescription: ログイン後、Read Frog が Notebase を作成し、この結果を自動で保存します。
   saveToNotebasePendingConnectedLoginDescription: ログイン後、Read Frog は可能であれば接続済み Notebase に保存します。このアカウントで利用できない場合は、新しい Notebase を作成して保存します。
+  upgrade: アップグレード
   openCustomActions: Custom AI Actions を開く
   openNotebase: Notebase を開く
   contextDetailsTitleLabel: タイトル

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -986,6 +986,7 @@ action:
   saveToNotebasePendingLogin: 로그인 후 저장 완료
   saveToNotebasePendingLoginDescription: 로그인 후 Read Frog가 Notebase를 만들고 이 결과를 자동으로 저장합니다.
   saveToNotebasePendingConnectedLoginDescription: 로그인 후 Read Frog는 가능하면 연결된 Notebase에 저장합니다. 이 계정에서 사용할 수 없으면 새 Notebase를 만들고 저장합니다.
+  upgrade: 업그레이드
   openCustomActions: Custom AI Actions 열기
   openNotebase: Notebase 열기
   contextDetailsTitleLabel: 제목

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -986,6 +986,7 @@ action:
   saveToNotebasePendingLogin: Войдите, чтобы завершить сохранение
   saveToNotebasePendingLoginDescription: После входа Read Frog автоматически создаст Notebase и сохранит этот результат.
   saveToNotebasePendingConnectedLoginDescription: После входа Read Frog сохранит в подключённую Notebase, если это возможно. Если аккаунт не может её использовать, будет создана новая Notebase.
+  upgrade: Повысить тариф
   openCustomActions: Открыть Custom AI Actions
   openNotebase: Открыть Notebase
   contextDetailsTitleLabel: Заголовок

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -986,6 +986,7 @@ action:
   saveToNotebasePendingLogin: Kaydetmeyi tamamlamak için giriş yapın
   saveToNotebasePendingLoginDescription: Giriş yaptıktan sonra Read Frog Notebase'i oluşturur ve bu sonucu otomatik olarak kaydeder.
   saveToNotebasePendingConnectedLoginDescription: Girişten sonra Read Frog mümkünse bağlı Notebase'e kaydeder. Bu hesap onu kullanamazsa yeni bir Notebase oluşturup kaydeder.
+  upgrade: Yükselt
   openCustomActions: Custom AI Actions'ı aç
   openNotebase: Notebase'i aç
   contextDetailsTitleLabel: Başlık

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -986,6 +986,7 @@ action:
   saveToNotebasePendingLogin: Đăng nhập để hoàn tất lưu
   saveToNotebasePendingLoginDescription: Sau khi đăng nhập, Read Frog sẽ tự động tạo Notebase và lưu kết quả này.
   saveToNotebasePendingConnectedLoginDescription: Sau khi đăng nhập, Read Frog sẽ lưu vào Notebase đã kết nối nếu có thể. Nếu tài khoản này không dùng được, Read Frog sẽ tạo Notebase mới và lưu kết quả này.
+  upgrade: Nâng cấp
   openCustomActions: Mở Custom AI Actions
   openNotebase: Mở Notebase
   contextDetailsTitleLabel: Tiêu đề

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -1101,6 +1101,7 @@ action:
   saveToNotebasePendingLogin: 登录后继续保存
   saveToNotebasePendingLoginDescription: 登录完成后，Read Frog 会自动创建笔记库并保存当前结果。
   saveToNotebasePendingConnectedLoginDescription: 登录完成后，Read Frog 会优先保存到已连接的笔记库；如果当前账号无法使用它，会创建新的笔记库并保存当前结果。
+  upgrade: 升级
   openCustomActions: 打开 Custom AI Actions
   openNotebase: 打开笔记库
   contextDetailsTitleLabel: 标题

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -1101,6 +1101,7 @@ action:
   saveToNotebasePendingLogin: 登入後繼續儲存
   saveToNotebasePendingLoginDescription: 登入完成後，陪讀蛙會自動建立筆記庫並儲存目前結果。
   saveToNotebasePendingConnectedLoginDescription: 登入完成後，陪讀蛙會優先儲存到已連線的筆記庫；如果目前帳號無法使用它，會建立新的筆記庫並儲存目前結果。
+  upgrade: 升級
   openCustomActions: 開啟自訂 AI 指令
   openNotebase: 開啟筆記庫
   contextDetailsTitleLabel: 標題


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [ ] ✨ New feature (feat)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Add a localized **Upgrade** action to foreground Notebase note-limit error toasts.

- Reuse one shared toast helper for direct row saves and create-and-save failures.
- Open `${WXT_WEBSITE_URL}/pricing` in an active tab through the existing background `openPage` message.
- Add the action label to all nine supported locales.
- Include a patch changeset for `@read-frog/extension`.

The background pending-save flow remains unchanged because it has no foreground toast surface.

## Related Issue

None.

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Validated both quota paths, including invoking the toast action and asserting the pricing URL and active-tab behavior.

- `pnpm fmt:check`
- `pnpm type-check`
- `pnpm lint`
- `SKIP_FREE_API=true pnpm test`
- Push hook: 177 test files passed, 1526 tests passed

## Screenshots

Not applicable.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

No public API, message protocol, or stored-data changes.