### PR TITLE
fix(translate): reduce translation-only HTML payloads while preserving attributes

### DIFF
--- a/.changeset/compact-html-attributes.md
+++ b/.changeset/compact-html-attributes.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): reduce translation-only HTML payloads while preserving attributes

--- a/src/entrypoints/background/__tests__/translation-queues.test.ts
+++ b/src/entrypoints/background/__tests__/translation-queues.test.ts
@@ -11,6 +11,7 @@ const articleSummaryCacheGetMock = vi.fn<(...args: any[]) => any>()
 const articleSummaryCachePutMock = vi.fn<(...args: any[]) => any>()
 const translationCacheGetMock = vi.fn<(...args: any[]) => any>()
 const translationCachePutMock = vi.fn<(...args: any[]) => any>()
+const translationCacheDeleteMock = vi.fn<(...args: any[]) => any>()
 
 vi.mock("@/utils/message", () => ({
   onMessage: onMessageMock,
@@ -39,6 +40,7 @@ vi.mock("@/utils/db/dexie/db", () => ({
       put: articleSummaryCachePutMock,
     },
     translationCache: {
+      delete: translationCacheDeleteMock,
       get: translationCacheGetMock,
       put: translationCachePutMock,
     },
@@ -108,6 +110,7 @@ describe("translation queue helpers", () => {
     articleSummaryCachePutMock.mockResolvedValue(undefined)
     translationCacheGetMock.mockResolvedValue(undefined)
     translationCachePutMock.mockResolvedValue(undefined)
+    translationCacheDeleteMock.mockResolvedValue(undefined)
   })
 
   it("routes only llm providers through the batch queue", async () => {
@@ -133,6 +136,63 @@ describe("translation queue helpers", () => {
     expect(shouldUseBatchQueue(deeplxProvider)).toBe(false)
     expect(shouldUseBatchQueue(llmProvider)).toBe(true)
   }, 15_000)
+
+  it("keeps request-local marker zero isolated across LLM batch items", async () => {
+    ensureInitializedConfigMock.mockResolvedValue({
+      ...DEFAULT_CONFIG,
+      translate: {
+        ...DEFAULT_CONFIG.translate,
+        providerId: llmProvider.id,
+        batchQueueConfig: {
+          maxCharactersPerBatch: 1000,
+          maxItemsPerBatch: 10,
+        },
+      },
+    })
+    executeTranslateMock.mockResolvedValueOnce(
+      `<span data-rf-attr="0">Bonjour</span>\n\n%%\n\n<a data-rf-attr="0">Lire</a>`,
+    )
+
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+
+    const results = await Promise.all([
+      handler({
+        data: {
+          text: `<span data-rf-attr="0">Hello</span>`,
+          langConfig: DEFAULT_CONFIG.language,
+          providerConfig: llmProvider,
+          scheduleAt: Date.now(),
+          hash: "marker-batch-one",
+          textFormat: "html",
+        },
+      }),
+      handler({
+        data: {
+          text: `<a data-rf-attr="0">Read</a>`,
+          langConfig: DEFAULT_CONFIG.language,
+          providerConfig: llmProvider,
+          scheduleAt: Date.now(),
+          hash: "marker-batch-two",
+          textFormat: "html",
+        },
+      }),
+    ])
+
+    expect(results).toEqual([
+      `<span data-rf-attr="0">Bonjour</span>`,
+      `<a data-rf-attr="0">Lire</a>`,
+    ])
+    expect(executeTranslateMock).toHaveBeenCalledTimes(1)
+    expect(executeTranslateMock).toHaveBeenCalledWith(
+      `<span data-rf-attr="0">Hello</span>\n\n%%\n\n<a data-rf-attr="0">Read</a>`,
+      DEFAULT_CONFIG.language,
+      llmProvider,
+      expect.any(Function),
+      expect.objectContaining({ isBatch: true }),
+    )
+  })
 
   it("passes subtitle summary through the translation queue without generating a new summary", async () => {
     const { setUpSubtitlesTranslationQueue } = await import("../translation-queues")
@@ -343,6 +403,202 @@ describe("translation queue helpers", () => {
       expect.objectContaining({
         key: "webpage-hash",
         translation: "write &amp; for ampersand — It's fine",
+      }),
+    )
+  })
+
+  it("uses cached HTML translations when all attribute markers remain on their tags", async () => {
+    translationCacheGetMock.mockResolvedValueOnce({
+      key: "webpage-hash",
+      translation: `<a data-rf-attr="1">Lire</a><span data-rf-attr="0">Bonjour</span>`,
+    })
+
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    const result = await handler({
+      data: {
+        text: `<span data-rf-attr="0">Hello</span><a data-rf-attr="1">Read</a>`,
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: googleProvider,
+        scheduleAt: Date.now(),
+        hash: "webpage-hash",
+        textFormat: "html",
+      },
+    })
+
+    expect(result).toBe(`<a data-rf-attr="1">Lire</a><span data-rf-attr="0">Bonjour</span>`)
+    expect(executeTranslateMock).not.toHaveBeenCalled()
+    expect(translationCacheDeleteMock).not.toHaveBeenCalled()
+  })
+
+  it("deletes an invalid cached HTML translation and replaces it with a valid fresh result", async () => {
+    translationCacheGetMock.mockResolvedValueOnce({
+      key: "webpage-hash",
+      translation: `<span>Bonjour</span>`,
+    })
+    executeTranslateMock.mockResolvedValueOnce(`<span data-rf-attr="0">Bonjour</span>`)
+
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    const result = await handler({
+      data: {
+        text: `<span data-rf-attr="0">Hello</span>`,
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: googleProvider,
+        scheduleAt: Date.now(),
+        hash: "webpage-hash",
+        textFormat: "html",
+      },
+    })
+
+    expect(result).toBe(`<span data-rf-attr="0">Bonjour</span>`)
+    expect(translationCacheDeleteMock).toHaveBeenCalledWith("webpage-hash")
+    expect(executeTranslateMock).toHaveBeenCalledTimes(1)
+    expect(translationCachePutMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "webpage-hash",
+        translation: `<span data-rf-attr="0">Bonjour</span>`,
+      }),
+    )
+  })
+
+  it("validates escaped page-marker fallback results before using or caching them", async () => {
+    translationCacheGetMock.mockResolvedValueOnce({
+      key: "legacy-marker-hash",
+      translation: `<span>Cached without the protected page attribute</span>`,
+    })
+    executeTranslateMock.mockResolvedValueOnce(
+      `<span data-rf-attr="rf-page-0">Fresh translation</span>`,
+    )
+
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    const result = await handler({
+      data: {
+        text: `<span data-rf-attr="rf-page-0">Hello</span>`,
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: googleProvider,
+        scheduleAt: Date.now(),
+        hash: "legacy-marker-hash",
+        textFormat: "html",
+      },
+    })
+
+    expect(result).toBe(`<span data-rf-attr="rf-page-0">Fresh translation</span>`)
+    expect(translationCacheDeleteMock).toHaveBeenCalledWith("legacy-marker-hash")
+    expect(translationCachePutMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "legacy-marker-hash",
+        translation: `<span data-rf-attr="rf-page-0">Fresh translation</span>`,
+      }),
+    )
+  })
+
+  it("throws and does not cache a fresh translation with invalid HTML markers", async () => {
+    executeTranslateMock.mockResolvedValueOnce(`<div data-rf-attr="0">Bonjour</div>`)
+
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    const request = handler({
+      data: {
+        text: `<span data-rf-attr="0">Hello</span>`,
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: googleProvider,
+        scheduleAt: Date.now(),
+        hash: "webpage-hash",
+        textFormat: "html",
+      },
+    })
+
+    await expect(request).rejects.toMatchObject({
+      code: "HTML_ATTR_MARKER_INTEGRITY",
+      reason: "wrong-output-tag",
+    })
+    expect(translationCachePutMock).not.toHaveBeenCalled()
+  })
+
+  it("treats an empty provider result as a missing-marker integrity failure", async () => {
+    executeTranslateMock.mockResolvedValueOnce("")
+
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    const request = handler({
+      data: {
+        text: `<span data-rf-attr="0">Hello</span>`,
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: googleProvider,
+        scheduleAt: Date.now(),
+        hash: "empty-html-result",
+        textFormat: "html",
+      },
+    })
+
+    await expect(request).rejects.toMatchObject({
+      code: "HTML_ATTR_MARKER_INTEGRITY",
+      reason: "missing-output-marker",
+    })
+    expect(translationCachePutMock).not.toHaveBeenCalled()
+  })
+
+  it("rejects duplicate input marker IDs before reading the cache or translating", async () => {
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    const request = handler({
+      data: {
+        text: `<span data-rf-attr="0">Hello</span><a data-rf-attr="0">Read</a>`,
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: googleProvider,
+        scheduleAt: Date.now(),
+        hash: "webpage-hash",
+        textFormat: "html",
+      },
+    })
+
+    await expect(request).rejects.toMatchObject({
+      code: "HTML_ATTR_MARKER_INTEGRITY",
+      reason: "duplicate-input-marker",
+    })
+    expect(translationCacheGetMock).not.toHaveBeenCalled()
+    expect(executeTranslateMock).not.toHaveBeenCalled()
+    expect(translationCacheDeleteMock).not.toHaveBeenCalled()
+    expect(translationCachePutMock).not.toHaveBeenCalled()
+  })
+
+  it("does not treat marker-shaped plain text as the translationOnly HTML protocol", async () => {
+    executeTranslateMock.mockResolvedValueOnce("translated plain text")
+
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    const result = await handler({
+      data: {
+        text: `Explain <span data-rf-attr="0">this example</span>`,
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: googleProvider,
+        scheduleAt: Date.now(),
+        hash: "plain-marker-shaped-text",
+        textFormat: "plain",
+      },
+    })
+
+    expect(result).toBe("translated plain text")
+    expect(translationCachePutMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "plain-marker-shaped-text",
+        translation: "translated plain text",
       }),
     )
   })

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -13,6 +13,11 @@ import { db } from "@/utils/db/dexie/db"
 import { Sha256Hex } from "@/utils/hash"
 import { microsoftTranslate } from "@/utils/host/translate/api/microsoft"
 import { executeTranslate } from "@/utils/host/translate/execute-translate"
+import {
+  assertHtmlAttributeMarkerIntegrity,
+  hasHtmlAttributeMarkerProtocol,
+  isHtmlAttributeMarkerIntegrityError,
+} from "@/utils/host/translate/html-attribute-markers"
 import { normalizePromptContextValue } from "@/utils/host/translate/translate-text"
 import { logger } from "@/utils/logger"
 import { onMessage } from "@/utils/message"
@@ -31,6 +36,27 @@ export function parseBatchResult(result: string): string[] {
 
 export function shouldUseBatchQueue(providerConfig: ProviderConfig): boolean {
   return isLLMProviderConfig(providerConfig)
+}
+
+async function getValidatedCachedTranslation(
+  hash: string,
+  sourceText: string,
+  validateHtmlAttributeMarkers: boolean,
+): Promise<string | undefined> {
+  const cached = await db.translationCache.get(hash)
+  if (!cached) return undefined
+  if (!validateHtmlAttributeMarkers) return cached.translation
+
+  try {
+    assertHtmlAttributeMarkerIntegrity(sourceText, cached.translation)
+    return cached.translation
+  } catch (error) {
+    if (!isHtmlAttributeMarkerIntegrityError(error)) throw error
+
+    await db.translationCache.delete(hash)
+    logger.warn("Deleted cached translation with invalid HTML attribute markers", error)
+    return undefined
+  }
 }
 
 export async function executeBatchTranslation<TContext>(
@@ -250,12 +276,20 @@ export async function setUpWebPageTranslationQueue() {
       },
     } = message
 
+    const validateHtmlAttributeMarkers =
+      textFormat === "html" && hasHtmlAttributeMarkerProtocol(text)
+    if (validateHtmlAttributeMarkers) {
+      assertHtmlAttributeMarkerIntegrity(text, text)
+    }
+
     // Check cache first
     if (hash) {
-      const cached = await db.translationCache.get(hash)
-      if (cached) {
-        return cached.translation
-      }
+      const cachedTranslation = await getValidatedCachedTranslation(
+        hash,
+        text,
+        validateHtmlAttributeMarkers,
+      )
+      if (cachedTranslation !== undefined) return cachedTranslation
     }
 
     let result: string
@@ -274,6 +308,10 @@ export async function setUpWebPageTranslationQueue() {
       const thunk = () =>
         executeTranslate(text, langConfig, providerConfig, getTranslatePrompt, { textFormat })
       result = await requestQueue.enqueue(thunk, scheduleAt, hash)
+    }
+
+    if (validateHtmlAttributeMarkers) {
+      assertHtmlAttributeMarkerIntegrity(text, result)
     }
 
     // Cache the translation result if successful

--- a/src/utils/host/__tests__/translate-text.test.tsx
+++ b/src/utils/host/__tests__/translate-text.test.tsx
@@ -28,6 +28,14 @@ vi.mock("@/utils/host/translate/api/google", () => ({
   googleTranslate: vi.fn<(...args: any[]) => any>(),
 }))
 
+vi.mock("@/utils/host/translate/api/deepl", () => ({
+  deeplTranslate: vi.fn<(...args: any[]) => any>(),
+}))
+
+vi.mock("@/utils/host/translate/api/deeplx", () => ({
+  deeplxTranslate: vi.fn<(...args: any[]) => any>(),
+}))
+
 vi.mock("@/utils/prompts/translate", () => ({
   getTranslatePrompt: vi.fn<(...args: any[]) => any>(),
 }))
@@ -47,6 +55,8 @@ vi.mock("@/utils/host/translate/webpage-summary", () => ({
 let mockSendMessage: any
 let mockMicrosoftTranslate: any
 let mockGoogleTranslate: any
+let mockDeepLTranslate: any
+let mockDeepLXTranslate: any
 let mockGetConfigFromStorage: any
 let mockGetTranslatePrompt: any
 let mockGetOrCreateWebPageContext: any
@@ -64,6 +74,12 @@ describe("translate-text", () => {
     )
     mockGoogleTranslate = vi.mocked(
       (await import("@/utils/host/translate/api/google")).googleTranslate,
+    )
+    mockDeepLTranslate = vi.mocked(
+      (await import("@/utils/host/translate/api/deepl")).deeplTranslate,
+    )
+    mockDeepLXTranslate = vi.mocked(
+      (await import("@/utils/host/translate/api/deeplx")).deeplxTranslate,
     )
     mockGetConfigFromStorage = vi.mocked((await import("@/utils/config/storage")).getLocalConfig)
     mockGetTranslatePrompt = vi.mocked(
@@ -436,6 +452,47 @@ describe("translate-text", () => {
       expect(result).toBe('L\'Iran chiama "Dichiarazione" AT&T <span>')
       expect(mockGoogleTranslate).toHaveBeenCalledWith("test input", "en", "zh", {
         textFormat: undefined,
+      })
+    })
+
+    it("forwards html text format to DeepL", async () => {
+      const deeplProviderConfig = {
+        id: "deepl-default",
+        enabled: true,
+        name: "DeepL",
+        provider: "deepl" as const,
+        apiKey: "test-key",
+      }
+      const html = '<p class="message">Hello</p>'
+      mockDeepLTranslate.mockResolvedValue("<p>你好</p>")
+
+      await executeTranslate(html, langConfig, deeplProviderConfig, getTranslatePrompt, {
+        textFormat: "html",
+      })
+
+      expect(mockDeepLTranslate).toHaveBeenCalledWith(html, "en", "zh", deeplProviderConfig, {
+        textFormat: "html",
+      })
+    })
+
+    it("forwards html text format to DeepLX", async () => {
+      const deeplxProviderConfig = {
+        id: "deeplx-default",
+        enabled: true,
+        name: "DeepLX",
+        provider: "deeplx" as const,
+        apiKey: "test-key",
+        baseURL: "https://api.deeplx.org/{{apiKey}}/translate",
+      }
+      const html = '<p class="message">Hello</p>'
+      mockDeepLXTranslate.mockResolvedValue("<p>你好</p>")
+
+      await executeTranslate(html, langConfig, deeplxProviderConfig, getTranslatePrompt, {
+        textFormat: "html",
+      })
+
+      expect(mockDeepLXTranslate).toHaveBeenCalledWith(html, "en", "zh", deeplxProviderConfig, {
+        textFormat: "html",
       })
     })
   })

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -2,7 +2,7 @@ import type { Config } from "@/types/config/config"
 // @vitest-environment jsdom
 import type { TranslationMode } from "@/types/config/translate"
 import { act, render, screen, waitFor } from "@testing-library/react"
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest"
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import {
   BLOCK_ATTRIBUTE,
@@ -18,6 +18,7 @@ import {
 import { flushBatchedOperations } from "@/utils/host/dom/batch-dom"
 import { walkAndLabelElement } from "@/utils/host/dom/traversal"
 import {
+  translateNodeTranslationOnlyMode,
   translateNodesBilingualMode,
   translateWalkedElement,
 } from "@/utils/host/translate/node-manipulation"
@@ -139,21 +140,15 @@ describe("translate", () => {
   async function removeOrShowPageTranslation(
     translationMode: TranslationMode,
     toggle: boolean = false,
+    config?: Config,
   ) {
     const id = crypto.randomUUID()
+    const effectiveConfig =
+      config ?? (translationMode === "bilingual" ? BILINGUAL_CONFIG : TRANSLATION_ONLY_CONFIG)
 
-    walkAndLabelElement(
-      document.body,
-      id,
-      translationMode === "bilingual" ? BILINGUAL_CONFIG : TRANSLATION_ONLY_CONFIG,
-    )
+    walkAndLabelElement(document.body, id, effectiveConfig)
     await act(async () => {
-      await translateWalkedElement(
-        document.body,
-        id,
-        translationMode === "bilingual" ? BILINGUAL_CONFIG : TRANSLATION_ONLY_CONFIG,
-        toggle,
-      )
+      await translateWalkedElement(document.body, id, effectiveConfig, toggle)
       // Flush batched DOM operations to ensure all changes are applied before assertions
       flushBatchedOperations()
     })
@@ -2177,6 +2172,354 @@ describe("translate", () => {
 
       expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
       expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
+    })
+  })
+
+  describe("translationOnly HTML attribute placeholders", () => {
+    beforeEach(() => {
+      vi.mocked(translateTextForPage).mockReset().mockResolvedValue(MOCK_TRANSLATION)
+    })
+
+    afterEach(() => {
+      vi.mocked(translateTextForPage).mockReset().mockResolvedValue(MOCK_TRANSLATION)
+    })
+
+    it("keeps bilingual translation on the existing plain-text path", async () => {
+      render(
+        <div data-testid="bilingual-node">
+          Hello <strong className="long framework classes">world</strong>.
+        </div>,
+      )
+
+      await removeOrShowPageTranslation("bilingual", true)
+
+      expect(translateTextForPage).toHaveBeenCalled()
+      expect(
+        vi
+          .mocked(translateTextForPage)
+          .mock.calls.every(
+            ([request, textFormat]) => !request.includes("data-rf-attr") && textFormat === "plain",
+          ),
+      ).toBe(true)
+    })
+
+    it("sends a compact HTML skeleton and restores attributes after translated tag movement", async () => {
+      const longClassName = `place ${"utility-class-".repeat(40)}`
+      vi.mocked(translateTextForPage).mockImplementation(async (text) => {
+        if (text.includes("data-rf-attr")) {
+          return `这个星期一我去了<strong data-rf-attr="0" title="城市" onclick="evil()">温哥华</strong>。`
+        }
+        return MOCK_TRANSLATION
+      })
+
+      render(
+        <div data-testid="test-node">
+          I went to
+          <strong className={longClassName} style={{ color: "red" }} data-place="yvr" title="City">
+            Vancouver
+          </strong>
+          this Monday.
+        </div>,
+      )
+      const node = screen.getByTestId("test-node")
+
+      await removeOrShowPageTranslation("translationOnly", true)
+
+      expect(translateTextForPage).toHaveBeenCalledOnce()
+      const [requestHtml, textFormat] = vi.mocked(translateTextForPage).mock.calls[0]
+      expect(textFormat).toBe("html")
+      expect(requestHtml).toContain(`<strong title="City" data-rf-attr="0">`)
+      expect(requestHtml).not.toContain(longClassName)
+      expect(requestHtml).not.toContain("data-place")
+
+      const wrapper = expectTranslationWrapper(node, "translationOnly")
+      const translatedStrong = wrapper?.querySelector("strong")
+      expect(translatedStrong?.className).toBe(longClassName)
+      expect((translatedStrong as HTMLElement | null)?.style.color).toBe("red")
+      expect(translatedStrong?.getAttribute("data-place")).toBe("yvr")
+      expect(translatedStrong?.getAttribute("title")).toBe("城市")
+      expect(translatedStrong?.hasAttribute("data-rf-attr")).toBe(false)
+      expect(translatedStrong?.hasAttribute("onclick")).toBe(false)
+      expect(wrapper?.textContent).toBe("这个星期一我去了温哥华。")
+
+      await removeOrShowPageTranslation("translationOnly", true)
+      const restoredStrong = node.querySelector("strong")
+      expect(restoredStrong?.className).toBe(longClassName)
+      expect(restoredStrong?.getAttribute("data-place")).toBe("yvr")
+      expect(restoredStrong?.textContent).toBe("Vancouver")
+    })
+
+    it("keeps the original DOM when only restored attribute order differs", async () => {
+      vi.mocked(translateTextForPage).mockImplementation(async (request) => request)
+      render(
+        <div data-testid="same-html-node">
+          <strong className="place" title="City" data-place="yvr">
+            Vancouver
+          </strong>
+        </div>,
+      )
+      const node = screen.getByTestId("same-html-node")
+      const originalStrong = node.querySelector("strong")
+
+      await removeOrShowPageTranslation("translationOnly", true)
+
+      expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+      expect(node.querySelector("strong")).toBe(originalStrong)
+    })
+
+    it("retries the canonical full HTML once when a marker contract is corrupted", async () => {
+      vi.mocked(translateTextForPage)
+        .mockResolvedValueOnce(`<strong>损坏的 marker</strong>`)
+        .mockResolvedValueOnce("完整 HTML 回退译文")
+
+      render(
+        <div data-testid="test-node">
+          I visited{" "}
+          <strong className="place" data-place="yvr">
+            Vancouver
+          </strong>
+          .
+        </div>,
+      )
+      const node = screen.getByTestId("test-node")
+
+      await removeOrShowPageTranslation("translationOnly", true)
+
+      expect(translateTextForPage).toHaveBeenCalledTimes(2)
+      expect(vi.mocked(translateTextForPage).mock.calls[0][0]).toContain(`data-rf-attr="0"`)
+      expect(vi.mocked(translateTextForPage).mock.calls[0][0]).not.toContain(`class="place"`)
+      expect(vi.mocked(translateTextForPage).mock.calls[1][0]).toContain(`class="place"`)
+      expect(vi.mocked(translateTextForPage).mock.calls[1][0]).not.toContain("data-rf-attr")
+      expect(expectTranslationWrapper(node, "translationOnly")?.textContent).toBe(
+        "完整 HTML 回退译文",
+      )
+    })
+
+    it("escapes and restores a page-owned numeric marker during full HTML fallback", async () => {
+      vi.mocked(translateTextForPage)
+        .mockResolvedValueOnce(`<strong>损坏的 marker</strong>`)
+        .mockResolvedValueOnce(`<strong class="place" data-rf-attr="rf-page-0">温哥华</strong>`)
+
+      render(
+        <div data-testid="test-node">
+          I visited{" "}
+          <strong className="place" data-rf-attr="0">
+            Vancouver
+          </strong>
+          .
+        </div>,
+      )
+      const node = screen.getByTestId("test-node")
+
+      await removeOrShowPageTranslation("translationOnly", true)
+
+      expect(translateTextForPage).toHaveBeenCalledTimes(2)
+      expect(vi.mocked(translateTextForPage).mock.calls[1][0]).toContain(`data-rf-attr="rf-page-0"`)
+      const translatedStrong = expectTranslationWrapper(node, "translationOnly")?.querySelector(
+        "strong",
+      )
+      expect(translatedStrong?.getAttribute("data-rf-attr")).toBe("0")
+      expect(translatedStrong?.className).toBe("place")
+    })
+
+    it("keeps the source DOM and existing error UI when the full HTML fallback fails", async () => {
+      vi.mocked(translateTextForPage)
+        .mockResolvedValueOnce(`<strong>损坏的 marker</strong>`)
+        .mockRejectedValueOnce(new Error("Fallback failed"))
+
+      render(
+        <div data-testid="test-node">
+          I visited <strong className="place">Vancouver</strong>.
+        </div>,
+      )
+      const node = screen.getByTestId("test-node")
+
+      await removeOrShowPageTranslation("translationOnly", true)
+
+      expect(translateTextForPage).toHaveBeenCalledTimes(2)
+      const wrapper = expectTranslationWrapper(node, "translationOnly")
+      expect(node.textContent).toContain("I visited Vancouver.")
+      await waitForTranslationError(wrapper)
+    })
+
+    it("disables placeholders for the current DeepLX endpoint after its first integrity failure", async () => {
+      const deeplxConfig: Config = {
+        ...TRANSLATION_ONLY_CONFIG,
+        providersConfig: [
+          ...TRANSLATION_ONLY_CONFIG.providersConfig,
+          {
+            id: "deeplx-default",
+            name: "DeepLX",
+            enabled: true,
+            provider: "deeplx",
+            baseURL: "https://deeplx.example/translate",
+          },
+        ],
+        translate: {
+          ...TRANSLATION_ONLY_CONFIG.translate,
+          providerId: "deeplx-default",
+        },
+      }
+      vi.mocked(translateTextForPage)
+        .mockResolvedValueOnce(`<strong>损坏的 marker</strong>`)
+        .mockResolvedValueOnce("第一次完整 HTML 回退")
+        .mockResolvedValueOnce("第二次直接使用完整 HTML")
+
+      const firstRender = render(
+        <div data-testid="first-node">
+          First <strong className="place">Vancouver</strong>.
+        </div>,
+      )
+      await removeOrShowPageTranslation("translationOnly", true, deeplxConfig)
+      firstRender.unmount()
+
+      render(
+        <div data-testid="second-node">
+          Second <strong className="place">Vancouver</strong>.
+        </div>,
+      )
+      await removeOrShowPageTranslation("translationOnly", true, deeplxConfig)
+
+      expect(translateTextForPage).toHaveBeenCalledTimes(3)
+      expect(vi.mocked(translateTextForPage).mock.calls[0][0]).toContain("data-rf-attr")
+      expect(vi.mocked(translateTextForPage).mock.calls[1][0]).not.toContain("data-rf-attr")
+      expect(vi.mocked(translateTextForPage).mock.calls[2][0]).not.toContain("data-rf-attr")
+      expect(vi.mocked(translateTextForPage).mock.calls[2][0]).toContain(`class="place"`)
+    })
+
+    it("shares the first DeepLX capability probe across concurrent paragraphs", async () => {
+      const deeplxConfig: Config = {
+        ...TRANSLATION_ONLY_CONFIG,
+        providersConfig: [
+          ...TRANSLATION_ONLY_CONFIG.providersConfig,
+          {
+            id: "deeplx-concurrent",
+            name: "DeepLX Concurrent",
+            enabled: true,
+            provider: "deeplx",
+            baseURL: "https://deeplx-concurrent.example/translate",
+          },
+        ],
+        translate: {
+          ...TRANSLATION_ONLY_CONFIG.translate,
+          providerId: "deeplx-concurrent",
+        },
+      }
+      let resolveProbe!: (value: string) => void
+      const probeResult = new Promise<string>((resolve) => {
+        resolveProbe = resolve
+      })
+      vi.mocked(translateTextForPage)
+        .mockImplementationOnce(() => probeResult)
+        .mockResolvedValueOnce("第一段完整 HTML 回退")
+        .mockResolvedValueOnce("第二段直接使用完整 HTML")
+
+      render(
+        <>
+          <div data-testid="first-concurrent-node">
+            First <strong className="first-place">Vancouver</strong>.
+          </div>
+          <div data-testid="second-concurrent-node">
+            Second <strong className="second-place">Victoria</strong>.
+          </div>
+        </>,
+      )
+      const firstNode = screen.getByTestId("first-concurrent-node")
+      const secondNode = screen.getByTestId("second-concurrent-node")
+      const translations = Promise.all([
+        translateNodeTranslationOnlyMode(
+          [...firstNode.childNodes],
+          "concurrent-walk",
+          deeplxConfig,
+        ),
+        translateNodeTranslationOnlyMode(
+          [...secondNode.childNodes],
+          "concurrent-walk",
+          deeplxConfig,
+        ),
+      ])
+
+      await waitFor(() => expect(translateTextForPage).toHaveBeenCalledTimes(1))
+      resolveProbe(`<strong>损坏的 marker</strong>`)
+      await act(async () => {
+        await translations
+        flushBatchedOperations()
+      })
+
+      expect(translateTextForPage).toHaveBeenCalledTimes(3)
+      expect(vi.mocked(translateTextForPage).mock.calls[0][0]).toContain("data-rf-attr")
+      const fallbackRequests = vi.mocked(translateTextForPage).mock.calls.slice(1)
+      expect(fallbackRequests.every(([request]) => !request.includes("data-rf-attr"))).toBe(true)
+      expect(fallbackRequests.some(([request]) => request.includes(`class="first-place"`))).toBe(
+        true,
+      )
+      expect(fallbackRequests.some(([request]) => request.includes(`class="second-place"`))).toBe(
+        true,
+      )
+    })
+
+    it("hands an inconclusive empty DeepLX probe to one waiter at a time", async () => {
+      const deeplxConfig: Config = {
+        ...TRANSLATION_ONLY_CONFIG,
+        providersConfig: [
+          ...TRANSLATION_ONLY_CONFIG.providersConfig,
+          {
+            id: "deeplx-empty-probe",
+            name: "DeepLX Empty Probe",
+            enabled: true,
+            provider: "deeplx",
+            baseURL: "https://deeplx-empty-probe.example/translate",
+          },
+        ],
+        translate: {
+          ...TRANSLATION_ONLY_CONFIG.translate,
+          providerId: "deeplx-empty-probe",
+        },
+      }
+      let compactRequestCount = 0
+      vi.mocked(translateTextForPage).mockImplementation(async (request) => {
+        if (request.includes("data-rf-attr")) {
+          compactRequestCount += 1
+          return compactRequestCount === 1 ? "" : `<strong>损坏的 marker</strong>`
+        }
+        return "完整 HTML 回退"
+      })
+
+      render(
+        <>
+          <div data-testid="empty-probe-one">
+            One <strong className="one">Vancouver</strong>.
+          </div>
+          <div data-testid="empty-probe-two">
+            Two <strong className="two">Victoria</strong>.
+          </div>
+          <div data-testid="empty-probe-three">
+            Three <strong className="three">Burnaby</strong>.
+          </div>
+        </>,
+      )
+      const nodes = [
+        screen.getByTestId("empty-probe-one"),
+        screen.getByTestId("empty-probe-two"),
+        screen.getByTestId("empty-probe-three"),
+      ]
+
+      await act(async () => {
+        await Promise.all(
+          nodes.map((node) =>
+            translateNodeTranslationOnlyMode(
+              [...node.childNodes],
+              "empty-probe-walk",
+              deeplxConfig,
+            ),
+          ),
+        )
+        flushBatchedOperations()
+      })
+
+      const requests = vi.mocked(translateTextForPage).mock.calls.map(([request]) => request)
+      expect(requests.filter((request) => request.includes("data-rf-attr"))).toHaveLength(2)
+      expect(requests.filter((request) => !request.includes("data-rf-attr"))).toHaveLength(2)
     })
   })
 

--- a/src/utils/host/translate/__tests__/html-attribute-markers.test.ts
+++ b/src/utils/host/translate/__tests__/html-attribute-markers.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest"
+import {
+  assertHtmlAttributeMarkerIntegrity,
+  hasHtmlAttributeMarkerProtocol,
+  HTML_ATTRIBUTE_MARKER_INTEGRITY_ERROR_CODE,
+  HtmlAttributeMarkerIntegrityError,
+  isHtmlAttributeMarkerIntegrityError,
+  parseHtmlAttributeMarkers,
+} from "../html-attribute-markers"
+
+describe("HTML attribute markers", () => {
+  it("extracts marker IDs and opening tag names from complete HTML tags", () => {
+    const html = [
+      `marker text: data-rf-attr="outside"`,
+      `<SPAN title="1 > 0" data-rf-attr = "first">Hello</SPAN>`,
+      `<a DATA-RF-ATTR='second' href="/path">World</a>`,
+      `<br data-rf-attr=third>`,
+    ].join("")
+
+    expect(parseHtmlAttributeMarkers(html)).toEqual([
+      { id: "first", tagName: "span" },
+      { id: "second", tagName: "a" },
+      { id: "third", tagName: "br" },
+    ])
+  })
+
+  it("ignores marker-shaped text that is not an attribute on a real opening tag", () => {
+    const html = [
+      `<!-- <span data-rf-attr="comment"> -->`,
+      `<script>const example = '<b data-rf-attr="script">text</b>'</script>`,
+      `<noscript><b data-rf-attr="noscript">text</b></noscript>`,
+      `<textarea><i data-rf-attr="textarea">text</i></textarea>`,
+      `<div title='<em data-rf-attr="attribute-value">'>text</div>`,
+      `<![CDATA[<strong data-rf-attr="cdata">text</strong>]]>`,
+      `&lt;strong data-rf-attr="escaped"&gt;`,
+    ].join("")
+
+    expect(parseHtmlAttributeMarkers(html)).toEqual([])
+  })
+
+  it("keeps scanner offsets stable around Unicode with length-changing lowercase forms", () => {
+    expect(
+      parseHtmlAttributeMarkers(
+        `İ<style>.example { color: red }</style><span data-rf-attr="0">Text</span>`,
+      ),
+    ).toEqual([{ id: "0", tagName: "span" }])
+  })
+
+  it("permits marked elements to change order and attributes to change quote style", () => {
+    const input =
+      `<span class="name" data-rf-attr="0">Hello</span>` +
+      `<a data-rf-attr='1' href="/docs">Read</a>`
+    const output =
+      `<a href='/docs' data-rf-attr=1>Lire</a>` +
+      `<span data-rf-attr='0' class="name">Bonjour</span>`
+
+    expect(() => assertHtmlAttributeMarkerIntegrity(input, output)).not.toThrow()
+  })
+
+  it("treats a valueless marker attribute as an empty marker ID", () => {
+    expect(parseHtmlAttributeMarkers(`<span data-rf-attr>Text</span>`)).toEqual([
+      { id: "", tagName: "span" },
+    ])
+    expect(() =>
+      assertHtmlAttributeMarkerIntegrity(
+        `<span data-rf-attr="0">Text</span>`,
+        `<span data-rf-attr>Texte</span>`,
+      ),
+    ).toThrowError(expect.objectContaining({ reason: "unknown-output-marker" }))
+  })
+
+  it("distinguishes generated numeric markers from page-owned marker attributes", () => {
+    expect(hasHtmlAttributeMarkerProtocol(`<span data-rf-attr="0">Text</span>`)).toBe(true)
+    expect(hasHtmlAttributeMarkerProtocol(`<span data-rf-attr="12">Text</span>`)).toBe(true)
+    expect(hasHtmlAttributeMarkerProtocol(`<span data-rf-attr="rf-page-0">Text</span>`)).toBe(true)
+    expect(hasHtmlAttributeMarkerProtocol(`<span data-rf-attr="page-owned">Text</span>`)).toBe(
+      false,
+    )
+    expect(
+      hasHtmlAttributeMarkerProtocol(
+        `<span data-rf-attr="0">Text</span><b data-rf-attr="rf-page-0">More</b>`,
+      ),
+    ).toBe(false)
+    expect(hasHtmlAttributeMarkerProtocol(`<span>Text</span>`)).toBe(false)
+  })
+
+  it.each([
+    {
+      name: "duplicate IDs in the input",
+      input: `<span data-rf-attr="0">One</span><b data-rf-attr="0">Two</b>`,
+      output: `<span data-rf-attr="0">Un</span>`,
+      reason: "duplicate-input-marker",
+    },
+    {
+      name: "missing output IDs",
+      input: `<span data-rf-attr="0">One</span><b data-rf-attr="1">Two</b>`,
+      output: `<b data-rf-attr="1">Deux</b>`,
+      reason: "missing-output-marker",
+    },
+    {
+      name: "duplicate output IDs",
+      input: `<span data-rf-attr="0">One</span>`,
+      output: `<span data-rf-attr="0">Un</span><span data-rf-attr="0">Encore</span>`,
+      reason: "duplicate-output-marker",
+    },
+    {
+      name: "unknown output IDs",
+      input: `<span data-rf-attr="0">One</span>`,
+      output: `<span data-rf-attr="0">Un</span><i data-rf-attr="9">Neuf</i>`,
+      reason: "unknown-output-marker",
+    },
+    {
+      name: "a marker moved to a different tag",
+      input: `<span data-rf-attr="0">One</span>`,
+      output: `<div data-rf-attr="0">Un</div>`,
+      reason: "wrong-output-tag",
+    },
+  ])("rejects $name", ({ input, output, reason }) => {
+    expect(() => assertHtmlAttributeMarkerIntegrity(input, output)).toThrowError(
+      expect.objectContaining({
+        code: HTML_ATTRIBUTE_MARKER_INTEGRITY_ERROR_CODE,
+        reason,
+      }),
+    )
+  })
+
+  it("recognizes integrity errors after structural cloning", () => {
+    const error = new HtmlAttributeMarkerIntegrityError("missing-output-marker", "3")
+
+    expect(isHtmlAttributeMarkerIntegrityError(error)).toBe(true)
+    expect(
+      isHtmlAttributeMarkerIntegrityError({
+        code: HTML_ATTRIBUTE_MARKER_INTEGRITY_ERROR_CODE,
+        message: error.message,
+      }),
+    ).toBe(true)
+    expect(isHtmlAttributeMarkerIntegrityError(new Error(error.message))).toBe(false)
+  })
+})

--- a/src/utils/host/translate/api/__tests__/deepl.test.ts
+++ b/src/utils/host/translate/api/__tests__/deepl.test.ts
@@ -83,6 +83,76 @@ describe("deepl translate adapter", () => {
     })
   })
 
+  it.each(["plain", undefined] as const)(
+    "omits tag_handling for %s text format",
+    async (textFormat) => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: vi.fn<(...args: any[]) => any>().mockResolvedValue({
+          translations: [{ text: "Hello" }],
+        }),
+        text: vi.fn<(...args: any[]) => any>().mockResolvedValue(""),
+      })
+
+      await deeplTranslate(
+        "Hello",
+        "en",
+        "de",
+        {
+          id: "deepl-default",
+          enabled: true,
+          name: "DeepL",
+          provider: "deepl",
+          apiKey: "test-key",
+        },
+        { textFormat },
+      )
+
+      const [, requestInit] = fetchMock.mock.calls[0]
+      expect(JSON.parse(requestInit.body)).toEqual({
+        text: ["Hello"],
+        source_lang: "EN",
+        target_lang: "DE",
+      })
+    },
+  )
+
+  it("sets tag_handling to html for html input", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: vi.fn<(...args: any[]) => any>().mockResolvedValue({
+        translations: [{ text: "<p>Hallo</p>" }],
+      }),
+      text: vi.fn<(...args: any[]) => any>().mockResolvedValue(""),
+    })
+
+    await deeplTranslate(
+      '<p class="message">Hello</p>',
+      "en",
+      "de",
+      {
+        id: "deepl-default",
+        enabled: true,
+        name: "DeepL",
+        provider: "deepl",
+        apiKey: "test-key",
+      },
+      { textFormat: "html" },
+    )
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    expect(JSON.parse(requestInit.body)).toEqual({
+      text: ['<p class="message">Hello</p>'],
+      source_lang: "EN",
+      target_lang: "DE",
+      tag_handling: "html",
+    })
+  })
+
   it("throws when the response count does not match the request count", async () => {
     fetchMock.mockResolvedValue({
       ok: true,

--- a/src/utils/host/translate/api/__tests__/deeplx-url-builder.test.ts
+++ b/src/utils/host/translate/api/__tests__/deeplx-url-builder.test.ts
@@ -88,6 +88,63 @@ describe("deeplxTranslate default URL fallback", () => {
         method: "POST",
       }),
     )
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    expect(JSON.parse(requestInit.body)).toEqual({
+      text: "Hi",
+      source_lang: "auto",
+      target_lang: "ZH",
+    })
+  })
+
+  it.each(["plain", undefined] as const)(
+    "omits tag_handling for %s text format",
+    async (textFormat) => {
+      await deeplxTranslate(
+        "Hi",
+        "en",
+        "zh",
+        {
+          id: "deeplx-default",
+          enabled: true,
+          name: "DeepLX",
+          provider: "deeplx",
+          apiKey: "token123",
+        },
+        { textFormat },
+      )
+
+      const [, requestInit] = fetchMock.mock.calls[0]
+      expect(JSON.parse(requestInit.body)).toEqual({
+        text: "Hi",
+        source_lang: "EN",
+        target_lang: "ZH",
+      })
+    },
+  )
+
+  it("sets tag_handling to html for html input", async () => {
+    await deeplxTranslate(
+      '<p class="message">Hi</p>',
+      "en",
+      "zh",
+      {
+        id: "deeplx-default",
+        enabled: true,
+        name: "DeepLX",
+        provider: "deeplx",
+        apiKey: "token123",
+      },
+      { textFormat: "html" },
+    )
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    expect(JSON.parse(requestInit.body)).toEqual({
+      text: '<p class="message">Hi</p>',
+      source_lang: "EN",
+      target_lang: "ZH",
+      tag_handling: "html",
+    })
   })
 
   it("throws the placeholder API key error when fallback URL needs a missing key", async () => {

--- a/src/utils/host/translate/api/__tests__/google.test.ts
+++ b/src/utils/host/translate/api/__tests__/google.test.ts
@@ -55,13 +55,16 @@ describe("google translate adapter", () => {
   it("sends html-format input unescaped so the endpoint preserves its tags", async () => {
     // translationOnly page mode sends outerHTML fragments and re-renders the
     // result via innerHTML — escaping them would expose tags to translation.
-    mockTranslateResponse("ok")
+    const source = 'See the <a data-rf-attr="0">docs &amp; API</a>'
+    const translated = '请参阅<a data-rf-attr="0">文档 &amp; API</a>'
+    mockTranslateResponse(translated)
 
-    await googleTranslate('See the <a href="/docs?a=1&b=2">docs</a>', "en", "zh", {
+    const result = await googleTranslate(source, "en", "zh", {
       textFormat: "html",
     })
 
-    expect(sentSourceText()).toBe('See the <a href="/docs?a=1&b=2">docs</a>')
+    expect(sentSourceText()).toBe(source)
+    expect(result).toBe(translated)
   })
 
   it("returns the HTML-encoded API payload without decoding it", async () => {

--- a/src/utils/host/translate/api/__tests__/microsoft.test.ts
+++ b/src/utils/host/translate/api/__tests__/microsoft.test.ts
@@ -2,10 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { microsoftTranslate } from "../microsoft"
 
 const fetchMock = vi.fn<(...args: any[]) => any>()
+let translatedText = "你好"
 
 describe("microsoft translate adapter", () => {
   beforeEach(() => {
     fetchMock.mockReset()
+    translatedText = "你好"
     fetchMock.mockImplementation((url: string) => {
       if (url === "https://edge.microsoft.com/translate/auth") {
         return Promise.resolve({
@@ -21,7 +23,7 @@ describe("microsoft translate adapter", () => {
         statusText: "OK",
         json: vi
           .fn<(...args: any[]) => any>()
-          .mockResolvedValue([{ translations: [{ text: "你好" }] }]),
+          .mockImplementation(async () => [{ translations: [{ text: translatedText }] }]),
         text: vi.fn<(...args: any[]) => any>().mockResolvedValue(""),
       })
     })
@@ -40,6 +42,14 @@ describe("microsoft translate adapter", () => {
     return String(translateCall![0])
   }
 
+  function sentTranslationText(): string {
+    const translateCall = fetchMock.mock.calls.find(([url]) =>
+      String(url).includes("microsofttranslator.com/translate"),
+    )
+    expect(translateCall).toBeDefined()
+    return JSON.parse(translateCall![1].body)[0].Text
+  }
+
   it("requests plain textType so tag-like text is translated instead of skipped", async () => {
     const result = await microsoftTranslate("if x <b then stop", "en", "zh")
 
@@ -49,10 +59,15 @@ describe("microsoft translate adapter", () => {
   })
 
   it("requests html textType for html-format input so markup is preserved", async () => {
-    await microsoftTranslate('See the <a href="/pricing">pricing</a>', "en", "zh", {
+    const source = 'See the <a data-rf-attr="0">pricing &amp; plans</a>'
+    translatedText = '查看<a data-rf-attr="0">价格与方案</a>'
+
+    const result = await microsoftTranslate(source, "en", "zh", {
       textFormat: "html",
     })
 
     expect(translateCallURL()).toContain("textType=html")
+    expect(sentTranslationText()).toBe(source)
+    expect(result).toBe(translatedText)
   })
 })

--- a/src/utils/host/translate/api/deepl.ts
+++ b/src/utils/host/translate/api/deepl.ts
@@ -1,5 +1,6 @@
 import type { LangCodeISO6391 } from "@read-frog/definitions"
 import type { ProviderConfig } from "@/types/config/provider"
+import type { TranslationTextFormat } from "@/types/config/translate"
 
 type DeepLProviderConfig = Extract<ProviderConfig, { provider: "deepl" }>
 
@@ -13,12 +14,14 @@ export async function deeplTranslate(
   fromLang: LangCodeISO6391 | "auto",
   toLang: LangCodeISO6391,
   providerConfig: DeepLProviderConfig,
+  options?: { textFormat?: TranslationTextFormat },
 ): Promise<string> {
   const [translatedText] = await requestDeepLTranslations(
     [sourceText],
     fromLang,
     toLang,
     providerConfig,
+    options,
   )
 
   if (translatedText === undefined) {
@@ -33,6 +36,7 @@ async function requestDeepLTranslations(
   fromLang: LangCodeISO6391 | "auto",
   toLang: LangCodeISO6391,
   providerConfig: DeepLProviderConfig,
+  options?: { textFormat?: TranslationTextFormat },
 ): Promise<string[]> {
   const apiKey = providerConfig.apiKey?.trim()
   if (!apiKey) {
@@ -47,6 +51,7 @@ async function requestDeepLTranslations(
     text: sourceTexts,
     ...(normalizedLanguages.source ? { source_lang: normalizedLanguages.source } : {}),
     target_lang: normalizedLanguages.target,
+    ...(options?.textFormat === "html" ? { tag_handling: "html" } : {}),
   })
 
   const fetchResponse = await fetchDirect(url, apiKey, requestBody)

--- a/src/utils/host/translate/api/deeplx.ts
+++ b/src/utils/host/translate/api/deeplx.ts
@@ -1,5 +1,6 @@
 import type { LangCodeISO6391 } from "@read-frog/definitions"
 import type { ProviderConfig } from "@/types/config/provider"
+import type { TranslationTextFormat } from "@/types/config/translate"
 import { DEFAULT_PROVIDER_CONFIG } from "@/utils/constants/providers"
 
 type DeepLXProviderConfig = Extract<ProviderConfig, { provider: "deeplx" }>
@@ -10,6 +11,7 @@ export async function deeplxTranslate(
   fromLang: LangCodeISO6391 | "auto",
   toLang: LangCodeISO6391,
   providerConfig: DeepLXProviderConfig,
+  options?: { textFormat?: TranslationTextFormat },
 ): Promise<string> {
   const baseURL = providerConfig.baseURL || DEFAULT_PROVIDER_CONFIG.deeplx.baseURL
   const apiKey = providerConfig.apiKey
@@ -31,6 +33,7 @@ export async function deeplxTranslate(
     text: sourceText,
     source_lang: formatLang(fromLang),
     target_lang: formatLang(toLang),
+    ...(options?.textFormat === "html" ? { tag_handling: "html" } : {}),
   })
 
   const fetchResponse = await fetchDirect(url, requestBody)

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -1,6 +1,8 @@
 import type { Config } from "@/types/config/config"
 import type { TranslationMode } from "@/types/config/translate"
 import type { TransNode } from "@/types/dom"
+import { resolveProviderConfig } from "@/utils/constants/feature-providers"
+import { logger } from "@/utils/logger"
 import {
   CONTENT_WRAPPER_CLASS,
   NOTRANSLATE_CLASS,
@@ -21,11 +23,14 @@ import {
   removeOrphanVirtualParagraphWrappers,
   removeTranslatedWrapperWithRestore,
 } from "../dom/translation-cleanup"
+import { protectTranslationHtmlAttributes } from "../dom/translation-html-attributes"
 import { insertTranslatedNodeIntoWrapper } from "../dom/translation-insertion"
 import { findPreviousTranslatedWrapperInside } from "../dom/translation-wrapper"
 import { insertVirtualParagraphWrappers } from "../dom/virtual-paragraph-insertion"
 import { shouldFilterSmallParagraph } from "../filter-small-paragraph"
+import { isHtmlAttributeMarkerIntegrityError } from "../html-attribute-markers"
 import { prepareTranslationText } from "../text-preparation"
+import { translateTextForPage } from "../translate-variants"
 import { setTranslationDirAndLang } from "../translation-attributes"
 import { createSpinnerInside, getTranslatedTextAndRemoveSpinner } from "../ui/spinner"
 import { isNumericContent } from "../ui/translation-utils"
@@ -35,7 +40,6 @@ import {
   getVirtualParagraphGroupForSource,
   isBilingualTranslationStateCurrent,
   isVirtualParagraphGroupCurrent,
-  MARK_ATTRIBUTES_REGEX,
   markVirtualParagraphGroupInserted,
   originalContentMap,
   registerBilingualTranslationState,
@@ -48,15 +52,75 @@ import {
   type VirtualParagraphSourceSnapshot,
 } from "./translation-state"
 
-const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g
 let virtualParagraphGroupSequence = 0
+const unsupportedDeepLXHtmlAttributeProviders = new Set<string>()
+const supportedDeepLXHtmlAttributeProviders = new Set<string>()
+type DeepLXHtmlAttributeProbeResult = "supported" | "unsupported" | "unknown"
+interface DeepLXHtmlAttributeProbe {
+  promise: Promise<DeepLXHtmlAttributeProbeResult>
+  resolve: (result: DeepLXHtmlAttributeProbeResult) => void
+}
+const deepLXHtmlAttributeProbes = new Map<string, DeepLXHtmlAttributeProbe>()
 
-function getDisplayTranslation(sourceText: string, translatedText: string | undefined) {
+function createDeepLXHtmlAttributeProbe(): DeepLXHtmlAttributeProbe {
+  let resolve!: (result: DeepLXHtmlAttributeProbeResult) => void
+  const promise = new Promise<DeepLXHtmlAttributeProbeResult>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function finishDeepLXHtmlAttributeProbe(
+  providerKey: string,
+  probe: DeepLXHtmlAttributeProbe | undefined,
+  result: DeepLXHtmlAttributeProbeResult,
+): void {
+  if (!probe || deepLXHtmlAttributeProbes.get(providerKey) !== probe) return
+  deepLXHtmlAttributeProbes.delete(providerKey)
+  probe.resolve(result)
+}
+
+async function acquireDeepLXHtmlAttributeProbe(providerKey: string): Promise<{
+  probe?: DeepLXHtmlAttributeProbe
+  useLegacy: boolean
+}> {
+  while (true) {
+    if (unsupportedDeepLXHtmlAttributeProviders.has(providerKey)) {
+      return { useLegacy: true }
+    }
+    if (supportedDeepLXHtmlAttributeProviders.has(providerKey)) {
+      return { useLegacy: false }
+    }
+
+    const activeProbe = deepLXHtmlAttributeProbes.get(providerKey)
+    if (!activeProbe) {
+      const probe = createDeepLXHtmlAttributeProbe()
+      deepLXHtmlAttributeProbes.set(providerKey, probe)
+      return { probe, useLegacy: false }
+    }
+
+    // An empty/skipped request or a transient error proves neither support nor
+    // incompatibility. Re-enter the loop so exactly one waiter owns the next probe.
+    await activeProbe.promise
+  }
+}
+
+function getDeepLXHtmlAttributeProviderKey(config: Config): string | undefined {
+  const providerConfig = resolveProviderConfig(config, "translate")
+  if (providerConfig.provider !== "deeplx") return undefined
+  return `${providerConfig.id}:${providerConfig.baseURL ?? ""}`
+}
+
+function getDisplayTranslation(
+  sourceText: string,
+  translatedText: string | undefined,
+  comparisonText: string | undefined = translatedText,
+) {
   if (translatedText === undefined) {
     return undefined
   }
 
-  return prepareTranslationText(sourceText) === prepareTranslationText(translatedText)
+  return prepareTranslationText(sourceText) === prepareTranslationText(comparisonText)
     ? ""
     : translatedText
 }
@@ -528,32 +592,17 @@ export async function translateNodeTranslationOnlyMode(
 
     if (await shouldFilterSmallParagraph(innerTextContent, config)) return
 
-    const cleanTextContent = (content: string): string => {
-      if (!content) return content
-
-      let cleanedContent = content.replace(MARK_ATTRIBUTES_REGEX, "")
-      cleanedContent = cleanedContent.replace(HTML_COMMENT_RE, " ")
-
-      return cleanedContent
-    }
-
     // Only save originalContent when there's no existing translation wrapper
     const hasExistingWrapperInParent = parentNode.querySelector(`.${CONTENT_WRAPPER_CLASS}`)
     if (!originalContentMap.has(parentNode) && !hasExistingWrapperInParent) {
       originalContentMap.set(parentNode, parentNode.innerHTML)
     }
 
-    const getStringFormatFromNode = (node: Element | Text) => {
-      if (isTextNode(node)) {
-        return node.textContent
-      }
-      return node.outerHTML
-    }
-
-    const textContent = cleanTextContent(transNodes.map(getStringFormatFromNode).join(""))
+    const ownerDoc = getOwnerDocument(targetNode)
+    const protectedHtml = protectTranslationHtmlAttributes(transNodes, ownerDoc)
+    const textContent = protectedHtml.sourceHtml
     if (!textContent) return
 
-    const ownerDoc = getOwnerDocument(targetNode)
     const translatedWrapperNode = ownerDoc.createElement("span")
     translatedWrapperNode.className = `${NOTRANSLATE_CLASS} ${CONTENT_WRAPPER_CLASS}`
     translatedWrapperNode.setAttribute(
@@ -578,6 +627,54 @@ export async function translateNodeTranslationOnlyMode(
     // The source string mixes text nodes with element outerHTML and the result
     // is re-rendered via innerHTML, so providers must treat it as HTML to keep
     // its tags intact.
+    const deepLXProviderKey = getDeepLXHtmlAttributeProviderKey(config)
+    const translateLegacyHtml = async () => {
+      const translatedHtml = await translateTextForPage(protectedHtml.legacyRequestHtml, "html")
+      return translatedHtml ? protectedHtml.restoreLegacy(translatedHtml) : translatedHtml
+    }
+    const translateRequest = async () => {
+      if (!protectedHtml.hasPlaceholders) return translateLegacyHtml()
+
+      let ownedDeepLXProbe: DeepLXHtmlAttributeProbe | undefined
+      if (deepLXProviderKey) {
+        const probeDecision = await acquireDeepLXHtmlAttributeProbe(deepLXProviderKey)
+        if (probeDecision.useLegacy) return translateLegacyHtml()
+        ownedDeepLXProbe = probeDecision.probe
+      }
+
+      try {
+        const translatedHtml = await translateTextForPage(protectedHtml.requestHtml, "html")
+        if (!translatedHtml) {
+          if (deepLXProviderKey) {
+            finishDeepLXHtmlAttributeProbe(deepLXProviderKey, ownedDeepLXProbe, "unknown")
+          }
+          return translatedHtml
+        }
+
+        const restoredHtml = protectedHtml.restore(translatedHtml)
+        if (deepLXProviderKey) {
+          supportedDeepLXHtmlAttributeProviders.add(deepLXProviderKey)
+          finishDeepLXHtmlAttributeProbe(deepLXProviderKey, ownedDeepLXProbe, "supported")
+        }
+        return restoredHtml
+      } catch (error) {
+        if (!isHtmlAttributeMarkerIntegrityError(error)) {
+          if (deepLXProviderKey) {
+            finishDeepLXHtmlAttributeProbe(deepLXProviderKey, ownedDeepLXProbe, "unknown")
+          }
+          throw error
+        }
+
+        if (deepLXProviderKey) {
+          unsupportedDeepLXHtmlAttributeProviders.add(deepLXProviderKey)
+          supportedDeepLXHtmlAttributeProviders.delete(deepLXProviderKey)
+          finishDeepLXHtmlAttributeProbe(deepLXProviderKey, ownedDeepLXProbe, "unsupported")
+        }
+        logger.warn("HTML attribute placeholders were not preserved; retrying full HTML", error)
+        return translateLegacyHtml()
+      }
+    }
+
     const realTranslatedText = await getTranslatedTextAndRemoveSpinner(
       nodes,
       textContent,
@@ -585,9 +682,14 @@ export async function translateNodeTranslationOnlyMode(
       translatedWrapperNode,
       () => true,
       "html",
+      translateRequest,
     )
     const translatedText = realTranslatedText
-      ? getDisplayTranslation(textContent, realTranslatedText)
+      ? getDisplayTranslation(
+          protectedHtml.comparisonSourceHtml,
+          realTranslatedText,
+          protectedHtml.normalizeForComparison(realTranslatedText),
+        )
       : realTranslatedText
 
     if (!translatedText) {

--- a/src/utils/host/translate/dom/__tests__/translation-html-attributes.test.ts
+++ b/src/utils/host/translate/dom/__tests__/translation-html-attributes.test.ts
@@ -1,0 +1,265 @@
+// @vitest-environment jsdom
+import type { TransNode } from "@/types/dom"
+import { describe, expect, it } from "vitest"
+import { HTML_ATTRIBUTE_MARKER } from "../../html-attribute-markers"
+import { protectTranslationHtmlAttributes } from "../translation-html-attributes"
+
+function createNodes(html: string): TransNode[] {
+  const container = document.createElement("div")
+  container.innerHTML = html
+  return Array.from(container.childNodes).filter(
+    (node): node is TransNode => node.nodeType === Node.TEXT_NODE || node instanceof HTMLElement,
+  )
+}
+
+describe("translation HTML attribute protection", () => {
+  it("removes non-language attributes while retaining translatable and no-translate semantics", () => {
+    const longToken = "utility-class-".repeat(80)
+    const [link] = createNodes(
+      `<a class="notranslate ${longToken}" translate="no" style="color: red" id="profile-link" data-state="${longToken}" href="https://example.com/${longToken}" title="Open profile" aria-label="Profile">Vancouver</a>`,
+    )
+
+    const protectedHtml = protectTranslationHtmlAttributes([link], document)
+
+    expect(protectedHtml.requestHtml).toContain(`class="notranslate"`)
+    expect(protectedHtml.requestHtml).toContain(`translate="no"`)
+    expect(protectedHtml.requestHtml).toContain(`title="Open profile"`)
+    expect(protectedHtml.requestHtml).toContain(`aria-label="Profile"`)
+    expect(protectedHtml.requestHtml).toContain(`${HTML_ATTRIBUTE_MARKER}="0"`)
+    expect(protectedHtml.requestHtml).not.toContain(longToken)
+    expect(protectedHtml.requestHtml.length).toBeLessThan(protectedHtml.sourceHtml.length * 0.2)
+
+    const restoredContainer = document.createElement("div")
+    restoredContainer.innerHTML = protectedHtml.restore(
+      `<a class="notranslate" translate="no" title="打开资料" aria-label="资料" data-rf-attr="0">Vancouver</a>`,
+    )
+    const restoredLink = restoredContainer.querySelector("a")
+    expect(restoredLink?.className).toBe(`notranslate ${longToken}`)
+    expect(restoredLink?.getAttribute("translate")).toBe("no")
+    expect(restoredLink?.getAttribute("title")).toBe("打开资料")
+    expect(restoredLink?.getAttribute("aria-label")).toBe("资料")
+  })
+
+  it("restores attributes after tags move and keeps translated human-readable attributes", () => {
+    const nodes = createNodes(
+      `I went to <strong class="place emphasized" style="color: red" data-place="yvr" title="City">Vancouver</strong> this Monday.`,
+    )
+    const protectedHtml = protectTranslationHtmlAttributes(nodes, document)
+
+    const restored = protectedHtml.restore(
+      `这个星期一我去了<strong data-rf-attr="0" title="城市" onclick="evil()">温哥华</strong><i onclick="evil()">。</i>`,
+    )
+    const container = document.createElement("div")
+    container.innerHTML = restored
+    const strong = container.querySelector("strong")
+
+    expect(strong?.className).toBe("place emphasized")
+    expect(strong?.getAttribute("style")).toBe("color: red")
+    expect(strong?.getAttribute("data-place")).toBe("yvr")
+    expect(strong?.getAttribute("title")).toBe("城市")
+    expect(strong?.hasAttribute("onclick")).toBe(false)
+    expect(container.querySelector("i")?.hasAttribute("onclick")).toBe(false)
+    expect(container.textContent).toBe("这个星期一我去了温哥华。")
+  })
+
+  it("preserves translated button values while restoring input behavior attributes", () => {
+    const [input] = createNodes(
+      `<input type="submit" value="Send" class="primary action" disabled data-action="send">`,
+    )
+    const protectedHtml = protectTranslationHtmlAttributes([input], document)
+
+    expect(protectedHtml.requestHtml).toBe(`<input value="Send" ${HTML_ATTRIBUTE_MARKER}="0">`)
+
+    const container = document.createElement("div")
+    container.innerHTML = protectedHtml.restore(
+      `<input value="发送" data-rf-attr="0" onclick="evil()">`,
+    )
+    const restoredInput = container.querySelector("input")
+
+    expect(restoredInput?.getAttribute("type")).toBe("submit")
+    expect(restoredInput?.getAttribute("value")).toBe("发送")
+    expect(restoredInput?.className).toBe("primary action")
+    expect(restoredInput?.hasAttribute("disabled")).toBe(true)
+    expect(restoredInput?.getAttribute("data-action")).toBe("send")
+    expect(restoredInput?.hasAttribute("onclick")).toBe(false)
+  })
+
+  it("falls back to source text when a provider drops translatable attributes", () => {
+    const [node] = createNodes(
+      `<img class="avatar" src="avatar.png" alt="Profile photo" title="Open profile" aria-label="User avatar">`,
+    )
+    const protectedHtml = protectTranslationHtmlAttributes([node], document)
+    const container = document.createElement("div")
+    container.innerHTML = protectedHtml.restore(`<img data-rf-attr="0">`)
+    const restored = container.querySelector("img")
+
+    expect(restored?.getAttribute("alt")).toBe("Profile photo")
+    expect(restored?.getAttribute("title")).toBe("Open profile")
+    expect(restored?.getAttribute("aria-label")).toBe("User avatar")
+    expect(restored?.className).toBe("avatar")
+    expect(restored?.getAttribute("src")).toBe("avatar.png")
+  })
+
+  it("restores a source attribute that already uses the internal marker name", () => {
+    const [node] = createNodes(
+      `<span data-rf-attr="page-owned" class="badge" data-read-frog-walked="walk-id">Hello<!-- hidden -->world</span>`,
+    )
+    const protectedHtml = protectTranslationHtmlAttributes([node], document)
+
+    expect(protectedHtml.sourceHtml).not.toContain("data-read-frog-walked")
+    expect(protectedHtml.sourceHtml).toContain("Hello world")
+    expect(protectedHtml.requestHtml).toContain(`data-rf-attr="0"`)
+
+    const container = document.createElement("div")
+    container.innerHTML = protectedHtml.restore(`<span data-rf-attr="0">你好世界</span>`)
+    const restored = container.querySelector("span")
+
+    expect(restored?.getAttribute("data-rf-attr")).toBe("page-owned")
+    expect(restored?.className).toBe("badge")
+  })
+
+  it("escapes page-owned numeric markers only for legacy requests and restores them", () => {
+    const nodes = createNodes(`<span data-rf-attr="0">Hello</span><b data-rf-attr="0">world</b>`)
+    const protectedHtml = protectTranslationHtmlAttributes(nodes, document)
+
+    expect(protectedHtml.sourceHtml).toContain(`data-rf-attr="0"`)
+    expect(protectedHtml.legacyRequestHtml).toBe(
+      `<span data-rf-attr="rf-page-0">Hello</span><b data-rf-attr="rf-page-1">world</b>`,
+    )
+    expect(
+      protectedHtml.restoreLegacy(
+        `<span data-rf-attr="rf-page-0">你好</span><b data-rf-attr="rf-page-1">世界</b>`,
+      ),
+    ).toBe(`<span data-rf-attr="0">你好</span><b data-rf-attr="0">世界</b>`)
+  })
+
+  it("restores parser-valid framework attributes without reparsing their names", () => {
+    const [node] = createNodes(
+      `<button @click="open = true" x-on:keydown="submit" wire:click="save">Open</button>`,
+    )
+    const protectedHtml = protectTranslationHtmlAttributes([node], document)
+
+    const container = document.createElement("div")
+    container.innerHTML = protectedHtml.restore(`<button data-rf-attr="0">打开</button>`)
+    const restored = container.querySelector("button")
+
+    expect(restored?.getAttribute("@click")).toBe("open = true")
+    expect(restored?.getAttribute("x-on:keydown")).toBe("submit")
+    expect(restored?.getAttribute("wire:click")).toBe("save")
+  })
+
+  it("serializes custom elements through inert template contents", () => {
+    let constructorCalls = 0
+    class CodecTestElement extends HTMLElement {
+      constructor() {
+        super()
+        constructorCalls += 1
+      }
+    }
+    customElements.define("rf-codec-test-element", CodecTestElement)
+    const node = document.createElement("rf-codec-test-element")
+    node.setAttribute("class", "hydrated-component")
+    node.textContent = "Hello"
+
+    expect(constructorCalls).toBe(1)
+    protectTranslationHtmlAttributes([node], document)
+    expect(constructorCalls).toBe(1)
+  })
+
+  it("restores nested same-name and void tags with entities, Unicode, and boolean attributes", () => {
+    const nodes = createNodes(
+      `<span class="outer">AT&amp;T 😀 <span class="inner" data-city="yvr">Vancouver</span></span><img class="avatar" src="avatar.png" hidden alt="Profile">`,
+    )
+    const protectedHtml = protectTranslationHtmlAttributes(nodes, document)
+    const restored = protectedHtml.restore(
+      `<img alt="头像" data-rf-attr="2"><span data-rf-attr="0"><span data-rf-attr="1">温哥华</span>的 AT&amp;T 😀</span>`,
+    )
+    const container = document.createElement("div")
+    container.innerHTML = restored
+    const spans = container.querySelectorAll("span")
+    const image = container.querySelector("img")
+
+    expect(spans).toHaveLength(2)
+    expect(spans[0].className).toBe("outer")
+    expect(spans[1].className).toBe("inner")
+    expect(spans[1].getAttribute("data-city")).toBe("yvr")
+    expect(container.textContent).toBe("温哥华的 AT&T 😀")
+    expect(image).toBe(container.firstElementChild)
+    expect(image?.className).toBe("avatar")
+    expect(image?.getAttribute("src")).toBe("avatar.png")
+    expect(image?.hasAttribute("hidden")).toBe(true)
+    expect(image?.getAttribute("alt")).toBe("头像")
+  })
+
+  it("protects attributes and page-owned markers inside nested template contents", () => {
+    const [node] = createNodes(
+      `<div class="visible">Visible<template><span class="hidden-template-class" data-rf-attr="0">Hidden<!-- note --></span></template></div>`,
+    )
+    const protectedHtml = protectTranslationHtmlAttributes([node], document)
+
+    expect(protectedHtml.requestHtml).toContain(`<div data-rf-attr="0">`)
+    expect(protectedHtml.requestHtml).toContain(`<span data-rf-attr="1">Hidden </span>`)
+    expect(protectedHtml.requestHtml).not.toContain("hidden-template-class")
+    expect(protectedHtml.legacyRequestHtml).toContain(`data-rf-attr="rf-page-0"`)
+
+    const container = document.createElement("div")
+    container.innerHTML = protectedHtml.restore(
+      `<div data-rf-attr="0">可见<template><span data-rf-attr="1">隐藏</span></template></div>`,
+    )
+    const restoredOuter = container.querySelector("div")
+    const nestedTemplate = container.querySelector("template")
+    const restoredInner = nestedTemplate?.content.querySelector("span")
+
+    expect(restoredOuter?.className).toBe("visible")
+    expect(restoredInner?.className).toBe("hidden-template-class")
+    expect(restoredInner?.getAttribute("data-rf-attr")).toBe("0")
+  })
+
+  it("normalizes attribute order when comparing restored HTML with the source", () => {
+    const [node] = createNodes(
+      `<strong class="place" title="City" data-city="yvr">Vancouver</strong>`,
+    )
+    const protectedHtml = protectTranslationHtmlAttributes([node], document)
+    const restored = protectedHtml.restore(
+      `<strong title="City" data-rf-attr="0">Vancouver</strong>`,
+    )
+
+    expect(restored).not.toBe(protectedHtml.sourceHtml)
+    expect(protectedHtml.normalizeForComparison(restored)).toBe(protectedHtml.comparisonSourceHtml)
+  })
+
+  it("uses deterministic skeletons with request-local restoration maps", () => {
+    const first = protectTranslationHtmlAttributes(
+      createNodes(`<strong class="first" data-owner="a">Vancouver</strong>`),
+      document,
+    )
+    const second = protectTranslationHtmlAttributes(
+      createNodes(`<strong class="second" data-owner="b">Vancouver</strong>`),
+      document,
+    )
+
+    expect(first.requestHtml).toBe(second.requestHtml)
+
+    const translated = `<strong data-rf-attr="0">温哥华</strong>`
+    expect(first.restore(translated)).toContain(`class="first"`)
+    expect(first.restore(translated)).toContain(`data-owner="a"`)
+    expect(second.restore(translated)).toContain(`class="second"`)
+    expect(second.restore(translated)).toContain(`data-owner="b"`)
+  })
+
+  it.each([
+    ["missing", `<strong>温哥华</strong>`],
+    ["duplicate", `<strong data-rf-attr="0">温</strong><strong data-rf-attr="0">哥华</strong>`],
+    ["unknown", `<strong data-rf-attr="9">温哥华</strong>`],
+    ["wrong tag", `<em data-rf-attr="0">温哥华</em>`],
+  ])("rejects %s markers", (_, translatedHtml) => {
+    const protectedHtml = protectTranslationHtmlAttributes(
+      createNodes(`<strong class="place">Vancouver</strong>`),
+      document,
+    )
+
+    expect(() => protectedHtml.restore(translatedHtml)).toThrowError(
+      expect.objectContaining({ code: "HTML_ATTR_MARKER_INTEGRITY" }),
+    )
+  })
+})

--- a/src/utils/host/translate/dom/translation-html-attributes.ts
+++ b/src/utils/host/translate/dom/translation-html-attributes.ts
@@ -1,0 +1,353 @@
+import type { TransNode } from "@/types/dom"
+import { MARK_ATTRIBUTES, NOTRANSLATE_CLASS } from "@/utils/constants/dom-labels"
+import {
+  assertHtmlAttributeMarkerIntegrity,
+  HTML_ATTRIBUTE_MARKER,
+  HtmlAttributeMarkerIntegrityError,
+} from "../html-attribute-markers"
+
+const TRANSLATABLE_ATTRIBUTE_NAMES = new Set([
+  "abbr",
+  "alt",
+  "aria-description",
+  "aria-label",
+  "aria-placeholder",
+  "aria-roledescription",
+  "aria-valuetext",
+  "label",
+  "placeholder",
+  "title",
+])
+
+const TRANSLATABLE_INPUT_VALUE_TYPES = new Set(["button", "reset", "submit"])
+const SHOW_COMMENT = 128
+const ELEMENT_NODE = 1
+
+interface AttributeSnapshot {
+  attribute: Attr
+  localName: string
+  name: string
+  namespaceURI: string | null
+  value: string
+}
+
+interface ElementAttributeSnapshot {
+  attributes: AttributeSnapshot[]
+  tagName: string
+  translatableAttributes: AttributeSnapshot[]
+  translatableAttributeNames: Set<string>
+}
+
+export interface ProtectedTranslationHtml {
+  comparisonSourceHtml: string
+  hasPlaceholders: boolean
+  legacyRequestHtml: string
+  normalizeForComparison: (html: string) => string
+  requestHtml: string
+  restore: (translatedHtml: string) => string
+  restoreLegacy: (translatedHtml: string) => string
+  sourceHtml: string
+}
+
+function isTranslatableAttribute(element: Element, attributeName: string): boolean {
+  const normalizedName = attributeName.toLowerCase()
+  if (TRANSLATABLE_ATTRIBUTE_NAMES.has(normalizedName)) return true
+
+  if (normalizedName !== "value" || element.localName.toLowerCase() !== "input") {
+    return false
+  }
+
+  const inputType = (element.getAttribute("type") ?? "text").toLowerCase()
+  return TRANSLATABLE_INPUT_VALUE_TYPES.has(inputType)
+}
+
+function removeAttribute(element: Element, attribute: AttributeSnapshot): void {
+  if (attribute.namespaceURI) {
+    element.removeAttributeNS(attribute.namespaceURI, attribute.localName)
+  } else {
+    element.removeAttribute(attribute.name)
+  }
+}
+
+function restoreAttribute(element: Element, attribute: AttributeSnapshot): void {
+  const clonedAttribute = attribute.attribute.cloneNode() as Attr
+  if (clonedAttribute.namespaceURI) {
+    element.setAttributeNodeNS(clonedAttribute)
+  } else {
+    // setAttribute rejects parser-valid framework syntax such as `@click`.
+    // Reattaching a cloned Attr preserves those names without reparsing them.
+    element.setAttributeNode(clonedAttribute)
+  }
+}
+
+function getAllElements(root: DocumentFragment | Element): Element[] {
+  const elements: Element[] = []
+
+  for (const child of root.childNodes) {
+    if (child.nodeType !== ELEMENT_NODE) continue
+    const element = child as Element
+    elements.push(element)
+
+    if (element.localName === "template" && "content" in element) {
+      elements.push(...getAllElements((element as HTMLTemplateElement).content))
+    } else {
+      elements.push(...getAllElements(element))
+    }
+  }
+
+  return elements
+}
+
+function getElementsWithAttribute(
+  root: DocumentFragment | Element,
+  attributeName: string,
+): Element[] {
+  return getAllElements(root).filter((element) => element.hasAttribute(attributeName))
+}
+
+function normalizeHtmlForComparison(html: string, ownerDoc: Document): string {
+  const template = ownerDoc.createElement("template")
+  template.innerHTML = html
+
+  getAllElements(template.content).forEach((element) => {
+    const attributes = Array.from(element.attributes).sort((left, right) => {
+      const leftKey = `${left.namespaceURI ?? ""}:${left.name}`
+      const rightKey = `${right.namespaceURI ?? ""}:${right.name}`
+      return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0
+    })
+    attributes.forEach((attribute) => element.removeAttributeNode(attribute))
+    attributes.forEach((attribute) => {
+      if (attribute.namespaceURI) {
+        element.setAttributeNodeNS(attribute)
+      } else {
+        element.setAttributeNode(attribute)
+      }
+    })
+  })
+
+  return template.innerHTML
+}
+
+function replaceCommentsWithSpaces(root: DocumentFragment, ownerDoc: Document): void {
+  const walker = ownerDoc.createTreeWalker(root, SHOW_COMMENT)
+  const comments: Comment[] = []
+  let currentNode = walker.nextNode()
+
+  while (currentNode) {
+    comments.push(currentNode as Comment)
+    currentNode = walker.nextNode()
+  }
+
+  comments.forEach((comment) => comment.replaceWith(ownerDoc.createTextNode(" ")))
+
+  root.querySelectorAll("template").forEach((element) => {
+    if ("content" in element) {
+      replaceCommentsWithSpaces(element.content, ownerDoc)
+    }
+  })
+}
+
+function serializeTextNode(node: Text, ownerDoc: Document): string {
+  const encoder = ownerDoc.createElement("div")
+  encoder.textContent = node.textContent
+  return encoder.innerHTML
+}
+
+function cloneAndCleanNodes(nodes: readonly TransNode[], ownerDoc: Document): HTMLTemplateElement {
+  const template = ownerDoc.createElement("template")
+  template.innerHTML = nodes
+    .map((node) =>
+      node.nodeType === Node.TEXT_NODE
+        ? serializeTextNode(node as Text, ownerDoc)
+        : (node as HTMLElement).outerHTML,
+    )
+    .join("")
+
+  // Template contents are inert: parsing custom elements here does not run
+  // their constructors or lifecycle callbacks.
+  replaceCommentsWithSpaces(template.content, ownerDoc)
+  getAllElements(template.content).forEach((element) => {
+    MARK_ATTRIBUTES.forEach((attributeName) => element.removeAttribute(attributeName))
+  })
+
+  return template
+}
+
+function snapshotAttribute(attribute: Attr): AttributeSnapshot {
+  return {
+    attribute: attribute.cloneNode() as Attr,
+    localName: attribute.localName,
+    name: attribute.name,
+    namespaceURI: attribute.namespaceURI,
+    value: attribute.value,
+  }
+}
+
+function stripUnexpectedAttributes(
+  element: Element,
+  allowedTranslatableAttributes?: ReadonlySet<string>,
+): void {
+  Array.from(element.attributes).forEach((attribute) => {
+    const normalizedName = attribute.name.toLowerCase()
+    const shouldKeep = allowedTranslatableAttributes
+      ? allowedTranslatableAttributes.has(normalizedName)
+      : isTranslatableAttribute(element, normalizedName)
+
+    if (!shouldKeep) {
+      element.removeAttributeNode(attribute)
+    }
+  })
+}
+
+export function protectTranslationHtmlAttributes(
+  nodes: readonly TransNode[],
+  ownerDoc: Document,
+): ProtectedTranslationHtml {
+  const container = cloneAndCleanNodes(nodes, ownerDoc)
+  const sourceHtml = container.innerHTML
+  const comparisonSourceHtml = normalizeHtmlForComparison(sourceHtml, ownerDoc)
+  const snapshots = new Map<string, ElementAttributeSnapshot>()
+  const legacyContainer = ownerDoc.createElement("template")
+  legacyContainer.innerHTML = sourceHtml
+  const legacyMarkerSnapshots = new Map<string, { value: string }>()
+
+  getElementsWithAttribute(legacyContainer.content, HTML_ATTRIBUTE_MARKER).forEach((element) => {
+    const markerId = `rf-page-${legacyMarkerSnapshots.size}`
+    legacyMarkerSnapshots.set(markerId, {
+      value: element.getAttribute(HTML_ATTRIBUTE_MARKER) ?? "",
+    })
+    element.setAttribute(HTML_ATTRIBUTE_MARKER, markerId)
+  })
+  const legacyRequestHtml = legacyContainer.innerHTML
+
+  getAllElements(container.content).forEach((element) => {
+    const attributes = Array.from(element.attributes)
+    const translatableAttributes = attributes
+      .filter((attribute) => isTranslatableAttribute(element, attribute.name))
+      .map(snapshotAttribute)
+    const translatableAttributeNames = new Set(
+      translatableAttributes.map((attribute) => attribute.name.toLowerCase()),
+    )
+    const protectedAttributes = attributes
+      .filter((attribute) => !translatableAttributeNames.has(attribute.name.toLowerCase()))
+      .map(snapshotAttribute)
+
+    if (protectedAttributes.length === 0) return
+
+    const markerId = String(snapshots.size)
+    const preserveNotranslateClass = protectedAttributes.some(
+      (attribute) =>
+        attribute.name.toLowerCase() === "class" &&
+        attribute.value.split(/\s+/).includes(NOTRANSLATE_CLASS),
+    )
+    const preserveTranslateNo = protectedAttributes.some(
+      (attribute) =>
+        attribute.name.toLowerCase() === "translate" && attribute.value.toLowerCase() === "no",
+    )
+
+    protectedAttributes.forEach((attribute) => removeAttribute(element, attribute))
+    if (preserveNotranslateClass) {
+      element.setAttribute("class", NOTRANSLATE_CLASS)
+    }
+    if (preserveTranslateNo) {
+      element.setAttribute("translate", "no")
+    }
+    element.setAttribute(HTML_ATTRIBUTE_MARKER, markerId)
+
+    snapshots.set(markerId, {
+      attributes: protectedAttributes,
+      tagName: element.localName.toLowerCase(),
+      translatableAttributes,
+      translatableAttributeNames,
+    })
+  })
+
+  const requestHtml = container.innerHTML
+
+  return {
+    comparisonSourceHtml,
+    hasPlaceholders: snapshots.size > 0,
+    legacyRequestHtml,
+    normalizeForComparison: (html) => normalizeHtmlForComparison(html, ownerDoc),
+    requestHtml,
+    sourceHtml,
+    restore(translatedHtml: string): string {
+      if (snapshots.size === 0 || translatedHtml === "") return translatedHtml
+
+      assertHtmlAttributeMarkerIntegrity(requestHtml, translatedHtml)
+
+      const template = ownerDoc.createElement("template")
+      template.innerHTML = translatedHtml
+      const markedElements = getElementsWithAttribute(template.content, HTML_ATTRIBUTE_MARKER)
+      const markedElementSet = new Set(markedElements)
+      const restoredIds = new Set<string>()
+
+      for (const element of markedElements) {
+        const markerId = element.getAttribute(HTML_ATTRIBUTE_MARKER)
+        const snapshot = markerId === null ? undefined : snapshots.get(markerId)
+        if (markerId === null || !snapshot) {
+          throw new HtmlAttributeMarkerIntegrityError("unknown-output-marker", markerId ?? "")
+        }
+        if (restoredIds.has(markerId)) {
+          throw new HtmlAttributeMarkerIntegrityError("duplicate-output-marker", markerId)
+        }
+        if (element.localName.toLowerCase() !== snapshot.tagName) {
+          throw new HtmlAttributeMarkerIntegrityError(
+            "wrong-output-tag",
+            markerId,
+            snapshot.tagName,
+            element.localName.toLowerCase(),
+          )
+        }
+
+        stripUnexpectedAttributes(element, snapshot.translatableAttributeNames)
+        snapshot.attributes.forEach((attribute) => restoreAttribute(element, attribute))
+        snapshot.translatableAttributes.forEach((attribute) => {
+          const hasTranslatedAttribute = attribute.namespaceURI
+            ? element.hasAttributeNS(attribute.namespaceURI, attribute.localName)
+            : element.hasAttribute(attribute.name)
+          if (!hasTranslatedAttribute) restoreAttribute(element, attribute)
+        })
+        restoredIds.add(markerId)
+      }
+
+      if (restoredIds.size !== snapshots.size) {
+        const missingMarkerId = [...snapshots.keys()].find((id) => !restoredIds.has(id)) ?? ""
+        throw new HtmlAttributeMarkerIntegrityError("missing-output-marker", missingMarkerId)
+      }
+
+      getAllElements(template.content).forEach((element) => {
+        if (!markedElementSet.has(element)) {
+          stripUnexpectedAttributes(element)
+        }
+      })
+
+      return template.innerHTML
+    },
+    restoreLegacy(translatedHtml: string): string {
+      if (translatedHtml === "") return translatedHtml
+
+      const template = ownerDoc.createElement("template")
+      template.innerHTML = translatedHtml
+
+      if (legacyMarkerSnapshots.size === 0) {
+        getElementsWithAttribute(template.content, HTML_ATTRIBUTE_MARKER).forEach((element) =>
+          element.removeAttribute(HTML_ATTRIBUTE_MARKER),
+        )
+        return template.innerHTML
+      }
+
+      assertHtmlAttributeMarkerIntegrity(legacyRequestHtml, translatedHtml)
+      getElementsWithAttribute(template.content, HTML_ATTRIBUTE_MARKER).forEach((element) => {
+        const markerId = element.getAttribute(HTML_ATTRIBUTE_MARKER)
+        const snapshot = markerId === null ? undefined : legacyMarkerSnapshots.get(markerId)
+        if (!snapshot) {
+          throw new HtmlAttributeMarkerIntegrityError("unknown-output-marker", markerId ?? "")
+        }
+        element.setAttribute(HTML_ATTRIBUTE_MARKER, snapshot.value)
+      })
+
+      return template.innerHTML
+    },
+  }
+}

--- a/src/utils/host/translate/execute-translate.ts
+++ b/src/utils/host/translate/execute-translate.ts
@@ -55,9 +55,13 @@ export async function executeTranslate<TContext>(
       throw new Error(`Invalid target language code: ${langConfig.targetCode}`)
     }
     if (provider === "deeplx") {
-      translatedText = await deeplxTranslate(preparedText, sourceLang, targetLang, providerConfig)
+      translatedText = await deeplxTranslate(preparedText, sourceLang, targetLang, providerConfig, {
+        textFormat: options?.textFormat,
+      })
     } else if (provider === "deepl") {
-      translatedText = await deeplTranslate(text, sourceLang, targetLang, providerConfig)
+      translatedText = await deeplTranslate(text, sourceLang, targetLang, providerConfig, {
+        textFormat: options?.textFormat,
+      })
     }
   } else if (isLLMProviderConfig(providerConfig)) {
     const targetLangName = LANG_CODE_TO_EN_NAME[langConfig.targetCode]

--- a/src/utils/host/translate/html-attribute-markers.ts
+++ b/src/utils/host/translate/html-attribute-markers.ts
@@ -1,0 +1,311 @@
+export const HTML_ATTRIBUTE_MARKER = "data-rf-attr"
+
+export const HTML_ATTRIBUTE_MARKER_INTEGRITY_ERROR_CODE = "HTML_ATTR_MARKER_INTEGRITY"
+
+export type HtmlAttributeMarkerIntegrityErrorReason =
+  | "duplicate-input-marker"
+  | "missing-output-marker"
+  | "duplicate-output-marker"
+  | "unknown-output-marker"
+  | "wrong-output-tag"
+
+export interface HtmlAttributeMarker {
+  id: string
+  tagName: string
+}
+
+function getIntegrityErrorMessage(
+  reason: HtmlAttributeMarkerIntegrityErrorReason,
+  markerId: string,
+  expectedTagName?: string,
+  actualTagName?: string,
+): string {
+  switch (reason) {
+    case "duplicate-input-marker":
+      return `Input contains duplicate HTML attribute marker "${markerId}"`
+    case "missing-output-marker":
+      return `Translation is missing HTML attribute marker "${markerId}"`
+    case "duplicate-output-marker":
+      return `Translation contains duplicate HTML attribute marker "${markerId}"`
+    case "unknown-output-marker":
+      return `Translation contains unknown HTML attribute marker "${markerId}"`
+    case "wrong-output-tag":
+      return `HTML attribute marker "${markerId}" moved from <${expectedTagName}> to <${actualTagName}>`
+    default:
+      throw new Error("Unknown HTML attribute marker integrity reason")
+  }
+}
+
+export class HtmlAttributeMarkerIntegrityError extends Error {
+  readonly code = HTML_ATTRIBUTE_MARKER_INTEGRITY_ERROR_CODE
+
+  constructor(
+    readonly reason: HtmlAttributeMarkerIntegrityErrorReason,
+    readonly markerId: string,
+    readonly expectedTagName?: string,
+    readonly actualTagName?: string,
+  ) {
+    super(getIntegrityErrorMessage(reason, markerId, expectedTagName, actualTagName))
+    this.name = "HtmlAttributeMarkerIntegrityError"
+  }
+}
+
+export function isHtmlAttributeMarkerIntegrityError(
+  error: unknown,
+): error is HtmlAttributeMarkerIntegrityError {
+  return (
+    error instanceof HtmlAttributeMarkerIntegrityError ||
+    (typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === HTML_ATTRIBUTE_MARKER_INTEGRITY_ERROR_CODE)
+  )
+}
+
+const RAW_TEXT_TAG_NAMES = new Set([
+  "iframe",
+  "noembed",
+  "noframes",
+  "noscript",
+  "plaintext",
+  "script",
+  "style",
+  "textarea",
+  "title",
+  "xmp",
+])
+
+function isHtmlWhitespace(character: string | undefined): boolean {
+  return (
+    character === " " ||
+    character === "\t" ||
+    character === "\n" ||
+    character === "\r" ||
+    character === "\f"
+  )
+}
+
+function isAsciiLetter(character: string | undefined): boolean {
+  if (!character) return false
+  const code = character.charCodeAt(0)
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122)
+}
+
+function toAsciiLowerCase(value: string): string {
+  let result = ""
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index)
+    result += code >= 65 && code <= 90 ? String.fromCharCode(code + 32) : value[index]
+  }
+  return result
+}
+
+function findOpeningTagEnd(html: string, start: number): number {
+  let quote: '"' | "'" | undefined
+
+  for (let index = start; index < html.length; index += 1) {
+    const character = html[index]
+    if (quote) {
+      if (character === quote) quote = undefined
+      continue
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character
+    } else if (character === ">") {
+      return index
+    }
+  }
+
+  return -1
+}
+
+function findRawTextEnd(html: string, lowerHtml: string, tagName: string, start: number): number {
+  const closingTagPrefix = `</${tagName}`
+  let searchFrom = start
+
+  while (searchFrom < html.length) {
+    const closingTagStart = lowerHtml.indexOf(closingTagPrefix, searchFrom)
+    if (closingTagStart === -1) return html.length
+
+    const afterTagName = lowerHtml[closingTagStart + closingTagPrefix.length]
+    if (isHtmlWhitespace(afterTagName) || afterTagName === ">") {
+      const closingTagEnd = html.indexOf(">", closingTagStart + closingTagPrefix.length)
+      return closingTagEnd === -1 ? html.length : closingTagEnd + 1
+    }
+
+    searchFrom = closingTagStart + closingTagPrefix.length
+  }
+
+  return html.length
+}
+
+function parseMarkerAttributes(
+  html: string,
+  attributesStart: number,
+  tagEnd: number,
+  tagName: string,
+): HtmlAttributeMarker[] {
+  const markers: HtmlAttributeMarker[] = []
+  let index = attributesStart
+
+  while (index < tagEnd) {
+    while (isHtmlWhitespace(html[index])) index += 1
+    if (index >= tagEnd || html[index] === "/") break
+
+    const attributeNameStart = index
+    while (
+      index < tagEnd &&
+      !isHtmlWhitespace(html[index]) &&
+      html[index] !== "/" &&
+      html[index] !== "=" &&
+      html[index] !== ">"
+    ) {
+      index += 1
+    }
+
+    if (attributeNameStart === index) {
+      index += 1
+      continue
+    }
+
+    const attributeName = toAsciiLowerCase(html.slice(attributeNameStart, index))
+    while (isHtmlWhitespace(html[index])) index += 1
+
+    if (html[index] !== "=") {
+      if (attributeName === HTML_ATTRIBUTE_MARKER) {
+        markers.push({ id: "", tagName })
+      }
+      continue
+    }
+
+    index += 1
+    while (isHtmlWhitespace(html[index])) index += 1
+
+    let value: string
+    const quote = html[index]
+    if (quote === '"' || quote === "'") {
+      const valueStart = ++index
+      while (index < tagEnd && html[index] !== quote) index += 1
+      if (index >= tagEnd) return markers
+      value = html.slice(valueStart, index)
+      index += 1
+    } else {
+      const valueStart = index
+      while (index < tagEnd && !isHtmlWhitespace(html[index]) && html[index] !== ">") {
+        index += 1
+      }
+      value = html.slice(valueStart, index)
+    }
+
+    if (attributeName === HTML_ATTRIBUTE_MARKER) {
+      markers.push({ id: value, tagName })
+    }
+  }
+
+  return markers
+}
+
+/**
+ * Extract protected-attribute markers without relying on DOM globals, which are
+ * unavailable in a Manifest V3 background service worker.
+ */
+export function parseHtmlAttributeMarkers(html: string): HtmlAttributeMarker[] {
+  const markers: HtmlAttributeMarker[] = []
+  const lowerHtml = toAsciiLowerCase(html)
+  let index = 0
+
+  while (index < html.length) {
+    const tagStart = html.indexOf("<", index)
+    if (tagStart === -1) break
+
+    if (html.startsWith("<!--", tagStart)) {
+      const commentEnd = html.indexOf("-->", tagStart + 4)
+      index = commentEnd === -1 ? html.length : commentEnd + 3
+      continue
+    }
+
+    if (html[tagStart + 1] === "!" || html[tagStart + 1] === "?") {
+      const declarationEnd = findOpeningTagEnd(html, tagStart + 2)
+      index = declarationEnd === -1 ? html.length : declarationEnd + 1
+      continue
+    }
+
+    const tagNameStart = tagStart + 1
+    if (!isAsciiLetter(html[tagNameStart])) {
+      index = tagNameStart
+      continue
+    }
+
+    let tagNameEnd = tagNameStart + 1
+    while (
+      tagNameEnd < html.length &&
+      !isHtmlWhitespace(html[tagNameEnd]) &&
+      html[tagNameEnd] !== "/" &&
+      html[tagNameEnd] !== ">"
+    ) {
+      tagNameEnd += 1
+    }
+
+    const tagEnd = findOpeningTagEnd(html, tagNameEnd)
+    if (tagEnd === -1) break
+
+    const tagName = toAsciiLowerCase(html.slice(tagNameStart, tagNameEnd))
+    markers.push(...parseMarkerAttributes(html, tagNameEnd, tagEnd, tagName))
+
+    index = RAW_TEXT_TAG_NAMES.has(tagName)
+      ? findRawTextEnd(html, lowerHtml, tagName, tagEnd + 1)
+      : tagEnd + 1
+  }
+
+  return markers
+}
+
+export function hasHtmlAttributeMarkerProtocol(html: string): boolean {
+  const markers = parseHtmlAttributeMarkers(html)
+  if (markers.length === 0) return false
+
+  const isCompactMarker = (id: string) => /^(?:0|[1-9]\d*)$/.test(id)
+  const isEscapedPageMarker = (id: string) => /^rf-page-(?:0|[1-9]\d*)$/.test(id)
+  return (
+    markers.every((marker) => isCompactMarker(marker.id)) ||
+    markers.every((marker) => isEscapedPageMarker(marker.id))
+  )
+}
+
+export function assertHtmlAttributeMarkerIntegrity(input: string, output: string): void {
+  const inputMarkersById = new Map<string, HtmlAttributeMarker>()
+  for (const marker of parseHtmlAttributeMarkers(input)) {
+    if (inputMarkersById.has(marker.id)) {
+      throw new HtmlAttributeMarkerIntegrityError("duplicate-input-marker", marker.id)
+    }
+    inputMarkersById.set(marker.id, marker)
+  }
+
+  const outputMarkerIds = new Set<string>()
+  for (const marker of parseHtmlAttributeMarkers(output)) {
+    if (outputMarkerIds.has(marker.id)) {
+      throw new HtmlAttributeMarkerIntegrityError("duplicate-output-marker", marker.id)
+    }
+    outputMarkerIds.add(marker.id)
+
+    const inputMarker = inputMarkersById.get(marker.id)
+    if (!inputMarker) {
+      throw new HtmlAttributeMarkerIntegrityError("unknown-output-marker", marker.id)
+    }
+    if (inputMarker.tagName !== marker.tagName) {
+      throw new HtmlAttributeMarkerIntegrityError(
+        "wrong-output-tag",
+        marker.id,
+        inputMarker.tagName,
+        marker.tagName,
+      )
+    }
+  }
+
+  for (const marker of inputMarkersById.values()) {
+    if (!outputMarkerIds.has(marker.id)) {
+      throw new HtmlAttributeMarkerIntegrityError("missing-output-marker", marker.id)
+    }
+  }
+}

--- a/src/utils/host/translate/ui/spinner.ts
+++ b/src/utils/host/translate/ui/spinner.ts
@@ -79,12 +79,13 @@ export async function getTranslatedTextAndRemoveSpinner(
   translatedWrapperNode: HTMLElement,
   isCurrent: () => boolean = () => true,
   textFormat: TranslationTextFormat = "plain",
+  translateRequest: () => Promise<string> = () => translateTextForPage(textContent, textFormat),
 ): Promise<string | undefined> {
   let translatedText: string | undefined
 
   try {
     if (!isCurrent()) return undefined
-    translatedText = await translateTextForPage(textContent, textFormat)
+    translatedText = await translateRequest()
     if (!isCurrent()) return undefined
   } catch (error) {
     if (!isCurrent()) return undefined

--- a/src/utils/prompts/__tests__/translate.test.ts
+++ b/src/utils/prompts/__tests__/translate.test.ts
@@ -1,6 +1,7 @@
 import type { Config } from "@/types/config/config"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { HTML_ATTRIBUTE_MARKER } from "@/utils/host/translate/html-attribute-markers"
 import { getSubtitlesTranslatePrompt } from "../subtitles"
 import { getTranslatePromptFromConfig } from "../translate"
 
@@ -9,6 +10,13 @@ vi.mock("@/utils/config/storage", () => ({
 }))
 
 let mockGetLocalConfig: any
+
+const defaultTranslatePromptConfig: Pick<Config["translate"], "customPromptsConfig"> = {
+  customPromptsConfig: {
+    promptId: null,
+    patterns: [],
+  },
+}
 
 describe("translate prompt tokens", () => {
   beforeEach(async () => {
@@ -75,6 +83,74 @@ describe("translate prompt tokens", () => {
 
     expect(result.systemPrompt).toBe("Legacy {{targetLang}} {{title}} {{summary}}")
     expect(result.prompt).toBe("Translate Hola to {{targetLang}}")
+  })
+
+  it("appends mandatory marker rules to the default system prompt", () => {
+    const input = `<span ${HTML_ATTRIBUTE_MARKER}="0">Hello</span>`
+
+    const result = getTranslatePromptFromConfig(defaultTranslatePromptConfig, "Chinese", input)
+
+    expect(result.systemPrompt).toContain("## Protected HTML Marker Rules")
+    expect(result.systemPrompt).toContain(
+      `preserve every \`${HTML_ATTRIBUTE_MARKER}\` attribute occurrence and its value exactly once`,
+    )
+    expect(result.systemPrompt).toContain("may move within its segment")
+    expect(result.prompt).toContain(input)
+  })
+
+  it("appends mandatory marker rules after a custom system prompt", () => {
+    const config: Pick<Config["translate"], "customPromptsConfig"> = {
+      customPromptsConfig: {
+        promptId: "custom-prompt",
+        patterns: [
+          {
+            id: "custom-prompt",
+            name: "Custom",
+            systemPrompt: "Custom instructions that omit marker handling.",
+            prompt: "Translate {{input}} to {{targetLanguage}}.",
+          },
+        ],
+      },
+    }
+    const input = `<a ${HTML_ATTRIBUTE_MARKER}="7">Read more</a>`
+
+    const result = getTranslatePromptFromConfig(config, "Japanese", input)
+
+    expect(result.systemPrompt).toMatch(/^Custom instructions that omit marker handling\./)
+    expect(result.systemPrompt.indexOf("## Protected HTML Marker Rules")).toBeGreaterThan(
+      result.systemPrompt.indexOf("Custom instructions that omit marker handling."),
+    )
+  })
+
+  it("keeps marker rules segment-scoped and after batch rules", () => {
+    const input = `<span ${HTML_ATTRIBUTE_MARKER}="0">First</span>\n\n%%\n\n<a ${HTML_ATTRIBUTE_MARKER}="0">Second</a>`
+
+    const result = getTranslatePromptFromConfig(defaultTranslatePromptConfig, "French", input, {
+      isBatch: true,
+    })
+
+    const batchRulesIndex = result.systemPrompt.indexOf("## Multi-paragraph Translation Rules")
+    const markerRulesIndex = result.systemPrompt.indexOf("## Protected HTML Marker Rules")
+    expect(batchRulesIndex).toBeGreaterThan(-1)
+    expect(markerRulesIndex).toBeGreaterThan(batchRulesIndex)
+    expect(result.systemPrompt).toContain(
+      "segments are separated by a standalone %% line when present",
+    )
+    expect(result.systemPrompt).toContain("move a marker to another segment")
+  })
+
+  it.each([
+    ["plain text", "Hello world"],
+    ["unmarked HTML", '<span class="message">Hello</span>'],
+    ["a marker name mentioned as text", `Explain ${HTML_ATTRIBUTE_MARKER} to me`],
+    [
+      "a marker-like string inside another attribute",
+      `<span title='preserve ${HTML_ATTRIBUTE_MARKER}="0" exactly'>Hello</span>`,
+    ],
+  ])("does not append marker rules for %s", (_case, input) => {
+    const result = getTranslatePromptFromConfig(defaultTranslatePromptConfig, "Chinese", input)
+
+    expect(result.systemPrompt).not.toContain("## Protected HTML Marker Rules")
   })
 
   it("replaces new subtitle prompt tokens from stored config", async () => {

--- a/src/utils/prompts/translate.ts
+++ b/src/utils/prompts/translate.ts
@@ -1,8 +1,13 @@
 import type { Config } from "@/types/config/config"
 import type { WebPagePromptContext } from "@/types/content"
 import { getLocalConfig } from "@/utils/config/storage"
+import {
+  HTML_ATTRIBUTE_MARKER,
+  parseHtmlAttributeMarkers,
+} from "@/utils/host/translate/html-attribute-markers"
 import { DEFAULT_CONFIG } from "../constants/config"
 import {
+  BATCH_SEPARATOR,
   DEFAULT_BATCH_TRANSLATE_PROMPT,
   DEFAULT_TRANSLATE_PROMPT,
   DEFAULT_TRANSLATE_SYSTEM_PROMPT,
@@ -14,6 +19,13 @@ import {
   WEB_SUMMARY,
   WEB_TITLE,
 } from "../constants/prompt"
+
+const HTML_ATTRIBUTE_MARKER_SYSTEM_PROMPT = `## Protected HTML Marker Rules
+These mandatory rules override any conflicting instructions above:
+1. Within each input segment (segments are separated by a standalone ${BATCH_SEPARATOR} line when present), preserve every \`${HTML_ATTRIBUTE_MARKER}\` attribute occurrence and its value exactly once in that segment's output.
+2. Never add, remove, change, duplicate, rename, renumber, or move a marker to another segment.
+3. Keep each marker on its original HTML element.
+4. The HTML element carrying a marker may move within its segment to follow the target-language word order.`
 
 export interface TranslatePromptOptions<TContext = unknown> {
   isBatch?: boolean
@@ -61,6 +73,12 @@ export function getTranslatePromptFromConfig(
     systemPrompt = `${systemPrompt}
 
 ${DEFAULT_BATCH_TRANSLATE_PROMPT}`
+  }
+
+  if (parseHtmlAttributeMarkers(input).length > 0) {
+    systemPrompt = `${systemPrompt}
+
+${HTML_ATTRIBUTE_MARKER_SYSTEM_PROMPT}`
   }
 
   // Build title and summary replacement values


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [ ] ✨ New feature (feat)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Reduce translation-only HTML payloads by replacing non-translatable element attributes with compact `data-rf-attr` markers before translation, then restoring the original attributes from request-local memory afterward.

- Applies attribute compaction to all translation-only providers while leaving bilingual translation unchanged.
- Preserves translatable attributes, `notranslate`, and `translate="no"` semantics.
- Validates marker integrity for cached and newly translated HTML before it reaches the page.
- Falls back once to legacy full HTML when a provider does not preserve markers, with session-level DeepLX capability detection.
- Enables DeepL and DeepLX HTML tag handling and adds mandatory marker-preservation rules to LLM prompts.
- Adds a patch changeset and coverage for codecs, providers, cache behavior, fallback, batching, restoration, and DOM integration.

Real-provider benchmarks showed request payload reductions of 69.8% for a typical attribute-heavy document fixture and 98.2% for an extreme Tailwind/GitHub-style fixture. Median request latency improved 1.54x/14.90x with OpenAI and 2.16x on the medium DeepSeek fixture; the old extreme DeepSeek request timed out in 2 of 3 trials while the compact request stayed near 1.25 seconds.

## Related Issue

Closes #1415
Closes #1430

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation performed:

- `SKIP_FREE_API=true pnpm test` — 1660 passed, 4 intentionally skipped
- Pre-push test suite — 1664 passed
- `pnpm type-check`
- `pnpm fmt:check`
- `WXT_SKIP_ENV_VALIDATION=true pnpm build`
- Fresh Edge profile smoke test using the built extension, including attribute restoration and translation toggle restoration
- Real API contract/performance checks with OpenAI, DeepSeek, Google, Microsoft, and DeepL

## Screenshots

Not applicable; this is an internal translation pipeline optimization with no UI changes.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The compact attribute map remains in the content-script request closure and is never persisted. IndexedDB stores only translated marker skeletons. Invalid cached skeletons are deleted and retried as cache misses.
