### PR TITLE
fix(translate): preserve rendered paragraph pairing and logical ancestor layout

### DIFF
--- a/.changeset/logical-ancestor-layout.md
+++ b/.changeset/logical-ancestor-layout.md
@@ -2,4 +2,4 @@
 "@read-frog/extension": patch
 ---
 
-fix(translate): preserve logical ancestor layout when unwrapping only-child content
+fix(translate): preserve rendered paragraph pairing and logical ancestor layout

--- a/.changeset/logical-ancestor-layout.md
+++ b/.changeset/logical-ancestor-layout.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): preserve logical ancestor layout when unwrapping only-child content

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -2,11 +2,17 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import {
+  registerBilingualTranslationState,
+  unregisterBilingualTranslationState,
+  type BilingualTranslationState,
+} from "@/utils/host/translate/core/translation-state"
 import { PageTranslationManager } from "../page-translation"
 
 const {
   mockDeepQueryTopLevelSelector,
   mockGetDetectedCodeFromStorage,
+  mockGetRandomUUID,
   mockGetLocalConfig,
   mockGetOrCreateWebPageContext,
   mockHasNoWalkAncestor,
@@ -15,11 +21,13 @@ const {
   mockRemoveAllTranslatedWrapperNodes,
   mockSendMessage,
   mockTranslateTextForPageTitle,
+  mockTranslateNodesBilingualMode,
   mockTranslateWalkedElement,
   mockValidateTranslationConfigAndToast,
   mockWalkAndLabelElement,
 } = vi.hoisted(() => ({
   mockGetDetectedCodeFromStorage: vi.fn<(...args: any[]) => any>(),
+  mockGetRandomUUID: vi.fn<(...args: any[]) => any>(),
   mockGetLocalConfig: vi.fn<(...args: any[]) => any>(),
   mockGetOrCreateWebPageContext: vi.fn<(...args: any[]) => any>(),
   mockDeepQueryTopLevelSelector: vi.fn<(...args: any[]) => any>(),
@@ -30,6 +38,7 @@ const {
   mockRemoveAllTranslatedWrapperNodes: vi.fn<(...args: any[]) => any>(),
   mockTranslateWalkedElement: vi.fn<(...args: any[]) => any>(),
   mockTranslateTextForPageTitle: vi.fn<(...args: any[]) => any>(),
+  mockTranslateNodesBilingualMode: vi.fn<(...args: any[]) => any>(),
   mockValidateTranslationConfigAndToast: vi.fn<(...args: any[]) => any>(),
   mockSendMessage: vi.fn<(...args: any[]) => any>(),
 }))
@@ -43,7 +52,7 @@ vi.mock("@/utils/config/storage", () => ({
 }))
 
 vi.mock("@/utils/crypto-polyfill", () => ({
-  getRandomUUID: () => "walk-id",
+  getRandomUUID: mockGetRandomUUID,
 }))
 
 vi.mock("@/utils/host/dom/filter", () => ({
@@ -63,6 +72,7 @@ vi.mock("@/utils/host/dom/traversal", () => ({
 
 vi.mock("@/utils/host/translate/node-manipulation", () => ({
   removeAllTranslatedWrapperNodes: mockRemoveAllTranslatedWrapperNodes,
+  translateNodesBilingualMode: mockTranslateNodesBilingualMode,
   translateWalkedElement: mockTranslateWalkedElement,
 }))
 
@@ -206,6 +216,7 @@ describe("pageTranslationManager mutation re-walk", () => {
     vi.stubGlobal("IntersectionObserver", MockIntersectionObserver)
 
     mockGetDetectedCodeFromStorage.mockResolvedValue("eng")
+    mockGetRandomUUID.mockReset().mockReturnValue("walk-id")
     mockGetLocalConfig.mockResolvedValue(DEFAULT_CONFIG)
     mockGetOrCreateWebPageContext.mockResolvedValue({
       url: window.location.href,
@@ -222,6 +233,7 @@ describe("pageTranslationManager mutation re-walk", () => {
       walkAndLabelVisibleParagraphs(element, walkId),
     )
     mockTranslateTextForPageTitle.mockResolvedValue("")
+    mockTranslateNodesBilingualMode.mockReset().mockResolvedValue(undefined)
     mockValidateTranslationConfigAndToast.mockReturnValue(true)
     mockSendMessage.mockResolvedValue(undefined)
   })
@@ -313,6 +325,200 @@ describe("pageTranslationManager mutation re-walk", () => {
 
     expect(mockTranslateWalkedElement).toHaveBeenCalledWith(panel, "walk-id", DEFAULT_CONFIG)
 
+    manager.stop()
+  })
+
+  it("retranslates an existing logical source after its text expands in place", async () => {
+    document.body.innerHTML = `
+      <p id="tweet"><span id="source">Truncated tweet</span></p>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const tweet = document.getElementById("tweet") as HTMLElement
+    const source = document.getElementById("source")!.firstChild as Text
+    const wrapper = document.createElement("span")
+    wrapper.className = "read-frog-translated-content-wrapper"
+    wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+    tweet.append(wrapper)
+    const state: BilingualTranslationState = {
+      layoutSource: tweet,
+      sourceTextContent: "Truncated tweet",
+      status: "active",
+      walkId: "walk-id",
+      wrapper,
+    }
+    registerBilingualTranslationState(state)
+    mockTranslateNodesBilingualMode.mockImplementation(async () => {
+      unregisterBilingualTranslationState(state)
+    })
+    await flushDomUpdates()
+    mockTranslateNodesBilingualMode.mockClear()
+
+    source.data = "Expanded tweet content"
+    await flushDomUpdates()
+
+    expect(mockWalkAndLabelElement).toHaveBeenCalledWith(tweet, "walk-id", DEFAULT_CONFIG)
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledWith([tweet], "walk-id", DEFAULT_CONFIG)
+
+    unregisterBilingualTranslationState(state)
+    manager.stop()
+  })
+
+  it("runs another refresh when the source changes during a pending retranslation", async () => {
+    document.body.innerHTML = `
+      <p id="tweet"><span id="source">Initial tweet</span></p>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const tweet = document.getElementById("tweet") as HTMLElement
+    const source = document.getElementById("source")!.firstChild as Text
+    const createState = (): BilingualTranslationState => {
+      const wrapper = document.createElement("span")
+      wrapper.className = "read-frog-translated-content-wrapper"
+      wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+      const state: BilingualTranslationState = {
+        layoutSource: tweet,
+        sourceTextContent: source.data,
+        status: "active",
+        walkId: "walk-id",
+        wrapper,
+      }
+      tweet.append(wrapper)
+      registerBilingualTranslationState(state)
+      return state
+    }
+
+    let activeState = createState()
+    let resolveFirstRefresh!: () => void
+    const firstRefresh = new Promise<void>((resolve) => {
+      resolveFirstRefresh = resolve
+    })
+    mockTranslateNodesBilingualMode.mockImplementation(async () => {
+      unregisterBilingualTranslationState(activeState)
+      activeState.wrapper?.remove()
+      if (mockTranslateNodesBilingualMode.mock.calls.length === 1) {
+        activeState = createState()
+        await firstRefresh
+      }
+    })
+    await flushDomUpdates()
+    mockTranslateNodesBilingualMode.mockClear()
+
+    source.data = "Expanded once"
+    await flushDomUpdates()
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(1)
+
+    source.data = "Expanded twice"
+    await flushDomUpdates()
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(1)
+
+    resolveFirstRefresh()
+    await flushDomUpdates()
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(2)
+
+    unregisterBilingualTranslationState(activeState)
+    manager.stop()
+  })
+
+  it("does not let a deferred refresh from an old session touch the restarted session", async () => {
+    mockGetRandomUUID.mockReturnValueOnce("old-walk").mockReturnValueOnce("new-walk")
+    document.body.innerHTML = `
+      <p id="tweet"><span id="source">Initial tweet</span></p>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const tweet = document.getElementById("tweet") as HTMLElement
+    const source = document.getElementById("source")!.firstChild as Text
+    const createState = (walkId: string): BilingualTranslationState => {
+      const wrapper = document.createElement("span")
+      wrapper.className = "read-frog-translated-content-wrapper"
+      wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+      const state: BilingualTranslationState = {
+        layoutSource: tweet,
+        sourceTextContent: source.data,
+        status: "active",
+        walkId,
+        wrapper,
+      }
+      tweet.append(wrapper)
+      registerBilingualTranslationState(state)
+      return state
+    }
+
+    let resolveOldRefresh!: () => void
+    let resolveNewRefresh!: () => void
+    const oldRefresh = new Promise<void>((resolve) => {
+      resolveOldRefresh = resolve
+    })
+    const newRefresh = new Promise<void>((resolve) => {
+      resolveNewRefresh = resolve
+    })
+    let activeOldState: BilingualTranslationState | undefined
+    let activeNewState: BilingualTranslationState | undefined
+    let newWalkCalls = 0
+    mockTranslateNodesBilingualMode.mockImplementation(async (_nodes, walkId) => {
+      if (walkId === "old-walk") {
+        if (activeOldState) {
+          unregisterBilingualTranslationState(activeOldState)
+          activeOldState.wrapper?.remove()
+          activeOldState = undefined
+        }
+        await oldRefresh
+      } else if (walkId === "new-walk") {
+        if (activeNewState) {
+          unregisterBilingualTranslationState(activeNewState)
+          activeNewState.wrapper?.remove()
+        }
+        activeNewState = createState("new-walk")
+        newWalkCalls += 1
+        if (newWalkCalls === 1) await newRefresh
+      }
+    })
+
+    activeOldState = createState("old-walk")
+    await flushDomUpdates()
+    mockTranslateNodesBilingualMode.mockClear()
+    source.data = "Old session mutation"
+    await flushDomUpdates()
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(1)
+
+    manager.stop()
+    await manager.start()
+    await flushDomUpdates()
+
+    activeNewState = createState("new-walk")
+    source.data = "New session mutation one"
+    await flushDomUpdates()
+    source.data = "New session mutation two"
+    await flushDomUpdates()
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(2)
+
+    resolveOldRefresh()
+    await flushDomUpdates()
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(2)
+
+    resolveNewRefresh()
+    await flushDomUpdates()
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(3)
+    expect(mockTranslateNodesBilingualMode.mock.calls.map((call) => call[1])).toEqual([
+      "old-walk",
+      "new-walk",
+      "new-walk",
+    ])
+
+    if (activeNewState) {
+      unregisterBilingualTranslationState(activeNewState)
+      activeNewState.wrapper?.remove()
+    }
     manager.stop()
   })
 })

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -15,8 +15,10 @@ import {
 } from "@/utils/host/dom/filter"
 import { deepQueryTopLevelSelector } from "@/utils/host/dom/find"
 import { walkAndLabelElement } from "@/utils/host/dom/traversal"
+import { findStaleBilingualLayoutSource } from "@/utils/host/translate/core/translation-state"
 import {
   removeAllTranslatedWrapperNodes,
+  translateNodesBilingualMode,
   translateWalkedElement,
 } from "@/utils/host/translate/node-manipulation"
 import { validateTranslationConfigAndToast } from "@/utils/host/translate/translate-text"
@@ -76,6 +78,9 @@ export class PageTranslationManager implements IPageTranslationManager {
   private walkId: string | null = null
   private intersectionOptions: IntersectionObserverInit
   private walkBlockedElementsCache = new WeakSet<HTMLElement>()
+  private refreshingTranslatedSources = new WeakSet<HTMLElement>()
+  private translatedSourceMutationVersions = new WeakMap<HTMLElement, number>()
+  private translationSessionVersion = 0
   private titleObserver: MutationObserver | null = null
   private lastSourceTitle: string | null = null
   private lastAppliedTranslatedTitle: string | null = null
@@ -143,6 +148,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       })
 
       this.isPageTranslating = true
+      this.translationSessionVersion += 1
 
       const siteRule = getEffectiveSiteRule(config, window.location.href)
       if (siteRule.injectedCss) {
@@ -227,8 +233,11 @@ export class PageTranslationManager implements IPageTranslationManager {
     }
 
     this.isPageTranslating = false
+    this.translationSessionVersion += 1
     this.walkId = null
     this.walkBlockedElementsCache = new WeakSet()
+    this.refreshingTranslatedSources = new WeakSet()
+    this.translatedSourceMutationVersions = new WeakMap()
     this.stopDocumentTitleTracking()
 
     if (this.intersectionObserver) {
@@ -546,6 +555,7 @@ export class PageTranslationManager implements IPageTranslationManager {
     mutationObserver.observe(container, {
       childList: true,
       subtree: true,
+      characterData: true,
       attributes: true,
       attributeFilter: ["style", "class", "hidden", "aria-hidden"],
     })
@@ -555,11 +565,26 @@ export class PageTranslationManager implements IPageTranslationManager {
   }
 
   private async handleMutationRecords(records: MutationRecord[]): Promise<void> {
+    const sessionVersion = this.translationSessionVersion
+    const staleTranslatedSources = new Set<HTMLElement>()
+    for (const record of records) {
+      const staleSource = findStaleBilingualLayoutSource(record.target)
+      if (staleSource) staleTranslatedSources.add(staleSource)
+    }
+    staleTranslatedSources.forEach((source) => {
+      const nextVersion = (this.translatedSourceMutationVersions.get(source) ?? 0) + 1
+      this.translatedSourceMutationVersions.set(source, nextVersion)
+    })
+
+    const needsTraversalHandling = records.some((record) => record.type !== "characterData")
+    if (staleTranslatedSources.size === 0 && !needsTraversalHandling) return
+
     const config = await getLocalConfig()
     if (!config) {
       logger.error("Global config is not initialized")
       return
     }
+    if (!this.isPageTranslating || this.translationSessionVersion !== sessionVersion) return
 
     for (const rec of records) {
       if (rec.type === "childList") {
@@ -575,6 +600,52 @@ export class PageTranslationManager implements IPageTranslationManager {
         if (isHTMLElement(el) && this.didChangeToWalkable(el, config)) {
           void this.observeTopLevelParagraphs(el, config)
         }
+      }
+    }
+
+    await Promise.all(
+      [...staleTranslatedSources].map((source) =>
+        this.retranslateChangedSource(source, config, sessionVersion),
+      ),
+    )
+  }
+
+  private async retranslateChangedSource(
+    source: HTMLElement,
+    config: Config,
+    sessionVersion: number,
+  ): Promise<void> {
+    const walkId = this.walkId
+    const refreshingSources = this.refreshingTranslatedSources
+    const mutationVersions = this.translatedSourceMutationVersions
+    if (
+      !this.isPageTranslating ||
+      this.translationSessionVersion !== sessionVersion ||
+      !walkId ||
+      !source.isConnected ||
+      refreshingSources.has(source)
+    ) {
+      return
+    }
+
+    refreshingSources.add(source)
+    let handledVersion = 0
+    try {
+      do {
+        handledVersion = mutationVersions.get(source) ?? 0
+        walkAndLabelElement(source, walkId, config)
+        await translateNodesBilingualMode([source], walkId, config)
+      } while (
+        this.isPageTranslating &&
+        this.translationSessionVersion === sessionVersion &&
+        this.walkId === walkId &&
+        source.isConnected &&
+        (mutationVersions.get(source) ?? 0) !== handledVersion
+      )
+    } finally {
+      refreshingSources.delete(source)
+      if (mutationVersions.get(source) === handledVersion) {
+        mutationVersions.delete(source)
       }
     }
   }

--- a/src/utils/constants/dom-labels.ts
+++ b/src/utils/constants/dom-labels.ts
@@ -10,6 +10,7 @@ export const BLOCK_ATTRIBUTE = "data-read-frog-block-node"
 export const INLINE_ATTRIBUTE = "data-read-frog-inline-node"
 
 export const TRANSLATION_MODE_ATTRIBUTE = "data-read-frog-translation-mode"
+export const VIRTUAL_PARAGRAPH_ATTRIBUTE = "data-read-frog-virtual-paragraph"
 
 export const MARK_ATTRIBUTES = new Set([
   WALKED_ATTRIBUTE,

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -30,10 +30,6 @@ vi.mock("@/utils/host/translate/translate-variants", () => ({
   translateTextForPage: vi.fn<(...args: any[]) => any>(() => Promise.resolve(MOCK_TRANSLATION)),
 }))
 
-vi.mock("@/utils/config/storage", () => ({
-  getLocalConfig: vi.fn<(...args: any[]) => any>(),
-}))
-
 const BILINGUAL_CONFIG: Config = {
   ...DEFAULT_CONFIG,
   translate: {
@@ -56,6 +52,20 @@ function setHost(host: string) {
     writable: true,
     configurable: true,
   })
+}
+
+async function withHost(host: string, callback: () => Promise<void>) {
+  const originalLocation = window.location
+  setHost(host)
+  try {
+    await callback()
+  } finally {
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    })
+  }
 }
 
 function createRect({
@@ -97,11 +107,7 @@ describe("translate", () => {
   // Setup and teardown for getComputedStyle mock
   const originalGetComputedStyle = window.getComputedStyle
 
-  beforeAll(async () => {
-    // Mock getLocalConfig to return DEFAULT_CONFIG
-    const { getLocalConfig } = await import("@/utils/config/storage")
-    vi.mocked(getLocalConfig).mockResolvedValue(DEFAULT_CONFIG)
-
+  beforeAll(() => {
     window.getComputedStyle = vi.fn<(...args: any[]) => any>((element) => {
       const originalStyle = originalGetComputedStyle(element)
 
@@ -192,7 +198,7 @@ describe("translate", () => {
       })
     })
     describe("inline HTML node", () => {
-      it("bilingual mode: should insert translation wrapper after inline node content", async () => {
+      it("bilingual mode: should keep block layout when inserting inside an inline child", async () => {
         render(
           <div data-testid="test-node">
             <div style={{ display: "inline" }}>{MOCK_ORIGINAL_TEXT}</div>
@@ -205,7 +211,7 @@ describe("translate", () => {
         expectNodeLabels(node.children[0], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
         const wrapper = expectTranslationWrapper(node, "bilingual")
         expect(wrapper).toBe(node.childNodes[0].childNodes[1])
-        expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+        expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
 
         await removeOrShowPageTranslation("bilingual", true)
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
@@ -270,7 +276,7 @@ describe("translate", () => {
       })
     })
     describe("block node -> block node -> inline node", () => {
-      it("bilingual mode: should insert translation wrapper after deepest inline node", async () => {
+      it("bilingual mode: should keep block layout when inserting after the deepest inline node", async () => {
         render(
           <div data-testid="test-node">
             <div>
@@ -286,7 +292,7 @@ describe("translate", () => {
         expectNodeLabels(node.children[0].children[0], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
         const wrapper = expectTranslationWrapper(node, "bilingual")
         expect(wrapper).toBe(node.childNodes[0].childNodes[0].childNodes[1])
-        expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+        expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
 
         await removeOrShowPageTranslation("bilingual", true)
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
@@ -360,7 +366,7 @@ describe("translate", () => {
       })
     })
     describe("block node -> shallow inline node -> inline node", () => {
-      it("bilingual mode: should insert translation wrapper after nested inline node content", async () => {
+      it("bilingual mode: should keep the outer block layout after unwrapping nested inline nodes", async () => {
         render(
           <div data-testid="test-node">
             <div style={{ display: "inline" }}>
@@ -376,7 +382,7 @@ describe("translate", () => {
         expectNodeLabels(node.children[0].children[0], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
         const wrapper = expectTranslationWrapper(node, "bilingual")
         expect(wrapper).toBe(node.childNodes[0].childNodes[0].childNodes[1])
-        expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+        expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
 
         await removeOrShowPageTranslation("bilingual", true)
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
@@ -405,7 +411,7 @@ describe("translate", () => {
       })
     })
     describe("block node -> shallow inline node (inline node) -> inline node + inline node", () => {
-      it("bilingual mode: should insert translation wrapper after parent inline node", async () => {
+      it("bilingual mode: should keep the outer block layout when insertion stops at the inline parent", async () => {
         render(
           <div data-testid="test-node">
             <div style={{ display: "inline" }}>
@@ -422,7 +428,7 @@ describe("translate", () => {
         expectNodeLabels(node.children[0].children[0], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
         const wrapper = expectTranslationWrapper(node, "bilingual")
         expect(wrapper).toBe(node.childNodes[0].childNodes[2])
-        expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+        expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
 
         await removeOrShowPageTranslation("bilingual", true)
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
@@ -452,7 +458,7 @@ describe("translate", () => {
       })
     })
     describe("block node -> shallow inline node (inline node) -> single inline node + block node", () => {
-      it("bilingual mode: should translate the unwrapped inline parent as a single inline wrapper", async () => {
+      it("bilingual mode: should translate the unwrapped inline parent with the outer block layout", async () => {
         // https://github.com/mengxi-ream/read-frog/pull/1055
         render(
           <div data-testid="test-node">
@@ -471,7 +477,7 @@ describe("translate", () => {
         expectNodeLabels(node.children[0].children[1], [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
         const wrapper = expectTranslationWrapper(node.children[0], "bilingual")
         expect(wrapper).toBe(node.children[0].lastChild)
-        expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+        expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
         expect(node.children[0].querySelectorAll(`.${CONTENT_WRAPPER_CLASS}`)).toHaveLength(1)
 
         await removeOrShowPageTranslation("bilingual", true)
@@ -502,7 +508,7 @@ describe("translate", () => {
       })
     })
     describe("block node -> shallow inline node (inline node) -> inline nodes + block node", () => {
-      it("bilingual mode: should translate the unwrapped inline parent as one inline wrapper", async () => {
+      it("bilingual mode: should translate the unwrapped inline parent as one block wrapper", async () => {
         render(
           <div data-testid="test-node">
             <div style={{ display: "inline" }}>
@@ -522,7 +528,7 @@ describe("translate", () => {
         expectNodeLabels(node.children[0].children[2], [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
         const wrapper = expectTranslationWrapper(node.children[0], "bilingual")
         expect(wrapper).toBe(node.children[0].lastChild)
-        expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+        expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
         expect(node.children[0].querySelectorAll(`.${CONTENT_WRAPPER_CLASS}`)).toHaveLength(1)
 
         await removeOrShowPageTranslation("bilingual", true)
@@ -550,6 +556,172 @@ describe("translate", () => {
         await removeOrShowPageTranslation("translationOnly", true)
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
       })
+    })
+  })
+
+  describe("real-world only-child layout regressions", () => {
+    describe("X tweet text", () => {
+      it("keeps a simple single-span tweet as one block translation", async () => {
+        await withHost("x.com", async () => {
+          const sourceText = "Music changes the way we think."
+          vi.mocked(translateTextForPage).mockClear()
+          render(
+            <div data-testid="tweetText">
+              <span>{sourceText}</span>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const deepestSpan = tweet.querySelector("span")!
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(translateTextForPage).toHaveBeenCalledTimes(1)
+          expect(translateTextForPage).toHaveBeenCalledWith(sourceText)
+          const wrapper = expectTranslationWrapper(deepestSpan, "bilingual")
+          expect(wrapper).toBe(deepestSpan.lastChild)
+          expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
+          expect(tweet.querySelectorAll(`.${CONTENT_WRAPPER_CLASS}`)).toHaveLength(1)
+        })
+      })
+
+      it("keeps mention and hashtag spacing in one block while preserving both anchors", async () => {
+        await withHost("x.com", async () => {
+          const sourceText =
+            "We're excited to welcome @SohunSanka as our new head of GTM.\nFollow #History."
+          vi.mocked(translateTextForPage).mockClear()
+          render(
+            <div data-testid="tweetText">
+              <span>{"We're excited to welcome "}</span>
+              <div className="r-xoduu5" style={{ display: "inline-flex" }}>
+                <span style={{ display: "block" }}>
+                  <a href="https://x.com/SohunSanka">@SohunSanka</a>
+                </span>
+              </div>
+              <span>{" as our new head of GTM.\nFollow "}</span>
+              <span>
+                <a href="https://x.com/hashtag/History">#History</a>
+              </span>
+              <span>.</span>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const [mention, hashtag] = tweet.querySelectorAll("a")
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(translateTextForPage).toHaveBeenCalledTimes(1)
+          expect(translateTextForPage).toHaveBeenCalledWith(sourceText)
+          expect(mention).toHaveTextContent("@SohunSanka")
+          expect(mention.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+          expect(hashtag).toHaveTextContent("#History")
+          expect(hashtag.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+          const wrapper = expectTranslationWrapper(tweet, "bilingual")
+          expect(wrapper).toBe(tweet.lastChild)
+          expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
+          expect(tweet.querySelectorAll(`.${CONTENT_WRAPPER_CLASS}`)).toHaveLength(1)
+        })
+      })
+    })
+
+    it("translates each Engoo paragraph once with block layout", async () => {
+      await withHost("engoo.com", async () => {
+        const nestedText = "Brain resonance shapes how music feels."
+        const mixedText = "Shared rhythms connect people."
+        vi.mocked(translateTextForPage).mockClear()
+        render(
+          <article>
+            <p data-testid="engoo-nested">
+              <span>
+                <span>{nestedText}</span>
+              </span>
+            </p>
+            <p data-testid="engoo-mixed">
+              <span>{"Shared rhythms "}</span>
+              <em>connect</em>
+              <span>{" people."}</span>
+            </p>
+          </article>,
+        )
+        const nestedParagraph = screen.getByTestId("engoo-nested")
+        const mixedParagraph = screen.getByTestId("engoo-mixed")
+        const deepestSpan = nestedParagraph.querySelector("span span")!
+
+        await removeOrShowPageTranslation("bilingual", true)
+
+        expect(translateTextForPage).toHaveBeenCalledTimes(2)
+        expect(translateTextForPage).toHaveBeenCalledWith(nestedText)
+        expect(translateTextForPage).toHaveBeenCalledWith(mixedText)
+
+        const nestedWrapper = expectTranslationWrapper(deepestSpan, "bilingual")
+        expect(nestedWrapper).toBe(deepestSpan.lastChild)
+        expectTranslatedContent(nestedWrapper, BLOCK_CONTENT_CLASS)
+        expect(nestedParagraph.querySelectorAll(`.${CONTENT_WRAPPER_CLASS}`)).toHaveLength(1)
+
+        const mixedWrapper = expectTranslationWrapper(mixedParagraph, "bilingual")
+        expect(mixedWrapper).toBe(mixedParagraph.lastChild)
+        expectTranslatedContent(mixedWrapper, BLOCK_CONTENT_CLASS)
+        expect(mixedParagraph.querySelectorAll(`.${CONTENT_WRAPPER_CLASS}`)).toHaveLength(1)
+      })
+    })
+
+    it("keeps force-inline tag priority when BUTTON is the logical source", async () => {
+      render(
+        <div data-testid="test-node">
+          <button type="button">
+            <span>Open translated menu</span>
+          </button>
+        </div>,
+      )
+      const node = screen.getByTestId("test-node")
+      const button = node.querySelector("button")!
+      const deepestSpan = button.querySelector("span")!
+
+      await removeOrShowPageTranslation("bilingual", true)
+
+      const wrapper = expectTranslationWrapper(deepestSpan, "bilingual")
+      expect(wrapper).toBe(deepestSpan.lastChild)
+      expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+      expect(button.querySelectorAll(`.${CONTENT_WRAPPER_CLASS}`)).toHaveLength(1)
+    })
+
+    it("keeps force-inline tag priority when a block-styled anchor is the logical source", async () => {
+      render(
+        <div data-testid="test-node">
+          <a href="https://example.com/share" style={{ display: "block" }}>
+            <span>Share this page</span>
+          </a>
+        </div>,
+      )
+      const node = screen.getByTestId("test-node")
+      const anchor = node.querySelector("a")!
+      const deepestSpan = anchor.querySelector("span")!
+
+      await removeOrShowPageTranslation("bilingual", true)
+
+      const wrapper = expectTranslationWrapper(deepestSpan, "bilingual")
+      expect(wrapper).toBe(deepestSpan.lastChild)
+      expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+      expect(anchor.querySelectorAll(`.${CONTENT_WRAPPER_CLASS}`)).toHaveLength(1)
+    })
+
+    it("keeps display contents as a block logical source after unwrapping", async () => {
+      render(
+        <div data-testid="test-node">
+          <div style={{ display: "contents" }}>
+            <span>Contents wrapper text</span>
+          </div>
+        </div>,
+      )
+      const node = screen.getByTestId("test-node")
+      const contents = node.children[0]
+      const deepestSpan = contents.querySelector("span")!
+
+      await removeOrShowPageTranslation("bilingual", true)
+
+      const wrapper = expectTranslationWrapper(deepestSpan, "bilingual")
+      expect(wrapper).toBe(deepestSpan.lastChild)
+      expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
+      expect(contents.querySelectorAll(`.${CONTENT_WRAPPER_CLASS}`)).toHaveLength(1)
     })
   })
 
@@ -1105,7 +1277,7 @@ describe("translate", () => {
         expectNodeLabels(inlineSpan, [INLINE_ATTRIBUTE])
         expectNodeLabels(inlineSpan.children[0], [BLOCK_ATTRIBUTE])
       })
-      it("should translate the inline parent itself when it has one block child and text siblings", async () => {
+      it("should translate inside the inline parent using the outer block layout", async () => {
         render(
           <div data-testid="test-node">
             <span style={{ display: "inline" }}>
@@ -1122,7 +1294,7 @@ describe("translate", () => {
 
         const wrapper = expectTranslationWrapper(node.children[0], "bilingual")
         expect(wrapper).toBe(node.children[0].lastChild)
-        expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+        expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
         expect(node.children[0].querySelectorAll(`.${CONTENT_WRAPPER_CLASS}`)).toHaveLength(1)
 
         await removeOrShowPageTranslation("bilingual", true)
@@ -1223,7 +1395,7 @@ describe("translate", () => {
   })
   describe("don't walk into siblings (SVG, style, etc.)", () => {
     // https://github.com/mengxi-ream/read-frog/issues/754
-    it("bilingual mode: should filter out SVG and style siblings and translate inside inline div", async () => {
+    it("bilingual mode: should filter ignored siblings and keep the outer block layout", async () => {
       render(
         <div data-testid="test-node">
           <svg viewBox="0 0 24 24">
@@ -1241,7 +1413,7 @@ describe("translate", () => {
       expectNodeLabels(node.children[2], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
       const wrapper = expectTranslationWrapper(node.children[2], "bilingual")
       expect(wrapper).toBe(node.children[2].lastChild)
-      expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+      expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
 
       await removeOrShowPageTranslation("bilingual", true)
       expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
@@ -1272,7 +1444,7 @@ describe("translate", () => {
     })
   })
   describe("empty nodes in multiple child nodes", () => {
-    it("bilingual mode: should not insert translation wrapper", async () => {
+    it("bilingual mode: should ignore the empty sibling and keep the non-empty block layout", async () => {
       // https://github.com/mengxi-ream/read-frog/issues/717
       render(
         <div data-testid="test-node">
@@ -1290,7 +1462,7 @@ describe("translate", () => {
       expectNodeLabels(node.children[0].children[0], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
       const wrapper = expectTranslationWrapper(node.children[0].children[0], "bilingual")
       expect(wrapper).toBe(node.children[0].children[0].lastChild)
-      expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+      expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
 
       await removeOrShowPageTranslation("bilingual", true)
       expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
@@ -1298,7 +1470,7 @@ describe("translate", () => {
     })
   })
   describe("empty text nodes with only one inline node in middle", () => {
-    it("bilingual mode: should insert translation wrapper in inline node", async () => {
+    it("bilingual mode: should insert a block translation inside the only inline node", async () => {
       render(
         <div data-testid="test-node">
           {" "}
@@ -1312,7 +1484,7 @@ describe("translate", () => {
       expectNodeLabels(node.children[0], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
       const wrapper = expectTranslationWrapper(node.children[0], "bilingual")
       expect(wrapper).toBe(node.children[0].lastChild)
-      expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+      expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
 
       await removeOrShowPageTranslation("bilingual", true)
       expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
@@ -1791,7 +1963,7 @@ describe("translate", () => {
         `${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}`,
       )
     })
-    it("inline-flex parent: should unwrap into the inline-flex container and translate it once", async () => {
+    it("block wrapper: should unwrap into an inline-flex child but keep block layout", async () => {
       render(
         <div data-testid="test-node">
           <div style={{ display: "inline-flex" }}>
@@ -1809,7 +1981,7 @@ describe("translate", () => {
       expectNodeLabels(node.children[0].children[0], [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
       const wrapper = expectTranslationWrapper(node.children[0], "bilingual")
       expect(wrapper).toBe(node.children[0].lastChild)
-      expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+      expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
       expect(node.children[0].querySelectorAll(`.${CONTENT_WRAPPER_CLASS}`)).toHaveLength(1)
 
       await removeOrShowPageTranslation("bilingual", true)

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -2,7 +2,7 @@ import type { Config } from "@/types/config/config"
 // @vitest-environment jsdom
 import type { TranslationMode } from "@/types/config/translate"
 import { act, render, screen, waitFor } from "@testing-library/react"
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import {
   BLOCK_ATTRIBUTE,
@@ -13,10 +13,14 @@ import {
   INLINE_CONTENT_CLASS,
   PARAGRAPH_ATTRIBUTE,
   TRANSLATION_ERROR_CONTAINER_CLASS,
+  VIRTUAL_PARAGRAPH_ATTRIBUTE,
 } from "@/utils/constants/dom-labels"
 import { flushBatchedOperations } from "@/utils/host/dom/batch-dom"
 import { walkAndLabelElement } from "@/utils/host/dom/traversal"
-import { translateWalkedElement } from "@/utils/host/translate/node-manipulation"
+import {
+  translateNodesBilingualMode,
+  translateWalkedElement,
+} from "@/utils/host/translate/node-manipulation"
 import { translateTextForPage } from "@/utils/host/translate/translate-variants"
 import {
   expectNodeLabels,
@@ -561,6 +565,37 @@ describe("translate", () => {
 
   describe("real-world only-child layout regressions", () => {
     describe("X tweet text", () => {
+      const getTranslationWrappers = (tweet: HTMLElement) => [
+        ...tweet.querySelectorAll<HTMLElement>(`.${CONTENT_WRAPPER_CLASS}`),
+      ]
+
+      const expectBlockTranslations = (tweet: HTMLElement, translations: string[]) => {
+        const wrappers = getTranslationWrappers(tweet)
+        expect(wrappers).toHaveLength(translations.length)
+        wrappers.forEach((wrapper, index) => {
+          expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS, translations[index])
+          expect(wrapper.querySelector(`.${INLINE_CONTENT_CLASS}`)).toBeFalsy()
+        })
+        return wrappers
+      }
+
+      const expectTextInDocumentOrder = (tweet: HTMLElement, expected: string[]) => {
+        const renderedText = tweet.textContent ?? ""
+        let previousIndex = -1
+        for (const text of expected) {
+          const nextIndex = renderedText.indexOf(text, previousIndex + 1)
+          expect(
+            nextIndex,
+            `Expected ${JSON.stringify(text)} after index ${previousIndex}`,
+          ).toBeGreaterThan(previousIndex)
+          previousIndex = nextIndex
+        }
+      }
+
+      afterEach(() => {
+        vi.mocked(translateTextForPage).mockReset().mockResolvedValue(MOCK_TRANSLATION)
+      })
+
       it("keeps a simple single-span tweet as one block translation", async () => {
         await withHost("x.com", async () => {
           const sourceText = "Music changes the way we think."
@@ -584,41 +619,578 @@ describe("translate", () => {
         })
       })
 
-      it("keeps mention and hashtag spacing in one block while preserving both anchors", async () => {
+      it("removes orphan virtual wrappers on toggle without changing source fragments", async () => {
         await withHost("x.com", async () => {
-          const sourceText =
-            "We're excited to welcome @SohunSanka as our new head of GTM.\nFollow #History."
+          const sourceText = "First paragraph.\n\nSecond paragraph."
           vi.mocked(translateTextForPage).mockClear()
           render(
-            <div data-testid="tweetText">
-              <span>{"We're excited to welcome "}</span>
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <span>{sourceText}</span>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const sourceSpan = tweet.querySelector("span")!
+          const source = sourceSpan.firstChild as Text
+          const tail = source.splitText(sourceText.indexOf("\n\n"))
+          const orphanWrappers = [0, 1].map((index) => {
+            const wrapper = document.createElement("span")
+            wrapper.className = `notranslate ${CONTENT_WRAPPER_CLASS}`
+            wrapper.setAttribute(VIRTUAL_PARAGRAPH_ATTRIBUTE, `orphan:${index}`)
+            wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+            wrapper.textContent = `Old translation ${index + 1}`
+            return wrapper
+          })
+          sourceSpan.insertBefore(orphanWrappers[0], tail)
+          sourceSpan.append(orphanWrappers[1])
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(translateTextForPage).not.toHaveBeenCalled()
+          expect(getTranslationWrappers(tweet)).toHaveLength(0)
+          expect(sourceSpan.textContent).toBe(sourceText)
+          expect(sourceSpan.firstChild).toBe(source)
+          expect(source.nextSibling).toBe(tail)
+        })
+      })
+
+      it("replaces a truncated translation after X expands the same tweetText node", async () => {
+        await withHost("x.com", async () => {
+          const truncatedRequestText = "I'm a cardiologist.No protein"
+          const expandedFirstParagraph = "I'm a cardiologist.\nNo protein and more."
+          const hashtagParagraph = "#Football #Soccer"
+          const translations = {
+            truncated: "【旧的截断译文】",
+            expanded: "【展开后的正文译文】",
+            hashtags: "【标签译文】",
+          }
+          vi.mocked(translateTextForPage).mockImplementation(async (text) => {
+            if (text === truncatedRequestText) return translations.truncated
+            if (text === expandedFirstParagraph) return translations.expanded
+            if (text === hashtagParagraph) return translations.hashtags
+            throw new Error(`Unexpected paragraph: ${text}`)
+          })
+
+          render(
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <span>{"I'm a cardiologist."}</span>
+              <span>{"\nNo protein"}</span>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const expandingText = tweet.lastElementChild!.firstChild as Text
+          const walkId = "x-show-more-walk"
+
+          walkAndLabelElement(tweet, walkId, BILINGUAL_CONFIG)
+          await act(async () => {
+            await translateNodesBilingualMode([tweet], walkId, BILINGUAL_CONFIG)
+          })
+          expectBlockTranslations(tweet, [translations.truncated])
+
+          expandingText.data = "\nNo protein and more.\n\n"
+          const football = document.createElement("a")
+          football.href = "https://x.com/hashtag/Football"
+          football.textContent = "#Football"
+          const soccer = document.createElement("a")
+          soccer.href = "https://x.com/hashtag/Soccer"
+          soccer.textContent = "#Soccer"
+          tweet.append(football, " ", soccer)
+
+          walkAndLabelElement(tweet, walkId, BILINGUAL_CONFIG)
+          await act(async () => {
+            await translateNodesBilingualMode([tweet], walkId, BILINGUAL_CONFIG)
+          })
+
+          expect(translateTextForPage).toHaveBeenCalledTimes(3)
+          expect(translateTextForPage).toHaveBeenNthCalledWith(1, truncatedRequestText)
+          expect(translateTextForPage).toHaveBeenNthCalledWith(2, expandedFirstParagraph)
+          expect(translateTextForPage).toHaveBeenNthCalledWith(3, hashtagParagraph)
+          expectBlockTranslations(tweet, [translations.expanded, translations.hashtags])
+          expect(tweet).not.toHaveTextContent(translations.truncated)
+          expectTextInDocumentOrder(tweet, [
+            expandedFirstParagraph,
+            translations.expanded,
+            hashtagParagraph,
+            translations.hashtags,
+          ])
+        })
+      })
+
+      it("reconciles virtual split tails when X expands its original Text node", async () => {
+        await withHost("x.com", async () => {
+          const initialParagraphs = ["Opening paragraph.", "Line one\nLine two", "Only ONE will"]
+          const expandedParagraphs = [
+            "Opening paragraph.",
+            "Line one\nLine two",
+            "Only ONE will lift the trophy.",
+            "#Football #Soccer",
+          ]
+          const initialSource = initialParagraphs.join("\n\n")
+          const expandedSource = expandedParagraphs.join("\n\n")
+          const translationByText = new Map(
+            [...new Set([...initialParagraphs, ...expandedParagraphs])].map((text, index) => [
+              text,
+              `【展开测试译文 ${index + 1}】`,
+            ]),
+          )
+          vi.mocked(translateTextForPage).mockImplementation(async (text) => {
+            const translation = translationByText.get(text)
+            if (!translation) throw new Error(`Unexpected paragraph: ${text}`)
+            return translation
+          })
+
+          render(
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <span>{initialSource}</span>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const sourceSpan = tweet.querySelector("span")!
+          const originalText = sourceSpan.firstChild as Text
+          const walkId = "x-virtual-show-more-walk"
+
+          walkAndLabelElement(tweet, walkId, BILINGUAL_CONFIG)
+          await act(async () => {
+            await translateNodesBilingualMode([tweet], walkId, BILINGUAL_CONFIG)
+          })
+          expect(getTranslationWrappers(tweet)).toHaveLength(3)
+
+          originalText.data = expandedSource
+          walkAndLabelElement(tweet, walkId, BILINGUAL_CONFIG)
+          await act(async () => {
+            await translateNodesBilingualMode([tweet], walkId, BILINGUAL_CONFIG)
+          })
+
+          expect(getTranslationWrappers(tweet)).toHaveLength(4)
+          expect((tweet.textContent?.match(/Only ONE will/g) ?? []).length).toBe(1)
+          expectTextInDocumentOrder(
+            tweet,
+            expandedParagraphs.flatMap((paragraph) => [
+              paragraph,
+              translationByText.get(paragraph)!,
+            ]),
+          )
+
+          await act(async () => {
+            await translateNodesBilingualMode([tweet], walkId, BILINGUAL_CONFIG, true)
+          })
+          expect(getTranslationWrappers(tweet)).toHaveLength(0)
+          expect(sourceSpan.firstChild).toBe(originalText)
+          expect(sourceSpan.textContent).toBe(expandedSource)
+        })
+      })
+
+      it("interleaves both RBReich paragraphs even when translations resolve out of order", async () => {
+        await withHost("x.com", async () => {
+          const paragraphs = [
+            "Thinking about shopping on Amazon for Cyber Monday?",
+            "Watch this first.",
+          ]
+          const translations = ["【购物译文】", "【观看译文】"]
+          let resolveFirst!: (value: string) => void
+          let resolveSecond!: (value: string) => void
+          const firstTranslation = new Promise<string>((resolve) => {
+            resolveFirst = resolve
+          })
+          const secondTranslation = new Promise<string>((resolve) => {
+            resolveSecond = resolve
+          })
+          vi.mocked(translateTextForPage).mockImplementation((text) => {
+            if (text === paragraphs[0]) return firstTranslation
+            if (text === paragraphs[1]) return secondTranslation
+            throw new Error(`Unexpected paragraph: ${text}`)
+          })
+
+          render(
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <span>{paragraphs.join("\n\n")}</span>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+
+          const translationPromise = removeOrShowPageTranslation("bilingual", true)
+          await waitFor(() => expect(translateTextForPage).toHaveBeenCalledTimes(2))
+
+          resolveSecond(translations[1])
+          await Promise.resolve()
+          resolveFirst(translations[0])
+          await translationPromise
+
+          expect(translateTextForPage).toHaveBeenNthCalledWith(1, paragraphs[0])
+          expect(translateTextForPage).toHaveBeenNthCalledWith(2, paragraphs[1])
+          expectBlockTranslations(tweet, translations)
+          expectTextInDocumentOrder(tweet, [
+            paragraphs[0],
+            translations[0],
+            paragraphs[1],
+            translations[1],
+          ])
+        })
+      })
+
+      it("keeps pending virtual paragraphs removed when providers settle after cleanup", async () => {
+        await withHost("x.com", async () => {
+          const paragraphs = ["Pending first paragraph.", "Pending second paragraph."]
+          const sourceText = paragraphs.join("\n\n")
+          let resolveFirst!: (value: string) => void
+          let rejectSecond!: (reason: Error) => void
+          const firstTranslation = new Promise<string>((resolve) => {
+            resolveFirst = resolve
+          })
+          const secondTranslation = new Promise<string>((_, reject) => {
+            rejectSecond = reject
+          })
+          vi.mocked(translateTextForPage).mockImplementation((text) => {
+            if (text === paragraphs[0]) return firstTranslation
+            if (text === paragraphs[1]) return secondTranslation
+            throw new Error(`Unexpected paragraph: ${text}`)
+          })
+
+          render(
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <span>{sourceText}</span>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const sourceSpan = tweet.querySelector("span")!
+          const originalTextNode = sourceSpan.firstChild
+          const originalInnerHTML = sourceSpan.innerHTML
+
+          const translationPromise = removeOrShowPageTranslation("bilingual", true)
+          await waitFor(() => expect(translateTextForPage).toHaveBeenCalledTimes(2))
+          expect(getTranslationWrappers(tweet)).toHaveLength(2)
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(getTranslationWrappers(tweet)).toHaveLength(0)
+          expect(sourceSpan.innerHTML).toBe(originalInnerHTML)
+          expect(sourceSpan.firstChild).toBe(originalTextNode)
+
+          resolveFirst("【迟到的第一段译文】")
+          rejectSecond(new Error("late provider failure"))
+          await translationPromise
+
+          expect(getTranslationWrappers(tweet)).toHaveLength(0)
+          expect(tweet.querySelector(`.${TRANSLATION_ERROR_CONTAINER_CLASS}`)).toBeFalsy()
+          expect(sourceSpan.innerHTML).toBe(originalInnerHTML)
+          expect(sourceSpan.firstChild).toBe(originalTextNode)
+        })
+      })
+
+      it("drops stale virtual translations when unsplit text and an atomic mention change", async () => {
+        await withHost("x.com", async () => {
+          let resolveFirst!: (value: string) => void
+          let resolveSecond!: (value: string) => void
+          vi.mocked(translateTextForPage)
+            .mockImplementationOnce(
+              () =>
+                new Promise<string>((resolve) => {
+                  resolveFirst = resolve
+                }),
+            )
+            .mockImplementationOnce(
+              () =>
+                new Promise<string>((resolve) => {
+                  resolveSecond = resolve
+                }),
+            )
+
+          render(
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <span>{"Welcome "}</span>
+              <a href="https://x.com/SohunSanka">@SohunSanka</a>
+              <span>{" to the team.\n\nSecond paragraph."}</span>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const prefix = tweet.firstElementChild!
+          const prefixText = prefix.firstChild as Text
+          const mention = tweet.querySelector("a")!
+          const mentionText = mention.firstChild as Text
+          const trailing = tweet.lastElementChild!
+          const trailingText = trailing.firstChild
+
+          const translationPromise = removeOrShowPageTranslation("bilingual", true)
+          await waitFor(() => expect(translateTextForPage).toHaveBeenCalledTimes(2))
+          expect(getTranslationWrappers(tweet)).toHaveLength(2)
+
+          prefixText.data = "Host now welcomes "
+          mentionText.data = "@UpdatedHandle"
+          resolveFirst("【过期第一段】")
+          resolveSecond("【过期第二段】")
+          await translationPromise
+
+          expect(getTranslationWrappers(tweet)).toHaveLength(0)
+          expect(prefix.firstChild).toBe(prefixText)
+          expect(prefixText.data).toBe("Host now welcomes ")
+          expect(tweet.querySelector("a")).toBe(mention)
+          expect(mention.firstChild).toBe(mentionText)
+          expect(mentionText.data).toBe("@UpdatedHandle")
+          expect(trailing.firstChild).toBe(trailingText)
+          expect(tweet).not.toHaveTextContent("【过期")
+        })
+      })
+
+      it("restores split text after every virtual paragraph translates to its source", async () => {
+        await withHost("x.com", async () => {
+          const paragraphs = ["Unchanged first paragraph.", "Unchanged second paragraph."]
+          const sourceText = paragraphs.join("\n\n")
+          vi.mocked(translateTextForPage).mockImplementation(async (text) => text)
+
+          render(
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <span>{sourceText}</span>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const sourceSpan = tweet.querySelector("span")!
+          const originalTextNode = sourceSpan.firstChild
+          const originalInnerHTML = sourceSpan.innerHTML
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(translateTextForPage).toHaveBeenCalledTimes(2)
+          expect(getTranslationWrappers(tweet)).toHaveLength(0)
+          expect(sourceSpan.innerHTML).toBe(originalInnerHTML)
+          expect(sourceSpan.firstChild).toBe(originalTextNode)
+        })
+      })
+
+      it("keeps Bora's mention in the first of five interleaved paragraphs", async () => {
+        await withHost("x.com", async () => {
+          const paragraphs = [
+            "Today we are announcing the biggest ACQUISITION of TikTok Shop, sales and marketing human capital in Reacher history... @SohunSanka as our new head of GTM.",
+            "It's been a long time coming - from dissing each other in TTS Lark groups.",
+            "We eventually decided to quit the shenanigans and put our differences aside.",
+            "Filmed a fun video for the announcement - but all fun and games aside time to get to WORK!!!",
+            "Let us know if you want any Reacher merch by the way - got a ton to give out!",
+          ]
+          const translations = paragraphs.map((_, index) => `【Bora 译文 ${index + 1}】`)
+          const translationByParagraph = new Map(
+            paragraphs.map((paragraph, index) => [paragraph, translations[index]]),
+          )
+          vi.mocked(translateTextForPage).mockImplementation(async (text) => {
+            const translatedText = translationByParagraph.get(text)
+            if (!translatedText) throw new Error(`Unexpected paragraph: ${text}`)
+            return translatedText
+          })
+
+          const mentionPrefix = paragraphs[0].split("@SohunSanka")[0]
+          const mentionSuffix = paragraphs[0].split("@SohunSanka")[1]
+          const trailingText = `${mentionSuffix}\n\n${paragraphs.slice(1).join("\n\n")}`
+          render(
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <span>{mentionPrefix}</span>
               <div className="r-xoduu5" style={{ display: "inline-flex" }}>
                 <span style={{ display: "block" }}>
                   <a href="https://x.com/SohunSanka">@SohunSanka</a>
                 </span>
               </div>
-              <span>{" as our new head of GTM.\nFollow "}</span>
-              <span>
-                <a href="https://x.com/hashtag/History">#History</a>
-              </span>
-              <span>.</span>
+              <span>{trailingText}</span>
             </div>,
           )
           const tweet = screen.getByTestId("tweetText")
-          const [mention, hashtag] = tweet.querySelectorAll("a")
+          const mention = tweet.querySelector("a")!
+          const mentionTextNode = mention.firstChild
+          const trailingSourceSpan = tweet.lastElementChild as HTMLElement
+          const trailingSourceTextNode = trailingSourceSpan.firstChild
+          const originalTrailingInnerHTML = trailingSourceSpan.innerHTML
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(translateTextForPage).toHaveBeenCalledTimes(5)
+          paragraphs.forEach((paragraph, index) => {
+            expect(translateTextForPage).toHaveBeenNthCalledWith(index + 1, paragraph)
+          })
+          expectBlockTranslations(tweet, translations)
+          expectTextInDocumentOrder(
+            tweet,
+            paragraphs.flatMap((paragraph, index) => [paragraph, translations[index]]),
+          )
+          expect(tweet.querySelector("a")).toBe(mention)
+          expect(mention.firstChild).toBe(mentionTextNode)
+          expect(mention).toHaveTextContent("@SohunSanka")
+          expect(mention.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(getTranslationWrappers(tweet)).toHaveLength(0)
+          expect(trailingSourceSpan.innerHTML).toBe(originalTrailingInnerHTML)
+          expect(tweet.querySelector("a")).toBe(mention)
+          expect(mention.firstChild).toBe(mentionTextNode)
+          expect(trailingSourceSpan.firstChild).toBe(trailingSourceTextNode)
+        })
+      })
+
+      it("keeps Boston's score separate from its single-newline hashtag paragraph", async () => {
+        await withHost("x.com", async () => {
+          const paragraphs = [
+            "Rebatida simples do Lowe e corrida anota pelo Yoshida.",
+            "BOS 1-0 TOR",
+            "#BOSvsTOR #DirtyWater #MLBnaEspn #MLB\n#Redsox",
+          ]
+          const translations = ["【比赛译文】", "【比分译文】", "【标签译文】"]
+          const translationByParagraph = new Map(
+            paragraphs.map((paragraph, index) => [paragraph, translations[index]]),
+          )
+          vi.mocked(translateTextForPage).mockImplementation(async (text) => {
+            const translatedText = translationByParagraph.get(text)
+            if (!translatedText) throw new Error(`Unexpected paragraph: ${text}`)
+            return translatedText
+          })
+
+          render(
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <span>{`${paragraphs[0]}\n\n${paragraphs[1]} \n\n`}</span>
+              <a href="https://x.com/hashtag/BOSvsTOR">#BOSvsTOR</a>{" "}
+              <a href="https://x.com/hashtag/DirtyWater">#DirtyWater</a>{" "}
+              <a href="https://x.com/hashtag/MLBnaEspn">#MLBnaEspn</a>{" "}
+              <a href="https://x.com/hashtag/MLB">#MLB</a>
+              {"\n"}
+              <a href="https://x.com/hashtag/Redsox">#Redsox</a>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const hashtags = [...tweet.querySelectorAll("a")]
+          const hashtagTextNodes = hashtags.map((hashtag) => hashtag.firstChild)
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(translateTextForPage).toHaveBeenCalledTimes(3)
+          paragraphs.forEach((paragraph, index) => {
+            expect(translateTextForPage).toHaveBeenNthCalledWith(index + 1, paragraph)
+          })
+          expectBlockTranslations(tweet, translations)
+          expectTextInDocumentOrder(
+            tweet,
+            paragraphs.flatMap((paragraph, index) => [paragraph, translations[index]]),
+          )
+          hashtags.forEach((hashtag, index) => {
+            expect(tweet.querySelectorAll("a")[index]).toBe(hashtag)
+            expect(hashtag.firstChild).toBe(hashtagTextNodes[index])
+            expect(hashtag.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+          })
+        })
+      })
+
+      it.each(["normal", "nowrap"] as const)(
+        "does not split literal blank lines under white-space: %s",
+        async (whiteSpace) => {
+          await withHost("x.com", async () => {
+            const sourceText = "Source formatting line one.\n\nSource formatting line two."
+            vi.mocked(translateTextForPage).mockResolvedValue("【整段译文】")
+            render(
+              <div data-testid="tweetText" style={{ whiteSpace }}>
+                <span>{sourceText}</span>
+              </div>,
+            )
+            const tweet = screen.getByTestId("tweetText")
+
+            await removeOrShowPageTranslation("bilingual", true)
+
+            expect(translateTextForPage).toHaveBeenCalledTimes(1)
+            expect(translateTextForPage).toHaveBeenCalledWith(sourceText)
+            expectBlockTranslations(tweet, ["【整段译文】"])
+          })
+        },
+      )
+
+      it("does not split a single preserved newline", async () => {
+        await withHost("x.com", async () => {
+          const sourceText = "#MLB\n#Redsox"
+          vi.mocked(translateTextForPage).mockResolvedValue("【标签整段译文】")
+          render(
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <span>{sourceText}</span>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
 
           await removeOrShowPageTranslation("bilingual", true)
 
           expect(translateTextForPage).toHaveBeenCalledTimes(1)
           expect(translateTextForPage).toHaveBeenCalledWith(sourceText)
-          expect(mention).toHaveTextContent("@SohunSanka")
-          expect(mention.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
-          expect(hashtag).toHaveTextContent("#History")
-          expect(hashtag.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
-          const wrapper = expectTranslationWrapper(tweet, "bilingual")
-          expect(wrapper).toBe(tweet.lastChild)
-          expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
-          expect(tweet.querySelectorAll(`.${CONTENT_WRAPPER_CLASS}`)).toHaveLength(1)
+          expectBlockTranslations(tweet, ["【标签整段译文】"])
+        })
+      })
+
+      it("keeps one eligible virtual unit positioned when the other is filtered", async () => {
+        await withHost("x.com", async () => {
+          const sourceText = "Translate this paragraph.\n\n@OnlyHandle"
+          vi.mocked(translateTextForPage).mockResolvedValue("【唯一译文】")
+          render(
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <span>{sourceText}</span>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const sourceSpan = tweet.querySelector("span")!
+          const originalText = sourceSpan.firstChild
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(translateTextForPage).toHaveBeenCalledTimes(1)
+          expect(translateTextForPage).toHaveBeenCalledWith("Translate this paragraph.")
+          expectBlockTranslations(tweet, ["【唯一译文】"])
+          expectTextInDocumentOrder(tweet, [
+            "Translate this paragraph.",
+            "【唯一译文】",
+            "@OnlyHandle",
+          ])
+
+          await removeOrShowPageTranslation("bilingual", true)
+          expect(getTranslationWrappers(tweet)).toHaveLength(0)
+          expect(sourceSpan.firstChild).toBe(originalText)
+          expect(sourceSpan.textContent).toBe(sourceText)
+        })
+      })
+
+      it("leaves no split state when every virtual unit is filtered", async () => {
+        await withHost("x.com", async () => {
+          const sourceText = "@FirstHandle\n\n@SecondHandle"
+          vi.mocked(translateTextForPage).mockClear()
+          render(
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <span>{sourceText}</span>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const sourceSpan = tweet.querySelector("span")!
+          const originalText = sourceSpan.firstChild
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(translateTextForPage).not.toHaveBeenCalled()
+          expect(getTranslationWrappers(tweet)).toHaveLength(0)
+          expect(sourceSpan.firstChild).toBe(originalText)
+          expect(sourceSpan.textContent).toBe(sourceText)
+        })
+      })
+
+      it("removes wrappers without restoring stale text after the host replaces a split source node", async () => {
+        await withHost("x.com", async () => {
+          const paragraphs = ["Original first paragraph.", "Original second paragraph."]
+          vi.mocked(translateTextForPage).mockImplementation(async (text) => `【${text}】`)
+          render(
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <span>{paragraphs.join("\n\n")}</span>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const sourceSpan = tweet.querySelector("span")!
+
+          await removeOrShowPageTranslation("bilingual", true)
+          expect(getTranslationWrappers(tweet)).toHaveLength(2)
+
+          const splitSourceNode = sourceSpan.firstChild!
+          const hostReplacement = document.createTextNode("Host-updated first paragraph.")
+          splitSourceNode.replaceWith(hostReplacement)
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(getTranslationWrappers(tweet)).toHaveLength(0)
+          expect(hostReplacement.isConnected).toBe(true)
+          expect(tweet).toHaveTextContent("Host-updated first paragraph.")
+          expect(tweet).not.toHaveTextContent(paragraphs[0])
         })
       })
     })

--- a/src/utils/host/dom/__tests__/find.test.ts
+++ b/src/utils/host/dom/__tests__/find.test.ts
@@ -1,18 +1,12 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import {
   BLOCK_CONTENT_CLASS,
   CONTENT_WRAPPER_CLASS,
   INLINE_CONTENT_CLASS,
 } from "@/utils/constants/dom-labels"
 import { findTranslatedContentWrapper, unwrapDeepestOnlyHTMLChild } from "../find"
-
-vi.mock("@/utils/config/storage", async () => {
-  const { DEFAULT_CONFIG } = await import("@/utils/constants/config")
-  return {
-    getLocalConfig: vi.fn<(...args: any[]) => any>(async () => DEFAULT_CONFIG),
-  }
-})
 
 describe("findTranslatedContentWrapper", () => {
   beforeEach(() => {
@@ -92,13 +86,9 @@ describe("findTranslatedContentWrapper", () => {
 describe("unwrapDeepestOnlyHTMLChild", () => {
   beforeEach(() => {
     document.body.innerHTML = ""
-    Object.defineProperty(window, "location", {
-      value: new URL("https://example.com/some/path"),
-      writable: true,
-    })
   })
 
-  it("unwraps nested single-child elements without mutating truncation styles", async () => {
+  it("unwraps nested single-child elements without mutating truncation styles", () => {
     const outer = document.createElement("div")
     outer.style.webkitLineClamp = "2"
     outer.style.maxHeight = "24px"
@@ -116,7 +106,7 @@ describe("unwrapDeepestOnlyHTMLChild", () => {
     outer.appendChild(middle)
     document.body.appendChild(outer)
 
-    await expect(unwrapDeepestOnlyHTMLChild(outer)).resolves.toBe(leaf)
+    expect(unwrapDeepestOnlyHTMLChild(outer, DEFAULT_CONFIG)).toBe(leaf)
 
     expect(outer.style.webkitLineClamp).toBe("2")
     expect(outer.style.maxHeight).toBe("24px")

--- a/src/utils/host/dom/find.ts
+++ b/src/utils/host/dom/find.ts
@@ -1,6 +1,5 @@
+import type { Config } from "@/types/config/config"
 import type { Point } from "@/types/dom"
-import { getLocalConfig } from "@/utils/config/storage"
-import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { CONTENT_WRAPPER_CLASS } from "@/utils/constants/dom-labels"
 import {
   isDontWalkIntoAndDontTranslateAsChildElement,
@@ -127,8 +126,7 @@ export function deepQueryTopLevelSelector(
   return result
 }
 
-export async function unwrapDeepestOnlyHTMLChild(element: HTMLElement) {
-  const config = (await getLocalConfig()) ?? DEFAULT_CONFIG
+export function unwrapDeepestOnlyHTMLChild(element: HTMLElement, config: Config) {
   let currentElement = element
   while (currentElement) {
     const shouldKeepNode = (child: ChildNode) => {

--- a/src/utils/host/translate/core/__tests__/translation-modes-pending.test.ts
+++ b/src/utils/host/translate/core/__tests__/translation-modes-pending.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import {
+  BLOCK_ATTRIBUTE,
+  CONTENT_WRAPPER_CLASS,
+  PARAGRAPH_ATTRIBUTE,
+} from "@/utils/constants/dom-labels"
+import { removeAllTranslatedWrapperNodes } from "../../dom/translation-cleanup"
+import { translateNodesBilingualMode } from "../translation-modes"
+import { getBilingualTranslationStateForSource } from "../translation-state"
+
+const { mockShouldFilterSmallParagraph, mockTranslateTextForPage } = vi.hoisted(() => ({
+  mockShouldFilterSmallParagraph: vi.fn<(...args: any[]) => any>(),
+  mockTranslateTextForPage: vi.fn<(...args: any[]) => any>(),
+}))
+
+vi.mock("@/utils/host/translate/filter-small-paragraph", () => ({
+  shouldFilterSmallParagraph: mockShouldFilterSmallParagraph,
+}))
+
+vi.mock("@/utils/host/translate/translate-variants", () => ({
+  translateTextForPage: mockTranslateTextForPage,
+}))
+
+function createSource(): HTMLElement {
+  const source = document.createElement("div")
+  source.textContent = "Pending legacy bilingual source"
+  source.setAttribute(BLOCK_ATTRIBUTE, "")
+  source.setAttribute(PARAGRAPH_ATTRIBUTE, "")
+  document.body.append(source)
+  return source
+}
+
+function deferredFilter(): { promise: Promise<boolean>; resolve: (value: boolean) => void } {
+  let resolve!: (value: boolean) => void
+  const promise = new Promise<boolean>((resolver) => {
+    resolve = resolver
+  })
+  return { promise, resolve }
+}
+
+describe("legacy bilingual pending lifecycle", () => {
+  beforeEach(() => {
+    document.body.replaceChildren()
+    mockShouldFilterSmallParagraph.mockReset()
+    mockTranslateTextForPage.mockReset().mockResolvedValue("translated")
+  })
+
+  afterEach(() => {
+    removeAllTranslatedWrapperNodes(document)
+  })
+
+  it("does not insert a wrapper after global cleanup while filtering is pending", async () => {
+    const source = createSource()
+    const filter = deferredFilter()
+    mockShouldFilterSmallParagraph.mockReturnValue(filter.promise)
+
+    const translation = translateNodesBilingualMode([source], "pending-stop", DEFAULT_CONFIG)
+    await Promise.resolve()
+    expect(getBilingualTranslationStateForSource(source)?.wrapper).toBeNull()
+
+    removeAllTranslatedWrapperNodes(document)
+    filter.resolve(false)
+    await translation
+
+    expect(mockTranslateTextForPage).not.toHaveBeenCalled()
+    expect(source.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeNull()
+    expect(getBilingualTranslationStateForSource(source)).toBeUndefined()
+  })
+
+  it("does not insert a wrapper after toggle cancels pending filtering", async () => {
+    const source = createSource()
+    const filter = deferredFilter()
+    mockShouldFilterSmallParagraph.mockReturnValue(filter.promise)
+
+    const translation = translateNodesBilingualMode([source], "pending-toggle", DEFAULT_CONFIG)
+    await Promise.resolve()
+
+    await translateNodesBilingualMode([source], "pending-toggle", DEFAULT_CONFIG, true)
+    filter.resolve(false)
+    await translation
+
+    expect(mockTranslateTextForPage).not.toHaveBeenCalled()
+    expect(source.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeNull()
+    expect(getBilingualTranslationStateForSource(source)).toBeUndefined()
+  })
+})

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -4,7 +4,9 @@ import type { TransNode } from "@/types/dom"
 import {
   CONTENT_WRAPPER_CLASS,
   NOTRANSLATE_CLASS,
+  TRANSLATION_ERROR_CONTAINER_CLASS,
   TRANSLATION_MODE_ATTRIBUTE,
+  VIRTUAL_PARAGRAPH_ATTRIBUTE,
   WALKED_ATTRIBUTE,
 } from "../../../constants/dom-labels"
 import { batchDOMOperation } from "../../dom/batch-dom"
@@ -12,17 +14,42 @@ import { isBlockTransNode, isHTMLElement, isTextNode, isTransNode } from "../../
 import { unwrapDeepestOnlyHTMLChild } from "../../dom/find"
 import { getOwnerDocument } from "../../dom/node"
 import { extractTextContent } from "../../dom/traversal"
-import { removeTranslatedWrapperWithRestore } from "../dom/translation-cleanup"
+import { buildVirtualParagraphPlan, type VirtualParagraphUnit } from "../dom/paragraph-segmentation"
+import {
+  disposeVirtualParagraphGroup,
+  dropVirtualParagraphWrapper,
+  removeOrphanVirtualParagraphWrappers,
+  removeTranslatedWrapperWithRestore,
+} from "../dom/translation-cleanup"
 import { insertTranslatedNodeIntoWrapper } from "../dom/translation-insertion"
 import { findPreviousTranslatedWrapperInside } from "../dom/translation-wrapper"
+import { insertVirtualParagraphWrappers } from "../dom/virtual-paragraph-insertion"
 import { shouldFilterSmallParagraph } from "../filter-small-paragraph"
 import { prepareTranslationText } from "../text-preparation"
 import { setTranslationDirAndLang } from "../translation-attributes"
 import { createSpinnerInside, getTranslatedTextAndRemoveSpinner } from "../ui/spinner"
 import { isNumericContent } from "../ui/translation-utils"
-import { MARK_ATTRIBUTES_REGEX, originalContentMap, translatingNodes } from "./translation-state"
+import {
+  attachBilingualTranslationWrapper,
+  getBilingualTranslationStateForSource,
+  getVirtualParagraphGroupForSource,
+  isBilingualTranslationStateCurrent,
+  isVirtualParagraphGroupCurrent,
+  MARK_ATTRIBUTES_REGEX,
+  markVirtualParagraphGroupInserted,
+  originalContentMap,
+  registerBilingualTranslationState,
+  registerVirtualParagraphGroup,
+  registerVirtualParagraphWrapper,
+  translatingNodes,
+  unregisterBilingualTranslationState,
+  type BilingualTranslationState,
+  type VirtualParagraphGroup,
+  type VirtualParagraphSourceSnapshot,
+} from "./translation-state"
 
 const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g
+let virtualParagraphGroupSequence = 0
 
 function getDisplayTranslation(sourceText: string, translatedText: string | undefined) {
   if (translatedText === undefined) {
@@ -32,6 +59,165 @@ function getDisplayTranslation(sourceText: string, translatedText: string | unde
   return prepareTranslationText(sourceText) === prepareTranslationText(translatedText)
     ? ""
     : translatedText
+}
+
+function createBilingualWrapper(
+  ownerDoc: Document,
+  walkId: string,
+  config: Config,
+  virtualParagraphId?: string,
+): { spinner: HTMLElement; wrapper: HTMLElement } {
+  const wrapper = ownerDoc.createElement("span")
+  wrapper.className = `${NOTRANSLATE_CLASS} ${CONTENT_WRAPPER_CLASS}`
+  wrapper.setAttribute(TRANSLATION_MODE_ATTRIBUTE, "bilingual" satisfies TranslationMode)
+  wrapper.setAttribute(WALKED_ATTRIBUTE, walkId)
+  if (virtualParagraphId) {
+    wrapper.setAttribute(VIRTUAL_PARAGRAPH_ATTRIBUTE, virtualParagraphId)
+  }
+  setTranslationDirAndLang(wrapper, config)
+  return { spinner: createSpinnerInside(wrapper), wrapper }
+}
+
+async function filterVirtualParagraphUnits(
+  units: VirtualParagraphUnit[],
+  config: Config,
+): Promise<VirtualParagraphUnit[]> {
+  const included = await Promise.all(
+    units.map(async (unit) => {
+      if (isNumericContent(unit.text)) return false
+      return !(await shouldFilterSmallParagraph(unit.text, config))
+    }),
+  )
+  return units.filter((_, index) => included[index])
+}
+
+async function translateVirtualParagraph(
+  entry: ReturnType<typeof insertVirtualParagraphWrappers>["inserted"][number],
+  spinner: HTMLElement,
+  group: VirtualParagraphGroup,
+  nodes: ChildNode[],
+  config: Config,
+  forceBlockTranslation: boolean,
+): Promise<void> {
+  const { flowSource, unit, wrapper } = entry
+  const isCurrent = () => isVirtualParagraphGroupCurrent(group, wrapper)
+  if (!isCurrent()) return
+
+  const realTranslatedText = await getTranslatedTextAndRemoveSpinner(
+    nodes,
+    unit.text,
+    spinner,
+    wrapper,
+    isCurrent,
+  )
+  if (!isCurrent()) {
+    disposeVirtualParagraphGroup(group)
+    return
+  }
+
+  const translatedText = getDisplayTranslation(unit.text, realTranslatedText)
+  if (translatedText === "") {
+    dropVirtualParagraphWrapper(group, wrapper)
+    return
+  }
+  if (translatedText === undefined) {
+    if (!wrapper.querySelector(`.${TRANSLATION_ERROR_CONTAINER_CLASS}`)) {
+      dropVirtualParagraphWrapper(group, wrapper)
+    }
+    return
+  }
+
+  await insertTranslatedNodeIntoWrapper(
+    wrapper,
+    { flowSource, isCurrent, layoutSource: group.layoutSource },
+    translatedText,
+    config.translate.translationNodeStyle,
+    config,
+    forceBlockTranslation,
+  )
+  if (!isCurrent()) disposeVirtualParagraphGroup(group)
+}
+
+async function translateVirtualParagraphs(
+  nodes: ChildNode[],
+  units: VirtualParagraphUnit[],
+  sourceSnapshots: VirtualParagraphSourceSnapshot[],
+  layoutSource: HTMLElement,
+  walkId: string,
+  config: Config,
+  forceBlockTranslation: boolean,
+): Promise<void> {
+  const group: VirtualParagraphGroup = {
+    id: `${walkId}:${virtualParagraphGroupSequence++}`,
+    walkId,
+    status: "active",
+    layoutSource,
+    wrappers: new Set(),
+    splitRecords: [],
+    sourceSnapshots,
+    sourceTextContent: layoutSource.textContent ?? "",
+    wrapperPlacements: new Map(),
+  }
+  registerVirtualParagraphGroup(group)
+
+  const sourceTextSnapshot = layoutSource.textContent
+  let includedUnits: VirtualParagraphUnit[]
+  try {
+    includedUnits = await filterVirtualParagraphUnits(units, config)
+  } catch (error) {
+    disposeVirtualParagraphGroup(group)
+    throw error
+  }
+
+  if (!isVirtualParagraphGroupCurrent(group) || layoutSource.textContent !== sourceTextSnapshot) {
+    disposeVirtualParagraphGroup(group)
+    return
+  }
+  if (includedUnits.length === 0) {
+    disposeVirtualParagraphGroup(group)
+    return
+  }
+
+  const ownerDoc = getOwnerDocument(layoutSource)
+  const spinners = new Map<HTMLElement, HTMLElement>()
+  const entries = includedUnits.map((unit) => {
+    const { spinner, wrapper } = createBilingualWrapper(
+      ownerDoc,
+      walkId,
+      config,
+      `${group.id}:${unit.id}`,
+    )
+    spinners.set(wrapper, spinner)
+    registerVirtualParagraphWrapper(group, wrapper)
+    return { unit, wrapper }
+  })
+
+  let inserted: ReturnType<typeof insertVirtualParagraphWrappers>["inserted"]
+  try {
+    ;({ inserted } = insertVirtualParagraphWrappers(entries, layoutSource, group.splitRecords))
+  } catch (error) {
+    disposeVirtualParagraphGroup(group)
+    throw error
+  }
+
+  markVirtualParagraphGroupInserted(group)
+  if (!isVirtualParagraphGroupCurrent(group)) {
+    disposeVirtualParagraphGroup(group)
+    return
+  }
+
+  await Promise.allSettled(
+    inserted.map((entry) =>
+      translateVirtualParagraph(
+        entry,
+        spinners.get(entry.wrapper)!,
+        group,
+        nodes,
+        config,
+        forceBlockTranslation,
+      ),
+    ),
+  )
 }
 
 export async function translateNodes(
@@ -60,6 +246,49 @@ export async function translateNodesBilingualMode(
   if (transNodes.length === 0) {
     return
   }
+
+  const layoutSource = transNodes.at(-1)!
+  const virtualLayoutSource =
+    transNodes.length === 1 && isHTMLElement(layoutSource) && isBlockTransNode(layoutSource)
+      ? layoutSource
+      : undefined
+
+  if (virtualLayoutSource) {
+    const existingGroup = getVirtualParagraphGroupForSource(virtualLayoutSource)
+    if (existingGroup) {
+      const isSameActiveWalk =
+        existingGroup.walkId === walkId && isVirtualParagraphGroupCurrent(existingGroup)
+      if (!toggle && isSameActiveWalk) return
+
+      disposeVirtualParagraphGroup(existingGroup)
+      if (toggle) return
+
+      // A previous generation may still be awaiting its provider. Its group
+      // ownership guard prevents stale writes, so the fresh walk can proceed.
+      transNodes.forEach((node) => translatingNodes.delete(node))
+    } else if (removeOrphanVirtualParagraphWrappers(virtualLayoutSource) && toggle) {
+      return
+    }
+  }
+
+  if (isHTMLElement(layoutSource)) {
+    const existingBilingualState = getBilingualTranslationStateForSource(layoutSource)
+    if (existingBilingualState) {
+      const isSameActiveWalk =
+        existingBilingualState.walkId === walkId &&
+        isBilingualTranslationStateCurrent(existingBilingualState)
+      if (!toggle && isSameActiveWalk) return
+
+      if (existingBilingualState.wrapper) {
+        removeTranslatedWrapperWithRestore(existingBilingualState.wrapper)
+      } else {
+        unregisterBilingualTranslationState(existingBilingualState)
+      }
+      if (toggle) return
+      transNodes.forEach((node) => translatingNodes.delete(node))
+    }
+  }
+
   try {
     // prevent duplicate translation
     if (transNodes.every((node) => translatingNodes.has(node))) {
@@ -67,7 +296,22 @@ export async function translateNodesBilingualMode(
     }
     transNodes.forEach((node) => translatingNodes.add(node))
 
-    const layoutSource = transNodes.at(-1)!
+    if (virtualLayoutSource) {
+      const virtualParagraphPlan = buildVirtualParagraphPlan(virtualLayoutSource, config)
+      if (virtualParagraphPlan.units.length >= 2) {
+        await translateVirtualParagraphs(
+          nodes,
+          virtualParagraphPlan.units,
+          virtualParagraphPlan.sourceSnapshots,
+          virtualLayoutSource,
+          walkId,
+          config,
+          forceBlockTranslation,
+        )
+        return
+      }
+    }
+
     const insertionTarget =
       transNodes.length === 1 && isBlockTransNode(layoutSource) && isHTMLElement(layoutSource)
         ? unwrapDeepestOnlyHTMLChild(layoutSource, config)
@@ -80,66 +324,113 @@ export async function translateNodesBilingualMode(
         return
       }
       nodes.forEach((node) => translatingNodes.delete(node))
-      void translateNodesBilingualMode(nodes, walkId, config, toggle)
-      return
+      return translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
     }
 
+    const sourceTextBeforeFilter = isHTMLElement(layoutSource) ? layoutSource.textContent : null
     const textContent = transNodes
       .map((node) => extractTextContent(node, config))
       .join("")
       .trim()
     if (!textContent || isNumericContent(textContent)) return
 
-    if (await shouldFilterSmallParagraph(textContent, config)) return
+    let bilingualState: BilingualTranslationState | undefined
+    if (isHTMLElement(layoutSource) && sourceTextBeforeFilter !== null) {
+      bilingualState = {
+        layoutSource,
+        sourceTextContent: sourceTextBeforeFilter,
+        status: "active",
+        walkId,
+        wrapper: null,
+      }
+      registerBilingualTranslationState(bilingualState)
+    }
+
+    let shouldFilter: boolean
+    try {
+      shouldFilter = await shouldFilterSmallParagraph(textContent, config)
+    } catch (error) {
+      if (bilingualState) unregisterBilingualTranslationState(bilingualState)
+      throw error
+    }
+
+    if (bilingualState && !isBilingualTranslationStateCurrent(bilingualState)) {
+      const shouldRetry =
+        getBilingualTranslationStateForSource(layoutSource as HTMLElement) === bilingualState &&
+        layoutSource.isConnected
+      unregisterBilingualTranslationState(bilingualState)
+      if (shouldRetry) {
+        nodes.forEach((node) => translatingNodes.delete(node))
+        return translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
+      }
+      return
+    }
+    if (shouldFilter) {
+      if (bilingualState) unregisterBilingualTranslationState(bilingualState)
+      return
+    }
 
     const ownerDoc = getOwnerDocument(insertionTarget)
-    const translatedWrapperNode = ownerDoc.createElement("span")
-    translatedWrapperNode.className = `${NOTRANSLATE_CLASS} ${CONTENT_WRAPPER_CLASS}`
-    translatedWrapperNode.setAttribute(
-      TRANSLATION_MODE_ATTRIBUTE,
-      "bilingual" satisfies TranslationMode,
+    const { spinner, wrapper: translatedWrapperNode } = createBilingualWrapper(
+      ownerDoc,
+      walkId,
+      config,
     )
-    translatedWrapperNode.setAttribute(WALKED_ATTRIBUTE, walkId)
-    setTranslationDirAndLang(translatedWrapperNode, config)
-    const spinner = createSpinnerInside(translatedWrapperNode)
 
-    // Batch DOM insertion to reduce layout thrashing
-    const insertOperation = () => {
-      if (isTextNode(insertionTarget) || transNodes.length > 1) {
-        insertionTarget.parentNode?.insertBefore(translatedWrapperNode, insertionTarget.nextSibling)
-      } else {
-        insertionTarget.appendChild(translatedWrapperNode)
-      }
+    if (isTextNode(insertionTarget) || transNodes.length > 1) {
+      insertionTarget.parentNode?.insertBefore(translatedWrapperNode, insertionTarget.nextSibling)
+    } else {
+      insertionTarget.appendChild(translatedWrapperNode)
     }
-    batchDOMOperation(insertOperation)
+
+    if (isHTMLElement(layoutSource) && layoutSource.contains(translatedWrapperNode)) {
+      if (bilingualState) {
+        attachBilingualTranslationWrapper(bilingualState, translatedWrapperNode)
+      }
+    } else if (bilingualState) {
+      unregisterBilingualTranslationState(bilingualState)
+      bilingualState = undefined
+    }
+    const isCurrent = () =>
+      bilingualState
+        ? isBilingualTranslationStateCurrent(bilingualState)
+        : translatedWrapperNode.isConnected
 
     const realTranslatedText = await getTranslatedTextAndRemoveSpinner(
       nodes,
       textContent,
       spinner,
       translatedWrapperNode,
+      isCurrent,
     )
+
+    if (!isCurrent()) {
+      removeTranslatedWrapperWithRestore(translatedWrapperNode)
+      return
+    }
 
     const translatedText = getDisplayTranslation(textContent, realTranslatedText)
 
-    if (!translatedText) {
-      // Only remove wrapper if translation returned empty (not needed),
-      // but keep it for error display (undefined)
-      if (translatedText === "") {
-        // Batch the remove operation to execute remove operation after insert operation
-        batchDOMOperation(() => translatedWrapperNode.remove())
+    if (translatedText === "") {
+      removeTranslatedWrapperWithRestore(translatedWrapperNode)
+      return
+    }
+    if (translatedText === undefined) {
+      if (!translatedWrapperNode.querySelector(`.${TRANSLATION_ERROR_CONTAINER_CLASS}`)) {
+        removeTranslatedWrapperWithRestore(translatedWrapperNode)
       }
       return
     }
 
     await insertTranslatedNodeIntoWrapper(
       translatedWrapperNode,
-      { insertionTarget, layoutSource },
+      { flowSource: insertionTarget, isCurrent, layoutSource },
       translatedText,
       config.translate.translationNodeStyle,
       config,
       forceBlockTranslation,
     )
+    if (!isCurrent()) removeTranslatedWrapperWithRestore(translatedWrapperNode)
   } finally {
     transNodes.forEach((node) => translatingNodes.delete(node))
   }

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -67,13 +67,13 @@ export async function translateNodesBilingualMode(
     }
     transNodes.forEach((node) => translatingNodes.add(node))
 
-    const lastNode = transNodes.at(-1)!
-    const targetNode =
-      transNodes.length === 1 && isBlockTransNode(lastNode) && isHTMLElement(lastNode)
-        ? await unwrapDeepestOnlyHTMLChild(lastNode)
-        : lastNode
+    const layoutSource = transNodes.at(-1)!
+    const insertionTarget =
+      transNodes.length === 1 && isBlockTransNode(layoutSource) && isHTMLElement(layoutSource)
+        ? unwrapDeepestOnlyHTMLChild(layoutSource, config)
+        : layoutSource
 
-    const existedTranslatedWrapper = findPreviousTranslatedWrapperInside(targetNode, walkId)
+    const existedTranslatedWrapper = findPreviousTranslatedWrapperInside(insertionTarget, walkId)
     if (existedTranslatedWrapper) {
       removeTranslatedWrapperWithRestore(existedTranslatedWrapper)
       if (toggle) {
@@ -92,7 +92,7 @@ export async function translateNodesBilingualMode(
 
     if (await shouldFilterSmallParagraph(textContent, config)) return
 
-    const ownerDoc = getOwnerDocument(targetNode)
+    const ownerDoc = getOwnerDocument(insertionTarget)
     const translatedWrapperNode = ownerDoc.createElement("span")
     translatedWrapperNode.className = `${NOTRANSLATE_CLASS} ${CONTENT_WRAPPER_CLASS}`
     translatedWrapperNode.setAttribute(
@@ -105,10 +105,10 @@ export async function translateNodesBilingualMode(
 
     // Batch DOM insertion to reduce layout thrashing
     const insertOperation = () => {
-      if (isTextNode(targetNode) || transNodes.length > 1) {
-        targetNode.parentNode?.insertBefore(translatedWrapperNode, targetNode.nextSibling)
+      if (isTextNode(insertionTarget) || transNodes.length > 1) {
+        insertionTarget.parentNode?.insertBefore(translatedWrapperNode, insertionTarget.nextSibling)
       } else {
-        targetNode.appendChild(translatedWrapperNode)
+        insertionTarget.appendChild(translatedWrapperNode)
       }
     }
     batchDOMOperation(insertOperation)
@@ -134,7 +134,7 @@ export async function translateNodesBilingualMode(
 
     await insertTranslatedNodeIntoWrapper(
       translatedWrapperNode,
-      targetNode,
+      { insertionTarget, layoutSource },
       translatedText,
       config.translate.translationNodeStyle,
       config,
@@ -182,7 +182,7 @@ export async function translateNodeTranslationOnlyMode(
   let transNodes: TransNode[] = []
   let allChildNodes: ChildNode[] = []
   if (outerTransNodes.length === 1 && isHTMLElement(outerTransNodes[0])) {
-    const unwrappedHTMLChild = await unwrapDeepestOnlyHTMLChild(outerTransNodes[0])
+    const unwrappedHTMLChild = unwrapDeepestOnlyHTMLChild(outerTransNodes[0], config)
     allChildNodes = [...unwrappedHTMLChild.childNodes]
     transNodes = allChildNodes.filter(isTransNodeAndNotTranslatedWrapper)
   } else {

--- a/src/utils/host/translate/core/translation-state.ts
+++ b/src/utils/host/translate/core/translation-state.ts
@@ -1,8 +1,302 @@
 import { MARK_ATTRIBUTES } from "../../../constants/dom-labels"
 
+export interface TextSplitRecord {
+  source: Text
+  parent: Node
+  originalValue: string
+  createdTails: Text[]
+  sourceValueAfterSplit: string
+  tailValuesAfterSplit: string[]
+}
+
+export interface VirtualParagraphSourceSnapshot {
+  source: Text | HTMLElement
+  parent: Node | null
+  value: string
+}
+
+interface VirtualParagraphWrapperPlacement {
+  parent: Node
+  previousSibling: ChildNode | null
+  nextSibling: ChildNode | null
+}
+
+export interface VirtualParagraphGroup {
+  id: string
+  walkId: string
+  status: "active" | "disposing" | "disposed"
+  layoutSource: HTMLElement
+  wrappers: Set<HTMLElement>
+  splitRecords: TextSplitRecord[]
+  sourceSnapshots: VirtualParagraphSourceSnapshot[]
+  sourceTextContent: string
+  wrapperPlacements: Map<HTMLElement, VirtualParagraphWrapperPlacement>
+}
+
+export interface BilingualTranslationState {
+  layoutSource: HTMLElement
+  sourceTextContent: string
+  status: "active" | "disposed"
+  walkId: string
+  wrapper: HTMLElement | null
+}
+
 // State management for translation operations
 export const translatingNodes = new WeakSet<ChildNode>()
 export const originalContentMap = new Map<Element, string>()
+
+const virtualParagraphGroupsBySource = new WeakMap<HTMLElement, VirtualParagraphGroup>()
+const virtualParagraphGroupsByWrapper = new WeakMap<HTMLElement, VirtualParagraphGroup>()
+const bilingualTranslationsBySource = new WeakMap<HTMLElement, BilingualTranslationState>()
+const bilingualTranslationsByWrapper = new WeakMap<HTMLElement, BilingualTranslationState>()
+// Filtering can await storage before wrappers are inserted. Keep only that
+// short-lived pre-insertion window enumerable so a global stop can cancel it.
+const pendingVirtualParagraphGroups = new Set<VirtualParagraphGroup>()
+const pendingBilingualTranslations = new Set<BilingualTranslationState>()
+
+export function registerVirtualParagraphGroup(group: VirtualParagraphGroup): void {
+  virtualParagraphGroupsBySource.set(group.layoutSource, group)
+  pendingVirtualParagraphGroups.add(group)
+  group.wrappers.forEach((wrapper) => virtualParagraphGroupsByWrapper.set(wrapper, group))
+}
+
+export function markVirtualParagraphGroupInserted(group: VirtualParagraphGroup): void {
+  pendingVirtualParagraphGroups.delete(group)
+  group.wrapperPlacements.clear()
+  for (const wrapper of group.wrappers) {
+    if (!wrapper.parentNode) continue
+    group.wrapperPlacements.set(wrapper, {
+      parent: wrapper.parentNode,
+      previousSibling: wrapper.previousSibling,
+      nextSibling: wrapper.nextSibling,
+    })
+  }
+}
+
+export function getPendingVirtualParagraphGroups(): VirtualParagraphGroup[] {
+  return [...pendingVirtualParagraphGroups]
+}
+
+function collectHostText(
+  layoutSource: HTMLElement,
+  excludedWrappers: ReadonlySet<HTMLElement>,
+): string {
+  let text = ""
+  const collect = (node: Node): void => {
+    for (const child of node.childNodes) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        text += (child as Text).data
+      } else if (!excludedWrappers.has(child as HTMLElement)) {
+        collect(child)
+      }
+    }
+  }
+  collect(layoutSource)
+  return text
+}
+
+export function registerBilingualTranslationState(state: BilingualTranslationState): void {
+  bilingualTranslationsBySource.set(state.layoutSource, state)
+  if (state.wrapper) bilingualTranslationsByWrapper.set(state.wrapper, state)
+  else pendingBilingualTranslations.add(state)
+}
+
+export function attachBilingualTranslationWrapper(
+  state: BilingualTranslationState,
+  wrapper: HTMLElement,
+): void {
+  if (
+    state.status !== "active" ||
+    bilingualTranslationsBySource.get(state.layoutSource) !== state
+  ) {
+    return
+  }
+  pendingBilingualTranslations.delete(state)
+  state.wrapper = wrapper
+  bilingualTranslationsByWrapper.set(wrapper, state)
+}
+
+export function getPendingBilingualTranslationStates(): BilingualTranslationState[] {
+  return [...pendingBilingualTranslations]
+}
+
+export function getBilingualTranslationStateForSource(
+  source: HTMLElement,
+): BilingualTranslationState | undefined {
+  return bilingualTranslationsBySource.get(source)
+}
+
+export function getBilingualTranslationStateForWrapper(
+  wrapper: HTMLElement,
+): BilingualTranslationState | undefined {
+  return bilingualTranslationsByWrapper.get(wrapper)
+}
+
+export function unregisterBilingualTranslationState(state: BilingualTranslationState): void {
+  pendingBilingualTranslations.delete(state)
+  if (bilingualTranslationsBySource.get(state.layoutSource) === state) {
+    bilingualTranslationsBySource.delete(state.layoutSource)
+  }
+  if (state.wrapper && bilingualTranslationsByWrapper.get(state.wrapper) === state) {
+    bilingualTranslationsByWrapper.delete(state.wrapper)
+  }
+  state.status = "disposed"
+}
+
+export function isBilingualTranslationStateCurrent(state: BilingualTranslationState): boolean {
+  if (
+    state.status !== "active" ||
+    bilingualTranslationsBySource.get(state.layoutSource) !== state ||
+    !state.layoutSource.isConnected
+  ) {
+    return false
+  }
+
+  if (state.wrapper === null) {
+    return (
+      pendingBilingualTranslations.has(state) &&
+      collectHostText(state.layoutSource, new Set()) === state.sourceTextContent
+    )
+  }
+
+  return (
+    bilingualTranslationsByWrapper.get(state.wrapper) === state &&
+    state.wrapper.isConnected &&
+    state.layoutSource.contains(state.wrapper) &&
+    collectHostText(state.layoutSource, new Set([state.wrapper])) === state.sourceTextContent
+  )
+}
+
+export function findStaleBilingualLayoutSource(node: Node): HTMLElement | undefined {
+  let current = node.nodeType === Node.ELEMENT_NODE ? (node as HTMLElement) : node.parentElement
+  while (current) {
+    const virtualGroup = virtualParagraphGroupsBySource.get(current)
+    if (virtualGroup && !isVirtualParagraphGroupCurrent(virtualGroup)) return current
+
+    const bilingualState = bilingualTranslationsBySource.get(current)
+    if (bilingualState && !isBilingualTranslationStateCurrent(bilingualState)) return current
+    current = current.parentElement
+  }
+  return undefined
+}
+
+export function registerVirtualParagraphWrapper(
+  group: VirtualParagraphGroup,
+  wrapper: HTMLElement,
+): void {
+  if (
+    group.status !== "active" ||
+    virtualParagraphGroupsBySource.get(group.layoutSource) !== group
+  ) {
+    return
+  }
+  group.wrappers.add(wrapper)
+  virtualParagraphGroupsByWrapper.set(wrapper, group)
+}
+
+export function getVirtualParagraphGroupForSource(
+  source: HTMLElement,
+): VirtualParagraphGroup | undefined {
+  return virtualParagraphGroupsBySource.get(source)
+}
+
+export function getVirtualParagraphGroupForWrapper(
+  wrapper: HTMLElement,
+): VirtualParagraphGroup | undefined {
+  return virtualParagraphGroupsByWrapper.get(wrapper)
+}
+
+export function isVirtualParagraphGroupCurrent(
+  group: VirtualParagraphGroup,
+  wrapper?: HTMLElement,
+): boolean {
+  if (
+    group.status !== "active" ||
+    virtualParagraphGroupsBySource.get(group.layoutSource) !== group ||
+    !group.layoutSource.isConnected
+  ) {
+    return false
+  }
+
+  if (collectHostText(group.layoutSource, group.wrappers) !== group.sourceTextContent) return false
+
+  const splitRecordsBySource = new Map(
+    group.splitRecords.map((record) => [record.source, record] as const),
+  )
+  for (const { source, parent, originalValue, createdTails } of group.splitRecords) {
+    const fragments = [source, ...createdTails]
+    let previousIndex = -1
+    for (const fragment of fragments) {
+      if (!fragment.isConnected || fragment.parentNode !== parent) return false
+      const index = [...parent.childNodes].indexOf(fragment)
+      if (index <= previousIndex) return false
+      previousIndex = index
+    }
+    if (fragments.map((fragment) => fragment.data).join("") !== originalValue) return false
+  }
+
+  for (const { source, parent, value } of group.sourceSnapshots) {
+    if (source.parentNode !== parent || !source.isConnected) return false
+
+    if (source.nodeType === Node.TEXT_NODE) {
+      const splitRecord = splitRecordsBySource.get(source as Text)
+      if (splitRecord) {
+        if (splitRecord.originalValue !== value) return false
+      } else if ((source as Text).data !== value) {
+        return false
+      }
+    } else if (source.textContent !== value) {
+      return false
+    }
+  }
+
+  for (let index = 1; index < group.sourceSnapshots.length; index += 1) {
+    const previous = group.sourceSnapshots[index - 1].source
+    const current = group.sourceSnapshots[index].source
+    if (!(previous.compareDocumentPosition(current) & 4)) return false
+  }
+
+  const isOwnedWrapper = (candidate: HTMLElement) => {
+    const placement = group.wrapperPlacements.get(candidate)
+    return (
+      group.wrappers.has(candidate) &&
+      virtualParagraphGroupsByWrapper.get(candidate) === group &&
+      candidate.isConnected &&
+      group.layoutSource.contains(candidate) &&
+      placement !== undefined &&
+      candidate.parentNode === placement.parent &&
+      candidate.previousSibling === placement.previousSibling &&
+      candidate.nextSibling === placement.nextSibling
+    )
+  }
+
+  if (wrapper !== undefined) return isOwnedWrapper(wrapper)
+  if (pendingVirtualParagraphGroups.has(group)) return true
+  return group.wrappers.size > 0 && [...group.wrappers].every(isOwnedWrapper)
+}
+
+export function unregisterVirtualParagraphWrapper(
+  group: VirtualParagraphGroup,
+  wrapper: HTMLElement,
+): void {
+  if (virtualParagraphGroupsByWrapper.get(wrapper) === group) {
+    virtualParagraphGroupsByWrapper.delete(wrapper)
+  }
+  group.wrappers.delete(wrapper)
+  group.wrapperPlacements.delete(wrapper)
+}
+
+export function unregisterVirtualParagraphGroup(group: VirtualParagraphGroup): void {
+  pendingVirtualParagraphGroups.delete(group)
+  if (virtualParagraphGroupsBySource.get(group.layoutSource) === group) {
+    virtualParagraphGroupsBySource.delete(group.layoutSource)
+  }
+  group.wrappers.forEach((wrapper) => {
+    if (virtualParagraphGroupsByWrapper.get(wrapper) === group) {
+      virtualParagraphGroupsByWrapper.delete(wrapper)
+    }
+  })
+}
 
 // Pre-compiled regex for better performance - removes all mark attributes
 export const MARK_ATTRIBUTES_REGEX = new RegExp(

--- a/src/utils/host/translate/dom/__tests__/paragraph-segmentation.test.ts
+++ b/src/utils/host/translate/dom/__tests__/paragraph-segmentation.test.ts
@@ -1,0 +1,261 @@
+// @vitest-environment jsdom
+import type { Config } from "@/types/config/config"
+import { beforeEach, describe, expect, it } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { CONTENT_WRAPPER_CLASS } from "@/utils/constants/dom-labels"
+import {
+  buildVirtualParagraphUnits,
+  liftParagraphInsertionBoundary,
+  type DOMBoundary,
+} from "../paragraph-segmentation"
+
+function setHost(host: string): void {
+  Object.defineProperty(window, "location", {
+    value: new URL(`https://${host}/some/path`),
+    writable: true,
+    configurable: true,
+  })
+}
+
+function createRoot(whiteSpace: string = "pre-wrap"): HTMLDivElement {
+  const root = document.createElement("div")
+  root.style.whiteSpace = whiteSpace
+  return root
+}
+
+function configWithSiteRule(rule: NonNullable<Config["siteRules"]>["userRules"][number]): Config {
+  const config = structuredClone(DEFAULT_CONFIG)
+  config.siteRules = {
+    userRules: [rule],
+    disabledBuiltInRules: [],
+  }
+  return config
+}
+
+function insertAtBoundary(boundary: DOMBoundary, marker: HTMLElement): void {
+  if (boundary.container.nodeType === Node.TEXT_NODE) {
+    const text = boundary.container as Text
+    const tail = text.splitText(boundary.offset)
+    tail.parentNode?.insertBefore(marker, tail)
+    return
+  }
+
+  boundary.container.insertBefore(marker, boundary.container.childNodes[boundary.offset] ?? null)
+}
+
+beforeEach(() => {
+  setHost("paragraph.example")
+})
+
+describe("buildVirtualParagraphUnits", () => {
+  it.each(["pre", "pre-wrap", "pre-line", "break-spaces"])(
+    "segments literal blank lines for white-space: %s",
+    (whiteSpace) => {
+      const root = createRoot(whiteSpace)
+      root.textContent = "First paragraph\n\nSecond paragraph"
+
+      const units = buildVirtualParagraphUnits(root, DEFAULT_CONFIG)
+
+      expect(units.map(({ id, text }) => ({ id, text }))).toEqual([
+        { id: 0, text: "First paragraph" },
+        { id: 1, text: "Second paragraph" },
+      ])
+    },
+  )
+
+  it.each(["normal", "nowrap"])(
+    "preserves the legacy single-unit path for white-space: %s",
+    (whiteSpace) => {
+      const root = createRoot(whiteSpace)
+      root.textContent = "First paragraph\n\nSecond paragraph"
+
+      expect(buildVirtualParagraphUnits(root, DEFAULT_CONFIG)).toEqual([])
+    },
+  )
+
+  it("does not split a single preserved newline", () => {
+    const root = createRoot()
+    root.textContent = "#MLB\n#Redsox"
+
+    expect(buildVirtualParagraphUnits(root, DEFAULT_CONFIG)).toEqual([])
+  })
+
+  it("keeps a single newline inside a paragraph split by a blank line", () => {
+    const root = createRoot()
+    root.textContent = "Score\n\n#MLB\n#Redsox"
+
+    const units = buildVirtualParagraphUnits(root, DEFAULT_CONFIG)
+
+    expect(units.map((unit) => unit.text)).toEqual(["Score", "#MLB\n#Redsox"])
+  })
+
+  it("accepts CRLF delimiters with horizontal whitespace", () => {
+    const root = createRoot()
+    root.textContent = "First\r\n \t\r\nSecond"
+
+    const units = buildVirtualParagraphUnits(root, DEFAULT_CONFIG)
+
+    expect(units.map((unit) => unit.text)).toEqual(["First", "Second"])
+  })
+
+  it("recognizes a delimiter that crosses Text nodes", () => {
+    const root = createRoot()
+    const firstText = document.createTextNode("First\n")
+    const span = document.createElement("span")
+    const secondText = document.createTextNode("\nSecond")
+    span.appendChild(secondText)
+    root.append(firstText, span)
+
+    const units = buildVirtualParagraphUnits(root, DEFAULT_CONFIG)
+
+    expect(units.map((unit) => unit.text)).toEqual(["First", "Second"])
+    expect(units[0].insertionBoundary).toEqual({ container: firstText, offset: 5 })
+    expect(units[1].sourceFragments).toEqual([
+      { source: secondText, startOffset: 1, endOffset: 7, atomic: false },
+    ])
+  })
+
+  it("keeps a preserve-text mention atomic inside its surrounding paragraph", () => {
+    setHost("preserve.example")
+    const config = configWithSiteRule({
+      id: "preserve",
+      matches: "preserve.example",
+      preserveTextSelectors: ["a.mention"],
+    })
+    const root = createRoot()
+    const before = document.createTextNode("Today we welcome ")
+    const mention = document.createElement("a")
+    mention.className = "mention"
+    mention.textContent = "@SohunSanka"
+    const after = document.createTextNode(" as our new head of GTM.\n\nNext paragraph")
+    root.append(before, mention, after)
+
+    const units = buildVirtualParagraphUnits(root, config)
+
+    expect(units.map((unit) => unit.text)).toEqual([
+      "Today we welcome @SohunSanka as our new head of GTM.",
+      "Next paragraph",
+    ])
+    expect(units[0].sourceFragments).toEqual([
+      { source: before, startOffset: 0, endOffset: 17, atomic: false },
+      { source: mention, startOffset: 0, endOffset: 11, atomic: true },
+      { source: after, startOffset: 0, endOffset: 24, atomic: false },
+    ])
+  })
+
+  it("does not interpret blank lines inside a dont-walk element as delimiters", () => {
+    const root = createRoot()
+    const code = document.createElement("code")
+    code.textContent = "literal\n\nvalue"
+    root.append("Before ", code, "\n\nAfter")
+
+    const units = buildVirtualParagraphUnits(root, DEFAULT_CONFIG)
+
+    expect(units.map((unit) => unit.text)).toEqual(["Before literal\n\nvalue", "After"])
+    expect(units[0].sourceFragments[1]).toEqual({
+      source: code,
+      startOffset: 0,
+      endOffset: 14,
+      atomic: true,
+    })
+  })
+
+  it("skips translated wrappers without joining newlines across the skipped subtree", () => {
+    const root = createRoot()
+    const wrapper = document.createElement("span")
+    wrapper.className = CONTENT_WRAPPER_CLASS
+    wrapper.textContent = "already translated"
+    root.append("One\n", wrapper, "\nTwo\n\nThree")
+
+    const units = buildVirtualParagraphUnits(root, DEFAULT_CONFIG)
+
+    expect(units.map((unit) => unit.text)).toEqual(["One\n\nTwo", "Three"])
+    expect(
+      units.flatMap((unit) => unit.sourceFragments).some((fragment) => fragment.source === wrapper),
+    ).toBe(false)
+  })
+
+  it("skips site-rule-excluded subtrees without joining newlines across them", () => {
+    setHost("exclude.example")
+    const config = configWithSiteRule({
+      id: "exclude",
+      matches: "exclude.example",
+      excludeSelectors: [".skip"],
+    })
+    const root = createRoot()
+    const excluded = document.createElement("span")
+    excluded.className = "skip"
+    excluded.textContent = "visible but excluded"
+    root.append("One\n", excluded, "\nTwo\n\nThree")
+
+    const units = buildVirtualParagraphUnits(root, config)
+
+    expect(units.map((unit) => unit.text)).toEqual(["One\n\nTwo", "Three"])
+    expect(units.map((unit) => unit.text).join(" ")).not.toContain("visible but excluded")
+  })
+
+  it("lifts a terminal preserve-text anchor boundary to the logical source", () => {
+    setHost("preserve.example")
+    const config = configWithSiteRule({
+      id: "preserve",
+      matches: "preserve.example",
+      preserveTextSelectors: ["a.mention"],
+    })
+    const root = createRoot()
+    const leading = document.createTextNode("First\n\n")
+    const span = document.createElement("span")
+    const mention = document.createElement("a")
+    mention.className = "mention"
+    mention.textContent = "@SohunSanka"
+    span.appendChild(mention)
+    root.append(leading, span)
+
+    const units = buildVirtualParagraphUnits(root, config)
+
+    expect(units[1].insertionBoundary).toEqual({ container: root, offset: 2 })
+  })
+
+  it("lifts a boundary out of a terminal BUTTON even when excluded children follow its text", () => {
+    const root = createRoot()
+    const button = document.createElement("button")
+    const text = document.createTextNode("Share")
+    const icon = document.createElement("svg")
+    button.append(text, icon)
+    root.appendChild(button)
+
+    const boundary = liftParagraphInsertionBoundary(
+      { container: text, offset: text.data.length },
+      root,
+      DEFAULT_CONFIG,
+    )
+
+    expect(boundary).toEqual({ container: root, offset: 1 })
+  })
+
+  it("returns boundaries that support reverse splitText insertion", () => {
+    const root = createRoot()
+    const source = document.createTextNode("One\n\nTwo\n\nThree")
+    root.appendChild(source)
+    const units = buildVirtualParagraphUnits(root, DEFAULT_CONFIG)
+
+    for (const unit of [...units].reverse()) {
+      const marker = document.createElement("i")
+      marker.dataset.paragraphId = String(unit.id)
+      insertAtBoundary(unit.insertionBoundary, marker)
+    }
+
+    expect([...root.childNodes].map((node) => node.textContent)).toEqual([
+      "One",
+      "",
+      "\n\nTwo",
+      "",
+      "\n\nThree",
+      "",
+    ])
+    expect([...root.querySelectorAll("i")].map((node) => node.dataset.paragraphId)).toEqual([
+      "0",
+      "1",
+      "2",
+    ])
+  })
+})

--- a/src/utils/host/translate/dom/__tests__/virtual-paragraph-lifecycle.test.ts
+++ b/src/utils/host/translate/dom/__tests__/virtual-paragraph-lifecycle.test.ts
@@ -1,0 +1,317 @@
+import type { VirtualParagraphUnit } from "../paragraph-segmentation"
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest"
+import {
+  getBilingualTranslationStateForSource,
+  getVirtualParagraphGroupForSource,
+  getVirtualParagraphGroupForWrapper,
+  isVirtualParagraphGroupCurrent,
+  markVirtualParagraphGroupInserted,
+  registerBilingualTranslationState,
+  registerVirtualParagraphGroup,
+  type BilingualTranslationState,
+  type VirtualParagraphGroup,
+} from "../../core/translation-state"
+import {
+  disposeVirtualParagraphGroup,
+  dropVirtualParagraphWrapper,
+  removeAllTranslatedWrapperNodes,
+} from "../translation-cleanup"
+import { insertVirtualParagraphWrappers } from "../virtual-paragraph-insertion"
+
+function unit(id: number, source: Text, offset: number): VirtualParagraphUnit {
+  return {
+    id,
+    text: `paragraph-${id}`,
+    insertionBoundary: { container: source, offset },
+    sourceFragments: [],
+  }
+}
+
+function createSplitGroup(
+  layoutSource: HTMLElement,
+  source: Text,
+  offsets: number[],
+  id: string = "generation",
+): { group: VirtualParagraphGroup; wrappers: HTMLElement[] } {
+  const sourceTextContent = layoutSource.textContent ?? ""
+  const wrappers = offsets.map(() => document.createElement("div"))
+  const entries = offsets.map((offset, index) => ({
+    unit: unit(index, source, offset),
+    wrapper: wrappers[index],
+  }))
+  const { splitRecords } = insertVirtualParagraphWrappers(entries, layoutSource)
+  const group: VirtualParagraphGroup = {
+    id,
+    walkId: id,
+    status: "active",
+    layoutSource,
+    wrappers: new Set(wrappers),
+    splitRecords,
+    sourceSnapshots: [],
+    sourceTextContent,
+    wrapperPlacements: new Map(),
+  }
+  registerVirtualParagraphGroup(group)
+  markVirtualParagraphGroupInserted(group)
+  return { group, wrappers }
+}
+
+beforeEach(() => {
+  document.body.replaceChildren()
+})
+
+describe("virtual paragraph lifecycle", () => {
+  it("restores one Text split at multiple reverse-applied boundaries without changing its identity", () => {
+    const originalValue = "one\n\ntwo\n\nthree"
+    const layoutSource = document.createElement("div")
+    const source = document.createTextNode(originalValue)
+    layoutSource.append(source)
+    document.body.append(layoutSource)
+
+    const { group } = createSplitGroup(layoutSource, source, [3, 8, originalValue.length])
+
+    expect(group.splitRecords).toHaveLength(1)
+    expect(group.splitRecords[0].source).toBe(source)
+    expect(group.splitRecords[0].createdTails).toHaveLength(2)
+    expect(layoutSource.textContent).toBe(originalValue)
+
+    expect(disposeVirtualParagraphGroup(group)).toEqual({ restored: 1, skipped: 0 })
+    expect(layoutSource.childNodes).toHaveLength(1)
+    expect(layoutSource.firstChild).toBe(source)
+    expect(source.data).toBe(originalValue)
+  })
+
+  it("disposes idempotently", () => {
+    const layoutSource = document.createElement("div")
+    const source = document.createTextNode("one\n\ntwo")
+    layoutSource.append(source)
+    document.body.append(layoutSource)
+    const { group } = createSplitGroup(layoutSource, source, [3, source.data.length])
+
+    expect(disposeVirtualParagraphGroup(group)).toEqual({ restored: 1, skipped: 0 })
+    expect(disposeVirtualParagraphGroup(group)).toEqual({ restored: 0, skipped: 0 })
+    expect(layoutSource.firstChild).toBe(source)
+    expect(source.data).toBe("one\n\ntwo")
+  })
+
+  it("removes wrappers but preserves split fragments when the host modifies the source", () => {
+    const originalValue = "one\n\ntwo\n\nthree"
+    const layoutSource = document.createElement("div")
+    const source = document.createTextNode(originalValue)
+    layoutSource.append(source)
+    document.body.append(layoutSource)
+    const { group, wrappers } = createSplitGroup(layoutSource, source, [3, 8])
+    const tails = [...group.splitRecords[0].createdTails]
+
+    source.data = "host update"
+
+    expect(disposeVirtualParagraphGroup(group)).toEqual({ restored: 0, skipped: 1 })
+    expect(source.data).toBe("host update")
+    expect(tails.every((tail) => tail.isConnected)).toBe(true)
+    expect(tails.every((tail) => layoutSource.contains(tail))).toBe(true)
+    expect(wrappers.every((wrapper) => !wrapper.isConnected)).toBe(true)
+  })
+
+  it("removes proven duplicate tails when the host expands the original Text node", () => {
+    const originalValue = "one\n\ntwo\n\nthree"
+    const expandedValue = `${originalValue} with expanded content`
+    const layoutSource = document.createElement("div")
+    const source = document.createTextNode(originalValue)
+    layoutSource.append(source)
+    document.body.append(layoutSource)
+    const { group } = createSplitGroup(layoutSource, source, [3, 8])
+    const tails = [...group.splitRecords[0].createdTails]
+
+    source.data = expandedValue
+
+    expect(disposeVirtualParagraphGroup(group)).toEqual({ restored: 1, skipped: 0 })
+    expect(source.data).toBe(expandedValue)
+    expect(layoutSource.childNodes).toHaveLength(1)
+    expect(layoutSource.firstChild).toBe(source)
+    expect(tails.every((tail) => !tail.isConnected)).toBe(true)
+  })
+
+  it("does not overwrite a replacement Text or delete the surviving tails", () => {
+    const originalValue = "one\n\ntwo\n\nthree"
+    const layoutSource = document.createElement("div")
+    const source = document.createTextNode(originalValue)
+    layoutSource.append(source)
+    document.body.append(layoutSource)
+    const { group, wrappers } = createSplitGroup(layoutSource, source, [3, 8])
+    const tails = [...group.splitRecords[0].createdTails]
+    const replacement = document.createTextNode("replacement")
+
+    source.replaceWith(replacement)
+
+    expect(disposeVirtualParagraphGroup(group)).toEqual({ restored: 0, skipped: 1 })
+    expect(replacement.data).toBe("replacement")
+    expect(layoutSource.firstChild).toBe(replacement)
+    expect(tails.every((tail) => tail.isConnected)).toBe(true)
+    expect(tails.every((tail) => layoutSource.contains(tail))).toBe(true)
+    expect(wrappers.every((wrapper) => !wrapper.isConnected)).toBe(true)
+  })
+
+  it("keeps split state until the last wrapper is dropped", () => {
+    const originalValue = "one\n\ntwo"
+    const layoutSource = document.createElement("div")
+    const source = document.createTextNode(originalValue)
+    layoutSource.append(source)
+    document.body.append(layoutSource)
+    const { group, wrappers } = createSplitGroup(layoutSource, source, [3, originalValue.length])
+    const tail = group.splitRecords[0].createdTails[0]
+
+    dropVirtualParagraphWrapper(group, wrappers[0])
+
+    expect(group.status).toBe("active")
+    expect(group.wrappers).toEqual(new Set([wrappers[1]]))
+    expect(source.data).toBe("one")
+    expect(tail.isConnected).toBe(true)
+    expect(getVirtualParagraphGroupForSource(layoutSource)).toBe(group)
+
+    dropVirtualParagraphWrapper(group, wrappers[1])
+
+    expect(group.status).toBe("disposed")
+    expect(layoutSource.firstChild).toBe(source)
+    expect(source.data).toBe(originalValue)
+    expect(tail.isConnected).toBe(false)
+    expect(getVirtualParagraphGroupForSource(layoutSource)).toBeUndefined()
+  })
+
+  it("does not erase a newer generation mapping when disposing an old generation", () => {
+    const layoutSource = document.createElement("div")
+    document.body.append(layoutSource)
+    const oldWrapper = document.createElement("div")
+    const newWrapper = document.createElement("div")
+    layoutSource.append(oldWrapper, newWrapper)
+    const oldGroup: VirtualParagraphGroup = {
+      id: "old",
+      walkId: "old",
+      status: "active",
+      layoutSource,
+      wrappers: new Set([oldWrapper]),
+      splitRecords: [],
+      sourceSnapshots: [],
+      sourceTextContent: "",
+      wrapperPlacements: new Map(),
+    }
+    const newGroup: VirtualParagraphGroup = {
+      id: "new",
+      walkId: "new",
+      status: "active",
+      layoutSource,
+      wrappers: new Set([newWrapper]),
+      splitRecords: [],
+      sourceSnapshots: [],
+      sourceTextContent: "",
+      wrapperPlacements: new Map(),
+    }
+    registerVirtualParagraphGroup(oldGroup)
+    registerVirtualParagraphGroup(newGroup)
+    markVirtualParagraphGroupInserted(oldGroup)
+    markVirtualParagraphGroupInserted(newGroup)
+
+    disposeVirtualParagraphGroup(oldGroup)
+
+    expect(getVirtualParagraphGroupForSource(layoutSource)).toBe(newGroup)
+    expect(getVirtualParagraphGroupForWrapper(newWrapper)).toBe(newGroup)
+    expect(newGroup.status).toBe("active")
+    expect(newWrapper.isConnected).toBe(true)
+    expect(oldWrapper.isConnected).toBe(false)
+
+    disposeVirtualParagraphGroup(newGroup)
+  })
+
+  it("cancels a pending group before its wrappers have been inserted", () => {
+    const layoutSource = document.createElement("div")
+    document.body.append(layoutSource)
+    const group: VirtualParagraphGroup = {
+      id: "pending",
+      walkId: "pending",
+      status: "active",
+      layoutSource,
+      wrappers: new Set(),
+      splitRecords: [],
+      sourceSnapshots: [],
+      sourceTextContent: "",
+      wrapperPlacements: new Map(),
+    }
+    registerVirtualParagraphGroup(group)
+
+    removeAllTranslatedWrapperNodes(document)
+
+    expect(group.status).toBe("disposed")
+    expect(getVirtualParagraphGroupForSource(layoutSource)).toBeUndefined()
+  })
+
+  it("cancels a pending legacy bilingual translation before wrapper insertion", () => {
+    const layoutSource = document.createElement("div")
+    layoutSource.textContent = "Pending source"
+    document.body.append(layoutSource)
+    const state: BilingualTranslationState = {
+      layoutSource,
+      sourceTextContent: "Pending source",
+      status: "active",
+      walkId: "pending-legacy",
+      wrapper: null,
+    }
+    registerBilingualTranslationState(state)
+
+    removeAllTranslatedWrapperNodes(document)
+
+    expect(state.status).toBe("disposed")
+    expect(getBilingualTranslationStateForSource(layoutSource)).toBeUndefined()
+  })
+
+  it("treats a removed tracked wrapper as stale after insertion", () => {
+    const layoutSource = document.createElement("div")
+    const source = document.createTextNode("one\n\ntwo")
+    layoutSource.append(source)
+    document.body.append(layoutSource)
+    const { group, wrappers } = createSplitGroup(layoutSource, source, [3, source.data.length])
+
+    expect(isVirtualParagraphGroupCurrent(group)).toBe(true)
+    wrappers[0].remove()
+
+    expect(isVirtualParagraphGroupCurrent(group)).toBe(false)
+    disposeVirtualParagraphGroup(group)
+  })
+
+  it("treats a tracked wrapper moved within the layout source as stale", () => {
+    const layoutSource = document.createElement("div")
+    const source = document.createTextNode("one\n\ntwo")
+    layoutSource.append(source)
+    document.body.append(layoutSource)
+    const { group, wrappers } = createSplitGroup(layoutSource, source, [3, source.data.length])
+
+    layoutSource.append(wrappers[0])
+
+    expect(isVirtualParagraphGroupCurrent(group)).toBe(false)
+    disposeVirtualParagraphGroup(group)
+  })
+
+  it("cancels pending groups inside an attached shadow root during document cleanup", () => {
+    const host = document.createElement("div")
+    const shadowRoot = host.attachShadow({ mode: "open" })
+    const layoutSource = document.createElement("div")
+    shadowRoot.append(layoutSource)
+    document.body.append(host)
+    const group: VirtualParagraphGroup = {
+      id: "shadow-pending",
+      walkId: "shadow-pending",
+      status: "active",
+      layoutSource,
+      wrappers: new Set(),
+      splitRecords: [],
+      sourceSnapshots: [],
+      sourceTextContent: "",
+      wrapperPlacements: new Map(),
+    }
+    registerVirtualParagraphGroup(group)
+
+    removeAllTranslatedWrapperNodes(document)
+
+    expect(group.status).toBe("disposed")
+    expect(getVirtualParagraphGroupForSource(layoutSource)).toBeUndefined()
+  })
+})

--- a/src/utils/host/translate/dom/paragraph-segmentation.ts
+++ b/src/utils/host/translate/dom/paragraph-segmentation.ts
@@ -1,0 +1,415 @@
+import type { VirtualParagraphSourceSnapshot } from "../core/translation-state"
+import type { Config } from "@/types/config/config"
+import {
+  isDontWalkIntoAndDontTranslateAsChildElement,
+  isDontWalkIntoButTranslateAsChildElement,
+  isHTMLElement,
+  isTextNode,
+  isTranslatedContentNode,
+  isTranslatedWrapperNode,
+} from "../../dom/filter"
+
+const PRESERVED_NEWLINE_WHITE_SPACE = new Set(["pre", "pre-wrap", "pre-line", "break-spaces"])
+
+const BLANK_LINE_DELIMITER_RE = /(?:\r\n?|\n)[^\S\r\n]*(?:\r\n?|\n)(?:[^\S\r\n]*(?:\r\n?|\n))*/g
+
+const PROTECTED_INSERTION_TAGS = new Set(["A", "BUTTON"])
+
+export interface DOMBoundary {
+  container: Node
+  offset: number
+}
+
+export interface VirtualParagraphSourceFragment {
+  source: Text | HTMLElement
+  startOffset: number
+  endOffset: number
+  atomic: boolean
+}
+
+export interface VirtualParagraphUnit {
+  id: number
+  text: string
+  insertionBoundary: DOMBoundary
+  sourceFragments: VirtualParagraphSourceFragment[]
+}
+
+export interface VirtualParagraphPlan {
+  units: VirtualParagraphUnit[]
+  sourceSnapshots: VirtualParagraphSourceSnapshot[]
+}
+
+interface RawSourceChunk {
+  source: Text | HTMLElement
+  streamStart: number
+  streamEnd: number
+  atomic: boolean
+  delimiterEligible: boolean
+}
+
+interface StreamState {
+  chunks: RawSourceChunk[]
+  parts: string[]
+  barriers: Set<number>
+  length: number
+}
+
+interface RawDelimiter {
+  start: number
+  end: number
+}
+
+interface RawSegment {
+  start: number
+  end: number
+  insertionIndex: number
+}
+
+function appendChunk(
+  state: StreamState,
+  source: Text | HTMLElement,
+  text: string,
+  atomic: boolean,
+  delimiterEligible: boolean,
+): void {
+  if (text === "") return
+
+  const streamStart = state.length
+  state.parts.push(text)
+  state.length += text.length
+  state.chunks.push({
+    source,
+    streamStart,
+    streamEnd: state.length,
+    atomic,
+    delimiterEligible,
+  })
+}
+
+function addBarrier(state: StreamState): void {
+  state.barriers.add(state.length)
+}
+
+function collectRawSource(
+  element: HTMLElement,
+  config: Config,
+  state: StreamState,
+  delimiterEligible: boolean = true,
+): void {
+  for (const child of element.childNodes) {
+    if (isTextNode(child)) {
+      appendChunk(state, child, child.data, false, delimiterEligible)
+      continue
+    }
+
+    if (!isHTMLElement(child)) continue
+
+    if (
+      isTranslatedWrapperNode(child) ||
+      isTranslatedContentNode(child) ||
+      isDontWalkIntoAndDontTranslateAsChildElement(child, config)
+    ) {
+      // Excluded DOM must not make otherwise separated newline characters
+      // look adjacent in the virtual text stream.
+      addBarrier(state)
+      continue
+    }
+
+    if (isDontWalkIntoButTranslateAsChildElement(child, config)) {
+      appendChunk(state, child, child.textContent ?? "", true, false)
+      // Empty atomic elements still separate the source on either side.
+      if (!child.textContent) addBarrier(state)
+      continue
+    }
+
+    const childDelimiterEligible = delimiterEligible && !PROTECTED_INSERTION_TAGS.has(child.tagName)
+    collectRawSource(child, config, state, childDelimiterEligible)
+  }
+}
+
+function findDelimiterEligibleIntervals(state: StreamState): Array<[number, number]> {
+  const intervals: Array<[number, number]> = []
+  let intervalStart: number | undefined
+  let intervalEnd = 0
+
+  const closeInterval = () => {
+    if (intervalStart !== undefined && intervalEnd > intervalStart) {
+      intervals.push([intervalStart, intervalEnd])
+    }
+    intervalStart = undefined
+  }
+
+  for (const chunk of state.chunks) {
+    if (!chunk.delimiterEligible) {
+      closeInterval()
+      continue
+    }
+
+    const canJoinPrevious =
+      intervalStart !== undefined &&
+      chunk.streamStart === intervalEnd &&
+      !state.barriers.has(chunk.streamStart)
+
+    if (!canJoinPrevious) {
+      closeInterval()
+      intervalStart = chunk.streamStart
+    }
+    intervalEnd = chunk.streamEnd
+  }
+
+  closeInterval()
+  return intervals
+}
+
+function findBlankLineDelimiters(stream: string, state: StreamState): RawDelimiter[] {
+  const delimiters: RawDelimiter[] = []
+
+  for (const [intervalStart, intervalEnd] of findDelimiterEligibleIntervals(state)) {
+    const intervalText = stream.slice(intervalStart, intervalEnd)
+    for (const match of intervalText.matchAll(BLANK_LINE_DELIMITER_RE)) {
+      const start = intervalStart + (match.index ?? 0)
+      delimiters.push({ start, end: start + match[0].length })
+    }
+  }
+
+  return delimiters
+}
+
+function createRawSegments(streamLength: number, delimiters: RawDelimiter[]): RawSegment[] {
+  const segments: RawSegment[] = []
+  let start = 0
+
+  for (const delimiter of delimiters) {
+    segments.push({ start, end: delimiter.start, insertionIndex: delimiter.start })
+    start = delimiter.end
+  }
+
+  segments.push({ start, end: streamLength, insertionIndex: streamLength })
+  return segments
+}
+
+function createSourceFragments(
+  chunks: RawSourceChunk[],
+  contentStart: number,
+  contentEnd: number,
+): VirtualParagraphSourceFragment[] {
+  const fragments: VirtualParagraphSourceFragment[] = []
+
+  for (const chunk of chunks) {
+    const intersectionStart = Math.max(contentStart, chunk.streamStart)
+    const intersectionEnd = Math.min(contentEnd, chunk.streamEnd)
+    if (intersectionStart >= intersectionEnd) continue
+
+    fragments.push({
+      source: chunk.source,
+      startOffset: intersectionStart - chunk.streamStart,
+      endOffset: intersectionEnd - chunk.streamStart,
+      atomic: chunk.atomic,
+    })
+  }
+
+  return fragments
+}
+
+function createSourceSnapshots(chunks: RawSourceChunk[]): VirtualParagraphSourceSnapshot[] {
+  const snapshots = new Map<Text | HTMLElement, VirtualParagraphSourceSnapshot>()
+  for (const { source } of chunks) {
+    if (snapshots.has(source)) continue
+    snapshots.set(source, {
+      source,
+      parent: source.parentNode,
+      value: isTextNode(source) ? source.data : (source.textContent ?? ""),
+    })
+  }
+  return [...snapshots.values()]
+}
+
+function boundaryAfterElement(element: HTMLElement): DOMBoundary | undefined {
+  const parent = element.parentNode
+  if (!parent) return undefined
+
+  const index = [...parent.childNodes].indexOf(element)
+  if (index === -1) return undefined
+  return { container: parent, offset: index + 1 }
+}
+
+function boundaryAtStreamOffset(
+  chunks: RawSourceChunk[],
+  streamOffset: number,
+  layoutSource: HTMLElement,
+): DOMBoundary {
+  const containingChunk = chunks.find(
+    (chunk) => chunk.streamStart <= streamOffset && streamOffset < chunk.streamEnd,
+  )
+
+  if (containingChunk) {
+    if (isTextNode(containingChunk.source)) {
+      return {
+        container: containingChunk.source,
+        offset: streamOffset - containingChunk.streamStart,
+      }
+    }
+
+    return (
+      boundaryAfterElement(containingChunk.source) ?? {
+        container: layoutSource,
+        offset: layoutSource.childNodes.length,
+      }
+    )
+  }
+
+  let precedingChunk: RawSourceChunk | undefined
+  for (let index = chunks.length - 1; index >= 0; index -= 1) {
+    if (chunks[index].streamEnd <= streamOffset) {
+      precedingChunk = chunks[index]
+      break
+    }
+  }
+  if (!precedingChunk) {
+    return { container: layoutSource, offset: 0 }
+  }
+
+  if (isTextNode(precedingChunk.source)) {
+    return { container: precedingChunk.source, offset: precedingChunk.source.data.length }
+  }
+
+  return (
+    boundaryAfterElement(precedingChunk.source) ?? {
+      container: layoutSource,
+      offset: layoutSource.childNodes.length,
+    }
+  )
+}
+
+function findProtectedBoundaryAncestor(
+  boundary: DOMBoundary,
+  layoutSource: HTMLElement,
+  config: Config,
+): HTMLElement | undefined {
+  let current = isHTMLElement(boundary.container)
+    ? boundary.container
+    : boundary.container.parentElement
+  let outermostProtected: HTMLElement | undefined
+
+  while (current && current !== layoutSource) {
+    if (
+      PROTECTED_INSERTION_TAGS.has(current.tagName) ||
+      isDontWalkIntoButTranslateAsChildElement(current, config)
+    ) {
+      outermostProtected = current
+    }
+    current = current.parentElement
+  }
+
+  return outermostProtected
+}
+
+function liftEdgeBoundary(boundary: DOMBoundary, layoutSource: HTMLElement): DOMBoundary {
+  let current = boundary
+
+  while (current.container !== layoutSource) {
+    if (isTextNode(current.container)) {
+      if (current.offset !== 0 && current.offset !== current.container.data.length) break
+
+      const parent = current.container.parentNode
+      if (!parent) break
+      const index = [...parent.childNodes].indexOf(current.container)
+      if (index === -1) break
+
+      current = {
+        container: parent,
+        offset: index + (current.offset === current.container.data.length ? 1 : 0),
+      }
+      continue
+    }
+
+    const childCount = current.container.childNodes.length
+    if (current.offset !== 0 && current.offset !== childCount) break
+
+    const parent = current.container.parentNode
+    if (!parent) break
+    const index = [...parent.childNodes].indexOf(current.container as ChildNode)
+    if (index === -1) break
+
+    current = {
+      container: parent,
+      offset: index + (current.offset === childCount ? 1 : 0),
+    }
+  }
+
+  return current
+}
+
+/**
+ * Lift terminal boundaries out of controls and atomic inline content. This is
+ * intentionally limited to boundaries at a paragraph edge; a boundary in the
+ * middle of an ordinary Text node stays in that Text node for splitText/Range.
+ */
+export function liftParagraphInsertionBoundary(
+  boundary: DOMBoundary,
+  layoutSource: HTMLElement,
+  config: Config,
+): DOMBoundary {
+  const protectedAncestor = findProtectedBoundaryAncestor(boundary, layoutSource, config)
+  const outsideProtected = protectedAncestor
+    ? (boundaryAfterElement(protectedAncestor) ?? boundary)
+    : boundary
+
+  return liftEdgeBoundary(outsideProtected, layoutSource)
+}
+
+/**
+ * Build virtual bilingual paragraphs from literal blank lines without changing
+ * the host DOM. An empty result means the caller should use the existing
+ * single-translation-unit path.
+ */
+export function buildVirtualParagraphPlan(
+  layoutSource: HTMLElement,
+  config: Config,
+): VirtualParagraphPlan {
+  const whiteSpace = window.getComputedStyle(layoutSource).whiteSpace.trim().toLowerCase()
+  if (!PRESERVED_NEWLINE_WHITE_SPACE.has(whiteSpace)) {
+    return { units: [], sourceSnapshots: [] }
+  }
+
+  const state: StreamState = {
+    chunks: [],
+    parts: [],
+    barriers: new Set(),
+    length: 0,
+  }
+  collectRawSource(layoutSource, config, state)
+
+  const stream = state.parts.join("")
+  const delimiters = findBlankLineDelimiters(stream, state)
+  if (delimiters.length === 0) return { units: [], sourceSnapshots: [] }
+
+  const units: VirtualParagraphUnit[] = []
+  for (const segment of createRawSegments(stream.length, delimiters)) {
+    const rawText = stream.slice(segment.start, segment.end)
+    const text = rawText.trim()
+    if (text === "") continue
+
+    const contentStart = segment.start + (rawText.length - rawText.trimStart().length)
+    const contentEnd = segment.end - (rawText.length - rawText.trimEnd().length)
+    const boundary = boundaryAtStreamOffset(state.chunks, segment.insertionIndex, layoutSource)
+
+    units.push({
+      id: units.length,
+      text,
+      insertionBoundary: liftParagraphInsertionBoundary(boundary, layoutSource, config),
+      sourceFragments: createSourceFragments(state.chunks, contentStart, contentEnd),
+    })
+  }
+
+  return units.length >= 2
+    ? { units, sourceSnapshots: createSourceSnapshots(state.chunks) }
+    : { units: [], sourceSnapshots: [] }
+}
+
+export function buildVirtualParagraphUnits(
+  layoutSource: HTMLElement,
+  config: Config,
+): VirtualParagraphUnit[] {
+  return buildVirtualParagraphPlan(layoutSource, config).units
+}

--- a/src/utils/host/translate/dom/translation-cleanup.ts
+++ b/src/utils/host/translate/dom/translation-cleanup.ts
@@ -1,9 +1,24 @@
-import { REACT_SHADOW_HOST_CLASS, TRANSLATION_MODE_ATTRIBUTE } from "../../../constants/dom-labels"
+import type { TextSplitRecord, VirtualParagraphGroup } from "../core/translation-state"
+import {
+  REACT_SHADOW_HOST_CLASS,
+  TRANSLATION_MODE_ATTRIBUTE,
+  VIRTUAL_PARAGRAPH_ATTRIBUTE,
+} from "../../../constants/dom-labels"
 import { removeReactShadowHost } from "../../../react-shadow-host/create-shadow-host"
 import { batchDOMOperation } from "../../dom/batch-dom"
 import { isHTMLElement, isTranslatedWrapperNode } from "../../dom/filter"
 import { deepQueryTopLevelSelector } from "../../dom/find"
-import { originalContentMap } from "../core/translation-state"
+import {
+  getBilingualTranslationStateForWrapper,
+  getPendingBilingualTranslationStates,
+  getPendingVirtualParagraphGroups,
+  getVirtualParagraphGroupForSource,
+  getVirtualParagraphGroupForWrapper,
+  originalContentMap,
+  unregisterBilingualTranslationState,
+  unregisterVirtualParagraphGroup,
+  unregisterVirtualParagraphWrapper,
+} from "../core/translation-state"
 
 export function removeShadowHostInTranslatedWrapper(wrapper: HTMLElement): void {
   // Remove React shadow hosts (for error components)
@@ -14,9 +29,111 @@ export function removeShadowHostInTranslatedWrapper(wrapper: HTMLElement): void 
 
   // Remove lightweight spinners
   const spinner = wrapper.querySelector(".read-frog-spinner")
-  if (spinner) {
-    batchDOMOperation(() => spinner.remove())
+  spinner?.remove()
+}
+
+function restoreTextSplit(record: TextSplitRecord): boolean {
+  const {
+    source,
+    parent,
+    originalValue,
+    createdTails,
+    sourceValueAfterSplit,
+    tailValuesAfterSplit,
+  } = record
+  if (!source.isConnected || source.parentNode !== parent) return false
+
+  let previous: Text = source
+  for (const tail of createdTails) {
+    if (!tail.isConnected || tail.parentNode !== parent || previous.nextSibling !== tail) {
+      return false
+    }
+    previous = tail
   }
+
+  const currentValue = [source, ...createdTails].map((node) => node.data).join("")
+  if (currentValue === originalValue) {
+    source.data = originalValue
+    createdTails.forEach((tail) => tail.remove())
+    return true
+  }
+
+  const tailsAreUnchanged = createdTails.every(
+    (tail, index) => tail.data === tailValuesAfterSplit[index],
+  )
+  const hostReconstructedFullText =
+    source.data !== sourceValueAfterSplit && source.data.startsWith(originalValue)
+  if (tailsAreUnchanged && hostReconstructedFullText) {
+    // Frameworks such as React can update their original Text node with the
+    // complete expanded value while leaving splitText-created tails behind.
+    // The unchanged tails are then proven duplicates; keep the host value and
+    // remove only the fragments Read Frog created.
+    createdTails.forEach((tail) => tail.remove())
+    return true
+  }
+
+  return false
+}
+
+export function disposeVirtualParagraphGroup(group: VirtualParagraphGroup): {
+  restored: number
+  skipped: number
+} {
+  if (group.status !== "active") return { restored: 0, skipped: 0 }
+
+  group.status = "disposing"
+  unregisterVirtualParagraphGroup(group)
+
+  for (const wrapper of group.wrappers) {
+    removeShadowHostInTranslatedWrapper(wrapper)
+    wrapper.remove()
+  }
+  group.wrappers.clear()
+  group.wrapperPlacements.clear()
+
+  let restored = 0
+  for (const record of group.splitRecords) {
+    if (restoreTextSplit(record)) restored += 1
+  }
+
+  group.status = "disposed"
+  return { restored, skipped: group.splitRecords.length - restored }
+}
+
+export function removeVirtualParagraphGroupForSource(source: HTMLElement): boolean {
+  const group = getVirtualParagraphGroupForSource(source)
+  if (!group) return false
+  disposeVirtualParagraphGroup(group)
+  return true
+}
+
+export function removeOrphanVirtualParagraphWrappers(source: HTMLElement): boolean {
+  const orphanWrappers = [
+    ...source.querySelectorAll<HTMLElement>(`[${VIRTUAL_PARAGRAPH_ATTRIBUTE}]`),
+  ].filter((wrapper) => !getVirtualParagraphGroupForWrapper(wrapper))
+
+  orphanWrappers.forEach((wrapper) => {
+    removeShadowHostInTranslatedWrapper(wrapper)
+    wrapper.remove()
+  })
+  return orphanWrappers.length > 0
+}
+
+export function dropVirtualParagraphWrapper(
+  group: VirtualParagraphGroup,
+  wrapper: HTMLElement,
+): void {
+  if (group.status !== "active" || !group.wrappers.has(wrapper)) return
+  removeShadowHostInTranslatedWrapper(wrapper)
+  unregisterVirtualParagraphWrapper(group, wrapper)
+  wrapper.remove()
+  if (group.wrappers.size === 0) disposeVirtualParagraphGroup(group)
+}
+
+export function removeVirtualParagraphWrapper(wrapper: HTMLElement): void {
+  const group = getVirtualParagraphGroupForWrapper(wrapper)
+  if (group) dropVirtualParagraphWrapper(group, wrapper)
+  else wrapper.remove()
 }
 
 /**
@@ -24,6 +141,15 @@ export function removeShadowHostInTranslatedWrapper(wrapper: HTMLElement): void 
  * @param wrapper - The translated wrapper element to remove
  */
 export function removeTranslatedWrapperWithRestore(wrapper: HTMLElement): void {
+  const virtualParagraphGroup = getVirtualParagraphGroupForWrapper(wrapper)
+  if (virtualParagraphGroup) {
+    disposeVirtualParagraphGroup(virtualParagraphGroup)
+    return
+  }
+
+  const bilingualState = getBilingualTranslationStateForWrapper(wrapper)
+  if (bilingualState) unregisterBilingualTranslationState(bilingualState)
+
   removeShadowHostInTranslatedWrapper(wrapper)
 
   const translationMode = wrapper.getAttribute(TRANSLATION_MODE_ATTRIBUTE)
@@ -46,11 +172,27 @@ export function removeTranslatedWrapperWithRestore(wrapper: HTMLElement): void {
     }
   }
 
-  // For bilingual mode or when no original content is found, just remove the wrapper
+  if (translationMode === "bilingual") {
+    wrapper.remove()
+    return
+  }
+
+  // When no original content is found, just remove the wrapper.
   batchDOMOperation(() => wrapper.remove())
 }
 
 export function removeAllTranslatedWrapperNodes(root: Document | ShadowRoot = document): void {
+  const isInsideRoot = (source: HTMLElement) =>
+    root.nodeType === Node.DOCUMENT_NODE
+      ? source.ownerDocument === root && source.isConnected
+      : source.getRootNode() === root || root.contains(source)
+
+  getPendingBilingualTranslationStates()
+    .filter((state) => isInsideRoot(state.layoutSource))
+    .forEach(unregisterBilingualTranslationState)
+  getPendingVirtualParagraphGroups()
+    .filter((group) => isInsideRoot(group.layoutSource))
+    .forEach(disposeVirtualParagraphGroup)
   const translatedNodes = deepQueryTopLevelSelector(root, isTranslatedWrapperNode)
   translatedNodes.forEach((contentWrapperNode) => {
     removeTranslatedWrapperWithRestore(contentWrapperNode)

--- a/src/utils/host/translate/dom/translation-insertion.ts
+++ b/src/utils/host/translate/dom/translation-insertion.ts
@@ -20,8 +20,9 @@ import { decorateTranslationNode } from "../ui/decorate-translation"
 import { isForceInlineTranslation } from "../ui/translation-utils"
 
 interface TranslationInsertionContext {
-  insertionTarget: TransNode
+  flowSource: TransNode
   layoutSource: TransNode
+  isCurrent?: () => boolean
 }
 
 function isFloatedElement(element: HTMLElement): boolean {
@@ -93,12 +94,14 @@ export function addBlockTranslation(
 
 export async function insertTranslatedNodeIntoWrapper(
   translatedWrapperNode: HTMLElement,
-  { insertionTarget, layoutSource }: TranslationInsertionContext,
+  { flowSource, layoutSource, isCurrent }: TranslationInsertionContext,
   translatedText: string,
   translationNodeStyle: TranslationNodeStyleConfig,
   config: Config,
   forceBlockTranslation: boolean = false,
 ): Promise<void> {
+  if (isCurrent && !isCurrent()) return
+
   // Use the wrapper's owner document
   const ownerDoc = getOwnerDocument(translatedWrapperNode)
   const translatedNode = ownerDoc.createElement("span")
@@ -128,9 +131,11 @@ export async function insertTranslatedNodeIntoWrapper(
   translatedWrapperNode.appendChild(translatedNode)
   await decorateTranslationNode(translatedNode, translationNodeStyle)
 
+  if (isCurrent && !isCurrent()) return
+
   if (
     translatedNode.classList.contains(BLOCK_CONTENT_CLASS) &&
-    shouldWrapInsideFloatFlow(insertionTarget)
+    shouldWrapInsideFloatFlow(flowSource)
   ) {
     translatedNode.setAttribute(FLOAT_WRAP_ATTRIBUTE, "true")
   }

--- a/src/utils/host/translate/dom/translation-insertion.ts
+++ b/src/utils/host/translate/dom/translation-insertion.ts
@@ -19,6 +19,11 @@ import { getOwnerDocument } from "../../dom/node"
 import { decorateTranslationNode } from "../ui/decorate-translation"
 import { isForceInlineTranslation } from "../ui/translation-utils"
 
+interface TranslationInsertionContext {
+  insertionTarget: TransNode
+  layoutSource: TransNode
+}
+
 function isFloatedElement(element: HTMLElement): boolean {
   const floatValue = window.getComputedStyle(element).float
   return floatValue === "left" || floatValue === "right"
@@ -88,7 +93,7 @@ export function addBlockTranslation(
 
 export async function insertTranslatedNodeIntoWrapper(
   translatedWrapperNode: HTMLElement,
-  targetNode: TransNode,
+  { insertionTarget, layoutSource }: TranslationInsertionContext,
   translatedText: string,
   translationNodeStyle: TranslationNodeStyleConfig,
   config: Config,
@@ -98,10 +103,10 @@ export async function insertTranslatedNodeIntoWrapper(
   const ownerDoc = getOwnerDocument(translatedWrapperNode)
   const translatedNode = ownerDoc.createElement("span")
   const siteRuleForceInline =
-    isHTMLElement(targetNode) && isSiteRuleForceInlineElement(targetNode, config)
-  const forceInlineTranslation = isForceInlineTranslation(targetNode) || siteRuleForceInline
+    isHTMLElement(layoutSource) && isSiteRuleForceInlineElement(layoutSource, config)
+  const forceInlineTranslation = isForceInlineTranslation(layoutSource) || siteRuleForceInline
   const siteRuleForceBlock =
-    isHTMLElement(targetNode) && isSiteRuleForceBlockElement(targetNode, config)
+    isHTMLElement(layoutSource) && isSiteRuleForceBlockElement(layoutSource, config)
 
   // priority: siteRuleForceBlock > forceInlineTranslation > forceBlockTranslation > isInlineTransNode > isBlockTransNode
   if (siteRuleForceBlock) {
@@ -110,9 +115,9 @@ export async function insertTranslatedNodeIntoWrapper(
     addInlineTranslation(ownerDoc, translatedWrapperNode, translatedNode)
   } else if (forceBlockTranslation) {
     addBlockTranslation(ownerDoc, translatedWrapperNode, translatedNode)
-  } else if (isInlineTransNode(targetNode)) {
+  } else if (isInlineTransNode(layoutSource)) {
     addInlineTranslation(ownerDoc, translatedWrapperNode, translatedNode)
-  } else if (isBlockTransNode(targetNode)) {
+  } else if (isBlockTransNode(layoutSource)) {
     addBlockTranslation(ownerDoc, translatedWrapperNode, translatedNode)
   } else {
     // not inline or block, maybe notranslate
@@ -125,7 +130,7 @@ export async function insertTranslatedNodeIntoWrapper(
 
   if (
     translatedNode.classList.contains(BLOCK_CONTENT_CLASS) &&
-    shouldWrapInsideFloatFlow(targetNode)
+    shouldWrapInsideFloatFlow(insertionTarget)
   ) {
     translatedNode.setAttribute(FLOAT_WRAP_ATTRIBUTE, "true")
   }

--- a/src/utils/host/translate/dom/virtual-paragraph-insertion.ts
+++ b/src/utils/host/translate/dom/virtual-paragraph-insertion.ts
@@ -1,0 +1,100 @@
+import type { TextSplitRecord } from "../core/translation-state"
+import type { VirtualParagraphUnit } from "./paragraph-segmentation"
+import type { TransNode } from "@/types/dom"
+import { isTextNode, isTransNode } from "../../dom/filter"
+
+export interface VirtualParagraphWrapperEntry {
+  unit: VirtualParagraphUnit
+  wrapper: HTMLElement
+}
+
+export interface InsertedVirtualParagraph extends VirtualParagraphWrapperEntry {
+  flowSource: TransNode
+}
+
+function insertWrapperAtBoundary(
+  { container, offset }: VirtualParagraphUnit["insertionBoundary"],
+  wrapper: HTMLElement,
+  splitRecords: Map<Text, TextSplitRecord>,
+  splitRecordTarget: TextSplitRecord[],
+): void {
+  if (isTextNode(container)) {
+    const parent = container.parentNode
+    if (!parent || offset < 0 || offset > container.data.length) {
+      throw new Error("Virtual paragraph Text boundary is no longer valid")
+    }
+
+    if (offset === 0) {
+      parent.insertBefore(wrapper, container)
+      return
+    }
+
+    if (offset === container.data.length) {
+      parent.insertBefore(wrapper, container.nextSibling)
+      return
+    }
+
+    let splitRecord = splitRecords.get(container)
+    if (!splitRecord) {
+      splitRecord = {
+        source: container,
+        parent,
+        originalValue: container.data,
+        createdTails: [],
+        sourceValueAfterSplit: container.data,
+        tailValuesAfterSplit: [],
+      }
+      splitRecords.set(container, splitRecord)
+      splitRecordTarget.push(splitRecord)
+    }
+
+    const tail = container.splitText(offset)
+    // Boundaries are applied in reverse document order. Prepending each new
+    // tail leaves the record in final DOM order for exact cleanup.
+    splitRecord.createdTails.unshift(tail)
+    parent.insertBefore(wrapper, tail)
+    return
+  }
+
+  if (offset < 0 || offset > container.childNodes.length) {
+    throw new Error("Virtual paragraph element boundary is no longer valid")
+  }
+  container.insertBefore(wrapper, container.childNodes[offset] ?? null)
+}
+
+/**
+ * Insert every wrapper synchronously from the end of the source towards the
+ * beginning. This keeps all precomputed Text offsets stable even when several
+ * paragraph boundaries live in the same Text node.
+ */
+export function insertVirtualParagraphWrappers(
+  entries: VirtualParagraphWrapperEntry[],
+  layoutSource: HTMLElement,
+  splitRecordTarget: TextSplitRecord[] = [],
+): { inserted: InsertedVirtualParagraph[]; splitRecords: TextSplitRecord[] } {
+  const splitRecords = new Map(splitRecordTarget.map((record) => [record.source, record] as const))
+
+  for (const entry of [...entries].reverse()) {
+    insertWrapperAtBoundary(
+      entry.unit.insertionBoundary,
+      entry.wrapper,
+      splitRecords,
+      splitRecordTarget,
+    )
+  }
+
+  for (const record of splitRecordTarget) {
+    record.sourceValueAfterSplit = record.source.data
+    record.tailValuesAfterSplit = record.createdTails.map((tail) => tail.data)
+  }
+
+  const inserted = entries.map((entry): InsertedVirtualParagraph => {
+    const previousSibling = entry.wrapper.previousSibling
+    return {
+      ...entry,
+      flowSource: previousSibling && isTransNode(previousSibling) ? previousSibling : layoutSource,
+    }
+  })
+
+  return { inserted, splitRecords: splitRecordTarget }
+}

--- a/src/utils/host/translate/ui/spinner.ts
+++ b/src/utils/host/translate/ui/spinner.ts
@@ -76,12 +76,17 @@ export async function getTranslatedTextAndRemoveSpinner(
   textContent: string,
   spinner: HTMLElement,
   translatedWrapperNode: HTMLElement,
+  isCurrent: () => boolean = () => true,
 ): Promise<string | undefined> {
   let translatedText: string | undefined
 
   try {
+    if (!isCurrent()) return undefined
     translatedText = await translateTextForPage(textContent)
+    if (!isCurrent()) return undefined
   } catch (error) {
+    if (!isCurrent()) return undefined
+
     const errorComponent = React.createElement(TranslationError, {
       nodes,
       error: error as APICallError,

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -4360,14 +4360,6 @@
     "forceBlockSelectors": ["task-lists"]
   },
   {
-    "id": "readfrog-engoo",
-    "description": "Force block layout for Engoo exercises",
-    "matches": "engoo.com",
-    "forceBlockSelectors": [
-      "#windowexercise-2 > div > div > div.css-ep7xq6 > div > div > div.css-19m2fbm *"
-    ]
-  },
-  {
     "id": "ieeexplore",
     "matches": "ieeexplore.ieee.org",
     "preserveTextSelectors": ["a[ref-type]", ".inline-formula", ".display-formula"]


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

- Preserve the logical block node for layout decisions while only unwrapping the physical insertion target.
- Split pre-like rendered text into CSS-aware virtual paragraphs at literal blank-line delimiters, so X posts render as original paragraph followed by its translation.
- Preserve mention, hashtag, and anchor boundaries; restore original Text node identity safely on toggle/retry.
- Detect X "Show more" mutations and retranslate the changed logical source with session and generation guards.

## Related Issue

Closes #1220
Closes #763
Closes #1096

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

- `SKIP_FREE_API=true pnpm test`
- `pnpm type-check`
- `pnpm fmt:check`
- `WXT_SKIP_ENV_VALIDATION=true pnpm build`
- Edge unpacked-build smoke test: RBReich-style two paragraphs, Bora mention content, and a Show more expansion from three to four translated paragraphs.

## Screenshots

Not applicable.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The implementation is generic and does not add Twitter-specific translation behavior in the core pipeline.