### PR TITLE
feat(translate): explicit no-translation sentinel for same-language paragraphs

### DIFF
--- a/.changeset/no-translation-sentinel.md
+++ b/.changeset/no-translation-sentinel.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(translate): teach the batch translation prompt to return a {{NO_TRANSLATION_NEEDED}} sentinel for paragraphs already in the target language and hide those paragraphs instead of showing an echo

--- a/src/entrypoints/background/__tests__/translation-queues.test.ts
+++ b/src/entrypoints/background/__tests__/translation-queues.test.ts
@@ -1,6 +1,7 @@
 import type { ProviderConfig } from "@/types/config/provider"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { NO_TRANSLATION_SENTINEL } from "@/utils/constants/prompt"
 
 const onMessageMock = vi.fn<(...args: any[]) => any>()
 const ensureInitializedConfigMock = vi.fn<(...args: any[]) => any>()
@@ -343,6 +344,34 @@ describe("translation queue helpers", () => {
       expect.objectContaining({
         key: "webpage-hash",
         translation: "write &amp; for ampersand — It's fine",
+      }),
+    )
+  })
+
+  it("returns and caches the no-translation sentinel RAW (mapping is content-side)", async () => {
+    executeTranslateMock.mockResolvedValue(NO_TRANSLATION_SENTINEL)
+
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+    const result = await handler({
+      data: {
+        text: "already in target language",
+        langConfig: DEFAULT_CONFIG.language,
+        providerConfig: googleProvider,
+        scheduleAt: Date.now(),
+        hash: "sentinel-hash",
+      },
+    })
+
+    // Mapping the sentinel to "" here would fall out of the truthy-only cache
+    // write and re-hit the provider on every request; translateTextCore maps it.
+    expect(result).toBe(NO_TRANSLATION_SENTINEL)
+    expect(translationCachePutMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "sentinel-hash",
+        translation: NO_TRANSLATION_SENTINEL,
       }),
     )
   })

--- a/src/utils/constants/prompt.ts
+++ b/src/utils/constants/prompt.ts
@@ -22,6 +22,19 @@ export const TOKENS = WEB_PAGE_PROMPT_TOKENS
 export const BATCH_SEPARATOR = "%%"
 export const BATCH_SEPARATOR_LINE_PATTERN = /\r?\n[ \t]*%%[ \t]*\r?\n/
 
+/**
+ * Marker an LLM outputs instead of a translation when the input paragraph is
+ * already entirely in the target language. Cached RAW (the background cache
+ * only stores truthy results); mapped to "" content-side in translateTextCore.
+ * The literal deliberately looks like a prompt token: replaceTokens only
+ * substitutes the known tokens, so it survives prompt assembly verbatim.
+ */
+export const NO_TRANSLATION_SENTINEL = "{{NO_TRANSLATION_NEEDED}}"
+
+export function isNoTranslationSentinel(text: string): boolean {
+  return text.trim() === NO_TRANSLATION_SENTINEL
+}
+
 export const TARGET_LANGUAGE = WEB_PAGE_PROMPT_TOKENS[0]
 export const INPUT = WEB_PAGE_PROMPT_TOKENS[1]
 export const WEB_TITLE = WEB_PAGE_PROMPT_TOKENS[2]
@@ -108,6 +121,9 @@ Single paragraph content
 ### Single paragraph Output:
 Direct translation without separators
 `
+
+export const DEFAULT_SENTINEL_TRANSLATE_PROMPT = `## Already-translated Input Rule
+If a paragraph of the input is already entirely written in ${getTokenCellText(TARGET_LANGUAGE)} and needs no translation, output the exact marker ${NO_TRANSLATION_SENTINEL} as that paragraph's entire translation instead of repeating the paragraph. Never mix the marker with translated text. If only part of a paragraph is in ${getTokenCellText(TARGET_LANGUAGE)}, translate the whole paragraph normally.`
 
 /**
  * UI sentinel value for default prompt selection

--- a/src/utils/constants/prompt.ts
+++ b/src/utils/constants/prompt.ts
@@ -126,6 +126,30 @@ export const DEFAULT_SENTINEL_TRANSLATE_PROMPT = `## Already-translated Input Ru
 If a paragraph of the input is already entirely written in ${getTokenCellText(TARGET_LANGUAGE)} and needs no translation, output the exact marker ${NO_TRANSLATION_SENTINEL} as that paragraph's entire translation instead of repeating the paragraph. Never mix the marker with translated text. If only part of a paragraph is in ${getTokenCellText(TARGET_LANGUAGE)}, translate the whole paragraph normally.`
 
 /**
+ * Batch prompt for the WEBPAGE pipeline only: the format example demonstrates
+ * the no-translation marker in place, which measurably doubles marker usage on
+ * mixed batches versus the rule alone (models imitate examples more reliably
+ * than they follow rules). Subtitles keep DEFAULT_BATCH_TRANSLATE_PROMPT —
+ * their pipeline has no sentinel mapping and must never see the marker.
+ * Derived via replace; the prompt unit tests pin that both anchors matched.
+ */
+export const DEFAULT_BATCH_TRANSLATE_PROMPT_WITH_SENTINEL = DEFAULT_BATCH_TRANSLATE_PROMPT.replace(
+  `Paragraph B
+
+${BATCH_SEPARATOR}`,
+  `Paragraph B (this one is already written in ${getTokenCellText(TARGET_LANGUAGE)})
+
+${BATCH_SEPARATOR}`,
+).replace(
+  `Translation B
+
+${BATCH_SEPARATOR}`,
+  `${NO_TRANSLATION_SENTINEL}
+
+${BATCH_SEPARATOR}`,
+)
+
+/**
  * UI sentinel value for default prompt selection
  * NOTE: This is NOT stored in config - it's only used in UI components
  * Config stores `null` for default, this string is just for Select/UI compatibility

--- a/src/utils/host/__tests__/translate-text.test.tsx
+++ b/src/utils/host/__tests__/translate-text.test.tsx
@@ -2,6 +2,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { NO_TRANSLATION_SENTINEL } from "@/utils/constants/prompt"
 import { detectLanguage } from "@/utils/content/language"
 import { executeTranslate } from "@/utils/host/translate/execute-translate"
 import {
@@ -116,6 +117,24 @@ describe("translate-text", () => {
       )
       expect(mockGetOrCreateWebPageContext).not.toHaveBeenCalled()
       expect(mockGetOrGenerateWebPageSummary).not.toHaveBeenCalled()
+    })
+
+    it("maps a full no-translation sentinel response to an empty string", async () => {
+      mockSendMessage.mockResolvedValue(NO_TRANSLATION_SENTINEL)
+
+      const result = await translateTextForPage("test text")
+
+      expect(result).toBe("")
+      expect(mockSendMessage).toHaveBeenCalledOnce()
+    })
+
+    it("returns a response containing the sentinel inside longer text verbatim", async () => {
+      const mixed = `some translation ${NO_TRANSLATION_SENTINEL}`
+      mockSendMessage.mockResolvedValue(mixed)
+
+      const result = await translateTextForPage("test text")
+
+      expect(result).toBe(mixed)
     })
 
     it("skips target-language text before sending a translation request by default", async () => {

--- a/src/utils/host/translate/translate-text.ts
+++ b/src/utils/host/translate/translate-text.ts
@@ -7,6 +7,7 @@ import { LANG_CODE_TO_EN_NAME } from "@read-frog/definitions"
 import { toast } from "sonner"
 import { isAPIProviderConfig, isLLMProviderConfig } from "@/types/config/provider"
 import { getProviderConfigById } from "@/utils/config/helpers"
+import { isNoTranslationSentinel } from "@/utils/constants/prompt"
 import { detectLanguage } from "@/utils/content/language"
 import { i18n } from "@/utils/i18n"
 import { logger } from "@/utils/logger"
@@ -170,7 +171,7 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
   // Add extra hash tags for cache differentiation
   hashComponents.push(...extraHashTags)
 
-  return await sendMessage("enqueueTranslateRequest", {
+  const result = await sendMessage("enqueueTranslateRequest", {
     text: preparedText,
     langConfig,
     providerConfig,
@@ -182,6 +183,12 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     webContent: normalizedWebPageContext?.webContent,
     webSummary: normalizedWebPageContext?.webSummary,
   })
+  // The sentinel must be mapped here and only here: every batch-pipeline
+  // consumer (page paragraphs, document title, input translation, selection
+  // toolbar standard path) routes through this function and already handles
+  // "" gracefully. Mapping earlier — in the background — would fall out of
+  // the truthy-only cache write and re-hit the provider on every request.
+  return isNoTranslationSentinel(result) ? "" : result
 }
 
 export function validateTranslationConfigAndToast(

--- a/src/utils/prompts/__tests__/translate.test.ts
+++ b/src/utils/prompts/__tests__/translate.test.ts
@@ -1,6 +1,7 @@
 import type { Config } from "@/types/config/config"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { isNoTranslationSentinel, NO_TRANSLATION_SENTINEL } from "@/utils/constants/prompt"
 import { getSubtitlesTranslatePrompt } from "../subtitles"
 import { getTranslatePromptFromConfig } from "../translate"
 
@@ -128,5 +129,52 @@ describe("translate prompt tokens", () => {
     expect(result.systemPrompt).toContain("Video title: No title available")
     expect(result.systemPrompt).toContain("Video summary: No summary available")
     expect(result.systemPrompt).not.toContain("Video description:")
+  })
+})
+
+describe("no-translation sentinel", () => {
+  const defaultPromptsConfig: Pick<Config["translate"], "customPromptsConfig"> = {
+    customPromptsConfig: { promptId: null, patterns: [] },
+  }
+
+  it("appends the sentinel rule to batch prompts with the target language substituted", () => {
+    const result = getTranslatePromptFromConfig(defaultPromptsConfig, "Simplified Chinese", "Hi", {
+      isBatch: true,
+    })
+
+    expect(result.systemPrompt).toContain("Already-translated Input Rule")
+    expect(result.systemPrompt).toContain(NO_TRANSLATION_SENTINEL)
+    expect(result.systemPrompt).toContain("already entirely written in Simplified Chinese")
+    expect(result.systemPrompt).not.toContain("{{targetLanguage}}")
+  })
+
+  it("appends the sentinel rule after a custom system prompt in batch mode", () => {
+    const config: Pick<Config["translate"], "customPromptsConfig"> = {
+      customPromptsConfig: {
+        promptId: "custom",
+        patterns: [
+          { id: "custom", name: "Custom", systemPrompt: "My prompt", prompt: "{{input}}" },
+        ],
+      },
+    }
+
+    const result = getTranslatePromptFromConfig(config, "English", "Hi", { isBatch: true })
+
+    expect(result.systemPrompt).toContain("My prompt")
+    expect(result.systemPrompt).toContain(NO_TRANSLATION_SENTINEL)
+  })
+
+  it("does not add the sentinel rule to non-batch prompts", () => {
+    const result = getTranslatePromptFromConfig(defaultPromptsConfig, "English", "Hi")
+
+    expect(result.systemPrompt).not.toContain(NO_TRANSLATION_SENTINEL)
+  })
+
+  it("matches only a full trimmed sentinel segment", () => {
+    expect(isNoTranslationSentinel(NO_TRANSLATION_SENTINEL)).toBe(true)
+    expect(isNoTranslationSentinel(`  ${NO_TRANSLATION_SENTINEL}\n`)).toBe(true)
+    expect(isNoTranslationSentinel(`text ${NO_TRANSLATION_SENTINEL}`)).toBe(false)
+    expect(isNoTranslationSentinel("{{NO_TRANSLATION")).toBe(false)
+    expect(isNoTranslationSentinel("")).toBe(false)
   })
 })

--- a/src/utils/prompts/__tests__/translate.test.ts
+++ b/src/utils/prompts/__tests__/translate.test.ts
@@ -224,6 +224,33 @@ describe("no-translation sentinel", () => {
     expect(result.systemPrompt).not.toContain("{{targetLanguage}}")
   })
 
+  it("demonstrates the sentinel inside the batch format example (both anchors replaced)", () => {
+    const result = getTranslatePromptFromConfig(defaultPromptsConfig, "Simplified Chinese", "Hi", {
+      isBatch: true,
+    })
+
+    // Input example: Paragraph B is annotated as already in the target language.
+    expect(result.systemPrompt).toContain(
+      "Paragraph B (this one is already written in Simplified Chinese)",
+    )
+    // Output example: Paragraph B's slot is the sentinel, not "Translation B".
+    expect(result.systemPrompt).toContain(`${NO_TRANSLATION_SENTINEL}\n\n%%`)
+    expect(result.systemPrompt).not.toContain("Translation B")
+  })
+
+  it("never leaks the sentinel into subtitle prompts, which share the batch rules", async () => {
+    mockGetLocalConfig.mockResolvedValue(DEFAULT_CONFIG)
+
+    const result = await getSubtitlesTranslatePrompt("Japanese", "Hello world", {
+      context: { webTitle: "Video", webDescription: "Desc", videoSummary: "Sum" },
+    })
+
+    // The subtitle pipeline has no sentinel mapping; the marker must never
+    // appear in its prompts (rule or example).
+    expect(result.systemPrompt).not.toContain(NO_TRANSLATION_SENTINEL)
+    expect(result.systemPrompt).not.toContain("Already-translated Input Rule")
+  })
+
   it("appends the sentinel rule after a custom system prompt in batch mode", () => {
     const config: Pick<Config["translate"], "customPromptsConfig"> = {
       customPromptsConfig: {

--- a/src/utils/prompts/translate.ts
+++ b/src/utils/prompts/translate.ts
@@ -4,6 +4,7 @@ import { getLocalConfig } from "@/utils/config/storage"
 import { DEFAULT_CONFIG } from "../constants/config"
 import {
   DEFAULT_BATCH_TRANSLATE_PROMPT,
+  DEFAULT_SENTINEL_TRANSLATE_PROMPT,
   DEFAULT_TRANSLATE_PROMPT,
   DEFAULT_TRANSLATE_SYSTEM_PROMPT,
   getTokenCellText,
@@ -56,11 +57,17 @@ export function getTranslatePromptFromConfig(
     prompt = customPrompt?.prompt ?? DEFAULT_TRANSLATE_PROMPT
   }
 
-  // For batch mode, append batch rules to system prompt
+  // For batch mode, append batch rules to system prompt. The sentinel rule is
+  // appended ONLY here: batch prompts are built exclusively for the background
+  // translation pipeline, whose results all return through translateTextCore
+  // where the sentinel is mapped — the selection-toolbar streaming path never
+  // sees this instruction and can never render the marker raw.
   if (options?.isBatch) {
     systemPrompt = `${systemPrompt}
 
-${DEFAULT_BATCH_TRANSLATE_PROMPT}`
+${DEFAULT_BATCH_TRANSLATE_PROMPT}
+
+${DEFAULT_SENTINEL_TRANSLATE_PROMPT}`
   }
 
   // Build title and summary replacement values

--- a/src/utils/prompts/translate.ts
+++ b/src/utils/prompts/translate.ts
@@ -8,7 +8,7 @@ import {
 import { DEFAULT_CONFIG } from "../constants/config"
 import {
   BATCH_SEPARATOR,
-  DEFAULT_BATCH_TRANSLATE_PROMPT,
+  DEFAULT_BATCH_TRANSLATE_PROMPT_WITH_SENTINEL,
   DEFAULT_SENTINEL_TRANSLATE_PROMPT,
   DEFAULT_TRANSLATE_PROMPT,
   DEFAULT_TRANSLATE_SYSTEM_PROMPT,
@@ -69,15 +69,16 @@ export function getTranslatePromptFromConfig(
     prompt = customPrompt?.prompt ?? DEFAULT_TRANSLATE_PROMPT
   }
 
-  // For batch mode, append batch rules to system prompt. The sentinel rule is
-  // appended ONLY here: batch prompts are built exclusively for the background
-  // translation pipeline, whose results all return through translateTextCore
-  // where the sentinel is mapped — the selection-toolbar streaming path never
-  // sees this instruction and can never render the marker raw.
+  // For batch mode, append batch rules to system prompt. The sentinel rule and
+  // the sentinel-bearing format example are appended ONLY here: batch prompts
+  // are built exclusively for the background translation pipeline, whose
+  // results all return through translateTextCore where the sentinel is mapped
+  // — the selection-toolbar streaming path never sees this instruction and can
+  // never render the marker raw.
   if (options?.isBatch) {
     systemPrompt = `${systemPrompt}
 
-${DEFAULT_BATCH_TRANSLATE_PROMPT}
+${DEFAULT_BATCH_TRANSLATE_PROMPT_WITH_SENTINEL}
 
 ${DEFAULT_SENTINEL_TRANSLATE_PROMPT}`
   }


### PR DESCRIPTION
Part of the #1831 same-language-echo family (LLM-path primary signal; complements the franc pre-skip for short/ambiguous text and the normalization backstop).

The default prompt had no same-language instruction, so LLMs echoed already-target-language input and detection leaned on fragile string equality. Batch system prompts now instruct the model to output the exact marker `{{NO_TRANSLATION_NEEDED}}` for paragraphs already entirely in the target language.

Design points that are load-bearing:
- **Appended in the `isBatch` branch only** (same mechanism as the batch rules block): batch prompts are built exclusively for the background pipeline, whose results all return through `translateTextCore` — the selection-toolbar streaming path never sees the instruction and can never render the marker raw. Custom prompts get the rule too, same precedent as the batch block.
- **Cached RAW, mapped content-side**: the background cache only stores truthy results, so mapping to `""` there would re-hit the provider on every request. `translateTextCore` — the single choke point shared by page paragraphs, document title, input translation, and the selection-toolbar standard path — maps the sentinel to `""`, which every consumer already handles. A background test pins the cached-RAW contract.
- **Exact match on the full trimmed segment**: a sentinel embedded in longer text is shown verbatim (never stripped); disobedient models simply echo and fall through to the normalization backstop.

Note: the appended block changes the system prompt, which participates in request hashing — existing cache entries are orphaned once (one-time re-translation cost, also flushes stale cached echoes). Subtitles are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Live model testing (6 prompt variants compared)

Tested the fully-assembled batch system prompt against real providers (gpt-4o-mini, gpt-4.1-nano, deepseek-chat, grok non-reasoning, llama-3.1-8b-instant) across mixed/all-target/all-source/short-text batches:

- **Rule-only prompts are weak on mixed batches** (4/10 detection); integrating the marker into the batch format example doubles it (**9/10**) — models imitate examples more reliably than they follow rules. The shipped prompt uses this form (language-parameterized example, byte-identical to the tested variant: **18/20 pass, 0 false positives, 0 reverse-translations**).
- **All-target-language inputs never trigger the marker on any variant** (models echo instead) — harmless: echoes are hidden by the normalization backstop (#1835) and ≥50-char cases are pre-skipped by franc (#1836) before reaching the LLM.
- **Aggressive anti-echo wording backfires**: a stronger variant caused mainstream models to false-positive (swallowing mixed-language paragraphs), and two rejected variants induced Chinese→English reverse-translations. The shipped wording exhibits neither.
- The sentinel-bearing example lives in a webpage-only derived constant; **subtitles keep the plain batch prompt** (no sentinel mapping there) with a test guarding the boundary.
