### PR TITLE
fix(translate): stop retaining detached elements in translationOnly originalContentMap

### DIFF
--- a/.changeset/original-content-weakmap.md
+++ b/.changeset/original-content-weakmap.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): store translationOnly original-content snapshots in a WeakMap so elements removed by the site (SPA re-renders, infinite scroll) no longer retain detached DOM nodes and their HTML strings for the page's lifetime

--- a/src/utils/host/translate/core/translation-state.ts
+++ b/src/utils/host/translate/core/translation-state.ts
@@ -44,7 +44,9 @@ export interface BilingualTranslationState {
 
 // State management for translation operations
 export const translatingNodes = new WeakSet<ChildNode>()
-export const originalContentMap = new Map<Element, string>()
+// WeakMap so elements removed by the site (SPA re-renders, infinite scroll)
+// don't pin themselves and their innerHTML snapshots for the page's lifetime.
+export const originalContentMap = new WeakMap<Element, string>()
 
 const virtualParagraphGroupsBySource = new WeakMap<HTMLElement, VirtualParagraphGroup>()
 const virtualParagraphGroupsByWrapper = new WeakMap<HTMLElement, VirtualParagraphGroup>()

--- a/src/utils/iconify/__tests__/iconify-internal-api.test.ts
+++ b/src/utils/iconify/__tests__/iconify-internal-api.test.ts
@@ -1,5 +1,11 @@
-import { _api } from "@iconify/react"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
+
+// This file is a canary against @iconify/react upgrades dropping the internal
+// _api that setup-background-fetch.ts depends on, so it must import the real
+// package, not the inert global mock from vitest.setup.ts.
+vi.unmock("@iconify/react")
+
+const { _api } = await import("@iconify/react")
 
 describe("iconify internal api", () => {
   it("exposes _api.setFetch", () => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -69,6 +69,23 @@ vi.mock("@/utils/i18n/locale-boundary", () => ({
   LocaleBoundary: ({ children }: { children: unknown }) => children,
 }))
 
+// Iconify's <Icon> fetches icon data from api.iconify.design on mount and schedules
+// retry timers when that fetch stalls (common in CI). Those Node timers outlive the
+// test file's jsdom environment and crash React with "window is not defined" as an
+// unhandled error attributed to whichever file runs next. Render an inert placeholder
+// instead; no test exercises real icon loading. iconify-internal-api.test.ts opts back
+// in via vi.unmock to keep its _api canary pointed at the real package.
+vi.mock("@iconify/react", async () => {
+  const { createElement } = await import("react")
+  return {
+    Icon: ({ className, icon }: { className?: string; icon: string }) =>
+      createElement("span", { "aria-hidden": true, className, "data-icon": icon }),
+    _api: {
+      setFetch: () => {},
+    },
+  }
+})
+
 // Mock the fakeBrowser's i18n.getMessage method which is not implemented in fake-browser
 // This is used when WxtVitest plugin replaces browser imports with fake-browser
 vi.mock("wxt/testing", async () => {


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

**Commit 1 — the leak fix.** `originalContentMap` (translationOnly mode's original-content snapshots) was a strong `Map<Element, string>`, and entries were only deleted on the extension-driven restore path in `translation-cleanup.ts`. When the **site** removes translated nodes instead — SPA re-renders, infinite scroll virtualization — the detached elements (with their whole subtrees) plus their `innerHTML` snapshot strings stayed pinned in memory for the page's lifetime. This was a confirmed finding from the #1831 investigation, matching the +11.7MB retained `ExternalStringData` in the heap profile.

Fix: switch to `WeakMap<Element, string>` so GC reclaims entries automatically once the site drops the nodes.

Safety of the swap was verified before changing anything: every call site is a keyed operation — `.has`/`.set` in the translationOnly path of `translation-modes.ts` (L549–550, L617–618), `.get`/`.delete` in the ancestor-walk restore in `translation-cleanup.ts` (L177–183). `removeAllTranslatedWrapperNodes` discovers wrappers via DOM query, never by enumerating the map, so nothing relies on iteration and behavior is unchanged. The four sibling lookup maps in `translation-state.ts` are already WeakMaps.

**Commit 2 — test-infra fix for a flaky CI unhandled error.** Tests rendering `<Icon>` loaded the real `@iconify/react`, which fetches icon data from api.iconify.design on mount and schedules retry timers when the fetch stalls (common in CI). Those Node timers outlive the test file's jsdom environment, so React's setState hits `ReferenceError: window is not defined` as a flaky unhandled error attributed to whichever test file runs next. Fix: mock `@iconify/react` globally in `vitest.setup.ts` with an inert placeholder (same shape as the existing per-file mocks, which still override it). `iconify-internal-api.test.ts` opts back in via `vi.unmock` so its `_api.setFetch` canary keeps checking the real package.

## Related Issue

Related to #1831 (retention leak confirmed during that investigation; the retranslation storm itself was fixed in #1833). Not marked as closing since #1831 covers more than this leak.

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

Full `pnpm test`: 188/188 files, 1708/1708 tests pass with no unhandled errors, including the translationOnly toggle on/off restore scenarios in `src/utils/host/__tests__/translate.integration.test.tsx`. Type-aware lint passes. (No new unit test for the leak: the observable behavior is GC reclamation, which isn't directly assertable in jsdom; existing integration tests cover the restore semantics.)

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

A patch changeset is included for the leak fix (`.changeset/original-content-weakmap.md`); the test-infra commit needs none. Remaining known flakiness: under heavy CPU contention, unrelated test files can still fail with 5s timeouts (the failing set varies between runs and all pass in isolation and in uncontended full runs) — that's separate from the Iconify unhandled error fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)