### PR TITLE
fix(translate): hide LLM near-echoes of the source text

### DIFF
--- a/.changeset/comparison-normalization.md
+++ b/.changeset/comparison-normalization.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): recognize LLM near-echoes of the source (whitespace reflow, NBSP, smart quotes, ellipsis, fullwidth punctuation, case drift) as untranslated and hide them instead of duplicating the paragraph

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -955,6 +955,37 @@ describe("translate", () => {
         })
       })
 
+      it("drops near-echo translations that differ only by cosmetic drift", async () => {
+        await withHost("x.com", async () => {
+          const paragraphs = ['It\'s a "first" paragraph… REALLY.', "Second paragraph stays."]
+          const sourceText = paragraphs.join("\n\n")
+          // LLM-style echo: NBSP for spaces, curly quotes, real ellipsis, case drift.
+          vi.mocked(translateTextForPage).mockImplementation(async (text) =>
+            text
+              .replace(/ /g, " ")
+              .replace(/'/g, "’")
+              .replace(/"/g, "“")
+              .replace(/\.\.\./g, "…")
+              .toLowerCase(),
+          )
+
+          render(
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <span>{sourceText}</span>
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const sourceSpan = tweet.querySelector("span")!
+          const originalInnerHTML = sourceSpan.innerHTML
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(translateTextForPage).toHaveBeenCalledTimes(2)
+          expect(getTranslationWrappers(tweet)).toHaveLength(0)
+          expect(sourceSpan.innerHTML).toBe(originalInnerHTML)
+        })
+      })
+
       it("keeps Bora's mention in the first of five interleaved paragraphs", async () => {
         await withHost("x.com", async () => {
           const paragraphs = [

--- a/src/utils/host/translate/__tests__/text-preparation.test.ts
+++ b/src/utils/host/translate/__tests__/text-preparation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+import { normalizeForComparison, prepareTranslationText } from "../text-preparation"
+
+const NBSP = " "
+const ZWSP = "​"
+const BOM = "﻿"
+
+describe("prepareTranslationText", () => {
+  it("strips zero-width characters and trims", () => {
+    expect(prepareTranslationText(`${ZWSP} hello ${BOM}`)).toBe("hello")
+  })
+
+  it("returns empty string for nullish input", () => {
+    expect(prepareTranslationText(null)).toBe("")
+    expect(prepareTranslationText(undefined)).toBe("")
+  })
+})
+
+describe("normalizeForComparison", () => {
+  it("treats NBSP as a regular space", () => {
+    expect(normalizeForComparison(`It is${NBSP}a${NBSP}test`)).toBe(
+      normalizeForComparison("It is a test"),
+    )
+  })
+
+  it("collapses whitespace reflow (newlines, tabs, runs of spaces)", () => {
+    expect(normalizeForComparison("a\n  b\tc")).toBe(normalizeForComparison("a b c"))
+  })
+
+  it("folds smart quotes to straight quotes", () => {
+    expect(normalizeForComparison("It’s a “test”")).toBe(normalizeForComparison(`It's a "test"`))
+    expect(normalizeForComparison("‚low‘ „high‟")).toBe(normalizeForComparison(`'low' "high"`))
+  })
+
+  it("folds the ellipsis character to three dots", () => {
+    expect(normalizeForComparison("wait…")).toBe(normalizeForComparison("wait..."))
+  })
+
+  it("ignores case differences", () => {
+    expect(normalizeForComparison("Hello World")).toBe(normalizeForComparison("hello world"))
+  })
+
+  it("folds fullwidth punctuation (NFKC)", () => {
+    expect(normalizeForComparison("你好！")).toBe(normalizeForComparison("你好!"))
+    expect(normalizeForComparison("２０２６")).toBe(normalizeForComparison("2026"))
+  })
+
+  it("treats a fully drifted echo as equal to its source", () => {
+    const source = `It's a "test" that runs on Monday… REALLY`
+    const echo = `It’s${NBSP}a${NBSP}“test” that runs on Monday... really`
+    expect(normalizeForComparison(source)).toBe(normalizeForComparison(echo))
+  })
+
+  it("keeps genuinely different strings different", () => {
+    expect(normalizeForComparison("hello world")).not.toBe(normalizeForComparison("你好世界"))
+    expect(normalizeForComparison("first sentence")).not.toBe(
+      normalizeForComparison("second sentence"),
+    )
+  })
+})

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -25,7 +25,7 @@ import { insertTranslatedNodeIntoWrapper } from "../dom/translation-insertion"
 import { findPreviousTranslatedWrapperInside } from "../dom/translation-wrapper"
 import { insertVirtualParagraphWrappers } from "../dom/virtual-paragraph-insertion"
 import { shouldFilterSmallParagraph } from "../filter-small-paragraph"
-import { prepareTranslationText } from "../text-preparation"
+import { normalizeForComparison } from "../text-preparation"
 import { setTranslationDirAndLang } from "../translation-attributes"
 import { createSpinnerInside, getTranslatedTextAndRemoveSpinner } from "../ui/spinner"
 import { isNumericContent } from "../ui/translation-utils"
@@ -56,7 +56,7 @@ function getDisplayTranslation(sourceText: string, translatedText: string | unde
     return undefined
   }
 
-  return prepareTranslationText(sourceText) === prepareTranslationText(translatedText)
+  return normalizeForComparison(sourceText) === normalizeForComparison(translatedText)
     ? ""
     : translatedText
 }

--- a/src/utils/host/translate/text-preparation.ts
+++ b/src/utils/host/translate/text-preparation.ts
@@ -3,3 +3,27 @@ const INVISIBLE_TRANSLATION_CHARACTERS_REGEX = /[\u200B-\u200D\uFEFF]/g
 export function prepareTranslationText(value: string | null | undefined): string {
   return value?.replace(INVISIBLE_TRANSLATION_CHARACTERS_REGEX, "").trim() ?? ""
 }
+
+// NFKC has no compatibility decomposition for curly quotes, so they need
+// explicit folding (includes the low-9 variants).
+const SMART_SINGLE_QUOTES_REGEX = /[\u2018\u2019\u201A\u201B]/g
+const SMART_DOUBLE_QUOTES_REGEX = /[\u201C\u201D\u201E\u201F]/g
+const WHITESPACE_RUN_REGEX = /\s+/g
+
+/**
+ * Normalization for source-vs-translation equality checks ONLY \u2014 never for
+ * text that is displayed, sent to a provider, or hashed for the cache.
+ *
+ * LLMs echo same-language input with cosmetic drift (whitespace reflow, NBSP,
+ * smart quotes, ellipsis, fullwidth punctuation, casing). Equality after this
+ * folding means the "translation" carries no information and should be hidden.
+ */
+export function normalizeForComparison(value: string | null | undefined): string {
+  return prepareTranslationText(value)
+    .normalize("NFKC")
+    .replace(SMART_SINGLE_QUOTES_REGEX, "'")
+    .replace(SMART_DOUBLE_QUOTES_REGEX, '"')
+    .replace(WHITESPACE_RUN_REGEX, " ")
+    .toLowerCase()
+    .trim()
+}


### PR DESCRIPTION
Part of the #1831 same-language-echo family (backstop layer).

`getDisplayTranslation` compared source and translation after only zero-width stripping and trimming, so an LLM echoing same-language input with cosmetic drift — whitespace reflow, NBSP, smart quotes, ellipsis, fullwidth punctuation, casing — slipped past the equality check and rendered a useless duplicate paragraph.

Comparison now goes through a new `normalizeForComparison` (NFKC → smart-quote folding → whitespace collapse → root-locale lowercase), used **only** for the equality check: displayed text, provider input, and cache hashing are untouched (`prepareTranslationText` is deliberately not modified — it feeds the request hash).

Casefold safety: hiding only triggers when the texts are equal after all other folds, i.e. the "translation" differs from the source at most cosmetically — it carries no information in any language. Subtitles bypass `getDisplayTranslation` and are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)