### PR TITLE
fix(translate): abort timed-out queue attempts and coalesce identical batch requests

### DIFF
--- a/.changeset/queue-abort-and-coalesce.md
+++ b/.changeset/queue-abort-and-coalesce.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): cancel timed-out queue attempts with an AbortSignal before retrying and coalesce concurrent identical batch requests by cache hash, so provider slowdowns no longer stack duplicate in-flight requests

--- a/src/entrypoints/background/__tests__/translation-queues.test.ts
+++ b/src/entrypoints/background/__tests__/translation-queues.test.ts
@@ -195,6 +195,33 @@ describe("translation queue helpers", () => {
     )
   })
 
+  it("coalesces concurrent identical translate requests into one provider call", async () => {
+    executeTranslateMock.mockResolvedValue("translated")
+
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+
+    const makeRequest = () =>
+      handler({
+        data: {
+          text: "hello",
+          langConfig: DEFAULT_CONFIG.language,
+          providerConfig: llmProvider,
+          scheduleAt: Date.now(),
+          hash: "same-request-hash",
+        },
+      })
+
+    // both requests arrive before the first result lands in the translation cache
+    const results = await Promise.all([makeRequest(), makeRequest()])
+
+    expect(results).toEqual(["translated", "translated"])
+    expect(executeTranslateMock).toHaveBeenCalledTimes(1)
+    // the shared item is sent once, not as a two-item batch
+    expect(executeTranslateMock.mock.calls[0][0]).toBe("hello")
+  })
+
   it("passes subtitle summary through the translation queue without generating a new summary", async () => {
     const { setUpSubtitlesTranslationQueue } = await import("../translation-queues")
     await setUpSubtitlesTranslationQueue()
@@ -653,7 +680,7 @@ describe("translation queue helpers", () => {
       DEFAULT_CONFIG.language,
       googleProvider,
       expect.any(Function),
-      { textFormat: "html" },
+      { textFormat: "html", signal: expect.any(AbortSignal) },
     )
   })
 

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -62,6 +62,7 @@ async function getValidatedCachedTranslation(
 export async function executeBatchTranslation<TContext>(
   dataList: TranslateBatchData<TContext>[],
   promptResolver: PromptResolver<TContext>,
+  signal?: AbortSignal,
 ): Promise<string[]> {
   const { langConfig, providerConfig, context } = dataList[0]
   const texts = dataList.map((d) => d.text)
@@ -70,6 +71,7 @@ export async function executeBatchTranslation<TContext>(
   const result = await executeTranslate(batchText, langConfig, providerConfig, promptResolver, {
     isBatch: true,
     context,
+    signal,
   })
   return parseBatchResult(result)
 }
@@ -215,23 +217,27 @@ async function createTranslationQueues<TContext>(config: TranslationQueueSetupCo
       )
     },
     getCharacters: (data) => data.text.length,
+    getDedupKey: (data) => data.hash,
     executeBatch: async (dataList) => {
       const { providerConfig } = dataList[0]
       const hash = Sha256Hex(...dataList.map((d) => d.hash))
       const earliestScheduleAt = Math.min(...dataList.map((d) => d.scheduleAt))
 
-      const batchThunk = async (): Promise<string[]> => {
+      const batchThunk = async (signal?: AbortSignal): Promise<string[]> => {
         await putBatchRequestRecord({ originalRequestCount: dataList.length, providerConfig })
-        return await executeBatchTranslation(dataList, promptResolver)
+        return await executeBatchTranslation(dataList, promptResolver, signal)
       }
 
       return requestQueue.enqueue(batchThunk, earliestScheduleAt, hash)
     },
     executeIndividual: async (data) => {
       const { text, langConfig, providerConfig, hash, scheduleAt, context } = data
-      const thunk = async () => {
+      const thunk = async (signal?: AbortSignal) => {
         await putBatchRequestRecord({ originalRequestCount: 1, providerConfig })
-        return executeTranslate(text, langConfig, providerConfig, promptResolver, { context })
+        return executeTranslate(text, langConfig, providerConfig, promptResolver, {
+          context,
+          signal,
+        })
       }
       return requestQueue.enqueue(thunk, scheduleAt, hash)
     },
@@ -305,8 +311,11 @@ export async function setUpWebPageTranslationQueue() {
       result = await batchQueue.enqueue(data)
     } else {
       // Create thunk based on type and params
-      const thunk = () =>
-        executeTranslate(text, langConfig, providerConfig, getTranslatePrompt, { textFormat })
+      const thunk = (signal?: AbortSignal) =>
+        executeTranslate(text, langConfig, providerConfig, getTranslatePrompt, {
+          textFormat,
+          signal,
+        })
       result = await requestQueue.enqueue(thunk, scheduleAt, hash)
     }
 
@@ -394,8 +403,8 @@ export async function setUpSubtitlesTranslationQueue() {
       const data = { text, langConfig, providerConfig, hash, scheduleAt, context }
       result = await batchQueue.enqueue(data)
     } else {
-      const thunk = () =>
-        executeTranslate(text, langConfig, providerConfig, getSubtitlesTranslatePrompt)
+      const thunk = (signal?: AbortSignal) =>
+        executeTranslate(text, langConfig, providerConfig, getSubtitlesTranslatePrompt, { signal })
       result = await requestQueue.enqueue(thunk, scheduleAt, hash)
     }
 
@@ -428,7 +437,7 @@ export async function setUpSubtitlesTranslationQueue() {
   onMessage("microsoftBatchTranslate", async (message) => {
     const { texts, fromLang, toLang } = message.data
     const hash = Sha256Hex("ms-batch", fromLang, toLang, ...texts)
-    const thunk = () => microsoftTranslate(texts, fromLang, toLang)
+    const thunk = (signal?: AbortSignal) => microsoftTranslate(texts, fromLang, toLang, { signal })
     return requestQueue.enqueue(thunk, Date.now(), hash)
   })
 

--- a/src/utils/host/translate/api/ai.ts
+++ b/src/utils/host/translate/api/ai.ts
@@ -21,7 +21,7 @@ export async function aiTranslate<TContext>(
   targetLangName: string,
   providerConfig: LLMProviderConfig,
   promptResolver: PromptResolver<TContext>,
-  options?: { isBatch?: boolean; context?: TContext },
+  options?: { isBatch?: boolean; context?: TContext; signal?: AbortSignal },
 ) {
   const {
     id: providerId,
@@ -50,6 +50,7 @@ export async function aiTranslate<TContext>(
       reasoning,
       temperature,
       providerOptions,
+      abortSignal: options?.signal,
       maxRetries: 0, // Disable SDK built-in retries, let RequestQueue/BatchQueue handle it
     })
 

--- a/src/utils/host/translate/api/deepl.ts
+++ b/src/utils/host/translate/api/deepl.ts
@@ -14,7 +14,7 @@ export async function deeplTranslate(
   fromLang: LangCodeISO6391 | "auto",
   toLang: LangCodeISO6391,
   providerConfig: DeepLProviderConfig,
-  options?: { textFormat?: TranslationTextFormat },
+  options?: { textFormat?: TranslationTextFormat; signal?: AbortSignal },
 ): Promise<string> {
   const [translatedText] = await requestDeepLTranslations(
     [sourceText],
@@ -36,7 +36,7 @@ async function requestDeepLTranslations(
   fromLang: LangCodeISO6391 | "auto",
   toLang: LangCodeISO6391,
   providerConfig: DeepLProviderConfig,
-  options?: { textFormat?: TranslationTextFormat },
+  options?: { textFormat?: TranslationTextFormat; signal?: AbortSignal },
 ): Promise<string[]> {
   const apiKey = providerConfig.apiKey?.trim()
   if (!apiKey) {
@@ -54,12 +54,17 @@ async function requestDeepLTranslations(
     ...(options?.textFormat === "html" ? { tag_handling: "html" } : {}),
   })
 
-  const fetchResponse = await fetchDirect(url, apiKey, requestBody)
+  const fetchResponse = await fetchDirect(url, apiKey, requestBody, options?.signal)
 
   return await parseDeepLResponse(fetchResponse, sourceTexts.length)
 }
 
-async function fetchDirect(url: string, apiKey: string, body: string): Promise<Response> {
+async function fetchDirect(
+  url: string,
+  apiKey: string,
+  body: string,
+  signal?: AbortSignal,
+): Promise<Response> {
   const resp = await fetch(url, {
     method: "POST",
     headers: {
@@ -67,6 +72,7 @@ async function fetchDirect(url: string, apiKey: string, body: string): Promise<R
       "Content-Type": "application/json",
     },
     body,
+    signal,
   }).catch((error) => {
     throw new Error(`Network error during DeepL translation: ${error.message}`)
   })

--- a/src/utils/host/translate/api/deeplx.ts
+++ b/src/utils/host/translate/api/deeplx.ts
@@ -11,7 +11,7 @@ export async function deeplxTranslate(
   fromLang: LangCodeISO6391 | "auto",
   toLang: LangCodeISO6391,
   providerConfig: DeepLXProviderConfig,
-  options?: { textFormat?: TranslationTextFormat },
+  options?: { textFormat?: TranslationTextFormat; signal?: AbortSignal },
 ): Promise<string> {
   const baseURL = providerConfig.baseURL || DEFAULT_PROVIDER_CONFIG.deeplx.baseURL
   const apiKey = providerConfig.apiKey
@@ -36,16 +36,17 @@ export async function deeplxTranslate(
     ...(options?.textFormat === "html" ? { tag_handling: "html" } : {}),
   })
 
-  const fetchResponse = await fetchDirect(url, requestBody)
+  const fetchResponse = await fetchDirect(url, requestBody, options?.signal)
 
   return parseDeepLXResponse(fetchResponse)
 }
 
-async function fetchDirect(url: string, body: string) {
+async function fetchDirect(url: string, body: string, signal?: AbortSignal) {
   const resp = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body,
+    signal,
   }).catch((error) => {
     throw new Error(`Network error during DeepLX translation: ${error.message}`)
   })

--- a/src/utils/host/translate/api/google.ts
+++ b/src/utils/host/translate/api/google.ts
@@ -10,7 +10,7 @@ export async function googleTranslate(
   sourceText: string,
   fromLang: string,
   toLang: string,
-  options?: { textFormat?: TranslationTextFormat },
+  options?: { textFormat?: TranslationTextFormat; signal?: AbortSignal },
 ): Promise<string> {
   // translateHtml parses the request text as HTML, so plain source text must be
   // escaped (& < > nbsp) before sending, while html input (translationOnly page
@@ -35,6 +35,7 @@ export async function googleTranslate(
       "X-Goog-API-Key": GOOGLE_TRANSLATE_HTML_API_KEY,
     },
     body: JSON.stringify([[[requestText], fromLang, toLang], GOOGLE_TRANSLATE_HTML_CLIENT]),
+    signal: options?.signal,
   }).catch((error) => {
     throw attachRequestErrorMeta(new Error(`Network error during translation: ${error.message}`), {
       kind: "network",

--- a/src/utils/host/translate/api/microsoft.ts
+++ b/src/utils/host/translate/api/microsoft.ts
@@ -4,19 +4,19 @@ export async function microsoftTranslate(
   source: string,
   fromLang: string,
   toLang: string,
-  options?: { textFormat?: TranslationTextFormat },
+  options?: { textFormat?: TranslationTextFormat; signal?: AbortSignal },
 ): Promise<string>
 export async function microsoftTranslate(
   source: string[],
   fromLang: string,
   toLang: string,
-  options?: { textFormat?: TranslationTextFormat },
+  options?: { textFormat?: TranslationTextFormat; signal?: AbortSignal },
 ): Promise<string[]>
 export async function microsoftTranslate(
   source: string | string[],
   fromLang: string,
   toLang: string,
-  options?: { textFormat?: TranslationTextFormat },
+  options?: { textFormat?: TranslationTextFormat; signal?: AbortSignal },
 ): Promise<string | string[]> {
   const isSingle = typeof source === "string"
   const texts = isSingle ? [source] : source
@@ -26,7 +26,7 @@ export async function microsoftTranslate(
   }
 
   const effectiveFromLang = fromLang === "auto" ? "" : fromLang
-  const token = await refreshMicrosoftToken()
+  const token = await refreshMicrosoftToken(options?.signal)
 
   // plain translates the source as literal text (tag-like text such as "<b then"
   // is otherwise left untranslated); html preserves the markup structure of
@@ -43,6 +43,7 @@ export async function microsoftTranslate(
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(texts.map((text) => ({ Text: text }))),
+      signal: options?.signal,
     },
   ).catch((error) => {
     throw new Error(`Network error during Microsoft translation: ${error.message}`)
@@ -83,9 +84,9 @@ export async function microsoftTranslate(
   }
 }
 
-export async function refreshMicrosoftToken(): Promise<string> {
+export async function refreshMicrosoftToken(signal?: AbortSignal): Promise<string> {
   try {
-    const resp = await fetch("https://edge.microsoft.com/translate/auth")
+    const resp = await fetch("https://edge.microsoft.com/translate/auth", { signal })
 
     if (!resp.ok) {
       throw new Error(`Failed to refresh Microsoft token: ${resp.status} ${resp.statusText}`)

--- a/src/utils/host/translate/execute-translate.ts
+++ b/src/utils/host/translate/execute-translate.ts
@@ -21,6 +21,7 @@ export async function executeTranslate<TContext>(
     isBatch?: boolean
     context?: TContext
     textFormat?: TranslationTextFormat
+    signal?: AbortSignal
   },
 ) {
   const preparedText = prepareTranslationText(text)
@@ -41,10 +42,12 @@ export async function executeTranslate<TContext>(
     if (provider === "google-translate") {
       translatedText = await googleTranslate(preparedText, sourceLang, targetLang, {
         textFormat: options?.textFormat,
+        signal: options?.signal,
       })
     } else if (provider === "microsoft-translate") {
       translatedText = await microsoftTranslate(preparedText, sourceLang, targetLang, {
         textFormat: options?.textFormat,
+        signal: options?.signal,
       })
     }
   } else if (isPureAPIProvider(provider)) {
@@ -57,10 +60,12 @@ export async function executeTranslate<TContext>(
     if (provider === "deeplx") {
       translatedText = await deeplxTranslate(preparedText, sourceLang, targetLang, providerConfig, {
         textFormat: options?.textFormat,
+        signal: options?.signal,
       })
     } else if (provider === "deepl") {
       translatedText = await deeplTranslate(text, sourceLang, targetLang, providerConfig, {
         textFormat: options?.textFormat,
+        signal: options?.signal,
       })
     }
   } else if (isLLMProviderConfig(providerConfig)) {

--- a/src/utils/request/__tests__/batch-queue.test.ts
+++ b/src/utils/request/__tests__/batch-queue.test.ts
@@ -82,6 +82,7 @@ function createBatchQueue(
   options?: {
     maxRetries?: number
     enableFallbackToIndividual?: boolean
+    getDedupKey?: (data: TranslateBatchData) => string | undefined
     executeIndividual?: (data: TranslateBatchData) => Promise<string>
     onError?: (
       error: Error,
@@ -93,6 +94,7 @@ function createBatchQueue(
     ...config,
     maxRetries: options?.maxRetries,
     enableFallbackToIndividual: options?.enableFallbackToIndividual,
+    getDedupKey: options?.getDedupKey,
     getBatchKey: (data) => {
       return `${data.langConfig.sourceCode}-${data.langConfig.targetCode}-${data.providerConfig.id}`
     },
@@ -720,6 +722,140 @@ describe("batchQueue – error handling", () => {
       error,
       expect.objectContaining({ retryCount: 0, isFallback: false }),
     )
+  })
+})
+
+describe("batchQueue – in-flight coalescing", () => {
+  const dedupOptions = {
+    getDedupKey: (data: TranslateBatchData) => data.hash,
+  }
+
+  it("coalesces concurrent enqueues with the same dedup key into one request", async () => {
+    vi.useFakeTimers()
+    mockTranslateSuccess(["result"])
+
+    const requestQueue = new RequestQueue(baseRequestQueueConfig)
+    const batchQueue = createBatchQueue(requestQueue, baseBatchConfig, dedupOptions)
+
+    const first = batchQueue.enqueue({
+      text: "Hello",
+      langConfig: sampleLangConfig,
+      providerConfig: sampleProviderConfig,
+      hash: "same-hash",
+    })
+    const second = batchQueue.enqueue({
+      text: "Hello",
+      langConfig: sampleLangConfig,
+      providerConfig: sampleProviderConfig,
+      hash: "same-hash",
+    })
+
+    expect(second).toBe(first)
+
+    vi.advanceTimersByTime(baseBatchConfig.batchDelay)
+    vi.advanceTimersByTime(0)
+
+    await expect(Promise.all([first, second])).resolves.toEqual(["result", "result"])
+    expect(mockExecuteTranslate).toHaveBeenCalledTimes(1)
+    // the coalesced item appears once in the batch payload, not twice
+    expect(mockExecuteTranslate.mock.calls[0][0]).toBe("Hello")
+  })
+
+  it("does not coalesce enqueues with different dedup keys", async () => {
+    vi.useFakeTimers()
+    mockTranslateSuccess(["result1", "result2"])
+
+    const requestQueue = new RequestQueue(baseRequestQueueConfig)
+    const batchQueue = createBatchQueue(requestQueue, baseBatchConfig, dedupOptions)
+
+    const first = batchQueue.enqueue({
+      text: "Hello",
+      langConfig: sampleLangConfig,
+      providerConfig: sampleProviderConfig,
+      hash: "hash-one",
+    })
+    const second = batchQueue.enqueue({
+      text: "Hello",
+      langConfig: sampleLangConfig,
+      providerConfig: sampleProviderConfig,
+      hash: "hash-two",
+    })
+
+    expect(second).not.toBe(first)
+
+    vi.advanceTimersByTime(baseBatchConfig.batchDelay)
+    vi.advanceTimersByTime(0)
+
+    await expect(Promise.all([first, second])).resolves.toEqual(["result1", "result2"])
+    // both items are translated as distinct entries of a single batch
+    expect(mockExecuteTranslate).toHaveBeenCalledTimes(1)
+    expect(mockExecuteTranslate.mock.calls[0][0]).toBe(`Hello\n\n${BATCH_SEPARATOR}\n\nHello`)
+  })
+
+  it("issues a fresh request for the same key after the in-flight one resolves", async () => {
+    vi.useFakeTimers()
+    let callCount = 0
+    mockExecuteTranslate.mockImplementation(() => {
+      callCount++
+      return Promise.resolve(`result-${callCount}`)
+    })
+
+    const requestQueue = new RequestQueue(baseRequestQueueConfig)
+    const batchQueue = createBatchQueue(requestQueue, baseBatchConfig, dedupOptions)
+
+    const data = {
+      text: "Hello",
+      langConfig: sampleLangConfig,
+      providerConfig: sampleProviderConfig,
+      hash: "same-hash",
+    }
+
+    const first = batchQueue.enqueue(data)
+    await vi.advanceTimersByTimeAsync(baseBatchConfig.batchDelay)
+    await expect(first).resolves.toBe("result-1")
+
+    const second = batchQueue.enqueue(data)
+    await vi.advanceTimersByTimeAsync(baseBatchConfig.batchDelay)
+    await expect(second).resolves.toBe("result-2")
+
+    expect(mockExecuteTranslate).toHaveBeenCalledTimes(2)
+  })
+
+  it("shares the failure across coalesced enqueues and releases the key", async () => {
+    vi.useFakeTimers()
+    const error = new Error("Translation failed")
+    mockTranslateError(error)
+
+    const requestQueue = new RequestQueue(baseRequestQueueConfig)
+    const batchQueue = createBatchQueue(requestQueue, baseBatchConfig, {
+      ...dedupOptions,
+      maxRetries: 0,
+      enableFallbackToIndividual: false,
+    })
+
+    const data = {
+      text: "Hello",
+      langConfig: sampleLangConfig,
+      providerConfig: sampleProviderConfig,
+      hash: "same-hash",
+    }
+
+    const first = batchQueue.enqueue(data)
+    const second = batchQueue.enqueue(data)
+
+    await vi.advanceTimersByTimeAsync(baseBatchConfig.batchDelay)
+
+    await expect(first).rejects.toBe(error)
+    await expect(second).rejects.toBe(error)
+    expect(mockExecuteTranslate).toHaveBeenCalledTimes(1)
+
+    // the failed key is released, so a later enqueue retries
+    mockTranslateSuccess(["recovered"])
+    const third = batchQueue.enqueue(data)
+    await vi.advanceTimersByTimeAsync(baseBatchConfig.batchDelay)
+
+    await expect(third).resolves.toBe("recovered")
+    expect(mockExecuteTranslate).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/src/utils/request/__tests__/request-queue.test.ts
+++ b/src/utils/request/__tests__/request-queue.test.ts
@@ -337,6 +337,130 @@ describe("requestQueue – timeout handling", () => {
   })
 })
 
+// 8b. Timeout aborts the in-flight attempt
+describe("requestQueue – timeout aborts the in-flight attempt", () => {
+  it("cancels the timed-out attempt so the retry never runs concurrently", async () => {
+    vi.useFakeTimers()
+
+    const q = new RequestQueue({
+      ...baseConfig,
+      timeoutMs: 1000,
+      maxRetries: 2,
+      baseRetryDelayMs: 100,
+    })
+
+    let running = 0
+    let maxConcurrent = 0
+    const attemptSignals: (AbortSignal | undefined)[] = []
+
+    const thunk = (signal?: AbortSignal) => {
+      const attempt = attemptSignals.push(signal)
+      running++
+      maxConcurrent = Math.max(maxConcurrent, running)
+      return new Promise<string>((resolve, reject) => {
+        // first attempt hangs far past the timeout, the retry finishes quickly
+        const timer = setTimeout(
+          () => {
+            running--
+            resolve("done")
+          },
+          attempt === 1 ? 60_000 : 100,
+        )
+        signal?.addEventListener("abort", () => {
+          clearTimeout(timer)
+          running--
+          reject(signal.reason)
+        })
+      })
+    }
+
+    const promise = q.enqueue(thunk, Date.now(), "abort-on-timeout")
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(running).toBe(1)
+
+    // timeout fires: the attempt must be cancelled before the retry starts
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(attemptSignals).toHaveLength(1)
+    expect(attemptSignals[0]?.aborted).toBe(true)
+    expect(running).toBe(0)
+
+    // retry (100ms base delay + jitter) runs alone and succeeds
+    await vi.advanceTimersByTimeAsync(500)
+    expect(attemptSignals).toHaveLength(2)
+    expect(maxConcurrent).toBe(1)
+    await expect(promise).resolves.toBe("done")
+  })
+
+  it("still rejects with the timeout error when retries are exhausted", async () => {
+    vi.useFakeTimers()
+
+    const q = new RequestQueue({
+      ...baseConfig,
+      timeoutMs: 1000,
+      maxRetries: 0,
+    })
+
+    let sawAbort = false
+    const thunk = (signal?: AbortSignal) =>
+      new Promise<string>((resolve, reject) => {
+        const timer = setTimeout(resolve, 60_000, "too-slow")
+        signal?.addEventListener("abort", () => {
+          clearTimeout(timer)
+          sawAbort = true
+          reject(signal.reason)
+        })
+      })
+
+    const promise = q.enqueue(thunk, Date.now(), "timeout-no-retry")
+    promise.catch(() => {})
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(sawAbort).toBe(true)
+    await expect(promise).rejects.toThrow("timed out after 1000ms")
+  })
+
+  it("aborts other in-flight attempts when a 429 drains the backlog", async () => {
+    vi.useFakeTimers()
+
+    const q = new RequestQueue({
+      ...baseConfig,
+      rate: 10,
+      capacity: 2,
+      maxRetries: 2,
+      baseRetryDelayMs: 100,
+    })
+
+    const rateLimitedError = Object.assign(new Error("Too Many Requests"), {
+      statusCode: 429,
+    })
+    let aborted = false
+
+    const firstPromise = q.enqueue(() => Promise.reject(rateLimitedError), Date.now(), "first")
+    firstPromise.catch(() => {})
+
+    const secondPromise = q.enqueue(
+      (signal?: AbortSignal) =>
+        new Promise((_, reject) => {
+          signal?.addEventListener("abort", () => {
+            aborted = true
+            reject(signal.reason)
+          })
+        }),
+      Date.now(),
+      "second",
+    )
+    secondPromise.catch(() => {})
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(aborted).toBe(true)
+    await expect(firstPromise).rejects.toBe(rateLimitedError)
+    await expect(secondPromise).rejects.toBe(rateLimitedError)
+  })
+})
+
 // 9. Retry functionality
 describe("requestQueue – retry functionality", () => {
   it("succeeds when retry eventually works", async () => {

--- a/src/utils/request/batch-queue.ts
+++ b/src/utils/request/batch-queue.ts
@@ -34,6 +34,7 @@ export interface BatchOptions<T, R> {
   enableFallbackToIndividual?: boolean
   getBatchKey: (data: T) => string
   getCharacters: (data: T) => number
+  getDedupKey?: (data: T) => string | undefined
   executeBatch: (dataList: T[]) => Promise<R[]>
   executeIndividual?: (data: T) => Promise<R>
   onError?: (
@@ -44,6 +45,7 @@ export interface BatchOptions<T, R> {
 
 export class BatchQueue<T, R> {
   private pendingBatchMap = new Map<string, PendingBatch<T, R>>()
+  private inFlightTasks = new Map<string, Promise<R>>()
   private nextScheduleTimer: NodeJS.Timeout | null = null
   private maxCharactersPerBatch: number
   private maxItemsPerBatch: number
@@ -52,6 +54,7 @@ export class BatchQueue<T, R> {
   private enableFallbackToIndividual: boolean
   private getBatchKey: (data: T) => string
   private getCharacters: (data: T) => number
+  private getDedupKey?: (data: T) => string | undefined
   private executeBatch: (dataList: T[]) => Promise<R[]>
   private executeIndividual?: (data: T) => Promise<R>
   private onError?: (
@@ -67,12 +70,21 @@ export class BatchQueue<T, R> {
     this.enableFallbackToIndividual = config.enableFallbackToIndividual ?? true
     this.getBatchKey = config.getBatchKey
     this.getCharacters = config.getCharacters
+    this.getDedupKey = config.getDedupKey
     this.executeBatch = config.executeBatch
     this.executeIndividual = config.executeIndividual
     this.onError = config.onError
   }
 
   enqueue(data: T): Promise<R> {
+    const dedupKey = this.getDedupKey?.(data)
+    if (dedupKey) {
+      const inFlightPromise = this.inFlightTasks.get(dedupKey)
+      if (inFlightPromise) {
+        return inFlightPromise
+      }
+    }
+
     let resolve!: (value: R) => void
     let reject!: (error: Error) => void
     const promise = new Promise<R>((res, rej) => {
@@ -82,6 +94,16 @@ export class BatchQueue<T, R> {
 
     const batchKey = this.getBatchKey(data)
     const task: BatchTask<T, R> = { data, resolve, reject }
+
+    if (dedupKey) {
+      this.inFlightTasks.set(dedupKey, promise)
+      const release = () => {
+        if (this.inFlightTasks.get(dedupKey) === promise) {
+          this.inFlightTasks.delete(dedupKey)
+        }
+      }
+      promise.then(release, release)
+    }
 
     this.addTaskToBatch(task, batchKey)
     this.schedule()

--- a/src/utils/request/request-queue.ts
+++ b/src/utils/request/request-queue.ts
@@ -7,7 +7,7 @@ import { defaultRequestRetryPolicy } from "./retry-policy"
 
 export interface RequestTask {
   id: string
-  thunk: () => Promise<any>
+  thunk: (signal?: AbortSignal) => Promise<any>
   promise: Promise<any>
   resolve: (value: any) => void
   reject: (error: any) => void
@@ -17,7 +17,7 @@ export interface RequestTask {
   drained: boolean
 }
 
-type QueuedRequestTask = RequestTask & { hash: string }
+type QueuedRequestTask = RequestTask & { hash: string; abortController?: AbortController }
 
 export interface QueueOptions {
   rate: number // tokens/sec
@@ -46,7 +46,11 @@ export class RequestQueue {
     this.waitingQueue = new BinaryHeapPQ<QueuedRequestTask>()
   }
 
-  enqueue<T>(thunk: () => Promise<T>, scheduleAt: number, hash: string): Promise<T> {
+  enqueue<T>(
+    thunk: (signal?: AbortSignal) => Promise<T>,
+    scheduleAt: number,
+    hash: string,
+  ): Promise<T> {
     const duplicateTask = this.duplicateTask(hash)
     if (duplicateTask) {
       // console.info(`🔄 Found duplicate task for hash: ${hash}, returning existing promise`)
@@ -144,18 +148,28 @@ export class RequestQueue {
     // console.info(`🏃 Starting execution of task ${task.id} (attempt ${task.retryCount + 1}) at ${Date.now()}`)
 
     let timeoutId: NodeJS.Timeout | null = null
+    const abortController = new AbortController()
+    task.abortController = abortController
 
     try {
       // Create a timeout promise
       const timeoutPromise = new Promise((_, reject) => {
         timeoutId = setTimeout(() => {
           // console.info(`⏰ Task ${task.id} timed out after ${this.options.timeoutMs}ms`)
-          reject(new Error(`Task ${task.id} timed out after ${this.options.timeoutMs}ms`))
+          const timeoutError = new Error(
+            `Task ${task.id} timed out after ${this.options.timeoutMs}ms`,
+          )
+          // Reject before aborting: the race must settle with the timeout error
+          // (which the retry policy treats as retryable), not with whatever abort
+          // error the cancelled thunk rejects with.
+          reject(timeoutError)
+          abortController.abort(timeoutError)
         }, this.options.timeoutMs)
       })
 
-      // Race between the actual task and timeout
-      const result = await Promise.race([task.thunk(), timeoutPromise])
+      // Race between the actual task and timeout; the signal cancels the
+      // in-flight attempt on timeout so a retry never runs concurrently with it
+      const result = await Promise.race([task.thunk(abortController.signal), timeoutPromise])
 
       // Clear timeout if task completed successfully
       if (timeoutId) {
@@ -216,6 +230,10 @@ export class RequestQueue {
         clearTimeout(timeoutId)
       }
 
+      if (task.abortController === abortController) {
+        task.abortController = undefined
+      }
+
       if (this.executingTasks.get(task.hash) === task) {
         this.executingTasks.delete(task.hash)
       }
@@ -256,6 +274,7 @@ export class RequestQueue {
 
     task.drained = true
     task.reject(error)
+    task.abortController?.abort(error)
   }
 
   private refillTokens() {


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Fixes the two #1831-family findings that were deliberately deferred from #1833:

**1. RequestQueue timeout didn't cancel the underlying request.** The timeout only rejected the `Promise.race`; the provider request kept running while the retry re-executed the thunk, so a slow provider could accumulate up to 3 concurrent copies of the same batch request. Each execution attempt now gets its own `AbortController`:

- On timeout, the race is rejected with the timeout error first (so the retry policy still classifies the failure as retryable), then the controller aborts — the timed-out attempt is cancelled before the retry starts.
- The 429/401/403/404 backlog drain also aborts in-flight attempts, which previously kept running after their promises were drained.
- The signal threads from the queue thunk through `executeTranslate` down to every provider: `abortSignal` on the AI-SDK `generateText` call, and `fetch(..., { signal })` for Google, Microsoft (including token refresh), DeepL, and DeepLX.

**2. BatchQueue had no in-flight coalescing.** Identical paragraph texts requested concurrently each became separate provider requests — the background handler checks `db.translationCache` before enqueueing, but nothing covered the window between concurrent identical requests and the first cache write. `BatchOptions` gains an optional `getDedupKey`; concurrent enqueues sharing a key get one promise and the item enters the batch once. The key is released when the request settles, so failures can be retried and the db cache stays the durable dedup. Translation queues wire it to `data.hash` — the same hash used for the translation cache.

Public queue APIs are unchanged: `enqueue(thunk, scheduleAt, hash)` keeps its shape (the thunk parameter widened to `(signal?: AbortSignal) => Promise<T>`, which accepts all existing zero-arg thunks), and `getDedupKey` is optional.

## Related Issue

Deferred follow-ups from #1833 (issue #1831). Does not close either.

## How Has This Been Tested?

- [x] Added unit tests

New tests cover: (a) timeout aborts the in-flight attempt with max concurrency asserted at 1, retries-exhausted still rejecting with the timeout error, and backlog drain aborting in-flight attempts; (b) two concurrent same-hash enqueues → one provider call, two resolved promises — at both the BatchQueue unit level and end-to-end through the `enqueueTranslateRequest` handler; (c) different-hash requests unaffected, plus key-release-after-settle and shared-failure-then-recovery.

Full suite green: 188 test files / 1716 tests, type-check and format clean. One existing assertion was updated ("forwards the textFormat to executeTranslate") because it strict-equality-matched the options object, which now always carries the abort signal.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Patch changeset included (`.changeset/queue-abort-and-coalesce.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)