### PR TITLE
fix(translate): remove orphan splitText tails when a failed restore leaves duplicates

### DIFF
--- a/.changeset/orphan-split-tail-cleanup.md
+++ b/.changeset/orphan-split-tail-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): remove orphan splitText tails when the host rewrites or replaces the source Text node, so failed split restores no longer duplicate stale tail text on pre-wrap sites

--- a/src/utils/host/translate/dom/__tests__/virtual-paragraph-lifecycle.test.ts
+++ b/src/utils/host/translate/dom/__tests__/virtual-paragraph-lifecycle.test.ts
@@ -98,7 +98,7 @@ describe("virtual paragraph lifecycle", () => {
     expect(source.data).toBe("one\n\ntwo")
   })
 
-  it("removes wrappers but preserves split fragments when the host modifies the source", () => {
+  it("removes proven duplicate tails when the host rewrites the source in place", () => {
     const originalValue = "one\n\ntwo\n\nthree"
     const layoutSource = document.createElement("div")
     const source = document.createTextNode(originalValue)
@@ -109,10 +109,33 @@ describe("virtual paragraph lifecycle", () => {
 
     source.data = "host update"
 
-    expect(disposeVirtualParagraphGroup(group)).toEqual({ restored: 0, skipped: 1 })
+    expect(disposeVirtualParagraphGroup(group)).toEqual({ restored: 1, skipped: 0 })
     expect(source.data).toBe("host update")
+    expect(layoutSource.childNodes).toHaveLength(1)
+    expect(layoutSource.firstChild).toBe(source)
+    expect(tails.every((tail) => !tail.isConnected)).toBe(true)
+    expect(wrappers.every((wrapper) => !wrapper.isConnected)).toBe(true)
+  })
+
+  it("preserves split fragments when the site inserts its own node between them", () => {
+    const originalValue = "one\n\ntwo\n\nthree"
+    const layoutSource = document.createElement("div")
+    const source = document.createTextNode(originalValue)
+    layoutSource.append(source)
+    document.body.append(layoutSource)
+    const { group, wrappers } = createSplitGroup(layoutSource, source, [3, 8])
+    const tails = [...group.splitRecords[0].createdTails]
+    const siteNode = document.createElement("span")
+    siteNode.textContent = "site content"
+
+    layoutSource.insertBefore(siteNode, tails[0])
+
+    expect(disposeVirtualParagraphGroup(group)).toEqual({ restored: 0, skipped: 1 })
+    expect(source.data).toBe("one")
+    expect(siteNode.isConnected).toBe(true)
     expect(tails.every((tail) => tail.isConnected)).toBe(true)
     expect(tails.every((tail) => layoutSource.contains(tail))).toBe(true)
+    expect(tails.map((tail) => tail.data)).toEqual(["\n\ntwo", "\n\nthree"])
     expect(wrappers.every((wrapper) => !wrapper.isConnected)).toBe(true)
   })
 
@@ -135,7 +158,7 @@ describe("virtual paragraph lifecycle", () => {
     expect(tails.every((tail) => !tail.isConnected)).toBe(true)
   })
 
-  it("does not overwrite a replacement Text or delete the surviving tails", () => {
+  it("removes connected unchanged tails when the host replaces the source Text node", () => {
     const originalValue = "one\n\ntwo\n\nthree"
     const layoutSource = document.createElement("div")
     const source = document.createTextNode(originalValue)
@@ -149,10 +172,30 @@ describe("virtual paragraph lifecycle", () => {
 
     expect(disposeVirtualParagraphGroup(group)).toEqual({ restored: 0, skipped: 1 })
     expect(replacement.data).toBe("replacement")
+    expect(layoutSource.childNodes).toHaveLength(1)
     expect(layoutSource.firstChild).toBe(replacement)
-    expect(tails.every((tail) => tail.isConnected)).toBe(true)
-    expect(tails.every((tail) => layoutSource.contains(tail))).toBe(true)
+    expect(tails.every((tail) => !tail.isConnected)).toBe(true)
     expect(wrappers.every((wrapper) => !wrapper.isConnected)).toBe(true)
+  })
+
+  it("keeps a host-edited tail when the source Text node is replaced", () => {
+    const originalValue = "one\n\ntwo\n\nthree"
+    const layoutSource = document.createElement("div")
+    const source = document.createTextNode(originalValue)
+    layoutSource.append(source)
+    document.body.append(layoutSource)
+    const { group } = createSplitGroup(layoutSource, source, [3, 8])
+    const tails = [...group.splitRecords[0].createdTails]
+    const replacement = document.createTextNode("replacement")
+
+    tails[1].data = "edited by host"
+    source.replaceWith(replacement)
+
+    expect(disposeVirtualParagraphGroup(group)).toEqual({ restored: 0, skipped: 1 })
+    expect(layoutSource.firstChild).toBe(replacement)
+    expect(tails[0].isConnected).toBe(false)
+    expect(tails[1].isConnected).toBe(true)
+    expect(tails[1].data).toBe("edited by host")
   })
 
   it("keeps split state until the last wrapper is dropped", () => {

--- a/src/utils/host/translate/dom/translation-cleanup.ts
+++ b/src/utils/host/translate/dom/translation-cleanup.ts
@@ -47,11 +47,25 @@ function restoreTextSplit(record: TextSplitRecord): boolean {
     sourceValueAfterSplit,
     tailValuesAfterSplit,
   } = record
-  if (!source.isConnected || source.parentNode !== parent) return false
+  const isUnchangedTail = (tail: Text, index: number) => tail.data === tailValuesAfterSplit[index]
+
+  if (!source.isConnected || source.parentNode !== parent) {
+    // The host replaced or moved the original Text node, so the split can never
+    // be rejoined. Tails still connected with their post-split values are stale
+    // fragments of content the replacement already owns; leaving them would
+    // duplicate the old tail text next to the host's new content (#1831).
+    createdTails.forEach((tail, index) => {
+      if (tail.isConnected && isUnchangedTail(tail, index)) tail.remove()
+    })
+    return false
+  }
 
   let previous: Text = source
   for (const tail of createdTails) {
     if (!tail.isConnected || tail.parentNode !== parent || previous.nextSibling !== tail) {
+      // The site inserted its own nodes between the fragments. The tails are
+      // real halves of live host content there, and removing them would delete
+      // host text (#249) — leave the split in place.
       return false
     }
     previous = tail
@@ -64,16 +78,13 @@ function restoreTextSplit(record: TextSplitRecord): boolean {
     return true
   }
 
-  const tailsAreUnchanged = createdTails.every(
-    (tail, index) => tail.data === tailValuesAfterSplit[index],
-  )
-  const hostReconstructedFullText =
-    source.data !== sourceValueAfterSplit && source.data.startsWith(originalValue)
-  if (tailsAreUnchanged && hostReconstructedFullText) {
-    // Frameworks such as React can update their original Text node with the
-    // complete expanded value while leaving splitText-created tails behind.
-    // The unchanged tails are then proven duplicates; keep the host value and
-    // remove only the fragments Read Frog created.
+  const tailsAreUnchanged = createdTails.every(isUnchangedTail)
+  if (tailsAreUnchanged && source.data !== sourceValueAfterSplit) {
+    // Frameworks such as React rewrite their original Text node with the
+    // complete new value while leaving splitText-created tails behind. With
+    // the chain intact and every tail still holding its post-split value, the
+    // tails are proven duplicates; keep the host value and remove only the
+    // fragments Read Frog created.
     createdTails.forEach((tail) => tail.remove())
     return true
   }


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Virtual-paragraph translation splits the site's `Text` nodes via `splitText` (recorded as `createdTails` in `TextSplitRecord`). On dispose, `restoreTextSplit` returned `false` whenever the host had changed the split region — leaving the splitText-created tails **connected in the DOM**. On pre-wrap sites this visibly duplicated the old tail text next to the host's new content, and the next retranslation rebuilt its plan from the corrupted DOM.

This PR removes proven-duplicate tails — still connected **and** still holding their exact post-split values — in the two failure shapes where they are provably stale:

- **Source rewritten in place** (source connected, sibling chain intact, tails unchanged): generalizes the existing `hostReconstructedFullText` special case by dropping the `startsWith(originalValue)` requirement. Any in-place rewrite with unchanged tails now drops the tails and keeps the host's value.
- **Source detached or moved** (replaced/removed by the host while tails remain connected): unchanged tails are removed; the replacement node is never touched.

Tails are deliberately **preserved** when:

- the site inserted its own nodes between the fragments while the source data is unchanged — there the tail half is real host content, and deleting it would be a #249-style regression;
- the host edited a tail's data — edited tails are treated as adopted host content in every shape.

## Related Issue

Related to #1831 (follow-up to the retranslation-storm family of fixes; the leftover tails were a remaining source of DOM corruption feeding retranslation).

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Extended `virtual-paragraph-lifecycle.test.ts` (17 tests, all passing):

- in-place rewrite → duplicate tails removed, host text preserved (expectation flipped from the previous preserve behavior)
- source `Text` replaced → connected unchanged tails removed, replacement untouched (expectation flipped)
- **new:** site-inserted node between fragments with unchanged source → tails preserved (#249 guard)
- **new:** host-edited tail survives source replacement while the unchanged tail is removed

Full suite: 188 files, 1710/1710 tests passing; `oxlint --type-aware --type-check` clean.

## Screenshots

N/A (DOM lifecycle fix; no UI change)

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Includes a `patch` changeset (`.changeset/orphan-split-tail-cleanup.md`). The `restored`/`skipped` counters keep honest semantics: the in-place-rewrite shape counts as `restored` (consistent with the pre-existing expanded-value path), while the detached-source shape counts as `skipped` — orphans are cleaned but nothing was restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)