### PR TITLE
feat(ui): align extension UI fonts with the web app (Onest Latin + 思源 CJK)

### DIFF
--- a/.changeset/onest-ui-latin-font.md
+++ b/.changeset/onest-ui-latin-font.md
@@ -2,4 +2,4 @@
 "@read-frog/extension": patch
 ---
 
-feat(ui): bundle Onest Variable (~62 KB) and use it for the extension's Latin UI text, matching the web app. Imported only in the extension's own pages (popup / options / side panel / translation hub), so no webfont is injected into content scripts on host pages — there "Onest Variable" is just named in the stack and falls back to the system sans
+feat(ui): bundle Onest Variable (~62 KB) and use it for the extension's Latin UI text, matching the web app. Imported only in the extension's own pages (popup / options / side panel / translation hub), so no webfont is injected into content scripts on host pages. Also adds an unlayered `body { font-family: var(--rf-font-sans) }` override — Chromium injects `body { font-family: system-ui, … }` into every extension page (extension_fonts.css), which otherwise intercepts the inherited font stack so neither Onest nor the CJK fallbacks would ever apply

--- a/.changeset/onest-ui-latin-font.md
+++ b/.changeset/onest-ui-latin-font.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(ui): bundle Onest Variable (~62 KB) and use it for the extension's Latin UI text, matching the web app. Imported only in the extension's own pages (popup / options / side panel / translation hub), so no webfont is injected into content scripts on host pages — there "Onest Variable" is just named in the stack and falls back to the system sans

--- a/.changeset/source-han-ui-font.md
+++ b/.changeset/source-han-ui-font.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(ui): add 思源黑体 (Source Han Sans / Noto Sans CJK) to the extension UI font fallback stack, after system-ui and before the generic sans-serif, so Chinese UI text resolves to it by name on platforms where it is the default (Android / ChromeOS / Linux) while macOS/Windows keep their lang-correct native PingFang / 微软雅黑

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@fontsource-variable/onest": "^5.2.11",
     "@headless-tree/core": "^1.7.0",
     "@headless-tree/react": "^1.7.0",
     "@json-render/core": "^0.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.7)
+      '@fontsource-variable/onest':
+        specifier: ^5.2.11
+        version: 5.2.11
       '@headless-tree/core':
         specifier: ^1.7.0
         version: 1.7.0
@@ -172,7 +175,7 @@ importers:
         version: 3.0.2
       '@wxt-dev/i18n':
         specifier: ^0.2.6
-        version: 0.2.6(wxt@0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(yaml@2.9.0))
+        version: 0.2.6(wxt@0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(supports-color@7.2.0)(yaml@2.9.0))
       ai:
         specifier: ^7.0.22
         version: 7.0.22(zod@4.4.3)
@@ -259,7 +262,7 @@ importers:
         version: 3.9.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@18.3.1)(react@19.2.7)(redux@5.0.1)
       shadcn:
         specifier: ^4.13.0
-        version: 4.13.0(typescript@7.0.2)
+        version: 4.13.0(supports-color@7.2.0)(typescript@7.0.2)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -335,7 +338,7 @@ importers:
         version: 4.1.10(vitest@4.1.10)
       '@wxt-dev/module-react':
         specifier: ^1.2.2
-        version: 1.2.2(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))(wxt@0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(yaml@2.9.0))
+        version: 1.2.2(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))(wxt@0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(supports-color@7.2.0)(yaml@2.9.0))
       autoprefixer:
         specifier: ^10.5.2
         version: 10.5.2(postcss@8.5.17)
@@ -395,7 +398,7 @@ importers:
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(@vitest/coverage-istanbul@4.1.10)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.14.6(@types/node@26.1.1)(typescript@7.0.2))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       wxt:
         specifier: 0.20.27
-        version: 0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(yaml@2.9.0)
+        version: 0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(supports-color@7.2.0)(yaml@2.9.0)
 
 packages:
 
@@ -1348,6 +1351,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource-variable/onest@5.2.11':
+    resolution: {integrity: sha512-knJww1KxK4g66+qu90q3CPBvl4zhL5oDRi3/JMkYMmlhW3OgyRgT4MMfgd6jg2lvho7bLPAXfsYPh59h0yzwUA==}
 
   '@headless-tree/core@1.7.0':
     resolution: {integrity: sha512-LxcX7LNepwfOPrZcs4PNfDwCzbi326uCAX5jYBfw94jI+pZQA7ANaE/No3LW0XFgcBcQtK/G2bInbVEhLF1C/Q==}
@@ -8080,6 +8086,8 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@fontsource-variable/onest@5.2.11': {}
+
   '@headless-tree/core@1.7.0': {}
 
   '@headless-tree/react@1.7.0(@headless-tree/core@1.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
@@ -8236,7 +8244,7 @@ snapshots:
   '@mixmark-io/domino@2.2.0':
     optional: true
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(supports-color@7.2.0)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.20.0
@@ -8246,8 +8254,8 @@ snapshots:
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
+      express: 5.2.1(supports-color@7.2.0)
+      express-rate-limit: 8.5.2(express@5.2.1(supports-color@7.2.0))
       hono: 4.12.25
       jose: 6.2.3
       json-schema-typed: 8.0.2
@@ -9471,20 +9479,20 @@ snapshots:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
 
-  '@wxt-dev/i18n@0.2.6(wxt@0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(yaml@2.9.0))':
+  '@wxt-dev/i18n@0.2.6(wxt@0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(supports-color@7.2.0)(yaml@2.9.0))':
     dependencies:
       '@wxt-dev/browser': 0.2.2
       chokidar: 5.0.0
       confbox: 0.2.4
       tinyglobby: 0.2.17
     optionalDependencies:
-      wxt: 0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(yaml@2.9.0)
+      wxt: 0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(supports-color@7.2.0)(yaml@2.9.0)
 
-  '@wxt-dev/module-react@1.2.2(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))(wxt@0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(yaml@2.9.0))':
+  '@wxt-dev/module-react@1.2.2(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))(wxt@0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(supports-color@7.2.0)(yaml@2.9.0))':
     dependencies:
       '@vitejs/plugin-react': 6.0.3(vite@8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0))
       vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
-      wxt: 0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(yaml@2.9.0)
+      wxt: 0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(supports-color@7.2.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@rolldown/plugin-babel'
       - babel-plugin-react-compiler
@@ -9711,7 +9719,7 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  body-parser@2.2.2:
+  body-parser@2.2.2(supports-color@7.2.0):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -9847,12 +9855,12 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
-  chrome-launcher@1.2.0:
+  chrome-launcher@1.2.0(supports-color@7.2.0):
     dependencies:
       '@types/node': 26.1.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
-      lighthouse-logger: 2.0.2
+      lighthouse-logger: 2.0.2(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10494,15 +10502,15 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.5.2(express@5.2.1):
+  express-rate-limit@8.5.2(express@5.2.1(supports-color@7.2.0)):
     dependencies:
-      express: 5.2.1
+      express: 5.2.1(supports-color@7.2.0)
       ip-address: 10.2.0
 
-  express@5.2.1:
+  express@5.2.1(supports-color@7.2.0):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.2.2
+      body-parser: 2.2.2(supports-color@7.2.0)
       content-disposition: 1.1.0
       content-type: 1.0.5
       cookie: 0.7.2
@@ -10512,7 +10520,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.1.1
+      finalhandler: 2.1.1(supports-color@7.2.0)
       fresh: 2.0.0
       http-errors: 2.0.1
       merge-descriptors: 2.0.0
@@ -10523,8 +10531,8 @@ snapshots:
       proxy-addr: 2.0.7
       qs: 6.15.2
       range-parser: 1.2.1
-      router: 2.2.0
-      send: 1.2.1
+      router: 2.2.0(supports-color@7.2.0)
+      send: 1.2.1(supports-color@7.2.0)
       serve-static: 2.2.1
       statuses: 2.0.2
       type-is: 2.1.0
@@ -10602,7 +10610,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@2.1.1:
+  finalhandler@2.1.1(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       encodeurl: 2.0.0
@@ -11204,7 +11212,7 @@ snapshots:
     dependencies:
       immediate: 3.0.6
 
-  lighthouse-logger@2.0.2:
+  lighthouse-logger@2.0.2(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       marky: 1.3.0
@@ -12608,7 +12616,7 @@ snapshots:
 
   rou3@0.7.12: {}
 
-  router@2.2.0:
+  router@2.2.0(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       depd: 2.0.0
@@ -12648,7 +12656,7 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@1.2.1:
+  send@1.2.1(supports-color@7.2.0):
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       encodeurl: 2.0.0
@@ -12669,7 +12677,7 @@ snapshots:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.2.1
+      send: 1.2.1(supports-color@7.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12684,14 +12692,14 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@4.13.0(typescript@7.0.2):
+  shadcn@4.13.0(supports-color@7.2.0)(typescript@7.0.2):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
       '@dotenvx/dotenvx': 1.71.2
-      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(supports-color@7.2.0)(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.4
       commander: 14.0.3
@@ -13341,11 +13349,11 @@ snapshots:
     dependencies:
       defaults: 1.0.4
 
-  web-ext-run@0.2.4:
+  web-ext-run@0.2.4(supports-color@7.2.0):
     dependencies:
       '@babel/runtime': 7.28.2
       '@devicefarmer/adbkit': 3.3.8
-      chrome-launcher: 1.2.0
+      chrome-launcher: 1.2.0(supports-color@7.2.0)
       debounce: 1.2.1
       es6-error: 4.1.1
       firefox-profile: 4.7.0
@@ -13462,7 +13470,7 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  wxt@0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(yaml@2.9.0):
+  wxt@0.20.27(@types/node@26.1.1)(eslint@10.6.0(jiti@2.7.0))(jiti@2.7.0)(rollup@4.53.2)(supports-color@7.2.0)(yaml@2.9.0):
     dependencies:
       '@1natsu/wait-element': 4.2.0
       '@aklinker1/rollup-plugin-visualizer': 5.12.0(rollup@4.53.2)
@@ -13505,7 +13513,7 @@ snapshots:
       unimport: 6.1.1
       vite: 8.1.4(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
       vite-node: 6.0.0(@types/node@26.1.1)(esbuild@0.27.7)(jiti@2.7.0)(yaml@2.9.0)
-      web-ext-run: 0.2.4
+      web-ext-run: 0.2.4(supports-color@7.2.0)
     optionalDependencies:
       eslint: 10.6.0(jiti@2.7.0)
     transitivePeerDependencies:

--- a/src/assets/styles/theme.css
+++ b/src/assets/styles/theme.css
@@ -60,8 +60,13 @@
 }
 
 :root {
+  /* Latin/UI → platform sans; CJK stays on the lang-correct native font via
+     system-ui (PingFang / 微软雅黑 on macOS/Windows), then falls to 思源黑体
+     (Source Han Sans / Noto Sans CJK) — the default on Android/ChromeOS/Linux —
+     before the generic sans-serif. Emoji families stay last. */
   --rf-font-sans:
-    ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+    ui-sans-serif, system-ui, "Source Han Sans SC", "Noto Sans SC", "Source Han Sans TC",
+    "Noto Sans TC", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
     "Noto Color Emoji";
   --rf-font-mono:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",

--- a/src/assets/styles/theme.css
+++ b/src/assets/styles/theme.css
@@ -161,3 +161,12 @@
     @apply bg-background text-foreground antialiased;
   }
 }
+
+/* Chromium injects `body { font-family: system-ui, … }` (extension_fonts.css)
+   into every extension page, which intercepts the font-family inherited from
+   Tailwind preflight's `html` rule. The injected sheet cascades as UNLAYERED
+   author CSS, so this override must be unlayered too — inside @layer base it
+   would lose. */
+body {
+  font-family: var(--rf-font-sans);
+}

--- a/src/assets/styles/theme.css
+++ b/src/assets/styles/theme.css
@@ -60,14 +60,16 @@
 }
 
 :root {
-  /* Latin/UI → platform sans; CJK stays on the lang-correct native font via
-     system-ui (PingFang / 微软雅黑 on macOS/Windows), then falls to 思源黑体
-     (Source Han Sans / Noto Sans CJK) — the default on Android/ChromeOS/Linux —
-     before the generic sans-serif. Emoji families stay last. */
+  /* Latin → Onest Variable (bundled via @fontsource-variable/onest, imported
+     only in the extension's own pages — not content scripts). CJK stays on the
+     lang-correct native font via system-ui (PingFang / 微软雅黑 on macOS/
+     Windows), then falls to 思源黑体 (Source Han Sans / Noto Sans CJK) — the
+     default on Android/ChromeOS/Linux — before the generic sans-serif. Emoji
+     families stay last. */
   --rf-font-sans:
-    ui-sans-serif, system-ui, "Source Han Sans SC", "Noto Sans SC", "Source Han Sans TC",
-    "Noto Sans TC", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
-    "Noto Color Emoji";
+    "Onest Variable", ui-sans-serif, system-ui, "Source Han Sans SC", "Noto Sans SC",
+    "Source Han Sans TC", "Noto Sans TC", sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+    "Segoe UI Symbol", "Noto Color Emoji";
   --rf-font-mono:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
     monospace;

--- a/src/entrypoints/options/main.tsx
+++ b/src/entrypoints/options/main.tsx
@@ -24,6 +24,7 @@ import { applyTheme, getLocalThemeMode, isDarkMode } from "@/utils/theme"
 import App from "./app"
 import { AppSidebar } from "./app-sidebar"
 import { SettingsSearch } from "./command-palette/settings-search"
+import "@fontsource-variable/onest/index.css"
 import "@/assets/styles/theme.css"
 import "./style.css"
 

--- a/src/entrypoints/popup/main.tsx
+++ b/src/entrypoints/popup/main.tsx
@@ -32,6 +32,7 @@ import {
   isCurrentSiteInWhitelistAtom,
   isInSiteControlList,
 } from "./atoms/site-control"
+import "@fontsource-variable/onest/index.css"
 import "@/assets/styles/text-small.css"
 import "@/assets/styles/theme.css"
 

--- a/src/entrypoints/sidepanel/main.tsx
+++ b/src/entrypoints/sidepanel/main.tsx
@@ -8,6 +8,7 @@ import { baseThemeModeAtom } from "@/utils/atoms/theme"
 import { APP_NAME } from "@/utils/constants/app"
 import { renderPersistentReactRoot } from "@/utils/react-root"
 import { getLocalThemeMode } from "@/utils/theme"
+import "@fontsource-variable/onest/index.css"
 import "@/assets/styles/text-small.css"
 import "@/assets/styles/theme.css"
 

--- a/src/entrypoints/translation-hub/main.tsx
+++ b/src/entrypoints/translation-hub/main.tsx
@@ -18,6 +18,7 @@ import { renderPersistentReactRoot } from "@/utils/react-root"
 import { queryClient } from "@/utils/tanstack-query"
 import { applyTheme, getLocalThemeMode, isDarkMode } from "@/utils/theme"
 import App from "./app"
+import "@fontsource-variable/onest/index.css"
 import "@/assets/styles/theme.css"
 
 interface HydrateAtomsProps {


### PR DESCRIPTION
Brings the extension's own UI typography in line with the web app (read-frog-monorepo#299). Three related changes:

## 1. Bundle Onest Variable for Latin UI text

- Add `@fontsource-variable/onest` (~62 KB: latin + latin-ext + cyrillic) and put `"Onest Variable"` first in `--rf-font-sans`, so Latin UI text matches the web app.
- Imported **only in the extension's own page entrypoints** (popup / options / side panel / translation hub), **not** in the shared `theme.css` that content scripts also load — so no webfont is injected into pages the user visits (verified: no `onest-*.woff2` in `content-scripts/` output).

## 2. Add 思源黑体 to the CJK fallback

- Name Source Han Sans / Noto Sans CJK (SC + TC) explicitly, **after `system-ui`** and before generic `sans-serif`: platforms where 思源 is the default (Android / ChromeOS / Linux) resolve to it by name; macOS/Windows keep their lang-correct native PingFang / 微软雅黑. Mirrors `translation-node-preset.css`.

Final stack:
```
"Onest Variable", ui-sans-serif, system-ui,
"Source Han Sans SC", "Noto Sans SC", "Source Han Sans TC", "Noto Sans TC",
sans-serif, <emoji families…>
```

## 3. Fix: Chromium's injected extension-page font was defeating the stack ⚠️

While verifying in a real browser, we found the UI never actually resolved to `--rf-font-sans` at all — **in dev or prod**. Root cause: Chromium injects `body { font-family: system-ui, … }` (`extension_fonts.css`) into every extension page. Tailwind preflight only sets font-family on `html`, so the injected `body` rule intercepted inheritance for the whole app.

Fix: an **unlayered** `body { font-family: var(--rf-font-sans) }` override in `theme.css`. The injected sheet cascades as unlayered author CSS, so the override must be unlayered too — inside `@layer base` it loses (verified).

## Verification (Edge + Playwright, real unpacked extension — per `extension-real-browser-testing` skill)

| Build | Before fix | After fix |
|---|---|---|
| `.output/chrome-mv3` (prod) | h1 computed `system-ui, sans-serif`, Onest never requested | h1 computes `"Onest Variable", ui-sans-serif, system-ui, "Source Han Sans SC", …`; latin face `loaded` |
| `.output/chrome-mv3-dev` (`wxt dev`) | same | same fix works — fonts serve fine from the Vite dev server (extension host permissions bypass CORS) |

No failed font requests, no console errors, `pnpm build` passes.

## Out of scope

No 陪读蛙 wordmark change — the extension renders no in-UI wordmark to restyle (its Chinese brand name only appears as the manifest name, which the browser draws). Companion web-app PR: read-frog-monorepo#299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)