### PR TITLE
fix(translate): make Google/Microsoft translation requests text-format aware

### DIFF
--- a/.changeset/google-translate-html-escaping.md
+++ b/.changeset/google-translate-html-escaping.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): make Google/Microsoft requests text-format aware — escape plain text sent to Google translateHtml, decode its output exactly once, use Microsoft plain textType for plain text, and keep the html behavior for translationOnly page-mode markup

--- a/src/entrypoints/background/__tests__/translation-queues.test.ts
+++ b/src/entrypoints/background/__tests__/translation-queues.test.ts
@@ -292,10 +292,14 @@ describe("translation queue helpers", () => {
     )
   })
 
-  it("normalizes cached Google translations before returning them", async () => {
+  // Cached values are already decoded once by executeTranslate; a second decode
+  // would corrupt legitimate entity mentions ("Tom &amp; Jerry" -> "Tom & Jerry").
+  // The fixtures below intentionally contain semicolon-terminated entities so a
+  // re-introduced decode call fails these tests.
+  it("returns cached Google translations verbatim without re-decoding", async () => {
     translationCacheGetMock.mockResolvedValueOnce({
       key: "webpage-hash",
-      translation: "L&#39;Iran chiama &quot;Dichiarazione&quot; &lt;span&gt;",
+      translation: "Tom &amp; Jerry — It's on https://example.com/?page=1&copy=true <span>",
     })
 
     const { setUpWebPageTranslationQueue } = await import("../translation-queues")
@@ -312,9 +316,111 @@ describe("translation queue helpers", () => {
       },
     })
 
-    expect(result).toBe('L\'Iran chiama "Dichiarazione" <span>')
+    expect(result).toBe("Tom &amp; Jerry — It's on https://example.com/?page=1&copy=true <span>")
     expect(executeTranslateMock).not.toHaveBeenCalled()
     expect(translationCachePutMock).not.toHaveBeenCalled()
+  })
+
+  it("returns and caches fresh Google translations verbatim without re-decoding", async () => {
+    executeTranslateMock.mockResolvedValue("write &amp; for ampersand — It's fine")
+
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    const result = await handler({
+      data: {
+        text: "hello",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: googleProvider,
+        scheduleAt: Date.now(),
+        hash: "webpage-hash",
+      },
+    })
+
+    expect(result).toBe("write &amp; for ampersand — It's fine")
+    expect(translationCachePutMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "webpage-hash",
+        translation: "write &amp; for ampersand — It's fine",
+      }),
+    )
+  })
+
+  it("forwards the textFormat to executeTranslate for non-batch providers", async () => {
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    await handler({
+      data: {
+        text: "<b>hello</b>",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: googleProvider,
+        scheduleAt: Date.now(),
+        hash: "webpage-hash",
+        textFormat: "html",
+      },
+    })
+
+    expect(executeTranslateMock).toHaveBeenCalledWith(
+      "<b>hello</b>",
+      DEFAULT_CONFIG.language,
+      googleProvider,
+      expect.any(Function),
+      { textFormat: "html" },
+    )
+  })
+
+  it("returns cached Google subtitle translations verbatim without re-decoding", async () => {
+    translationCacheGetMock.mockResolvedValueOnce({
+      key: "subtitle-hash",
+      translation: "Tom &amp; Jerry — It's a subtitle",
+    })
+
+    const { setUpSubtitlesTranslationQueue } = await import("../translation-queues")
+    await setUpSubtitlesTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueSubtitlesTranslateRequest")
+    const result = await handler({
+      data: {
+        text: "hello",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: googleProvider,
+        scheduleAt: Date.now(),
+        hash: "subtitle-hash",
+      },
+    })
+
+    expect(result).toBe("Tom &amp; Jerry — It's a subtitle")
+    expect(executeTranslateMock).not.toHaveBeenCalled()
+    expect(translationCachePutMock).not.toHaveBeenCalled()
+  })
+
+  it("returns and caches fresh Google subtitle translations verbatim without re-decoding", async () => {
+    executeTranslateMock.mockResolvedValue("write &amp; for ampersand — It's a subtitle")
+
+    const { setUpSubtitlesTranslationQueue } = await import("../translation-queues")
+    await setUpSubtitlesTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueSubtitlesTranslateRequest")
+    const result = await handler({
+      data: {
+        text: "hello",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: googleProvider,
+        scheduleAt: Date.now(),
+        hash: "subtitle-hash",
+      },
+    })
+
+    expect(result).toBe("write &amp; for ampersand — It's a subtitle")
+    expect(translationCachePutMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "subtitle-hash",
+        translation: "write &amp; for ampersand — It's a subtitle",
+      }),
+    )
   })
 
   it("does not normalize cached non-Google translations", async () => {

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -14,7 +14,6 @@ import { Sha256Hex } from "@/utils/hash"
 import { microsoftTranslate } from "@/utils/host/translate/api/microsoft"
 import { executeTranslate } from "@/utils/host/translate/execute-translate"
 import { normalizePromptContextValue } from "@/utils/host/translate/translate-text"
-import { normalizeTranslationOutput } from "@/utils/host/translate/translation-output-normalization"
 import { logger } from "@/utils/logger"
 import { onMessage } from "@/utils/message"
 import { getSubtitlesTranslatePrompt } from "@/utils/prompts/subtitles"
@@ -243,6 +242,7 @@ export async function setUpWebPageTranslationQueue() {
         providerConfig,
         scheduleAt,
         hash,
+        textFormat,
         webTitle,
         webDescription,
         webContent,
@@ -254,7 +254,7 @@ export async function setUpWebPageTranslationQueue() {
     if (hash) {
       const cached = await db.translationCache.get(hash)
       if (cached) {
-        return normalizeTranslationOutput(providerConfig, cached.translation)
+        return cached.translation
       }
     }
 
@@ -271,13 +271,13 @@ export async function setUpWebPageTranslationQueue() {
       result = await batchQueue.enqueue(data)
     } else {
       // Create thunk based on type and params
-      const thunk = () => executeTranslate(text, langConfig, providerConfig, getTranslatePrompt)
+      const thunk = () =>
+        executeTranslate(text, langConfig, providerConfig, getTranslatePrompt, { textFormat })
       result = await requestQueue.enqueue(thunk, scheduleAt, hash)
     }
 
     // Cache the translation result if successful
     if (result && hash) {
-      result = normalizeTranslationOutput(providerConfig, result)
       await db.translationCache.put({
         key: hash,
         translation: result,
@@ -341,7 +341,7 @@ export async function setUpSubtitlesTranslationQueue() {
     if (hash) {
       const cached = await db.translationCache.get(hash)
       if (cached) {
-        return normalizeTranslationOutput(providerConfig, cached.translation)
+        return cached.translation
       }
     }
 
@@ -362,7 +362,6 @@ export async function setUpSubtitlesTranslationQueue() {
     }
 
     if (result && hash) {
-      result = normalizeTranslationOutput(providerConfig, result)
       await db.translationCache.put({
         key: hash,
         translation: result,

--- a/src/types/config/translate.ts
+++ b/src/types/config/translate.ts
@@ -126,5 +126,10 @@ export const translateConfigSchema = z.object({
 
 export type RequestQueueConfig = z.infer<typeof requestQueueConfigSchema>
 export type BatchQueueConfig = z.infer<typeof batchQueueConfigSchema>
+
+// How the source text sent to a translation provider should be interpreted:
+// "plain" for plain text (the default), "html" for markup-bearing strings such
+// as the outerHTML fragments produced by translationOnly page mode.
+export type TranslationTextFormat = "plain" | "html"
 export type TranslateConfig = z.infer<typeof translateConfigSchema>
 export type TranslationMode = z.infer<typeof translationModeSchema>

--- a/src/utils/host/__tests__/translate-text.test.tsx
+++ b/src/utils/host/__tests__/translate-text.test.tsx
@@ -397,7 +397,9 @@ describe("translate-text", () => {
       )
       expect(result).toBe("你好")
       // Shared translation core should send minimally prepared text to the provider
-      expect(mockMicrosoftTranslate).toHaveBeenCalledWith("hello", "en", "zh")
+      expect(mockMicrosoftTranslate).toHaveBeenCalledWith("hello", "en", "zh", {
+        textFormat: undefined,
+      })
     })
 
     it("should trim translation result", async () => {
@@ -432,7 +434,9 @@ describe("translate-text", () => {
       )
 
       expect(result).toBe('L\'Iran chiama "Dichiarazione" AT&T <span>')
-      expect(mockGoogleTranslate).toHaveBeenCalledWith("test input", "en", "zh")
+      expect(mockGoogleTranslate).toHaveBeenCalledWith("test input", "en", "zh", {
+        textFormat: undefined,
+      })
     })
   })
 })

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -611,7 +611,7 @@ describe("translate", () => {
           await removeOrShowPageTranslation("bilingual", true)
 
           expect(translateTextForPage).toHaveBeenCalledTimes(1)
-          expect(translateTextForPage).toHaveBeenCalledWith(sourceText)
+          expect(translateTextForPage).toHaveBeenCalledWith(sourceText, "plain")
           const wrapper = expectTranslationWrapper(deepestSpan, "bilingual")
           expect(wrapper).toBe(deepestSpan.lastChild)
           expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
@@ -701,9 +701,9 @@ describe("translate", () => {
           })
 
           expect(translateTextForPage).toHaveBeenCalledTimes(3)
-          expect(translateTextForPage).toHaveBeenNthCalledWith(1, truncatedRequestText)
-          expect(translateTextForPage).toHaveBeenNthCalledWith(2, expandedFirstParagraph)
-          expect(translateTextForPage).toHaveBeenNthCalledWith(3, hashtagParagraph)
+          expect(translateTextForPage).toHaveBeenNthCalledWith(1, truncatedRequestText, "plain")
+          expect(translateTextForPage).toHaveBeenNthCalledWith(2, expandedFirstParagraph, "plain")
+          expect(translateTextForPage).toHaveBeenNthCalledWith(3, hashtagParagraph, "plain")
           expectBlockTranslations(tweet, [translations.expanded, translations.hashtags])
           expect(tweet).not.toHaveTextContent(translations.truncated)
           expectTextInDocumentOrder(tweet, [
@@ -815,8 +815,8 @@ describe("translate", () => {
           resolveFirst(translations[0])
           await translationPromise
 
-          expect(translateTextForPage).toHaveBeenNthCalledWith(1, paragraphs[0])
-          expect(translateTextForPage).toHaveBeenNthCalledWith(2, paragraphs[1])
+          expect(translateTextForPage).toHaveBeenNthCalledWith(1, paragraphs[0], "plain")
+          expect(translateTextForPage).toHaveBeenNthCalledWith(2, paragraphs[1], "plain")
           expectBlockTranslations(tweet, translations)
           expectTextInDocumentOrder(tweet, [
             paragraphs[0],
@@ -999,7 +999,7 @@ describe("translate", () => {
 
           expect(translateTextForPage).toHaveBeenCalledTimes(5)
           paragraphs.forEach((paragraph, index) => {
-            expect(translateTextForPage).toHaveBeenNthCalledWith(index + 1, paragraph)
+            expect(translateTextForPage).toHaveBeenNthCalledWith(index + 1, paragraph, "plain")
           })
           expectBlockTranslations(tweet, translations)
           expectTextInDocumentOrder(
@@ -1057,7 +1057,7 @@ describe("translate", () => {
 
           expect(translateTextForPage).toHaveBeenCalledTimes(3)
           paragraphs.forEach((paragraph, index) => {
-            expect(translateTextForPage).toHaveBeenNthCalledWith(index + 1, paragraph)
+            expect(translateTextForPage).toHaveBeenNthCalledWith(index + 1, paragraph, "plain")
           })
           expectBlockTranslations(tweet, translations)
           expectTextInDocumentOrder(
@@ -1088,7 +1088,7 @@ describe("translate", () => {
             await removeOrShowPageTranslation("bilingual", true)
 
             expect(translateTextForPage).toHaveBeenCalledTimes(1)
-            expect(translateTextForPage).toHaveBeenCalledWith(sourceText)
+            expect(translateTextForPage).toHaveBeenCalledWith(sourceText, "plain")
             expectBlockTranslations(tweet, ["【整段译文】"])
           })
         },
@@ -1108,7 +1108,7 @@ describe("translate", () => {
           await removeOrShowPageTranslation("bilingual", true)
 
           expect(translateTextForPage).toHaveBeenCalledTimes(1)
-          expect(translateTextForPage).toHaveBeenCalledWith(sourceText)
+          expect(translateTextForPage).toHaveBeenCalledWith(sourceText, "plain")
           expectBlockTranslations(tweet, ["【标签整段译文】"])
         })
       })
@@ -1129,7 +1129,7 @@ describe("translate", () => {
           await removeOrShowPageTranslation("bilingual", true)
 
           expect(translateTextForPage).toHaveBeenCalledTimes(1)
-          expect(translateTextForPage).toHaveBeenCalledWith("Translate this paragraph.")
+          expect(translateTextForPage).toHaveBeenCalledWith("Translate this paragraph.", "plain")
           expectBlockTranslations(tweet, ["【唯一译文】"])
           expectTextInDocumentOrder(tweet, [
             "Translate this paragraph.",
@@ -1221,8 +1221,8 @@ describe("translate", () => {
         await removeOrShowPageTranslation("bilingual", true)
 
         expect(translateTextForPage).toHaveBeenCalledTimes(2)
-        expect(translateTextForPage).toHaveBeenCalledWith(nestedText)
-        expect(translateTextForPage).toHaveBeenCalledWith(mixedText)
+        expect(translateTextForPage).toHaveBeenCalledWith(nestedText, "plain")
+        expect(translateTextForPage).toHaveBeenCalledWith(mixedText, "plain")
 
         const nestedWrapper = expectTranslationWrapper(deepestSpan, "bilingual")
         expect(nestedWrapper).toBe(deepestSpan.lastChild)
@@ -2263,6 +2263,7 @@ describe("translate", () => {
 
           expect(translateTextForPage).toHaveBeenCalledWith(
             "perf(main): drop localhost label routes when a worktree is removed by @taiiiyang in #7557",
+            "plain",
           )
           expect(document.querySelector(".user-mention")!.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(
             false,
@@ -2582,6 +2583,7 @@ describe("translate", () => {
         // Whitespace-only nodes return single space for word separation
         expect(translateTextForPage).toHaveBeenCalledWith(
           `${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`,
+          "plain",
         )
       })
     })
@@ -2599,6 +2601,7 @@ describe("translate", () => {
 
         expect(translateTextForPage).toHaveBeenCalledWith(
           `${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`,
+          "plain",
         )
       })
     })
@@ -2611,7 +2614,7 @@ describe("translate", () => {
         render(<div data-testid="test-node">{`\n${MOCK_ORIGINAL_TEXT} \n`}</div>)
         await removeOrShowPageTranslation("bilingual", true)
 
-        expect(translateTextForPage).toHaveBeenCalledWith(MOCK_ORIGINAL_TEXT)
+        expect(translateTextForPage).toHaveBeenCalledWith(MOCK_ORIGINAL_TEXT, "plain")
       })
 
       it("bilingual mode: space leading/trailing is trimmed before translation", async () => {
@@ -2621,7 +2624,7 @@ describe("translate", () => {
         await removeOrShowPageTranslation("bilingual", true)
 
         // Final text is trimmed before translation
-        expect(translateTextForPage).toHaveBeenCalledWith(MOCK_ORIGINAL_TEXT)
+        expect(translateTextForPage).toHaveBeenCalledWith(MOCK_ORIGINAL_TEXT, "plain")
       })
     })
 
@@ -2640,6 +2643,7 @@ describe("translate", () => {
         // Whitespace-only node returns single space to preserve word separation
         expect(translateTextForPage).toHaveBeenCalledWith(
           `${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`,
+          "plain",
         )
       })
 
@@ -2655,6 +2659,7 @@ describe("translate", () => {
 
         expect(translateTextForPage).toHaveBeenCalledWith(
           `${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`,
+          "plain",
         )
       })
     })
@@ -2673,8 +2678,8 @@ describe("translate", () => {
 
         // BR elements are handled as paragraph separators, each paragraph translated separately
         expect(translateTextForPage).toHaveBeenCalledTimes(2)
-        expect(translateTextForPage).toHaveBeenNthCalledWith(1, MOCK_ORIGINAL_TEXT)
-        expect(translateTextForPage).toHaveBeenNthCalledWith(2, MOCK_ORIGINAL_TEXT)
+        expect(translateTextForPage).toHaveBeenNthCalledWith(1, MOCK_ORIGINAL_TEXT, "plain")
+        expect(translateTextForPage).toHaveBeenNthCalledWith(2, MOCK_ORIGINAL_TEXT, "plain")
       })
 
       it("translationOnly mode: should handle BR elements as paragraph separators", async () => {
@@ -2689,8 +2694,8 @@ describe("translate", () => {
         await removeOrShowPageTranslation("translationOnly", true)
 
         expect(translateTextForPage).toHaveBeenCalledTimes(2)
-        expect(translateTextForPage).toHaveBeenNthCalledWith(1, MOCK_ORIGINAL_TEXT)
-        expect(translateTextForPage).toHaveBeenNthCalledWith(2, MOCK_ORIGINAL_TEXT)
+        expect(translateTextForPage).toHaveBeenNthCalledWith(1, MOCK_ORIGINAL_TEXT, "html")
+        expect(translateTextForPage).toHaveBeenNthCalledWith(2, MOCK_ORIGINAL_TEXT, "html")
       })
     })
   })

--- a/src/utils/host/translate/__tests__/filter-small-paragraph.test.ts
+++ b/src/utils/host/translate/__tests__/filter-small-paragraph.test.ts
@@ -120,6 +120,9 @@ describe.each(["bilingual", "translationOnly"] as const)("%s translation", (mode
     await translateNodes([textNode], "walk-id", false, createConfig({ mode }))
 
     expect(mocks.translateTextForPage).toHaveBeenCalledOnce()
-    expect(mocks.translateTextForPage).toHaveBeenCalledWith("Hello @openai")
+    expect(mocks.translateTextForPage).toHaveBeenCalledWith(
+      "Hello @openai",
+      mode === "translationOnly" ? "html" : "plain",
+    )
   })
 })

--- a/src/utils/host/translate/__tests__/google-roundtrip.test.ts
+++ b/src/utils/host/translate/__tests__/google-roundtrip.test.ts
@@ -1,0 +1,63 @@
+import { decodeHTML, escapeText } from "entities"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { executeTranslate } from "../execute-translate"
+
+// Integration coverage for the escape -> translateHtml -> decode pipeline. The
+// fetch stub emulates the endpoint's observed identity-translation behavior:
+// input is parsed as HTML — an unescaped tag-open swallows the rest of the
+// string (live behavior for "<b then stop") and entities (including legacy
+// semicolon-less ones such as "&copy") are resolved — then the resulting plain
+// text is re-serialized as escaped HTML. executeTranslate must therefore return
+// the original plain text byte-for-byte only when the request was escaped.
+function simulateTranslateHtmlEndpoint(requestText: string): string {
+  const withoutBogusTag = requestText.replace(/<[a-z][\s\S]*$/i, "")
+  return escapeText(decodeHTML(withoutBogusTag))
+}
+
+const fetchMock = vi.fn<(...args: any[]) => any>()
+
+const langConfig = {
+  sourceCode: "eng" as const,
+  targetCode: "cmn" as const,
+  detectedCode: "eng" as const,
+  level: "intermediate" as const,
+}
+
+const googleProviderConfig = {
+  id: "google-translate-default",
+  enabled: true,
+  name: "Google Translate",
+  provider: "google-translate" as const,
+}
+
+describe("google translate escape/decode round trip", () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    fetchMock.mockImplementation((_url: string, init: { body: string }) => {
+      const requestText = JSON.parse(init.body)[0][0][0]
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => [[simulateTranslateHtmlEndpoint(requestText)]],
+        text: async () => "",
+      })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it.each([
+    ["tag-like text is not truncated", "if x <b then stop"],
+    ["URL query params survive intact", "访问 https://example.com/?page=1&copy=true 查看详情"],
+    ["literal entity mentions survive intact", "write &amp; for ampersand"],
+    ["apostrophes and quotes survive intact", `It's called "Read Frog"`],
+  ])("%s", async (_name, text) => {
+    const result = await executeTranslate(text, langConfig, googleProviderConfig, vi.fn())
+
+    expect(result).toBe(text)
+  })
+})

--- a/src/utils/host/translate/__tests__/translation-output-normalization.test.ts
+++ b/src/utils/host/translate/__tests__/translation-output-normalization.test.ts
@@ -30,4 +30,18 @@ describe("normalizeTranslationOutput", () => {
   it("does not normalize non-Google providers", () => {
     expect(normalizeTranslationOutput(microsoftProvider, "A&amp;B")).toBe("A&amp;B")
   })
+
+  it("decodes apostrophes in input-translation results (issue #1517)", () => {
+    expect(normalizeTranslationOutput(googleProvider, "It&#39;s")).toBe("It's")
+  })
+
+  it("does not decode semicolon-less legacy entities such as URL query params", () => {
+    expect(normalizeTranslationOutput(googleProvider, "?page=1&copy=true")).toBe(
+      "?page=1&copy=true",
+    )
+  })
+
+  it("decodes escaped entity mentions exactly once", () => {
+    expect(normalizeTranslationOutput(googleProvider, "&amp;amp;")).toBe("&amp;")
+  })
 })

--- a/src/utils/host/translate/api/__tests__/google.test.ts
+++ b/src/utils/host/translate/api/__tests__/google.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { googleTranslate } from "../google"
+
+const fetchMock = vi.fn<(...args: any[]) => any>()
+
+function mockTranslateResponse(translation: string) {
+  fetchMock.mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: vi.fn<(...args: any[]) => any>().mockResolvedValue([[translation]]),
+    text: vi.fn<(...args: any[]) => any>().mockResolvedValue(""),
+  })
+}
+
+function sentSourceText(): string {
+  const [, requestInit] = fetchMock.mock.calls[0]
+  return JSON.parse(requestInit.body)[0][0][0]
+}
+
+describe("google translate adapter", () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("escapes < and > so tag-like text is not swallowed by the HTML endpoint", async () => {
+    mockTranslateResponse("如果 x &lt;b 则停止")
+
+    await googleTranslate("if x <b then stop", "en", "zh")
+
+    expect(sentSourceText()).toBe("if x &lt;b then stop")
+  })
+
+  it("escapes & so URL query params are not parsed as legacy entities", async () => {
+    mockTranslateResponse("ok")
+
+    await googleTranslate("访问 https://example.com/?page=1&copy=true 查看详情", "zh-CN", "en")
+
+    expect(sentSourceText()).toBe("访问 https://example.com/?page=1&amp;copy=true 查看详情")
+  })
+
+  it("escapes literal entity mentions so they survive the round trip", async () => {
+    mockTranslateResponse("ok")
+
+    await googleTranslate("write &amp; for < and >", "en", "zh")
+
+    expect(sentSourceText()).toBe("write &amp;amp; for &lt; and &gt;")
+  })
+
+  it("sends html-format input unescaped so the endpoint preserves its tags", async () => {
+    // translationOnly page mode sends outerHTML fragments and re-renders the
+    // result via innerHTML — escaping them would expose tags to translation.
+    mockTranslateResponse("ok")
+
+    await googleTranslate('See the <a href="/docs?a=1&b=2">docs</a>', "en", "zh", {
+      textFormat: "html",
+    })
+
+    expect(sentSourceText()).toBe('See the <a href="/docs?a=1&b=2">docs</a>')
+  })
+
+  it("returns the HTML-encoded API payload without decoding it", async () => {
+    // Decoding happens exactly once, in executeTranslate via normalizeTranslationOutput.
+    mockTranslateResponse("It&#39;s")
+
+    await expect(googleTranslate("это", "ru", "en")).resolves.toBe("It&#39;s")
+  })
+
+  it("throws on a non-ok response", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 429,
+      statusText: "Too Many Requests",
+      headers: new Map(),
+      text: vi.fn<(...args: any[]) => any>().mockResolvedValue("rate limited"),
+    })
+
+    await expect(googleTranslate("hello", "en", "zh")).rejects.toThrow(
+      "Translation request failed: 429",
+    )
+  })
+
+  it("throws on an unexpected response shape", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: vi.fn<(...args: any[]) => any>().mockResolvedValue({ unexpected: true }),
+      text: vi.fn<(...args: any[]) => any>().mockResolvedValue(""),
+    })
+
+    await expect(googleTranslate("hello", "en", "zh")).rejects.toThrow("Unexpected response format")
+  })
+})

--- a/src/utils/host/translate/api/__tests__/microsoft.test.ts
+++ b/src/utils/host/translate/api/__tests__/microsoft.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { microsoftTranslate } from "../microsoft"
+
+const fetchMock = vi.fn<(...args: any[]) => any>()
+
+describe("microsoft translate adapter", () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    fetchMock.mockImplementation((url: string) => {
+      if (url === "https://edge.microsoft.com/translate/auth") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          text: vi.fn<(...args: any[]) => any>().mockResolvedValue("test-token"),
+        })
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: vi
+          .fn<(...args: any[]) => any>()
+          .mockResolvedValue([{ translations: [{ text: "你好" }] }]),
+        text: vi.fn<(...args: any[]) => any>().mockResolvedValue(""),
+      })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  function translateCallURL(): string {
+    const translateCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes("microsofttranslator.com/translate"),
+    )
+    expect(translateCall).toBeDefined()
+    return String(translateCall![0])
+  }
+
+  it("requests plain textType so tag-like text is translated instead of skipped", async () => {
+    const result = await microsoftTranslate("if x <b then stop", "en", "zh")
+
+    expect(result).toBe("你好")
+    expect(translateCallURL()).toContain("textType=plain")
+    expect(translateCallURL()).not.toContain("textType=html")
+  })
+
+  it("requests html textType for html-format input so markup is preserved", async () => {
+    await microsoftTranslate('See the <a href="/pricing">pricing</a>', "en", "zh", {
+      textFormat: "html",
+    })
+
+    expect(translateCallURL()).toContain("textType=html")
+  })
+})

--- a/src/utils/host/translate/api/google.ts
+++ b/src/utils/host/translate/api/google.ts
@@ -1,3 +1,5 @@
+import type { TranslationTextFormat } from "@/types/config/translate"
+import { escapeText } from "entities"
 import { attachRequestErrorMeta } from "@/utils/request/retry-policy"
 
 const GOOGLE_TRANSLATE_HTML_URL = "https://translate-pa.googleapis.com/v1/translateHtml"
@@ -8,14 +10,31 @@ export async function googleTranslate(
   sourceText: string,
   fromLang: string,
   toLang: string,
+  options?: { textFormat?: TranslationTextFormat },
 ): Promise<string> {
+  // translateHtml parses the request text as HTML, so plain source text must be
+  // escaped (& < > nbsp) before sending, while html input (translationOnly page
+  // mode) is sent as-is so the endpoint preserves its tags. The response stays
+  // HTML-encoded and is decoded exactly once by normalizeTranslationOutput in
+  // executeTranslate.
+  //
+  // Known issue: the endpoint also treats newlines as collapsible HTML whitespace,
+  // so multi-line text loses its line structure (e.g. X tweet paragraphs separated
+  // by literal "\n\n" under white-space: pre-wrap in translationOnly mode, or
+  // multi-line input translation). No escape can protect "\n" ("&#10;" collapses
+  // too). A future fix must inject <br> markers before sending and restore them
+  // after (a lone <br> can be merged away by the sentence segmenter, a "\n\n" pair
+  // never is) — gated by a content-layer signal, because only the content script
+  // knows whether the container's white-space CSS makes newlines meaningful;
+  // ordinary pages rely on this collapsing for pretty-printed source newlines.
+  const requestText = options?.textFormat === "html" ? sourceText : escapeText(sourceText)
   const resp = await fetch(GOOGLE_TRANSLATE_HTML_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json+protobuf",
       "X-Goog-API-Key": GOOGLE_TRANSLATE_HTML_API_KEY,
     },
-    body: JSON.stringify([[[sourceText], fromLang, toLang], GOOGLE_TRANSLATE_HTML_CLIENT]),
+    body: JSON.stringify([[[requestText], fromLang, toLang], GOOGLE_TRANSLATE_HTML_CLIENT]),
   }).catch((error) => {
     throw attachRequestErrorMeta(new Error(`Network error during translation: ${error.message}`), {
       kind: "network",

--- a/src/utils/host/translate/api/microsoft.ts
+++ b/src/utils/host/translate/api/microsoft.ts
@@ -1,17 +1,22 @@
+import type { TranslationTextFormat } from "@/types/config/translate"
+
 export async function microsoftTranslate(
   source: string,
   fromLang: string,
   toLang: string,
+  options?: { textFormat?: TranslationTextFormat },
 ): Promise<string>
 export async function microsoftTranslate(
   source: string[],
   fromLang: string,
   toLang: string,
+  options?: { textFormat?: TranslationTextFormat },
 ): Promise<string[]>
 export async function microsoftTranslate(
   source: string | string[],
   fromLang: string,
   toLang: string,
+  options?: { textFormat?: TranslationTextFormat },
 ): Promise<string | string[]> {
   const isSingle = typeof source === "string"
   const texts = isSingle ? [source] : source
@@ -23,8 +28,13 @@ export async function microsoftTranslate(
   const effectiveFromLang = fromLang === "auto" ? "" : fromLang
   const token = await refreshMicrosoftToken()
 
+  // plain translates the source as literal text (tag-like text such as "<b then"
+  // is otherwise left untranslated); html preserves the markup structure of
+  // translationOnly page-mode fragments.
+  const textType = options?.textFormat === "html" ? "html" : "plain"
+
   const resp = await fetch(
-    `https://api-edge.cognitive.microsofttranslator.com/translate?from=${effectiveFromLang}&to=${toLang}&api-version=3.0&includeSentenceLength=true&textType=html`,
+    `https://api-edge.cognitive.microsofttranslator.com/translate?from=${effectiveFromLang}&to=${toLang}&api-version=3.0&includeSentenceLength=true&textType=${textType}`,
     {
       method: "POST",
       headers: {

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -575,11 +575,16 @@ export async function translateNodeTranslationOnlyMode(
     }
     batchDOMOperation(insertOperation)
 
+    // The source string mixes text nodes with element outerHTML and the result
+    // is re-rendered via innerHTML, so providers must treat it as HTML to keep
+    // its tags intact.
     const realTranslatedText = await getTranslatedTextAndRemoveSpinner(
       nodes,
       textContent,
       spinner,
       translatedWrapperNode,
+      () => true,
+      "html",
     )
     const translatedText = realTranslatedText
       ? getDisplayTranslation(textContent, realTranslatedText)

--- a/src/utils/host/translate/execute-translate.ts
+++ b/src/utils/host/translate/execute-translate.ts
@@ -1,6 +1,7 @@
 import type { PromptResolver } from "./api/ai"
 import type { Config } from "@/types/config/config"
 import type { ProviderConfig } from "@/types/config/provider"
+import type { TranslationTextFormat } from "@/types/config/translate"
 import { ISO6393_TO_6391, LANG_CODE_TO_EN_NAME } from "@read-frog/definitions"
 import { isLLMProviderConfig, isNonAPIProvider, isPureAPIProvider } from "@/types/config/provider"
 import { aiTranslate } from "./api/ai"
@@ -19,6 +20,7 @@ export async function executeTranslate<TContext>(
   options?: {
     isBatch?: boolean
     context?: TContext
+    textFormat?: TranslationTextFormat
   },
 ) {
   const preparedText = prepareTranslationText(text)
@@ -37,9 +39,13 @@ export async function executeTranslate<TContext>(
       throw new Error(`Invalid target language code: ${langConfig.targetCode}`)
     }
     if (provider === "google-translate") {
-      translatedText = await googleTranslate(preparedText, sourceLang, targetLang)
+      translatedText = await googleTranslate(preparedText, sourceLang, targetLang, {
+        textFormat: options?.textFormat,
+      })
     } else if (provider === "microsoft-translate") {
-      translatedText = await microsoftTranslate(preparedText, sourceLang, targetLang)
+      translatedText = await microsoftTranslate(preparedText, sourceLang, targetLang, {
+        textFormat: options?.textFormat,
+      })
     }
   } else if (isPureAPIProvider(provider)) {
     const sourceLang =

--- a/src/utils/host/translate/translate-text.ts
+++ b/src/utils/host/translate/translate-text.ts
@@ -1,6 +1,7 @@
 import type { LangCodeISO6393, LangLevel } from "@read-frog/definitions"
 import type { Config } from "@/types/config/config"
 import type { ProviderConfig } from "@/types/config/provider"
+import type { TranslationTextFormat } from "@/types/config/translate"
 import type { WebPagePromptContext } from "@/types/content"
 import { LANG_CODE_TO_EN_NAME } from "@read-frog/definitions"
 import { toast } from "sonner"
@@ -72,6 +73,7 @@ async function buildWebPageHashComponents(
   providerConfig: ProviderConfig,
   partialLangConfig: { sourceCode: LangCodeISO6393 | "auto"; targetCode: LangCodeISO6393 },
   enableAIContentAware: boolean,
+  textFormat: TranslationTextFormat,
   webPageContext?: WebPagePromptContext,
 ): Promise<string[]> {
   const preparedText = prepareTranslationText(text)
@@ -84,6 +86,10 @@ async function buildWebPageHashComponents(
   ]
 
   if (!isLLMProviderConfig(providerConfig)) {
+    // The provider request depends on the text format (escaping / textType), so
+    // cache entries must too. This component also orphans entries cached before
+    // the format-aware pipeline existed, which could hold corrupted output.
+    hashComponents.push(`textFormat:${textFormat}`)
     return hashComponents
   }
 
@@ -127,6 +133,7 @@ export interface TranslateTextOptions {
   enableAIContentAware?: boolean
   extraHashTags?: string[]
   webPageContext?: WebPagePromptContext
+  textFormat?: TranslationTextFormat
 }
 
 /**
@@ -141,6 +148,7 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     enableAIContentAware = false,
     extraHashTags = [],
     webPageContext,
+    textFormat = "plain",
   } = options
 
   const preparedText = prepareTranslationText(text)
@@ -155,6 +163,7 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     providerConfig,
     { sourceCode: langConfig.sourceCode, targetCode: langConfig.targetCode },
     enableAIContentAware,
+    textFormat,
     normalizedWebPageContext,
   )
 
@@ -167,6 +176,7 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     providerConfig,
     scheduleAt: Date.now(),
     hash: Sha256Hex(...hashComponents),
+    textFormat,
     webTitle: normalizedWebPageContext?.webTitle,
     webDescription: normalizedWebPageContext?.webDescription,
     webContent: normalizedWebPageContext?.webContent,

--- a/src/utils/host/translate/translate-variants.ts
+++ b/src/utils/host/translate/translate-variants.ts
@@ -1,5 +1,6 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { Config, InputTranslationLang } from "@/types/config/config"
+import type { TranslationTextFormat } from "@/types/config/translate"
 import { isLLMProviderConfig } from "@/types/config/provider"
 import { getDetectedCodeFromStorage, getFinalSourceCode } from "@/utils/config/languages"
 import { resolveProviderConfig } from "@/utils/constants/feature-providers"
@@ -70,6 +71,7 @@ async function translateTextUsingPageConfig(
       webContent?: string | null
       webSummary?: string | null
     }
+    textFormat?: TranslationTextFormat
   } = {},
 ): Promise<string> {
   const preparedText = prepareTranslationText(text)
@@ -112,6 +114,7 @@ async function translateTextUsingPageConfig(
     enableAIContentAware: config.translate.enableAIContentAware,
     extraHashTags: options.extraHashTags,
     webPageContext: options.webPageContext,
+    textFormat: options.textFormat,
   })
 }
 
@@ -119,7 +122,10 @@ async function translateTextUsingPageConfig(
  * Page translation — uses FEATURE_PROVIDER_DEFS['translate'].
  * Includes skip-language logic (page translation only).
  */
-export async function translateTextForPage(text: string): Promise<string> {
+export async function translateTextForPage(
+  text: string,
+  textFormat: TranslationTextFormat = "plain",
+): Promise<string> {
   const config = await getConfigOrThrow()
   const providerConfig = resolveProviderConfig(config, "translate")
   const webPageContext = await getWebPagePromptContext(
@@ -130,6 +136,7 @@ export async function translateTextForPage(text: string): Promise<string> {
 
   return translateTextUsingPageConfig(config, text, {
     webPageContext,
+    textFormat,
   })
 }
 

--- a/src/utils/host/translate/translation-output-normalization.ts
+++ b/src/utils/host/translate/translation-output-normalization.ts
@@ -1,9 +1,9 @@
 import type { ProviderConfig } from "@/types/config/provider"
-import { decodeHTML } from "entities"
+import { decodeHTMLStrict } from "entities"
 
 export function normalizeTranslationOutput(
   providerConfig: Pick<ProviderConfig, "provider">,
   text: string,
 ): string {
-  return providerConfig.provider === "google-translate" ? decodeHTML(text) : text
+  return providerConfig.provider === "google-translate" ? decodeHTMLStrict(text) : text
 }

--- a/src/utils/host/translate/ui/spinner.ts
+++ b/src/utils/host/translate/ui/spinner.ts
@@ -1,4 +1,5 @@
 import type { APICallError } from "ai"
+import type { TranslationTextFormat } from "@/types/config/translate"
 import * as React from "react"
 import textSmallCSS from "@/assets/styles/text-small.css?inline"
 import themeCSS from "@/assets/styles/theme.css?inline"
@@ -77,12 +78,13 @@ export async function getTranslatedTextAndRemoveSpinner(
   spinner: HTMLElement,
   translatedWrapperNode: HTMLElement,
   isCurrent: () => boolean = () => true,
+  textFormat: TranslationTextFormat = "plain",
 ): Promise<string | undefined> {
   let translatedText: string | undefined
 
   try {
     if (!isCurrent()) return undefined
-    translatedText = await translateTextForPage(textContent)
+    translatedText = await translateTextForPage(textContent, textFormat)
     if (!isCurrent()) return undefined
   } catch (error) {
     if (!isCurrent()) return undefined

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -7,7 +7,11 @@ import type {
 } from "@/types/background-generate-text"
 import type { Config } from "@/types/config/config"
 import type { ProviderConfig } from "@/types/config/provider"
-import type { BatchQueueConfig, RequestQueueConfig } from "@/types/config/translate"
+import type {
+  BatchQueueConfig,
+  RequestQueueConfig,
+  TranslationTextFormat,
+} from "@/types/config/translate"
 import type {
   EdgeTTSHealthStatus,
   EdgeTTSSynthesizeRequest,
@@ -91,6 +95,7 @@ interface ProtocolMap {
     providerConfig: ProviderConfig
     scheduleAt: number
     hash: string
+    textFormat?: TranslationTextFormat
     webTitle?: string | null
     webDescription?: string | null
     webContent?: string | null


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Investigating #1517 (`It&#39;s` entities in Google Translate output) showed the original symptom was already fixed by #1468, but uncovered three remaining defects, all verified against the live endpoints:

1. **Source text was sent unescaped to Google's `translateHtml` endpoint**, which parses input as HTML: `if x <b then stop` came back as `如果 x` (everything after `<b ` swallowed), `?page=1&copy=true` in URLs became `?page=1©=true` (legacy entity parsing), and literal `&amp;` mentions were destroyed.
2. **Google output was decoded 2–3 times** (in `executeTranslate`, again before cache write, again on cache read). `decodeHTML` is not idempotent, so entity-sensitive text shown to users was over-decoded (`&amp;` mentions became `&`, URL query params corrupted).
3. **Microsoft used `textType=html` for plain text**, which passes tag-like text through untranslated (`if x <b then stop` → `如果 x <b then stop`).

### Fix

- A `textFormat` (`"plain" | "html"`) flag threads from the translation-mode call sites through `translateTextForPage` → `translateTextCore` → `enqueueTranslateRequest` → `executeTranslate` → the provider adapters. translationOnly page mode — which joins element `outerHTML` and re-renders via `innerHTML` — declares `"html"`; every other path is `"plain"`.
- **Google**: plain input is escaped with `escapeText` before sending (round-trips exactly through the endpoint + decode); html input is sent as-is so tags are preserved. Output is decoded **exactly once**, in `executeTranslate`, now with `decodeHTMLStrict` (Google only emits semicolon-terminated entities; strict decoding cannot corrupt `&copy=`-style URL params even if double-decoded).
- **Microsoft**: `textType=plain` for plain input, `textType=html` for translationOnly markup (both live-verified: plain translates tag-like text correctly, html preserves tag structure; neither mode entity-encodes output, so no decode pairing is needed).
- The redundant decode calls in both background queue handlers (cache read + pre-cache-put, webpage and subtitles) are removed. Non-LLM cache hashes now include the text format, which also orphans stale entries cached by the unescaped pipeline.

### Cache semantics

Cache entries were previously written twice-decoded and returned thrice-decoded on hits; they are now written once-decoded and returned verbatim. No migration is needed: decoding is idempotent for unaffected text, previously corrupted entries were already corrupted, the hash change orphans old non-LLM entries, and the translation cache has a 7-day TTL.

### Known limitation (documented, deliberately not fixed here)

`translateHtml` collapses newlines as HTML whitespace, so multi-line text (e.g. X tweet paragraphs separated by literal `\n\n` under `white-space: pre-wrap` in translationOnly mode, or multi-line input translation) loses its line structure and can get merged-sentence translations. No escape protects `\n` (`&#10;` collapses too, verified live). The constraints for a future fix (paired `<br>` markers gated by a content-layer white-space signal) are documented in a comment in `src/utils/host/translate/api/google.ts`.

## Related Issue

Closes #1517

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

- New mocked-fetch adapter tests (`google.test.ts`, `microsoft.test.ts`) pin the wire format: escaping of `< > &` for plain input, raw pass-through for html input, `textType` selection, and that the adapter returns encoded output without decoding.
- New integration round-trip suite (`google-roundtrip.test.ts`) simulates the endpoint's HTML parse/serialize (including tag-swallowing and legacy entity expansion) and asserts byte-exact round trips for the regression corpus; mutation-tested — reverting the escaping fails 3/4 cases.
- Queue tests now use entity-bearing fixtures that fail if a redundant decode is reintroduced (mutation-tested), and cover the previously untested subtitles handler cache paths.
- `pnpm test --exclude="**/free-api.test.ts"` (mirrors CI): 182 files / 1597 tests pass; live `free-api.test.ts` passes locally; `pnpm lint` and `pnpm fmt:check` clean.
- All defects and fixes were reproduced/verified against the live Google and Microsoft endpoints.

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The `translationOnly` html-format handling exists because that mode sends real markup: an earlier draft that escaped unconditionally silently dropped links/formatting on translationOnly pages (verified against the live endpoint). Reviewers touching the adapters should check both formats — see the contract comment in `google.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)