### PR TITLE
chore(skills): add extension-perf-forensics skill

### DIFF
--- a/.agents/skills/extension-perf-forensics/SKILL.md
+++ b/.agents/skills/extension-perf-forensics/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: extension-perf-forensics
+description: Diagnose extension-caused memory leaks, freezes, and CPU storms on live third-party sites via controlled attribution experiments, CDP metrics, heap snapshots, and browser-process trace profiling that works even when the renderer is starved.
+metadata:
+  author: read-frog
+  version: "1.0.0"
+---
+
+# Extension Performance Forensics
+
+Use this skill when a user reports that the extension makes a page **leak memory, freeze, or burn CPU** ("卡死", OOM, fans spinning, page renders wrong AND slows down), especially on a specific third-party site. It turns "it feels broken" into a measured, attributed root cause with pass/fail numbers you can re-run after every fix.
+
+This skill complements [extension-real-browser-testing](../extension-real-browser-testing/SKILL.md) (functional validation, screenshots). Use that one to prove behavior; use this one to find out **who is burning the resources**.
+
+## Core principle: the attribution ladder
+
+Never conclude from a single run. A perf report on a live site has at least four possible culprits, and the fix differs for each. Run the ladder top-down; each rung is the same scripted interaction, changing exactly one variable:
+
+1. **No-extension control** on the reported page — measures the site's own baseline (live sites leak and churn on their own).
+2. **Extension-on run** on the reported page — the reported scenario. Delta vs (1) is the extension's total contribution.
+3. **Static-page control** (e.g., a simple news site) with the extension on — separates "extension reacts to site churn" from "extension misbehaves everywhere".
+4. **Feature-isolation runs** — same page, extension on, but one suspect neutralized (e.g., pre-mark a DOM region as excluded before the extension walks it; force a different config). If neutralizing X makes the numbers clean, X is the trigger.
+
+Two hard-won corollaries:
+
+- **Verify the effective config after the run** (dump it from the extension's storage in the same profile). This session's first three runs silently tested the wrong target language because an onboarding page had overwritten it — every conclusion drawn before the dump was mis-attributed.
+- **Suspect the site, not just the extension.** Sites ship their own unbounded fit-loops (`while (overflows()) moveItem()` inside a ResizeObserver). Any extension that changes element sizes can trip them. If rung (4) with a region excluded is clean while your own code is already loop-free, read the site's bundle — the hot loop may be theirs, and the right fix is an exclusion rule, not more extension code.
+
+## Quick reference
+
+| Topic | Reference |
+|-------|-----------|
+| Repro harness: launching with the extension (Chrome 137+), config patching races, instrumentation, sampling loop, freeze tolerance, control modes | [references/repro-harness.md](references/repro-harness.md) |
+| Metric semantics, GC-disciplined baselines, heap snapshots, memlab, retention signatures | [references/heap-and-metrics.md](references/heap-and-metrics.md) |
+| Profiling a starved renderer via the Tracing domain, mapping minified frames back to site code, the detached-DOM churn signature | [references/starved-renderer-profiling.md](references/starved-renderer-profiling.md) |
+
+## Workflow
+
+1. Build the exact artifact under suspicion (or the fix candidate) and script the reported interaction (load → wait for the feature to engage → N interaction cycles → idle watch → final measurements). Log every sample as JSONL.
+2. Run the attribution ladder. Force-GC before baseline and final samples; snapshot heap only in runs where you are not measuring timing (snapshots pause the world).
+3. Read the failure signature from the metrics (see [heap-and-metrics](references/heap-and-metrics.md) for the table). The three big ones:
+   - heap grows after GC with DOM unchanged → JS-side retention → heap snapshots + memlab retainers;
+   - CDP `Nodes` explodes while `getElementsByTagName("*").length` stays flat AND layout/style counters freeze → a JS loop building **detached** DOM at full speed → CPU profile, not heap;
+   - everything stable but `TaskDuration` runs hot → churn without retention → count your own DOM insert/remove operations per cycle.
+4. If probes hang (evaluate timeouts, `Profiler.start` never returns), the renderer main thread is starved — capture the CPU profile through the **browser-process Tracing domain** instead ([starved-renderer-profiling](references/starved-renderer-profiling.md)).
+5. Attribute the hot frames. Extension frames → fix the extension. Site frames → reproduce the site's trigger without the extension (simulate the DOM change by hand), then neutralize via exclusion/site rule and re-verify.
+6. After each fix: rebuild, rerun the *identical* harness, compare against the recorded broken/control baselines in a pass-criteria table (nodes order-of-magnitude, TaskDuration, freeze count, heap-after-GC delta, feature-still-works count). A fix that only moves one number may have missed a second cooperating root cause — this session's storm fix was correct yet the freeze persisted until the site's own loop was also neutralized.
+
+## Verdict discipline
+
+- Distinguish **harmless churn** (allocated then GC'd; oscillating `Nodes`) from **retention** (survives forced GC). Only the latter is a leak.
+- Distinguish **deterministic** failures from **storm-intensity-dependent** ones; re-run the broken build if a fix seems to "work" on a single lucky run.
+- Record which failure modes are absorbed by existing safety nets vs which escape them; prioritize the escaping ones.
+
+## Gotchas that cost hours
+
+- **Chrome ≥137 ignores `--load-extension`.** Launch with `pipe: true, enableExtensions: true` and call `browser.installExtension(path)` (Puppeteer ≥22.11). The install does not persist across sessions — re-install per run.
+- **Config patch races**: the extension's own init/migrations/onboarding can clobber your patch seconds after install. Patch → wait → re-assert → **verify** before navigating, and re-verify after the run.
+- **Cloudflare**: fresh automated profiles get challenged; `curl` gets 5xx. Grab site bundles via response interception inside a real page load, or use an interactive in-app browser pane which typically passes.
+- **zsh nukes `PATH`** if a loop variable is named `path` (lowercase `path` is tied to `PATH`).
+- Run timing-sensitive rungs **sequentially**, one browser at a time, separate profile dirs per experiment.
+- WXT builds need the env files; copy `.env.development` / `.env.production` into worktrees before `pnpm build`.

--- a/.agents/skills/extension-perf-forensics/references/heap-and-metrics.md
+++ b/.agents/skills/extension-perf-forensics/references/heap-and-metrics.md
@@ -1,0 +1,65 @@
+# Heap & Metrics Interpretation
+
+## Metric semantics (the two node counts are different on purpose)
+
+| Metric | Source | Meaning |
+|---|---|---|
+| `Nodes` | CDP `Performance.getMetrics` | ALL DOM nodes the renderer holds, **including detached-but-referenced ones**, across frames |
+| `allNodes` | in-page `getElementsByTagName('*').length` | attached elements in the main document only |
+| `JSHeapUsedSize` | CDP | JS heap; only meaningful **after forced GC** (`HeapProfiler.collectGarbage`) |
+| `JSEventListeners` | CDP | live listener count — a leak of handlers shows here even when heap looks flat |
+| `LayoutCount` / `RecalcStyleCount` | CDP | how often the renderer laid out / recalced style — the key to the detached-DOM signature |
+| `TaskDuration` | CDP | cumulative main-thread task time — the honest "how busy was this page" number |
+
+## Failure signatures
+
+| Observation | Diagnosis | Next tool |
+|---|---|---|
+| heap grows after forced GC, DOM counts flat | JS-side retention (real leak) | heap snapshots + memlab retainers |
+| CDP `Nodes` explodes; `allNodes` flat; **layout/style counters frozen** | a JS loop building/discarding **detached** DOM at full speed (never renders, so nothing invalidates) | CPU profile (see starved-renderer-profiling) |
+| `Nodes` oscillates up and down in waves; heap stable | allocation churn being GC'd — not a leak, but CPU waste | churn counters; find who allocates |
+| listeners climb monotonically | handler leak (UI mounted per item, never unmounted) | grep mount paths; check unmount on site-driven removal |
+| everything stable but TaskDuration ≫ control | pure CPU overhead | CPU profile / count your per-mutation work |
+| artifact adds ≫ artifacts needed; removals trail adds for minutes | rebuild/teardown storm or slow-queue draining | churn counters per cycle + queue inspection |
+
+Also watch for **non-determinism**: storm-intensity-dependent failures can pass on a lucky run. Re-run the broken build before believing a fix.
+
+## Heap snapshots over CDP
+
+```js
+async function takeHeapSnapshot(cdp, file) {
+  const ws = fs.createWriteStream(file)
+  const onChunk = (e) => ws.write(e.chunk)
+  cdp.on('HeapProfiler.addHeapSnapshotChunk', onChunk)
+  const res = await withTimeout(
+    cdp.send('HeapProfiler.takeHeapSnapshot', { reportProgress: false }), 180000, 'snapshot')
+  cdp.off('HeapProfiler.addHeapSnapshotChunk', onChunk)
+  await new Promise((r) => ws.end(r))
+  return res.ok
+}
+```
+
+- Snapshot **pauses the world** — never mix snapshot runs with timing measurements; a mutation backlog processed after a 2-minute snapshot can fake a freeze.
+- "Snapshot hung" on a pegged main thread is itself a result — log it, don't retry forever.
+- Take three when hunting retention: baseline (after settle+GC), target (after interactions+GC), final (after revert/idle+GC).
+
+## memlab (never read .heapsnapshot files raw — they're hundreds of MB)
+
+```bash
+npx memlab find-leaks --baseline baseline.heapsnapshot --target target.heapsnapshot \
+  --final final.heapsnapshot --work-dir memlab-out          # clustered leaks + retainer traces
+npx memlab analyze detached-DOM --snapshot final.heapsnapshot # all detached elements w/ sizes
+```
+
+Reading retainer traces:
+- your artifact's class name inside a `Detached <element>` line = your DOM retained by someone — walk the chain upward to the owner (closure variable, Map entry, listener);
+- site-owned scripts (ad/analytics closures) also retain detached nodes — don't claim those; the **no-extension control** tells you the site's baseline detached population;
+- `WeakMap`/`WeakSet` edges do NOT retain — if the only path is through a WeakMap, the key is exonerated;
+- signature of "many small things leaked per item": tens of thousands of `closure` nodes + MBs of `ExternalStringData` (strings you generated per item, e.g. translations/HTML snapshots).
+
+## Retention patterns worth grepping for in extension code
+
+- **Module-level strong `Map<Element, …>`** caches — entries survive site-driven node removal forever. WeakMap unless you must enumerate.
+- **UI roots mounted into page DOM** (error badges, tooltips): if the site removes the subtree, your unmount path never runs; anything the component subscribed to (`window.matchMedia` listeners, global store subscriptions) pins the whole tree. Sweep removedNodes in your MutationObserver and unmount there.
+- **Infinite Web Animations**: `el.animate(..., { iterations: Infinity })` — a running animation roots its detached target. `el.getAnimations().forEach(a => a.cancel())` before every `.remove()` path.
+- **Grow-only arrays of observers** (`this.observers.push(...)` per subtree with no dedup) — WeakSet of observed roots.

--- a/.agents/skills/extension-perf-forensics/references/repro-harness.md
+++ b/.agents/skills/extension-perf-forensics/references/repro-harness.md
@@ -1,0 +1,151 @@
+# Repro Harness
+
+A Puppeteer + real-Chrome harness that loads the built extension, force-enables the feature under test, scripts the reported interaction, and samples metrics into JSONL. One script, three modes: extension run, no-extension control (`CONTROL=1`), snapshot-free timing run (`SKIP_SNAPSHOTS=1`).
+
+## Launching with the extension (Chrome ≥137)
+
+`--load-extension` is ignored by branded Chrome ≥137. Use the CDP extension API:
+
+```js
+const browser = await puppeteer.launch({
+  executablePath: '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  headless: false,
+  pipe: true,                 // required for installExtension
+  enableExtensions: true,     // adds --enable-unsafe-extension-debugging
+  userDataDir: PROFILE_DIR,   // one dir PER experiment mode
+  defaultViewport: null,
+  protocolTimeout: 300000,
+  args: ['--no-first-run', '--no-default-browser-check', '--window-size=1440,900'],
+})
+const extId = await browser.installExtension(EXT_PATH) // .output/chrome-mv3
+```
+
+`installExtension` does **not** persist across sessions — call it every run, even on a reused profile.
+
+## Force-enabling the feature (config patching, with race guards)
+
+Patch the extension's storage from its service worker target. The extension's own init/migrations/onboarding pages can overwrite your patch seconds later, so: patch → settle → re-assert → verify. Never navigate before `verified === true`, and dump the config again after the run before trusting any conclusion.
+
+```js
+const swTarget = await browser.waitForTarget(
+  (t) => t.type() === 'service_worker' && t.url().startsWith('chrome-extension://'),
+  { timeout: 30000 },
+)
+const sw = await swTarget.worker()
+const patchOnce = () => sw.evaluate(async () => {
+  const { config } = await chrome.storage.local.get('config')
+  if (!config) return null
+  let dirty = false
+  // pin EVERYTHING the experiment depends on, not just the trigger:
+  if (!config.translate.page.autoTranslatePatterns.includes('example.com')) {
+    config.translate.page.autoTranslatePatterns.push('example.com'); dirty = true
+  }
+  if (config.language.targetCode !== 'cmn') { config.language.targetCode = 'cmn'; dirty = true }
+  if (dirty) await chrome.storage.local.set({ config })
+  return config.translate.providerId
+})
+let provider = null
+for (let i = 0; i < 30 && !provider; i++) { provider = await patchOnce(); if (!provider) await sleep(1000) }
+await sleep(5000)      // let init/migrations settle…
+await patchOnce()      // …then re-assert
+const verified = await sw.evaluate(async () => {
+  const { config } = await chrome.storage.local.get('config')
+  return config?.translate?.page?.autoTranslatePatterns?.includes('example.com')
+    && config?.language?.targetCode === 'cmn'
+})
+if (!verified) throw new Error('config patch did not stick')
+```
+
+## Instrumentation injected before the page loads
+
+`evaluateOnNewDocument` runs before site scripts — install counters the samples will read:
+
+```js
+await page.evaluateOnNewDocument(() => {
+  // long tasks = main-thread blocking evidence
+  window.__lt = { count: 0, max: 0, total: 0 }
+  try {
+    new PerformanceObserver((list) => {
+      for (const e of list.getEntries()) {
+        window.__lt.count++; window.__lt.total += e.duration
+        if (e.duration > window.__lt.max) window.__lt.max = e.duration
+      }
+    }).observe({ entryTypes: ['longtask'] })
+  } catch {}
+  // domain churn counter: how often does OUR OWN artifact get inserted/removed?
+  window.__churn = { adds: 0, removals: 0 }
+  const count = (n) => n.nodeType !== 1 ? 0
+    : (n.classList?.contains('my-extension-artifact') ? 1 : 0)
+      + (n.querySelectorAll?.('.my-extension-artifact').length ?? 0)
+  document.addEventListener('DOMContentLoaded', () => {
+    new MutationObserver((records) => {
+      for (const r of records) {
+        for (const n of r.addedNodes) window.__churn.adds += count(n)
+        for (const n of r.removedNodes) window.__churn.removals += count(n)
+      }
+    }).observe(document.documentElement, { childList: true, subtree: true })
+  })
+})
+```
+
+Churn counters answer the question metrics can't: "inserted 2,451 times for a page that needs ~800" is a re-render storm even when the end state looks fine.
+
+## Sampling loop
+
+Every probe that runs in the page must be raced against a timeout — hangs ARE data (freeze evidence), not errors:
+
+```js
+const withTimeout = (p, ms, label) => Promise.race([
+  p.then((v) => ({ ok: true, value: v })),
+  new Promise((r) => setTimeout(() => r({ ok: false, hang: label }), ms)),
+])
+
+async function getMetrics(cdp) {           // CDP: works via a separate channel
+  const res = await withTimeout(cdp.send('Performance.getMetrics'), 15000, 'metrics')
+  if (!res.ok) return null
+  const m = Object.fromEntries(res.value.metrics.map((x) => [x.name, x.value]))
+  return {
+    heapMB: +(m.JSHeapUsedSize / 1048576).toFixed(1),
+    nodes: m.Nodes,                        // ALL nodes incl. detached-but-referenced
+    listeners: m.JSEventListeners,
+    layoutCount: m.LayoutCount,
+    recalcStyleCount: m.RecalcStyleCount,
+    taskDurationS: +m.TaskDuration.toFixed(1),
+  }
+}
+async function countMarkers(page) {        // in-page: hangs when main thread is pegged
+  const res = await withTimeout(page.evaluate(() => ({
+    artifacts: document.querySelectorAll('.my-extension-artifact').length,
+    allNodes: document.getElementsByTagName('*').length,  // ATTACHED elements only
+    adds: window.__churn?.adds, removals: window.__churn?.removals,
+    longTasks: window.__lt?.count, longTaskTotalMs: Math.round(window.__lt?.total ?? -1),
+  })), 15000, 'markers')
+  return res.ok ? res.value : null
+}
+```
+
+Run shape: `baseline (settle → forceGC → sample → snapshot)` → `N interaction cycles (scroll/click script, sample each)` → `idle watch (30s, sample every 3s — growth at idle = self-sustaining loop)` → `final (2× forceGC → sample → snapshot)`. Force GC via `cdp.send('HeapProfiler.collectGarbage')`. Write every record as a JSONL line; the analysis step greps these.
+
+## Freeze tolerance
+
+On a badly broken build the page can lock up during initial load — the harness must record that instead of dying:
+
+- never `throw` on a hung probe; log `main_thread_hung` and continue polling;
+- don't `page.reload()` on a frozen page (navigation will time out and kill the run);
+- wrap snapshots in a generous timeout and log `snapshot_hang` — "heap snapshot impossible" is itself a headline result;
+- abort interaction cycles after 2 consecutive hangs, then still attempt idle-watch and final metrics (CDP metrics usually still respond).
+
+## Pass-criteria table
+
+Fixes are judged against recorded baselines, e.g.:
+
+| Metric | broken | control | pass criteria |
+|---|---|---|---|
+| CDP Nodes after cycles | 1.33M | 177k | same order as control |
+| TaskDuration total | 840s | 10.7s | same order as control |
+| probes hung >45s | every cycle | 0 | 0 |
+| heap after 2×GC | unmeasurable | +0.8MB | < +5MB |
+| artifact churn (adds vs needed) | 2451 / ~800 | — | ≈1 insert per needed artifact |
+| feature still works (artifact count) | 0 (vanished) | — | grows with interaction, persists |
+
+The last row matters: a "fix" that zeroes the churn by breaking the feature passes every perf number.

--- a/.agents/skills/extension-perf-forensics/references/starved-renderer-profiling.md
+++ b/.agents/skills/extension-perf-forensics/references/starved-renderer-profiling.md
@@ -1,0 +1,91 @@
+# Profiling a Starved Renderer
+
+## Symptoms
+
+- in-page probes (`page.evaluate`) hit their timeout race every time;
+- `Profiler.start` / `Runtime.evaluate` never return (even with minutes of protocolTimeout) — renderer-targeted CDP commands queue behind the busy main thread;
+- `Performance.getMetrics` still answers, `TaskDuration` climbs ~1s per wall-clock second;
+- if layout/style counters are frozen while `Nodes` churns: the loop runs entirely on detached DOM (nothing invalidates rendering, so the cached layout is served and the loop is pure CPU).
+
+## Capture via the Tracing domain (browser process — immune to renderer starvation)
+
+Start tracing **before** navigation; stop is handled by the browser process, so it works while the renderer spins:
+
+```js
+const page = await browser.newPage()
+await page.tracing.start({
+  path: 'churn.trace.json',
+  categories: [
+    '-*',
+    'toplevel',
+    'v8.execute',
+    'disabled-by-default-v8.cpu_profiler',   // embeds sampling profiles in the trace
+    'devtools.timeline',
+  ],
+})
+await page.goto(TARGET_URL, { waitUntil: 'domcontentloaded', timeout: 60000 })
+await sleep(30000)              // let the churn develop while sampling
+await page.tracing.stop()       // browser-process; returns even when renderer is pegged
+```
+
+## Extract the top frames from the trace
+
+`Profile` / `ProfileChunk` events carry standard cpuprofile fragments per `pid:tid:id`; merge chunks and rank self-time by sample counts:
+
+```js
+const trace = JSON.parse(fs.readFileSync('churn.trace.json', 'utf8'))
+const profiles = new Map()
+for (const e of trace.traceEvents) {
+  const key = `${e.pid}:${e.tid}:${e.id}`
+  if (e.name === 'Profile') profiles.set(key, { nodes: [], samples: [] })
+  else if (e.name === 'ProfileChunk') {
+    const p = profiles.get(key) ?? { nodes: [], samples: [] }
+    profiles.set(key, p)
+    const cpu = e.args?.data?.cpuProfile
+    if (cpu?.nodes) p.nodes.push(...cpu.nodes)
+    if (cpu?.samples) p.samples.push(...cpu.samples)
+  }
+}
+const { nodes, samples } = [...profiles.values()].sort((a, b) => b.samples.length - a.samples.length)[0]
+const byId = new Map(nodes.map((n) => [n.id, n]))
+const hits = new Map()
+for (const s of samples) hits.set(s, (hits.get(s) ?? 0) + 1)
+for (const [id, n] of [...hits.entries()].sort((a, b) => b[1] - a[1]).slice(0, 25).map(([id, h]) => [id, h])) {
+  const f = byId.get(id)?.callFrame ?? {}
+  // keep the FULL url — you need it to fetch the bundle; also print a short
+  // ancestor chain (walk .parent) — minified leaf names alone are useless.
+  console.log(((n / samples.length) * 100).toFixed(1) + '%', f.functionName || '(anon)', f.url, f.lineNumber, f.columnNumber)
+}
+```
+
+## Attribute the frames
+
+- Frames in `chrome-extension://…` files → your code. Column offsets map into your built bundle.
+- Frames in a **site-hashed bundle** (`https://…/app.abc123.js`) → the SITE's code is the hot loop. The stack shape often identifies the library (jQuery: `css/attr/prepend` + `T.fn.<computed>`).
+- Minified names mean nothing — fetch the bundle and cut a window around the hot column offsets:
+
+```js
+// Cloudflare blocks curl and fresh headless profiles. Grab the asset from a
+// real page load via response interception instead:
+page.on('response', async (res) => {
+  if (res.url().includes('abc123')) body = await res.text().catch(() => null)
+})
+await page.goto(SITE_URL, { waitUntil: 'networkidle2' }).catch(() => {})
+fs.writeFileSync('site-bundle.js', body)
+// then: src.slice(col - 200, col + 400) around each hot offset — method names
+// and string literals in the window usually identify the feature (e.g. a
+// navbar overflow handler: `while (this.menuIsOverflowing()) this.moveSingleMainItemToExtras()`).
+```
+
+## Confirm site-vs-extension with paired experiments
+
+When the hot frames are the site's, prove the interaction both ways before writing the fix:
+
+1. **No extension + hand-made trigger**: reproduce what the extension does to the DOM with a one-line evaluate (append text to widen elements, etc.). If the site freezes on its own → the site's loop is real and extension-independent.
+2. **Extension + neutralized region**: `evaluateOnNewDocument` that pre-marks the suspect region with your exclusion mechanism before the extension walks it. Clean numbers here = that region is the trigger; ship it as a site rule / default exclusion.
+
+Beware: a hand-made trigger that DOESN'T freeze does not exonerate the site — the real interaction may need the extension's exact churn pattern (insert/remove cycles, observer feedback timing). Experiment (2) is the decisive one; (1) is corroboration.
+
+## Reading the result
+
+The combination this skill was born from: storm fixes in the extension were correct (unit-proven) yet the page still burned 840s CPU — the trace showed 90% self-time in the site's own jQuery width-measurement chain, spinning in a `while (menuIsOverflowing())` overflow handler retriggered by a ResizeObserver after translations widened the menu. One exclusion rule fixed what no amount of extension-side code could.

--- a/.claude/skills/extension-perf-forensics
+++ b/.claude/skills/extension-perf-forensics
@@ -1,0 +1,1 @@
+../../.agents/skills/extension-perf-forensics


### PR DESCRIPTION
Distills the #1831 investigation methodology into a reusable, locally-authored skill (same layout as `extension-real-browser-testing`: source under `.agents/skills/`, symlinked from `.claude/skills/`).

## What it teaches

- **The attribution ladder**: no-extension control → extension run → static-page control → feature-isolation runs, plus the two corollaries that cost us the most time in #1831 (dump the *effective* config after every run; suspect the site's own code, not just the extension).
- **Repro harness** ([references/repro-harness.md](../blob/docs/extension-perf-forensics-skill/.agents/skills/extension-perf-forensics/references/repro-harness.md)): Chrome ≥137 `installExtension` launch, config-patch race guards, injected long-task/churn counters, timeout-raced probes where hangs are recorded as freeze evidence, and the pass-criteria table pattern (including the "feature still works" row).
- **Metric forensics** ([references/heap-and-metrics.md](../blob/docs/extension-perf-forensics-skill/.agents/skills/extension-perf-forensics/references/heap-and-metrics.md)): failure-signature table (e.g. frozen layout counters + exploding CDP `Nodes` = JS loop on detached DOM), GC-disciplined baselines, memlab retainer reading, and the retention patterns worth grepping for (strong Element maps, unmounted UI roots, `iterations: Infinity` animations, grow-only observer arrays).
- **Starved-renderer profiling** ([references/starved-renderer-profiling.md](../blob/docs/extension-perf-forensics-skill/.agents/skills/extension-perf-forensics/references/starved-renderer-profiling.md)): when `Profiler.start` itself hangs, capture `disabled-by-default-v8.cpu_profiler` through the browser-process Tracing domain, extract top self-time frames from Profile/ProfileChunk events, map minified frames back to site bundles via response interception, and confirm site-vs-extension with paired neutralization experiments.

No runtime code changes; docs/skill files + one symlink only. Locally-authored skills are not tracked in skills-lock.json (matches `extension-real-browser-testing`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)