### PR TITLE
fix(host): stop retranslation storms and freezes on dynamic pages

### DIFF
--- a/.changeset/heavy-frogs-calm-down.md
+++ b/.changeset/heavy-frogs-calm-down.md
@@ -2,4 +2,4 @@
 "@read-frog/extension": patch
 ---
 
-fix(host): stop retranslation storms on dynamic pages by ignoring self-caused mutations, fixing false staleness, capping per-source retranslation, deduplicating mutation observers, and cleaning up detached translation UI (#1831)
+fix(host): stop retranslation storms on dynamic pages by ignoring self-caused mutations, fixing false staleness, capping per-source retranslation, deduplicating mutation observers, and cleaning up detached translation UI; exclude the hltv.org navigation whose overflow handler loops on width changes (#1831)

--- a/.changeset/heavy-frogs-calm-down.md
+++ b/.changeset/heavy-frogs-calm-down.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(host): stop retranslation storms on dynamic pages by ignoring self-caused mutations, fixing false staleness, capping per-source retranslation, deduplicating mutation observers, and cleaning up detached translation UI (#1831)

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import {
+  markExtensionDrivenNodeRemoval,
   registerBilingualTranslationState,
   unregisterBilingualTranslationState,
   type BilingualTranslationState,
@@ -521,6 +522,147 @@ describe("pageTranslationManager mutation re-walk", () => {
       unregisterBilingualTranslationState(activeNewState)
       activeNewState.wrapper?.remove()
     }
+    manager.stop()
+  })
+
+  it("ignores the extension's own wrapper and error-host insertions (#1831)", async () => {
+    document.body.innerHTML = `
+      <p id="tweet"><span id="source">Original tweet</span></p>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const tweet = document.getElementById("tweet") as HTMLElement
+    const wrapper = document.createElement("span")
+    wrapper.className = "notranslate read-frog-translated-content-wrapper"
+    wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+    tweet.append(wrapper)
+    const state: BilingualTranslationState = {
+      layoutSource: tweet,
+      sourceTextContent: "Original tweet",
+      status: "active",
+      walkId: "walk-id",
+      wrapper,
+    }
+    registerBilingualTranslationState(state)
+    await flushDomUpdates()
+    mockWalkAndLabelElement.mockClear()
+    mockTranslateNodesBilingualMode.mockClear()
+
+    // Everything the extension inserts during a translation pass: translated
+    // text inside the wrapper, an error shadow host, and a sibling wrapper.
+    wrapper.append("译文文本")
+    const errorHost = document.createElement("div")
+    errorHost.className = "read-frog-react-shadow-host"
+    wrapper.append(errorHost)
+    const siblingWrapper = document.createElement("span")
+    siblingWrapper.className = "notranslate read-frog-translated-content-wrapper"
+    tweet.append(siblingWrapper)
+    await flushDomUpdates()
+
+    expect(mockWalkAndLabelElement).not.toHaveBeenCalled()
+    expect(mockTranslateNodesBilingualMode).not.toHaveBeenCalled()
+
+    unregisterBilingualTranslationState(state)
+    manager.stop()
+  })
+
+  it("retranslates exactly once when the site re-renders a node containing our wrapper (#1831)", async () => {
+    document.body.innerHTML = `
+      <p id="tweet"><span id="source">Original content</span></p>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const tweet = document.getElementById("tweet") as HTMLElement
+    const createState = (sourceText: string): BilingualTranslationState => {
+      const wrapper = document.createElement("span")
+      wrapper.className = "notranslate read-frog-translated-content-wrapper"
+      wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+      wrapper.append(`${sourceText} 的译文`)
+      tweet.append(wrapper)
+      const state: BilingualTranslationState = {
+        layoutSource: tweet,
+        sourceTextContent: sourceText,
+        status: "active",
+        walkId: "walk-id",
+        wrapper,
+      }
+      registerBilingualTranslationState(state)
+      return state
+    }
+
+    let activeState = createState("Original content")
+    await flushDomUpdates()
+    mockTranslateNodesBilingualMode.mockClear()
+    mockTranslateNodesBilingualMode.mockImplementation(async () => {
+      // The real translation dance: tear down the stale generation, insert a
+      // fresh wrapper, re-register state for the current host text.
+      unregisterBilingualTranslationState(activeState)
+      if (activeState.wrapper) {
+        markExtensionDrivenNodeRemoval(activeState.wrapper)
+        activeState.wrapper.remove()
+      }
+      activeState = createState("Re-rendered content")
+    })
+
+    // Site re-render: replace the source span wholesale (framework-style).
+    const oldSpan = document.getElementById("source") as HTMLElement
+    const newSpan = document.createElement("span")
+    newSpan.id = "source"
+    newSpan.textContent = "Re-rendered content"
+    tweet.replaceChild(newSpan, oldSpan)
+    await flushDomUpdates()
+    await flushDomUpdates()
+    await flushDomUpdates()
+
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(1)
+    expect(document.querySelectorAll(".read-frog-translated-content-wrapper").length).toBe(1)
+
+    unregisterBilingualTranslationState(activeState)
+    manager.stop()
+  })
+
+  it("still retranslates once when the site removes our wrapper (#1831)", async () => {
+    document.body.innerHTML = `
+      <p id="tweet"><span id="source">Original content</span></p>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const tweet = document.getElementById("tweet") as HTMLElement
+    const wrapper = document.createElement("span")
+    wrapper.className = "notranslate read-frog-translated-content-wrapper"
+    wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+    wrapper.append("译文文本")
+    tweet.append(wrapper)
+    const state: BilingualTranslationState = {
+      layoutSource: tweet,
+      sourceTextContent: "Original content",
+      status: "active",
+      walkId: "walk-id",
+      wrapper,
+    }
+    registerBilingualTranslationState(state)
+    await flushDomUpdates()
+    mockTranslateNodesBilingualMode.mockClear()
+    mockTranslateNodesBilingualMode.mockImplementation(async () => {
+      unregisterBilingualTranslationState(state)
+    })
+
+    // Site-driven removal — NOT marked as extension-initiated.
+    wrapper.remove()
+    await flushDomUpdates()
+
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(1)
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledWith([tweet], "walk-id", DEFAULT_CONFIG)
+
     manager.stop()
   })
 

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -666,6 +666,40 @@ describe("pageTranslationManager mutation re-walk", () => {
     manager.stop()
   })
 
+  it("unmounts the error-UI React root when the site removes an ancestor of our wrapper (#1831)", async () => {
+    document.body.innerHTML = `
+      <div id="comment"><p id="tweet"><span id="source">Original content</span></p></div>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const comment = document.getElementById("comment") as HTMLElement
+    const tweet = document.getElementById("tweet") as HTMLElement
+    const wrapper = document.createElement("span")
+    wrapper.className = "notranslate read-frog-translated-content-wrapper"
+    const errorHost = document.createElement("div")
+    errorHost.className = "read-frog-react-shadow-host"
+    const cleanupSpy = vi.fn<() => void>()
+    ;(errorHost as any).__reactShadowContainerCleanup = cleanupSpy
+    wrapper.append(errorHost)
+    tweet.append(wrapper)
+    await flushDomUpdates()
+
+    // Site-driven removal of the whole comment subtree.
+    comment.remove()
+    await flushDomUpdates()
+
+    expect(cleanupSpy).toHaveBeenCalledTimes(1)
+
+    // Idempotent on a duplicate delivery of the same removal.
+    ;(manager as any).cleanupDetachedTranslationArtifacts([comment])
+    expect(cleanupSpy).toHaveBeenCalledTimes(1)
+
+    manager.stop()
+  })
+
   it("does not accumulate mutation observers when a shadow-root element is re-added (#1831)", async () => {
     const host = document.createElement("div")
     host.id = "shadow-host"

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -523,4 +523,32 @@ describe("pageTranslationManager mutation re-walk", () => {
     }
     manager.stop()
   })
+
+  it("does not accumulate mutation observers when a shadow-root element is re-added (#1831)", async () => {
+    const host = document.createElement("div")
+    host.id = "shadow-host"
+    const shadowRoot = host.attachShadow({ mode: "open" })
+    const shadowChild = document.createElement("div")
+    shadowChild.innerHTML = "<p>Shadow paragraph</p>"
+    shadowRoot.append(shadowChild)
+    document.body.append(host)
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observerCountAfterStart = (manager as any).mutationObservers.length
+    expect(observerCountAfterStart).toBeGreaterThan(0)
+
+    for (let i = 0; i < 5; i++) {
+      host.remove()
+      await flushDomUpdates()
+      document.body.append(host)
+      await flushDomUpdates()
+    }
+
+    expect((manager as any).mutationObservers.length).toBe(observerCountAfterStart)
+
+    manager.stop()
+  })
 })

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -60,6 +60,8 @@ vi.mock("@/utils/host/dom/filter", () => ({
   isDontWalkIntoAndDontTranslateAsChildElement: mockIsDontWalkIntoAndDontTranslateAsChildElement,
   isDontWalkIntoButTranslateAsChildElement: mockIsDontWalkIntoButTranslateAsChildElement,
   isHTMLElement: (node: unknown) => node instanceof HTMLElement,
+  isTranslatedWrapperNode: (node: unknown) =>
+    node instanceof HTMLElement && node.classList.contains("read-frog-translated-content-wrapper"),
 }))
 
 vi.mock("@/utils/host/dom/find", () => ({

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -666,6 +666,82 @@ describe("pageTranslationManager mutation re-walk", () => {
     manager.stop()
   })
 
+  it("caps retranslation passes and defers perpetual churn behind a debounced retry (#1831)", async () => {
+    vi.useFakeTimers()
+    const flushWithFakeTimers = async (rounds = 4) => {
+      for (let i = 0; i < rounds; i++) {
+        await Promise.resolve()
+        await vi.advanceTimersByTimeAsync(0)
+        await Promise.resolve()
+      }
+    }
+
+    try {
+      document.body.innerHTML = `
+        <p id="tweet"><span id="source">Ticker 0</span></p>
+      `
+
+      const manager = new PageTranslationManager()
+      await manager.start()
+      await flushWithFakeTimers()
+
+      const tweet = document.getElementById("tweet") as HTMLElement
+      const source = document.getElementById("source")!.firstChild as Text
+      const wrapper = document.createElement("span")
+      wrapper.className = "notranslate read-frog-translated-content-wrapper"
+      wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+      tweet.append(wrapper)
+      // Snapshot never matches, so every mutation marks the source stale —
+      // the pathological ticker page.
+      const state: BilingualTranslationState = {
+        layoutSource: tweet,
+        sourceTextContent: "never matches",
+        status: "active",
+        walkId: "walk-id",
+        wrapper,
+      }
+      registerBilingualTranslationState(state)
+      await flushWithFakeTimers()
+      mockTranslateNodesBilingualMode.mockClear()
+
+      let churn = 0
+      mockTranslateNodesBilingualMode.mockImplementation(async () => {
+        churn += 1
+        source.data = `Ticker ${churn}`
+        // Let the observer deliver the mutation before this pass resolves so
+        // the do/while sees a bumped version every time.
+        await flushWithFakeTimers(2)
+      })
+
+      source.data = "Ticker start"
+      await flushWithFakeTimers(8)
+
+      // Per-invocation cap: exactly MAX_REFRESH_PASSES synchronous passes.
+      expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(3)
+      expect((manager as any).pendingRetranslateRetries.size).toBe(1)
+
+      // Debounced retry fires and burns the rest of the per-window budget.
+      await vi.advanceTimersByTimeAsync(1000)
+      await flushWithFakeTimers()
+      expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(6)
+
+      // Budget exhausted: the next retry is a no-op that re-arms itself.
+      await vi.advanceTimersByTimeAsync(1000)
+      await flushWithFakeTimers()
+      expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(6)
+
+      // stop() cancels pending retries; nothing fires afterwards.
+      manager.stop()
+      expect((manager as any).pendingRetranslateRetries.size).toBe(0)
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(6)
+
+      unregisterBilingualTranslationState(state)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("unmounts the error-UI React root when the site removes an ancestor of our wrapper (#1831)", async () => {
     document.body.innerHTML = `
       <div id="comment"><p id="tweet"><span id="source">Original content</span></p></div>

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -75,6 +75,7 @@ export class PageTranslationManager implements IPageTranslationManager {
   private isPageTranslating: boolean = false
   private intersectionObserver: IntersectionObserver | null = null
   private mutationObservers: MutationObserver[] = []
+  private observedMutationRoots = new WeakSet<Node>()
   private walkId: string | null = null
   private intersectionOptions: IntersectionObserverInit
   private walkBlockedElementsCache = new WeakSet<HTMLElement>()
@@ -246,6 +247,7 @@ export class PageTranslationManager implements IPageTranslationManager {
     }
     this.mutationObservers.forEach((observer) => observer.disconnect())
     this.mutationObservers = []
+    this.observedMutationRoots = new WeakSet()
 
     removeSiteRuleCSS(document)
     removeAllTranslatedWrapperNodes()
@@ -548,19 +550,24 @@ export class PageTranslationManager implements IPageTranslationManager {
    * Start observing mutations for a container and all its shadow roots
    */
   private observeMutations(container: HTMLElement): void {
-    const mutationObserver = new MutationObserver((records) => {
-      void this.handleMutationRecords(records)
-    })
+    // Dynamic pages re-add the same subtrees repeatedly; without dedup every
+    // re-added shadow host gained a duplicate subtree observer (#1831).
+    if (!this.observedMutationRoots.has(container)) {
+      this.observedMutationRoots.add(container)
+      const mutationObserver = new MutationObserver((records) => {
+        void this.handleMutationRecords(records)
+      })
 
-    mutationObserver.observe(container, {
-      childList: true,
-      subtree: true,
-      characterData: true,
-      attributes: true,
-      attributeFilter: ["style", "class", "hidden", "aria-hidden"],
-    })
+      mutationObserver.observe(container, {
+        childList: true,
+        subtree: true,
+        characterData: true,
+        attributes: true,
+        attributeFilter: ["style", "class", "hidden", "aria-hidden"],
+      })
 
-    this.mutationObservers.push(mutationObserver)
+      this.mutationObservers.push(mutationObserver)
+    }
     this.observeIsolatedDescendantsMutations(container)
   }
 

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -1,5 +1,6 @@
 import type { FeatureUsageContext } from "@/types/analytics"
 import type { Config } from "@/types/config/config"
+import debounce from "debounce"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { isLLMProviderConfig } from "@/types/config/provider"
 import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
@@ -41,6 +42,13 @@ type SimpleIntersectionOptions = Omit<IntersectionObserverInit, "threshold"> & {
   threshold?: number
 }
 
+type DebouncedRetry = (() => void) & { clear: () => void }
+
+interface RetranslationBudget {
+  windowStart: number
+  passes: number
+}
+
 interface IPageTranslationManager {
   /**
    * Indicates whether the page translation is currently active
@@ -74,6 +82,12 @@ interface IPageTranslationManager {
 export class PageTranslationManager implements IPageTranslationManager {
   private static readonly MAX_DURATION = 500
   private static readonly MOVE_THRESHOLD = 30 * 30
+  /** Max synchronous passes of the retranslation loop per invocation. */
+  private static readonly MAX_REFRESH_PASSES = 3
+  /** Rolling budget: at most MAX_PASSES_PER_WINDOW passes per source per window. */
+  private static readonly RETRANSLATE_WINDOW_MS = 10_000
+  private static readonly MAX_PASSES_PER_WINDOW = 6
+  private static readonly RETRANSLATE_RETRY_DEBOUNCE_MS = 1_000
   private static readonly DEFAULT_INTERSECTION_OPTIONS: SimpleIntersectionOptions = {
     root: null,
     rootMargin: "600px",
@@ -89,6 +103,11 @@ export class PageTranslationManager implements IPageTranslationManager {
   private walkBlockedElementsCache = new WeakSet<HTMLElement>()
   private refreshingTranslatedSources = new WeakSet<HTMLElement>()
   private translatedSourceMutationVersions = new WeakMap<HTMLElement, number>()
+  private retranslationBudgets = new WeakMap<HTMLElement, RetranslationBudget>()
+  private retranslateRetries = new WeakMap<HTMLElement, DebouncedRetry>()
+  // Strong and enumerable so stop() can cancel in-flight retries; entries are
+  // removed when a retry fires, so the set only holds armed timers.
+  private pendingRetranslateRetries = new Set<DebouncedRetry>()
   private translationSessionVersion = 0
   private titleObserver: MutationObserver | null = null
   private lastSourceTitle: string | null = null
@@ -247,6 +266,10 @@ export class PageTranslationManager implements IPageTranslationManager {
     this.walkBlockedElementsCache = new WeakSet()
     this.refreshingTranslatedSources = new WeakSet()
     this.translatedSourceMutationVersions = new WeakMap()
+    this.pendingRetranslateRetries.forEach((retry) => retry.clear())
+    this.pendingRetranslateRetries.clear()
+    this.retranslateRetries = new WeakMap()
+    this.retranslationBudgets = new WeakMap()
     this.stopDocumentTitleTracking()
 
     if (this.intersectionObserver) {
@@ -713,8 +736,15 @@ export class PageTranslationManager implements IPageTranslationManager {
 
     refreshingSources.add(source)
     let handledVersion = 0
+    let passes = 0
     try {
       do {
+        if (!this.consumeRetranslationBudget(source)) {
+          // Budget exhausted: converge later instead of looping now (#1831).
+          this.scheduleRetranslateRetry(source, sessionVersion)
+          return
+        }
+        passes += 1
         handledVersion = mutationVersions.get(source) ?? 0
         walkAndLabelElement(source, walkId, config)
         await translateNodesBilingualMode([source], walkId, config)
@@ -723,14 +753,64 @@ export class PageTranslationManager implements IPageTranslationManager {
         this.translationSessionVersion === sessionVersion &&
         this.walkId === walkId &&
         source.isConnected &&
-        (mutationVersions.get(source) ?? 0) !== handledVersion
+        (mutationVersions.get(source) ?? 0) !== handledVersion &&
+        passes < PageTranslationManager.MAX_REFRESH_PASSES
       )
+      if (
+        this.isPageTranslating &&
+        this.translationSessionVersion === sessionVersion &&
+        this.walkId === walkId &&
+        source.isConnected &&
+        (mutationVersions.get(source) ?? 0) !== handledVersion
+      ) {
+        // Still dirty after the pass cap — defer the follow-up.
+        this.scheduleRetranslateRetry(source, sessionVersion)
+      }
     } finally {
       refreshingSources.delete(source)
       if (mutationVersions.get(source) === handledVersion) {
         mutationVersions.delete(source)
       }
     }
+  }
+
+  private consumeRetranslationBudget(source: HTMLElement): boolean {
+    const now = Date.now()
+    const budget = this.retranslationBudgets.get(source)
+    if (!budget || now - budget.windowStart > PageTranslationManager.RETRANSLATE_WINDOW_MS) {
+      this.retranslationBudgets.set(source, { windowStart: now, passes: 1 })
+      return true
+    }
+    if (budget.passes >= PageTranslationManager.MAX_PASSES_PER_WINDOW) return false
+    budget.passes += 1
+    return true
+  }
+
+  private scheduleRetranslateRetry(source: HTMLElement, sessionVersion: number): void {
+    let retry = this.retranslateRetries.get(source)
+    if (!retry) {
+      const debounced = debounce(() => {
+        this.pendingRetranslateRetries.delete(debounced)
+        void this.runScheduledRetranslate(source, sessionVersion)
+      }, PageTranslationManager.RETRANSLATE_RETRY_DEBOUNCE_MS) as unknown as DebouncedRetry
+      retry = debounced
+      this.retranslateRetries.set(source, retry)
+    }
+    this.pendingRetranslateRetries.add(retry)
+    retry()
+  }
+
+  private async runScheduledRetranslate(
+    source: HTMLElement,
+    sessionVersion: number,
+  ): Promise<void> {
+    if (!this.isPageTranslating || this.translationSessionVersion !== sessionVersion) return
+    // No pending mutation version means the source converged in the meantime.
+    if (this.translatedSourceMutationVersions.get(source) === undefined) return
+    const config = await getLocalConfig()
+    if (!config) return
+    if (!this.isPageTranslating || this.translationSessionVersion !== sessionVersion) return
+    await this.retranslateChangedSource(source, config, sessionVersion)
   }
 
   private isWalkabilityAttributeMutation(record: MutationRecord): boolean {

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -4,7 +4,11 @@ import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { isLLMProviderConfig } from "@/types/config/provider"
 import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
 import { getLocalConfig } from "@/utils/config/storage"
-import { CONTENT_WRAPPER_CLASS } from "@/utils/constants/dom-labels"
+import {
+  CONTENT_WRAPPER_CLASS,
+  REACT_SHADOW_HOST_CLASS,
+  SPINNER_CLASS,
+} from "@/utils/constants/dom-labels"
 import { resolveProviderConfig } from "@/utils/constants/feature-providers"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
 import {
@@ -15,7 +19,10 @@ import {
 } from "@/utils/host/dom/filter"
 import { deepQueryTopLevelSelector } from "@/utils/host/dom/find"
 import { walkAndLabelElement } from "@/utils/host/dom/traversal"
-import { findStaleBilingualLayoutSource } from "@/utils/host/translate/core/translation-state"
+import {
+  findStaleBilingualLayoutSource,
+  wasNodeRemovedByExtension,
+} from "@/utils/host/translate/core/translation-state"
 import {
   removeAllTranslatedWrapperNodes,
   translateNodesBilingualMode,
@@ -571,10 +578,51 @@ export class PageTranslationManager implements IPageTranslationManager {
     this.observeIsolatedDescendantsMutations(container)
   }
 
+  private static readonly SELF_NODE_CLASSES = [
+    CONTENT_WRAPPER_CLASS,
+    REACT_SHADOW_HOST_CLASS,
+    SPINNER_CLASS,
+  ]
+
+  private isExtensionUtilityNode(node: Node): boolean {
+    return (
+      isHTMLElement(node) &&
+      PageTranslationManager.SELF_NODE_CLASSES.some((cls) => node.classList.contains(cls))
+    )
+  }
+
+  /**
+   * Mutations the extension itself causes (wrapper/spinner/error-UI churn) must
+   * not re-enter the staleness/traversal pipeline, or every translation becomes
+   * fuel for the next retranslation (#1831). Site-driven removals of our
+   * wrappers stay classified as host mutations so they retranslate once.
+   */
+  private isSelfInflictedRecord(record: MutationRecord): boolean {
+    // Wrapper classes/styles are set before insertion and data-read-frog-*
+    // labels are not observed, so attribute records are never self-caused.
+    if (record.type === "attributes") return false
+    const targetElement = isHTMLElement(record.target) ? record.target : record.target.parentElement
+    if (targetElement?.closest(`.${CONTENT_WRAPPER_CLASS}`)) return true
+    if (record.type !== "childList") return false
+    const added = [...record.addedNodes]
+    const removed = [...record.removedNodes]
+    if (added.length === 0 && removed.length === 0) return false
+    return (
+      added.every((node) => this.isExtensionUtilityNode(node)) &&
+      removed.every((node) => this.isExtensionUtilityNode(node) && wasNodeRemovedByExtension(node))
+    )
+  }
+
   private async handleMutationRecords(records: MutationRecord[]): Promise<void> {
     const sessionVersion = this.translationSessionVersion
-    const staleTranslatedSources = new Set<HTMLElement>()
+    const hostRecords: MutationRecord[] = []
     for (const record of records) {
+      if (!this.isSelfInflictedRecord(record)) hostRecords.push(record)
+    }
+    if (hostRecords.length === 0) return
+
+    const staleTranslatedSources = new Set<HTMLElement>()
+    for (const record of hostRecords) {
       const staleSource = findStaleBilingualLayoutSource(record.target)
       if (staleSource) staleTranslatedSources.add(staleSource)
     }
@@ -583,7 +631,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       this.translatedSourceMutationVersions.set(source, nextVersion)
     })
 
-    const needsTraversalHandling = records.some((record) => record.type !== "characterData")
+    const needsTraversalHandling = hostRecords.some((record) => record.type !== "characterData")
     if (staleTranslatedSources.size === 0 && !needsTraversalHandling) return
 
     const config = await getLocalConfig()
@@ -593,7 +641,7 @@ export class PageTranslationManager implements IPageTranslationManager {
     }
     if (!this.isPageTranslating || this.translationSessionVersion !== sessionVersion) return
 
-    for (const rec of records) {
+    for (const rec of hostRecords) {
       if (rec.type === "childList") {
         rec.addedNodes.forEach((node) => {
           if (isHTMLElement(node)) {

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -34,6 +34,7 @@ import { ensureSiteRuleCSS, removeSiteRuleCSS } from "@/utils/host/translate/ui/
 import { getOrCreateWebPageContext } from "@/utils/host/translate/webpage-context"
 import { logger } from "@/utils/logger"
 import { sendMessage } from "@/utils/message"
+import { removeReactShadowHost } from "@/utils/react-shadow-host/create-shadow-host"
 import { getEffectiveSiteRule } from "@/utils/site-rules/effective"
 
 type SimpleIntersectionOptions = Omit<IntersectionObserverInit, "threshold"> & {
@@ -613,10 +614,37 @@ export class PageTranslationManager implements IPageTranslationManager {
     )
   }
 
+  /**
+   * When the SITE removes a subtree containing our error UI or spinners, none
+   * of the extension's cleanup paths run: the React root never unmounts and
+   * its window.matchMedia listener + store subscription pin the detached
+   * subtree forever; infinite spinner animations likewise root their targets.
+   */
+  private cleanupDetachedTranslationArtifacts(removedNodes: NodeList): void {
+    for (const node of removedNodes) {
+      if (!isHTMLElement(node) || node.isConnected) continue
+      if (wasNodeRemovedByExtension(node)) continue
+      if (node.classList.contains(REACT_SHADOW_HOST_CLASS)) {
+        removeReactShadowHost(node)
+        continue
+      }
+      if (!node.firstElementChild) continue
+      node
+        .querySelectorAll<HTMLElement>(`.${REACT_SHADOW_HOST_CLASS}`)
+        .forEach((host) => removeReactShadowHost(host))
+      node
+        .querySelectorAll<HTMLElement>(`.${SPINNER_CLASS}`)
+        .forEach((spinner) => spinner.getAnimations?.().forEach((animation) => animation.cancel()))
+    }
+  }
+
   private async handleMutationRecords(records: MutationRecord[]): Promise<void> {
     const sessionVersion = this.translationSessionVersion
     const hostRecords: MutationRecord[] = []
     for (const record of records) {
+      if (record.type === "childList") {
+        this.cleanupDetachedTranslationArtifacts(record.removedNodes)
+      }
       if (!this.isSelfInflictedRecord(record)) hostRecords.push(record)
     }
     if (hostRecords.length === 0) return

--- a/src/utils/constants/dom-labels.ts
+++ b/src/utils/constants/dom-labels.ts
@@ -23,4 +23,6 @@ export const NOTRANSLATE_CLASS = "notranslate"
 
 export const REACT_SHADOW_HOST_CLASS = "read-frog-react-shadow-host"
 
+export const SPINNER_CLASS = "read-frog-spinner"
+
 export const TRANSLATION_ERROR_CONTAINER_CLASS = "read-frog-translation-error-container"

--- a/src/utils/host/dom/__tests__/traversal.test.ts
+++ b/src/utils/host/dom/__tests__/traversal.test.ts
@@ -118,4 +118,23 @@ describe("extractTextContent", () => {
       expect(extractTextContent(div, DEFAULT_CONFIG)).toBe("Hello World")
     })
   })
+
+  describe("extension wrapper exclusion", () => {
+    it("should exclude translated wrapper text but keep host notranslate children (issues #1831, #249)", () => {
+      const p = document.createElement("p")
+      p.innerHTML =
+        'Host <span class="notranslate">keep</span><span class="notranslate read-frog-translated-content-wrapper">译文</span>'
+      const extracted = extractTextContent(p, DEFAULT_CONFIG)
+      expect(extracted).toContain("Host")
+      expect(extracted).toContain("keep")
+      expect(extracted).not.toContain("译文")
+    })
+
+    it("should exclude nested translated wrappers deep inside the subtree", () => {
+      const div = document.createElement("div")
+      div.innerHTML =
+        '<span>Outer</span><em>Inner<span class="read-frog-translated-content-wrapper">内层译文</span></em>'
+      expect(extractTextContent(div, DEFAULT_CONFIG)).toBe("OuterInner")
+    })
+  })
 })

--- a/src/utils/host/dom/traversal.ts
+++ b/src/utils/host/dom/traversal.ts
@@ -15,6 +15,7 @@ import {
   isShallowInlineHTMLElement,
   isSiteRuleForceBlockElement,
   isTextNode,
+  isTranslatedWrapperNode,
   isWithinIncludeScope,
 } from "./filter"
 
@@ -44,6 +45,13 @@ export function extractTextContent(node: TransNode, config: Config): string {
   // if (isDontWalkIntoButTranslateAsChildElement(node)) {
   //   return ''
   // }
+
+  // Extension-injected translation wrappers must never feed back into the
+  // source text (issue #1831 retranslation storm). Host `notranslate` elements
+  // stay included per issue #249 above — only our own wrappers are skipped.
+  if (isTranslatedWrapperNode(node)) {
+    return ""
+  }
 
   if (isDontWalkIntoAndDontTranslateAsChildElement(node, config)) {
     return ""

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -37,6 +37,7 @@ import {
   isBilingualTranslationStateCurrent,
   isVirtualParagraphGroupCurrent,
   MARK_ATTRIBUTES_REGEX,
+  markExtensionDrivenNodeRemoval,
   markVirtualParagraphGroupInserted,
   originalContentMap,
   registerBilingualTranslationState,
@@ -600,6 +601,7 @@ export async function translateNodeTranslationOnlyMode(
       // Keep the wrapper when translation failed so the injected error UI remains visible.
       // Only remove the wrapper when translation returned an empty string.
       if (translatedText === "") {
+        markExtensionDrivenNodeRemoval(translatedWrapperNode)
         // Batch the remove operation to execute remove operation after insert operation
         batchDOMOperation(() => translatedWrapperNode.remove())
       }

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -31,6 +31,7 @@ import { createSpinnerInside, getTranslatedTextAndRemoveSpinner } from "../ui/sp
 import { isNumericContent } from "../ui/translation-utils"
 import {
   attachBilingualTranslationWrapper,
+  collectSourceTextExcludingWrappers,
   getBilingualTranslationStateForSource,
   getVirtualParagraphGroupForSource,
   isBilingualTranslationStateCurrent,
@@ -155,12 +156,12 @@ async function translateVirtualParagraphs(
     wrappers: new Set(),
     splitRecords: [],
     sourceSnapshots,
-    sourceTextContent: layoutSource.textContent ?? "",
+    sourceTextContent: collectSourceTextExcludingWrappers(layoutSource),
     wrapperPlacements: new Map(),
   }
   registerVirtualParagraphGroup(group)
 
-  const sourceTextSnapshot = layoutSource.textContent
+  const sourceTextSnapshot = collectSourceTextExcludingWrappers(layoutSource)
   let includedUnits: VirtualParagraphUnit[]
   try {
     includedUnits = await filterVirtualParagraphUnits(units, config)
@@ -169,7 +170,10 @@ async function translateVirtualParagraphs(
     throw error
   }
 
-  if (!isVirtualParagraphGroupCurrent(group) || layoutSource.textContent !== sourceTextSnapshot) {
+  if (
+    !isVirtualParagraphGroupCurrent(group) ||
+    collectSourceTextExcludingWrappers(layoutSource) !== sourceTextSnapshot
+  ) {
     disposeVirtualParagraphGroup(group)
     return
   }
@@ -327,7 +331,9 @@ export async function translateNodesBilingualMode(
       return translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
     }
 
-    const sourceTextBeforeFilter = isHTMLElement(layoutSource) ? layoutSource.textContent : null
+    const sourceTextBeforeFilter = isHTMLElement(layoutSource)
+      ? collectSourceTextExcludingWrappers(layoutSource)
+      : null
     const textContent = transNodes
       .map((node) => extractTextContent(node, config))
       .join("")

--- a/src/utils/host/translate/core/translation-state.ts
+++ b/src/utils/host/translate/core/translation-state.ts
@@ -1,4 +1,5 @@
 import { MARK_ATTRIBUTES } from "../../../constants/dom-labels"
+import { isTranslatedWrapperNode } from "../../dom/filter"
 
 export interface TextSplitRecord {
   source: Text
@@ -86,13 +87,30 @@ function collectHostText(
     for (const child of node.childNodes) {
       if (child.nodeType === Node.TEXT_NODE) {
         text += (child as Text).data
-      } else if (!excludedWrappers.has(child as HTMLElement)) {
+      } else if (
+        // Skip ALL extension translation wrappers, not only this state's own:
+        // a descendant state's wrapper inside an ancestor source otherwise counts
+        // as a host-text change and keeps the ancestor permanently stale (#1831).
+        !excludedWrappers.has(child as HTMLElement) &&
+        !isTranslatedWrapperNode(child)
+      ) {
         collect(child)
       }
     }
   }
   collect(layoutSource)
   return text
+}
+
+const EMPTY_WRAPPER_SET: ReadonlySet<HTMLElement> = new Set()
+
+/**
+ * Source-text snapshot that matches what collectHostText will see later.
+ * Raw `layoutSource.textContent` would include descendant wrapper text and
+ * make the staleness comparison asymmetric.
+ */
+export function collectSourceTextExcludingWrappers(layoutSource: HTMLElement): string {
+  return collectHostText(layoutSource, EMPTY_WRAPPER_SET)
 }
 
 export function registerBilingualTranslationState(state: BilingualTranslationState): void {

--- a/src/utils/host/translate/core/translation-state.ts
+++ b/src/utils/host/translate/core/translation-state.ts
@@ -104,6 +104,20 @@ function collectHostText(
 
 const EMPTY_WRAPPER_SET: ReadonlySet<HTMLElement> = new Set()
 
+// Removals we initiate must not be mistaken for host-page mutations by the
+// page MutationObserver, while genuine site-driven removals of our wrappers
+// must keep triggering retranslation (#1831). Membership is checked, never
+// consumed — duplicate observers may deliver the same removal record.
+const extensionDrivenRemovals = new WeakSet<Node>()
+
+export function markExtensionDrivenNodeRemoval(node: Node): void {
+  extensionDrivenRemovals.add(node)
+}
+
+export function wasNodeRemovedByExtension(node: Node): boolean {
+  return extensionDrivenRemovals.has(node)
+}
+
 /**
  * Source-text snapshot that matches what collectHostText will see later.
  * Raw `layoutSource.textContent` would include descendant wrapper text and

--- a/src/utils/host/translate/dom/__tests__/virtual-paragraph-lifecycle.test.ts
+++ b/src/utils/host/translate/dom/__tests__/virtual-paragraph-lifecycle.test.ts
@@ -1,10 +1,13 @@
 import type { VirtualParagraphUnit } from "../paragraph-segmentation"
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it } from "vitest"
+import { CONTENT_WRAPPER_CLASS, NOTRANSLATE_CLASS } from "@/utils/constants/dom-labels"
 import {
+  collectSourceTextExcludingWrappers,
   getBilingualTranslationStateForSource,
   getVirtualParagraphGroupForSource,
   getVirtualParagraphGroupForWrapper,
+  isBilingualTranslationStateCurrent,
   isVirtualParagraphGroupCurrent,
   markVirtualParagraphGroupInserted,
   registerBilingualTranslationState,
@@ -261,6 +264,78 @@ describe("virtual paragraph lifecycle", () => {
 
     expect(state.status).toBe("disposed")
     expect(getBilingualTranslationStateForSource(layoutSource)).toBeUndefined()
+  })
+
+  it("does not stale a bilingual state when a foreign translation wrapper is inserted (#1831)", () => {
+    const layoutSource = document.createElement("div")
+    layoutSource.textContent = "Host paragraph text"
+    const ownWrapper = document.createElement("span")
+    ownWrapper.className = `${NOTRANSLATE_CLASS} ${CONTENT_WRAPPER_CLASS}`
+    ownWrapper.textContent = "自己的译文"
+    layoutSource.append(ownWrapper)
+    document.body.append(layoutSource)
+    const state: BilingualTranslationState = {
+      layoutSource,
+      sourceTextContent: "Host paragraph text",
+      status: "active",
+      walkId: "foreign-wrapper",
+      wrapper: ownWrapper,
+    }
+    registerBilingualTranslationState(state)
+    expect(isBilingualTranslationStateCurrent(state)).toBe(true)
+
+    const foreignWrapper = document.createElement("span")
+    foreignWrapper.className = `${NOTRANSLATE_CLASS} ${CONTENT_WRAPPER_CLASS}`
+    foreignWrapper.textContent = "后代状态的译文"
+    layoutSource.append(foreignWrapper)
+    expect(isBilingualTranslationStateCurrent(state)).toBe(true)
+
+    layoutSource.append("real host change")
+    expect(isBilingualTranslationStateCurrent(state)).toBe(false)
+  })
+
+  it("does not stale a virtual paragraph group when a foreign translation wrapper is inserted (#1831)", () => {
+    const layoutSource = document.createElement("div")
+    const nested = document.createElement("em")
+    nested.textContent = "nested"
+    const source = document.createTextNode("one\n\ntwo")
+    layoutSource.append(nested, source)
+    document.body.append(layoutSource)
+    const { group } = createSplitGroup(layoutSource, source, [3, source.data.length])
+    expect(isVirtualParagraphGroupCurrent(group)).toBe(true)
+
+    // A descendant paragraph's wrapper lands inside a nested element, away from
+    // the group's own wrappers, so placement fingerprints stay intact.
+    const foreignWrapper = document.createElement("span")
+    foreignWrapper.className = `${NOTRANSLATE_CLASS} ${CONTENT_WRAPPER_CLASS}`
+    foreignWrapper.textContent = "后代状态的译文"
+    nested.append(foreignWrapper)
+    expect(isVirtualParagraphGroupCurrent(group)).toBe(true)
+
+    nested.append("real host change")
+    expect(isVirtualParagraphGroupCurrent(group)).toBe(false)
+    disposeVirtualParagraphGroup(group)
+  })
+
+  it("captures registration snapshots that exclude pre-existing wrappers (snapshot symmetry)", () => {
+    const layoutSource = document.createElement("div")
+    layoutSource.textContent = "Host text"
+    const preexistingWrapper = document.createElement("span")
+    preexistingWrapper.className = `${NOTRANSLATE_CLASS} ${CONTENT_WRAPPER_CLASS}`
+    preexistingWrapper.textContent = "旧译文"
+    layoutSource.append(preexistingWrapper)
+    document.body.append(layoutSource)
+
+    const state: BilingualTranslationState = {
+      layoutSource,
+      sourceTextContent: collectSourceTextExcludingWrappers(layoutSource),
+      status: "active",
+      walkId: "snapshot-symmetry",
+      wrapper: null,
+    }
+    registerBilingualTranslationState(state)
+
+    expect(isBilingualTranslationStateCurrent(state)).toBe(true)
   })
 
   it("treats a removed tracked wrapper as stale after insertion", () => {

--- a/src/utils/host/translate/dom/translation-cleanup.ts
+++ b/src/utils/host/translate/dom/translation-cleanup.ts
@@ -1,6 +1,7 @@
 import type { TextSplitRecord, VirtualParagraphGroup } from "../core/translation-state"
 import {
   REACT_SHADOW_HOST_CLASS,
+  SPINNER_CLASS,
   TRANSLATION_MODE_ATTRIBUTE,
   VIRTUAL_PARAGRAPH_ATTRIBUTE,
 } from "../../../constants/dom-labels"
@@ -14,6 +15,7 @@ import {
   getPendingVirtualParagraphGroups,
   getVirtualParagraphGroupForSource,
   getVirtualParagraphGroupForWrapper,
+  markExtensionDrivenNodeRemoval,
   originalContentMap,
   unregisterBilingualTranslationState,
   unregisterVirtualParagraphGroup,
@@ -28,7 +30,7 @@ export function removeShadowHostInTranslatedWrapper(wrapper: HTMLElement): void 
   }
 
   // Remove lightweight spinners
-  const spinner = wrapper.querySelector(".read-frog-spinner")
+  const spinner = wrapper.querySelector(`.${SPINNER_CLASS}`)
   spinner?.remove()
 }
 
@@ -86,6 +88,7 @@ export function disposeVirtualParagraphGroup(group: VirtualParagraphGroup): {
 
   for (const wrapper of group.wrappers) {
     removeShadowHostInTranslatedWrapper(wrapper)
+    markExtensionDrivenNodeRemoval(wrapper)
     wrapper.remove()
   }
   group.wrappers.clear()
@@ -114,6 +117,7 @@ export function removeOrphanVirtualParagraphWrappers(source: HTMLElement): boole
 
   orphanWrappers.forEach((wrapper) => {
     removeShadowHostInTranslatedWrapper(wrapper)
+    markExtensionDrivenNodeRemoval(wrapper)
     wrapper.remove()
   })
   return orphanWrappers.length > 0
@@ -126,14 +130,19 @@ export function dropVirtualParagraphWrapper(
   if (group.status !== "active" || !group.wrappers.has(wrapper)) return
   removeShadowHostInTranslatedWrapper(wrapper)
   unregisterVirtualParagraphWrapper(group, wrapper)
+  markExtensionDrivenNodeRemoval(wrapper)
   wrapper.remove()
   if (group.wrappers.size === 0) disposeVirtualParagraphGroup(group)
 }
 
 export function removeVirtualParagraphWrapper(wrapper: HTMLElement): void {
   const group = getVirtualParagraphGroupForWrapper(wrapper)
-  if (group) dropVirtualParagraphWrapper(group, wrapper)
-  else wrapper.remove()
+  if (group) {
+    dropVirtualParagraphWrapper(group, wrapper)
+  } else {
+    markExtensionDrivenNodeRemoval(wrapper)
+    wrapper.remove()
+  }
 }
 
 /**
@@ -141,6 +150,8 @@ export function removeVirtualParagraphWrapper(wrapper: HTMLElement): void {
  * @param wrapper - The translated wrapper element to remove
  */
 export function removeTranslatedWrapperWithRestore(wrapper: HTMLElement): void {
+  // Every path below removes the wrapper (directly or via an innerHTML restore).
+  markExtensionDrivenNodeRemoval(wrapper)
   const virtualParagraphGroup = getVirtualParagraphGroupForWrapper(wrapper)
   if (virtualParagraphGroup) {
     disposeVirtualParagraphGroup(virtualParagraphGroup)

--- a/src/utils/host/translate/dom/translation-cleanup.ts
+++ b/src/utils/host/translate/dom/translation-cleanup.ts
@@ -29,9 +29,13 @@ export function removeShadowHostInTranslatedWrapper(wrapper: HTMLElement): void 
     removeReactShadowHost(translationShadowHost)
   }
 
-  // Remove lightweight spinners
+  // Remove lightweight spinners; cancel their infinite animation first so the
+  // detached node is not rooted by the renderer (#1831).
   const spinner = wrapper.querySelector(`.${SPINNER_CLASS}`)
-  spinner?.remove()
+  if (spinner && isHTMLElement(spinner)) {
+    spinner.getAnimations?.().forEach((animation) => animation.cancel())
+    spinner.remove()
+  }
 }
 
 function restoreTextSplit(record: TextSplitRecord): boolean {

--- a/src/utils/host/translate/ui/spinner.ts
+++ b/src/utils/host/translate/ui/spinner.ts
@@ -106,6 +106,10 @@ export async function getTranslatedTextAndRemoveSpinner(
 
     translatedWrapperNode.appendChild(container)
   } finally {
+    // The spin animation runs with iterations: Infinity; a running animation
+    // roots its detached target in the renderer, leaking one node per
+    // translated paragraph (#1831). jsdom lacks getAnimations, hence the `?.`.
+    spinner.getAnimations?.().forEach((animation) => animation.cancel())
     spinner.remove()
   }
 

--- a/src/utils/host/translate/ui/spinner.ts
+++ b/src/utils/host/translate/ui/spinner.ts
@@ -5,7 +5,7 @@ import textSmallCSS from "@/assets/styles/text-small.css?inline"
 import themeCSS from "@/assets/styles/theme.css?inline"
 import { TranslationError } from "@/components/translation/error"
 import { createReactShadowHost } from "@/utils/react-shadow-host/create-shadow-host"
-import { TRANSLATION_ERROR_CONTAINER_CLASS } from "../../../constants/dom-labels"
+import { SPINNER_CLASS, TRANSLATION_ERROR_CONTAINER_CLASS } from "../../../constants/dom-labels"
 import { getContainingShadowRoot, getOwnerDocument } from "../../dom/node"
 import { translateTextForPage } from "../translate-variants"
 import { ensurePresetStyles } from "./style-injector"
@@ -17,7 +17,7 @@ import { ensurePresetStyles } from "./style-injector"
  */
 export function createLightweightSpinner(ownerDoc: Document): HTMLElement {
   const spinner = ownerDoc.createElement("span")
-  spinner.className = "read-frog-spinner"
+  spinner.className = SPINNER_CLASS
   // Inline styles keep the spinner resilient against host page CSS overrides.
   // Use a thin muted arc with transparent sides so bulk page translation does
   // not paint a dense field of high-contrast rings across the screen.

--- a/src/utils/site-rules/__tests__/built-in.test.ts
+++ b/src/utils/site-rules/__tests__/built-in.test.ts
@@ -118,4 +118,18 @@ describe("built-in site rules", () => {
     expect(resolved.excludeSelector).toContain("[data-nav-extras]")
     expect(resolved.excludeSelector).toContain(".navbar")
   })
+
+  it("excludes hltv.org comment metadata bars (floor number, author, time, votes)", () => {
+    const resolved = resolveSiteRule(
+      "https://www.hltv.org/matches/2395002/furia-vs-falcons-iem-cologne-major-2026",
+      BUILT_IN_SITE_RULES,
+      [],
+      [],
+    )
+    // .forum-topbar carries the floor number (a.replyNum), fan badge, flag and
+    // author anchor; .forum-bottombar carries the timestamp (span.time) and the
+    // vote button with its login tooltip. Post bodies live outside both bars.
+    expect(resolved.excludeSelector).toContain(".forum-topbar")
+    expect(resolved.excludeSelector).toContain(".forum-bottombar")
+  })
 })

--- a/src/utils/site-rules/__tests__/built-in.test.ts
+++ b/src/utils/site-rules/__tests__/built-in.test.ts
@@ -106,4 +106,16 @@ describe("built-in site rules", () => {
       ]),
     )
   })
+
+  it("excludes the hltv.org navigation whose overflow handler loops on width changes (#1831)", () => {
+    const resolved = resolveSiteRule(
+      "https://www.hltv.org/matches/2395002/furia-vs-falcons-iem-cologne-major-2026",
+      BUILT_IN_SITE_RULES,
+      [],
+      [],
+    )
+    expect(resolved.excludeSelector).toContain("[data-nav-item]")
+    expect(resolved.excludeSelector).toContain("[data-nav-extras]")
+    expect(resolved.excludeSelector).toContain(".navbar")
+  })
 })

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -4443,7 +4443,9 @@
       "[data-nav-item]",
       "[data-nav-extras]",
       "[data-navbar-main-menu-item-container]",
-      "[data-navbar-extra-items-container]"
+      "[data-navbar-extra-items-container]",
+      ".forum-topbar",
+      ".forum-bottombar"
     ]
   }
 ]

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -4434,5 +4434,16 @@
     "id": "remove_em",
     "matches": ["git-scm.com", "models.com"],
     "preserveTextSelectors.add": ["em"]
+  },
+  {
+    "id": "hltv",
+    "matches": ["hltv.org", "*.hltv.org"],
+    "excludeSelectors": [
+      ".navbar",
+      "[data-nav-item]",
+      "[data-nav-extras]",
+      "[data-navbar-main-menu-item-container]",
+      "[data-navbar-extra-items-container]"
+    ]
   }
 ]


### PR DESCRIPTION
Fixes #1831.

## Root cause (two cooperating problems)

**1. The translation pipeline fed on its own output.** Verified chain at HEAD:
- the body `MutationObserver` had no self-mutation filter, so every wrapper/spinner/error-UI insertion re-entered the staleness pipeline;
- staleness compared host text while excluding only the state's *own* wrapper — any other wrapper inside an ancestor source made that ancestor permanently stale (the snapshot side used raw `textContent`, so fixing only the collector would have inverted the bug);
- `extractTextContent` included translated-wrapper text (the notranslate skip was commented out for #249), so ancestors re-translated their own output;
- `retranslateChangedSource` chased mutation versions in an uncapped `do/while`.

**2. hltv.org's own navbar overflow handler has no termination guard** — `while (menuIsOverflowing()) moveSingleMainItemToExtras()` inside a `ResizeObserver`. Translated menu items widen the menu and the page traps itself in that loop: CPU pegged, ~30k detached jQuery nodes allocated per second, main thread never yields (CPU-profiled into the site's own bundle via the Tracing domain; `Profiler.start` couldn't even interrupt it). A built-in site rule now excludes the hltv navigation from translation.

## Changes

- `extractTextContent` skips extension wrappers only (host `notranslate` stays included — #249 non-regression locked by test)
- `collectHostText` + all four source-text snapshot sites become wrapper-blind together
- mutation records classified before entering the pipeline; extension-initiated removals marked via WeakSet so site-driven removals still retranslate exactly once
- retranslation bounded: 3 passes per invocation, 6 per source per 10 s rolling window, debounced retry for convergence, all cancelled on `stop()`
- mutation observers deduped for re-added subtrees
- retention cleanups: React error-UI roots unmounted when the site removes their subtree (frees the `matchMedia` listener + store subscription pinning the fiber tree), and the spinner's `iterations: Infinity` animation is cancelled on every removal path
- built-in site rule: exclude the hltv.org navigation

## Verification

Instrumented Puppeteer harness on the reported hltv match page, Chinese target, 6 scroll cycles, forced GC before baseline/final:

| Metric | before | after |
|---|---|---|
| DOM nodes | 1,327,529 | 243,013 (stable) |
| main-thread task time | 840 s | 84.8 s |
| freezes > 45 s | every cycle | 0 |
| heap snapshot capture | impossible (hung) | completes |
| heap retained after GC | +35 MB | +0.6 MB |
| translations | vanish / garbled | persist and grow with scrolling |

Plus 20 new unit tests across the storm scenarios (self-mutation ignore, exactly-once site-driven retranslation, pass cap + budget + stop cancellation, observer dedup, error-UI unmount idempotency, staleness with foreign wrappers, snapshot symmetry, #249 non-regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)