### PR TITLE
fix(site-rules): keep PR/discussion/commit reference links in GitHub markdown translations

### DIFF
--- a/.changeset/github-preserve-reference-links.md
+++ b/.changeset/github-preserve-reference-links.md
@@ -1,0 +1,7 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(site-rules): keep PR/discussion/commit reference links in GitHub markdown translations
+
+Modern GitHub markup renders references like `#1837` as a bare `a[data-hovercard-type='pull_request']` with no `.issue-link` class, so the broad `a[data-hovercard-type]` exclude dropped them from the translation source (e.g. release notes lost every PR number). Preserve `pull_request`, `discussion`, and `commit` hovercard links inside `.markdown-body` as source text so they survive translation verbatim.

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -14,6 +14,7 @@ import {
   PARAGRAPH_ATTRIBUTE,
   TRANSLATION_ERROR_CONTAINER_CLASS,
   VIRTUAL_PARAGRAPH_ATTRIBUTE,
+  WALKED_ATTRIBUTE,
 } from "@/utils/constants/dom-labels"
 import { flushBatchedOperations } from "@/utils/host/dom/batch-dom"
 import { walkAndLabelElement } from "@/utils/host/dom/traversal"
@@ -2645,6 +2646,53 @@ describe("translate", () => {
           expect(document.querySelector(".issue-link")!.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(
             false,
           )
+        } finally {
+          Object.defineProperty(window, "location", {
+            value: originalLocation,
+            writable: true,
+            configurable: true,
+          })
+        }
+      })
+
+      it("bilingual mode: should keep classless PR reference links in release notes source", async () => {
+        // Modern GitHub release markup renders PR references as a bare
+        // `a[data-hovercard-type='pull_request']` with no `.issue-link` class,
+        // so the old preserveText rule no longer matched and the broad
+        // `a[data-hovercard-type]` exclude dropped "#1837" from the source
+        // (issue: PR numbers missing from release-notes translations).
+        const originalLocation = window.location
+        setHost("github.com")
+        vi.mocked(translateTextForPage).mockClear()
+
+        try {
+          render(
+            <div data-testid="test-node" className="markdown-body">
+              <ul>
+                <li>
+                  <a
+                    data-hovercard-type="pull_request"
+                    data-hovercard-url="/mengxi-ream/read-frog/pull/1837/hovercard"
+                    href="/mengxi-ream/read-frog/pull/1837"
+                  >
+                    #1837
+                  </a>
+                  {" feat(translate): return a NO_TRANSLATION_NEEDED sentinel"}
+                </li>
+              </ul>
+            </div>,
+          )
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(translateTextForPage).toHaveBeenCalledWith(
+            "#1837 feat(translate): return a NO_TRANSLATION_NEEDED sentinel",
+            "plain",
+          )
+          // Preserved as source text, not promoted to its own paragraph/walked node.
+          const prLink = document.querySelector("a[data-hovercard-type='pull_request']")!
+          expect(prLink.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(false)
+          expect(prLink.hasAttribute(WALKED_ATTRIBUTE)).toBe(false)
         } finally {
           Object.defineProperty(window, "location", {
             value: originalLocation,

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -616,7 +616,12 @@
       "[data-testid=list-row-repo-name-and-number]"
     ],
     "forceBlockSelectors.add": ["bdi"],
-    "preserveTextSelectors.add": [".issue-link"],
+    "preserveTextSelectors.add": [
+      ".issue-link",
+      ".markdown-body a[data-hovercard-type='pull_request']",
+      ".markdown-body a[data-hovercard-type='discussion']",
+      ".markdown-body a[data-hovercard-type='commit']"
+    ],
     "injectedCss.add": [
       ".bpDald,.discussion-title {-webkit-line-clamp:unset!important;}",
       "li>div[class*='Box-sc'],div[class*='Box-sc']>button[class*='prc-Token-TokenBase'],li[class*='card-label-module']>button[class*='prc-Token-TokenBase'] {height:unset!important;}",


### PR DESCRIPTION
## Problem

On pages like the [releases page](https://github.com/mengxi-ream/read-frog/releases), bilingual translation of changelog items **drops the leading PR reference** (`#1837`). The translated line starts at `64f3ac2 感谢 @mengxi-ream…` with no PR number.

## Root cause

1. The built-in `github` site rule excludes `a[data-hovercard-type]` broadly (`excludeSelectors.add`).
2. Modern GitHub markup renders PR references in markdown as a **bare** `<a href=".../pull/1837" data-hovercard-type="pull_request">#1837</a>` — **no `.issue-link` class** (verified: `issue-link` appears 0 times on the releases page).
3. An excluded element is only re-included if it *itself* matches an include selector (`isSiteRuleExcludedElement`). The include list only whitelists `a[data-hovercard-type='issue']` and dashboard-feed PR titles — a `pull_request` link in a release body matches neither.
4. Excluded ⇒ `isDontWalkIntoAndDontTranslateAsChildElement` is true ⇒ `extractTextContent` returns `""` for the anchor ⇒ `#1837` is silently dropped from the source text sent to the translator, and the anchor never gets any `data-read-frog-*` label (matches the observed DOM).

[PR #1796](https://github.com/mengxi-ream/read-frog/pull/1796) previously added `preserveTextSelectors.add: [".issue-link"]` to fix exactly this, but that class no longer exists in current GitHub markup, so the rule became dead and the broad exclude wins. This affects PR/discussion/commit autolinks in any `.markdown-body` (releases, issue comments, READMEs). Issue autolinks are unaffected (globally re-included).

## Fix

Extend the github rule's `preserveTextSelectors.add` to keep `pull_request`, `discussion`, and `commit` hovercard links inside `.markdown-body` as source text:

```json
".markdown-body a[data-hovercard-type='pull_request']",
".markdown-body a[data-hovercard-type='discussion']",
".markdown-body a[data-hovercard-type='commit']"
```

`preserveText` (not `includeSelectors`) reproduces the semantics #1796 established for `.issue-link`: the reference text stays in the parent paragraph's source and is translated verbatim in context, without being promoted to its own walked/translated node. Scoping to `.markdown-body` avoids overriding the existing include rule for dashboard-feed PR **titles**.

## Testing

- New integration test in `translate.integration.test.tsx` using **today's real releases markup** (classless PR anchor): asserts `translateTextForPage` receives the full string including `#1837`, and the anchor gets neither `PARAGRAPH_ATTRIBUTE` nor `WALKED_ATTRIBUTE`. Verified it **fails without the rules.json change** and passes with it.
- `pnpm test` (full NX test target) green; lint/type-check clean.
- Confirmed against the live releases page that release bodies use `.markdown-body` and contain `data-hovercard-type="pull_request"` links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)