### PR TITLE
fix(options): stack site rule descriptions above their controls

### DIFF
--- a/.changeset/quiet-frogs-stack.md
+++ b/.changeset/quiet-frogs-stack.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(options): stack site rule descriptions above their controls

--- a/src/entrypoints/options/pages/site-rules/built-in-rules.tsx
+++ b/src/entrypoints/options/pages/site-rules/built-in-rules.tsx
@@ -34,6 +34,7 @@ export function BuiltInRules() {
       id="site-rules-built-in"
       title={i18n.t("options.siteRules.builtIn.title")}
       description={i18n.t("options.siteRules.builtIn.description")}
+      className="lg:flex-col lg:[&>div]:basis-auto"
     >
       <div className="flex flex-col gap-3">
         <Input

--- a/src/entrypoints/options/pages/site-rules/user-rules-editor.tsx
+++ b/src/entrypoints/options/pages/site-rules/user-rules-editor.tsx
@@ -79,6 +79,7 @@ export function UserRulesEditor() {
       id="site-rules-user-rules"
       title={i18n.t("options.siteRules.userRules.title")}
       description={i18n.t("options.siteRules.userRules.description")}
+      className="lg:flex-col lg:[&>div]:basis-auto"
     >
       <div className="flex flex-col gap-3">
         <JSONCodeEditor


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [x] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

- Stack the User Rules heading and description above the JSON editor.
- Stack the Built-in Rules heading and description above the search and rule list.
- Remove the inherited large-screen basis constraints so both controls use the full available width.
- Add a patch changeset for the extension.

## Related Issue

N/A

## How Has This Been Tested?

- [ ] Added unit tests
- [ ] Verified through manual testing
- Existing Site Rules tests: 6 passed.
- Type-aware lint and type checking passed.
- Chrome MV3 production build passed with local placeholder environment values.
- Pre-push formatting, lint, and full test hooks passed.

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The layout continues to use the existing ConfigCard className override API; the shared component behavior is unchanged.
