### PR TITLE
fix(site-rules): restore missing title translations on PubMed search results

### DIFF
--- a/.changeset/pubmed-docsum-layout.md
+++ b/.changeset/pubmed-docsum-layout.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(site-rules): restore missing title translations on PubMed search results (#1412)

--- a/src/utils/host/dom/__tests__/custom-force-block.test.ts
+++ b/src/utils/host/dom/__tests__/custom-force-block.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, describe, expect, it } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
-import { isSiteRuleForceBlockElement } from "../filter"
+import { isSiteRuleExcludedElement, isSiteRuleForceBlockElement } from "../filter"
 
 function setHost(host: string) {
   // jsdom exposes location as read-only; override via defineProperty
@@ -74,5 +74,47 @@ describe("isSiteRuleForceBlockElement", () => {
     expect(window.location.hostname).toBe("non-configured-example.org")
 
     expect(isSiteRuleForceBlockElement(taskLists, DEFAULT_CONFIG)).toBe(false)
+  })
+
+  // PubMed search results wrap each item's content in inline-block containers
+  // (.docsum-wrap / a.docsum-title), which the shallow classifier would treat as
+  // inline and collapse the whole result into one piled-up translation unit.
+  // Forcing them to block keeps the title and abstract snippet as separate units.
+  it("matches .docsum-wrap on pubmed.ncbi.nlm.nih.gov", () => {
+    setHost("pubmed.ncbi.nlm.nih.gov")
+
+    const docsumWrap = document.createElement("div")
+    docsumWrap.className = "docsum-wrap"
+    document.body.appendChild(docsumWrap)
+
+    expect(isSiteRuleForceBlockElement(docsumWrap, DEFAULT_CONFIG)).toBe(true)
+  })
+
+  it("matches a.docsum-title on pubmed.ncbi.nlm.nih.gov", () => {
+    setHost("pubmed.ncbi.nlm.nih.gov")
+
+    const title = document.createElement("a")
+    title.className = "docsum-title"
+    document.body.appendChild(title)
+
+    expect(isSiteRuleForceBlockElement(title, DEFAULT_CONFIG)).toBe(true)
+  })
+})
+
+describe("isSiteRuleExcludedElement", () => {
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  // The leading result index number would otherwise be translated as its own
+  // throwaway unit (one wasted call per result), so it is excluded.
+  it("excludes .search-result-position on pubmed.ncbi.nlm.nih.gov", () => {
+    setHost("pubmed.ncbi.nlm.nih.gov")
+
+    const position = document.createElement("label")
+    position.className = "search-result-position"
+    document.body.appendChild(position)
+
+    expect(isSiteRuleExcludedElement(position, DEFAULT_CONFIG)).toBe(true)
   })
 })

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -2387,10 +2387,11 @@
       ".sort-dropdown .option-label",
       ".display-options .button-label",
       ".actions-buttons.sidebar",
-      ".title-copy"
+      ".title-copy",
+      ".search-result-position"
     ],
     "injectedCss": "#Scholarscope_HighlightOrigin > p font,#Scholarscope_HighlightContent > p font {display: inline!important;}\n#Scholarscope_HighlightOrigin > p font br,#Scholarscope_HighlightContent > p font br {display: none!important;}\n.title-translate {display:block;}\n.read-frog-translated-content-wrapper {content-visibility:auto;}",
-    "forceBlockSelectors.add": [".mixed-citation"]
+    "forceBlockSelectors.add": [".mixed-citation", ".docsum-wrap", "a.docsum-title"]
   },
   {
     "id": "chosun",


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

On PubMed search-results pages (`https://pubmed.ncbi.nlm.nih.gov/?term=...`), each result's title translation was missing — the title's translation was fused with the abstract snippet into a single block rendered at the bottom of the result card, so the title appeared untranslated.

**Root cause:** PubMed wraps each result's content in `inline-block` containers (`.docsum-wrap`, `a.docsum-title`). Read Frog's shallow classifier (`isInlineDisplay` in `filter.ts`) treats `inline-block` as inline, so `walkAndLabelElement` never marks a block child inside `article.full-docsum`. The walker (`translation-walker.ts`) then folds the entire result subtree into one "consecutive inline run" and emits a single translation unit, inserted once at the end.

**Fix (site-rule only, no engine change):** extend the existing built-in `pubmed` rule:
- `forceBlockSelectors.add`: add `.docsum-wrap` (breaks the whole-result collapse) and `a.docsum-title` (renders the translated title on its own line directly under the English title).
- `excludeSelectors`: add `.search-result-position` so the leading result index number is not translated as a throwaway unit (saves ~10 calls per results page).

Verified by replicating the exact classifier + walker against the live page:
- Before: `["1", "Primary renal neoplasia of dogs. METHODS: … Median surviv …"]` (title + snippet fused)
- After: `["1", "Primary renal neoplasia of dogs.", "METHODS: …"]` (title and snippet split cleanly)

## Related Issue

Closes #1412

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Added cases to `custom-force-block.test.ts` asserting the effective `pubmed` rule force-blocks `.docsum-wrap` / `a.docsum-title` and excludes `.search-result-position` (through the real `DEFAULT_CONFIG` resolution path). The `dom` + `site-rules` suites pass (127 tests), including `built-in.test.ts` which validates `rules.json` still parses. Behavior confirmed at the algorithm level via a faithful classifier/walker replication on the live PubMed DOM.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The deeper root cause is general: an `inline-block` element whose children are block-level should arguably be classified as block (the intent is even documented at `filter.ts:27`, but `isShallowInlineHTMLElement` never checks children). A broader engine-level fix could remove the need for per-site `forceBlock` patches like this, but it touches the hot-path classifier for all pages and carries regression risk — better as its own PR with cross-site testing. This PR keeps the fix surgical and consistent with the rule's existing `.mixed-citation` force-block entry.