### PR TITLE
fix(config): default page translation to main content

### DIFF
--- a/.changeset/quiet-frogs-translate.md
+++ b/.changeset/quiet-frogs-translate.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(config): default page translation to main content

--- a/src/utils/constants/__tests__/config.test.ts
+++ b/src/utils/constants/__tests__/config.test.ts
@@ -61,6 +61,7 @@ describe("dEFAULT_CONFIG", () => {
       "atlascloud-default",
     ])
     expect(DEFAULT_CONFIG.translate.providerId).toBe("microsoft-translate-default")
+    expect(DEFAULT_CONFIG.translate.page.range).toBe("main")
     expect(DEFAULT_CONFIG.selectionToolbar.features.translate.providerId).toBe(
       "microsoft-translate-default",
     )

--- a/src/utils/constants/config.ts
+++ b/src/utils/constants/config.ts
@@ -96,7 +96,7 @@ export const DEFAULT_CONFIG: Config = {
       hotkey: "control",
     },
     page: {
-      range: "all",
+      range: "main",
       autoTranslatePatterns: ["news.ycombinator.com"],
       neverAutoTranslatePatterns: [],
       autoTranslateLanguages: [],


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Change the default page translation range from all page content to main content. This keeps fresh installs and settings resets focused on the primary article content by default.

Also add a regression assertion for the default range and a patch changeset for `@read-frog/extension`.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Focused config test: 2 passed.

Pre-push validation:
- Formatting passed
- Type-aware lint/type-check passed
- Full test suite passed: 1,733 tests across 189 files

## Screenshots

N/A — configuration default only.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Existing users keep their saved range preference; this only changes generated default configuration.