### PR TITLE
fix(guide): ignore setTargetLanguage without a valid language code

### DIFF
--- a/.changeset/guide-eng-fallback.md
+++ b/.changeset/guide-eng-fallback.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(guide): ignore setTargetLanguage messages without a valid language code instead of defaulting to English, which silently overwrote the configured target language

--- a/src/entrypoints/guide.content/index.ts
+++ b/src/entrypoints/guide.content/index.ts
@@ -9,6 +9,8 @@ import {
   getGuideDictionaryNotebaseState,
   startGuideDictionaryNotebaseTracking,
 } from "@/utils/guide/dictionary-notebase"
+import { resolveGuideTargetLanguage } from "@/utils/guide/target-language"
+import { logger } from "@/utils/logger"
 import { onMessage, sendMessage } from "@/utils/message"
 
 export default defineContentScript({
@@ -58,7 +60,11 @@ export default defineContentScript({
         if (!config) return
 
         if (type === "setTargetLanguage") {
-          const langCodeISO6393 = e.data.langCodeISO6393 ?? "eng"
+          const langCodeISO6393 = resolveGuideTargetLanguage(e.data)
+          if (!langCodeISO6393) {
+            logger.warn("guide setTargetLanguage ignored: missing or invalid language code", e.data)
+            return
+          }
           // If we set storage too early, react of side content has not been mounted yet,
           // so this set storage will not trigger the watch of storage adapter of atom in react of side content
           // i.e. the side content will not be updated with the new config

--- a/src/utils/guide/__tests__/target-language.test.ts
+++ b/src/utils/guide/__tests__/target-language.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { resolveGuideTargetLanguage } from "../target-language"
+
+describe("resolveGuideTargetLanguage", () => {
+  it("passes through a valid ISO 639-3 code", () => {
+    expect(resolveGuideTargetLanguage({ langCodeISO6393: "cmn" })).toBe("cmn")
+    expect(resolveGuideTargetLanguage({ langCodeISO6393: "eng" })).toBe("eng")
+  })
+
+  it("returns null when the code is missing", () => {
+    expect(resolveGuideTargetLanguage({})).toBeNull()
+    expect(resolveGuideTargetLanguage({ langCodeISO6393: undefined })).toBeNull()
+    expect(resolveGuideTargetLanguage({ langCodeISO6393: null })).toBeNull()
+  })
+
+  it("returns null for invalid codes and non-object payloads", () => {
+    expect(resolveGuideTargetLanguage({ langCodeISO6393: "zz" })).toBeNull()
+    expect(resolveGuideTargetLanguage({ langCodeISO6393: "english" })).toBeNull()
+    expect(resolveGuideTargetLanguage({ langCodeISO6393: 42 })).toBeNull()
+    expect(resolveGuideTargetLanguage(null)).toBeNull()
+    expect(resolveGuideTargetLanguage(undefined)).toBeNull()
+    expect(resolveGuideTargetLanguage("cmn")).toBeNull()
+  })
+})

--- a/src/utils/guide/target-language.ts
+++ b/src/utils/guide/target-language.ts
@@ -1,0 +1,15 @@
+import type { LangCodeISO6393 } from "@read-frog/definitions"
+import { langCodeISO6393Schema } from "@read-frog/definitions"
+
+/**
+ * The guide page may omit or mistype the language code; only a valid explicit
+ * code may reach the config. The old literal "eng" fallback silently
+ * overwrote the user's configured target language on every onboarding visit.
+ */
+export function resolveGuideTargetLanguage(data: unknown): LangCodeISO6393 | null {
+  if (typeof data !== "object" || data === null) return null
+  const parsed = langCodeISO6393Schema.safeParse(
+    (data as { langCodeISO6393?: unknown }).langCodeISO6393,
+  )
+  return parsed.success ? parsed.data : null
+}


### PR DESCRIPTION
Found during #1831 triage.

The guide content script fell back to a literal `"eng"` whenever the onboarding page omitted `langCodeISO6393`, silently overwriting the user's configured target language on every onboarding visit. On a fresh install this turned the default `cmn` into `eng`, after which the target-language skip discarded every translation on English pages.

The language code is now validated with `langCodeISO6393Schema`; missing or invalid values are logged and ignored. Intentional guide-driven language choices write exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)