### PR TITLE
fix(translate): rebuild translation-only mode on node-identity restore + in-place text swap

### DIFF
--- a/.agents/skills/extension-puppeteer-debugging/SKILL.md
+++ b/.agents/skills/extension-puppeteer-debugging/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: extension-puppeteer-debugging
+description: Use when you need to drive the BUILT read-frog extension in real Chrome with Puppeteer — verifying a translation fix end-to-end, reproducing a DOM bug on a fixture page, or asserting restore/toggle behavior programmatically. Covers Chrome 137+ extension loading, config patching, and message-based toggling. For Playwright/Edge screenshots use extension-real-browser-testing; for leaks/freezes use extension-perf-forensics.
+metadata:
+  author: read-frog
+  version: "1.0.0"
+---
+
+# Extension Puppeteer Debugging
+
+Drive the built extension in headed Chrome from a Node script: install it, force a known config, toggle translation via the extension's own message bus, and assert on live DOM. Every step below exists because the obvious alternative **failed in practice** (2026-07-13, issue #1846 verification).
+
+## Quick reference
+
+| Step | Do this | NOT this (fails silently) |
+|---|---|---|
+| Build | `pnpm build` then `test -f .output/chrome-mv3/manifest.json` | Trusting `pnpm build \| tail` exit code (tail's exit code masks failure); missing `.env.production` in a worktree kills the build with a buried error — copy it from the main checkout |
+| Load | `puppeteer.launch({ pipe: true, enableExtensions: true })` + `browser.installExtension(path)` (Puppeteer ≥22.11) | `--load-extension` / `--disable-extensions-except` — ignored by branded Chrome 137+ |
+| Config | Read-merge-write the WHOLE `config` object in `chrome.storage.local` from the service-worker target; **re-patch after ~4s and verify** (background init/migration clobbers early writes) | Patching once and navigating immediately; writing a partial config object — it fails `configSchema.safeParse` and `getLocalConfig()` silently falls back to `DEFAULT_CONFIG` (bilingual mode) |
+| Target language | **Always force `config.language.targetCode = 'cmn'`** | Trusting the default — onboarding overwrites targetCode with the browser UI language, and the same-language skip then translates NOTHING on English fixtures |
+| Toggle | Send the webext-core envelope to the content script from the SW: `chrome.tabs.sendMessage(tabId, { id, type: 'askManagerToTogglePageTranslation', data: { enabled }, timestamp })` | Synthesizing Alt+E — on macOS Option+E is a dead key (`event.key !== 'e'`), the hotkey listener never fires |
+| Assert translated | CJK regex `/[一-鿿]/` on textContent; count `.read-frog-translated-content-wrapper` (fallback-B) and `[data-read-frog-translation-only]` (in-place swap) | Waiting a fixed sleep |
+| Assert restored | Compare innerHTML **modulo walk labels** (`data-read-frog-walked/-paragraph/-block-node/-inline-node` persist by design in every mode) | Byte-identical innerHTML comparison |
+
+## Workflow
+
+1. Build and verify the artifact exists (see table).
+2. Copy `references/harness-template.js` into the session scratchpad, point `EXT_PATH` at `.output/chrome-mv3`, adjust the fixture/assertions.
+3. Serve fixtures over `http://localhost` (content scripts don't run on `file://`). For framework-safety checks, use a React fixture with a focus-triggered re-render (simulates React Query `refetchOnWindowFocus` — the trigger behind logged-in-only bugs like #1846) and a counter button to prove listeners survived.
+4. Run headed; capture `page.on('console')` + `pageerror` for `Minified React error|NotFoundError` — a clean screenshot can hide a broken fiber tree.
+5. Provider: `microsoft-translate-default` needs no API key but real network. Slow the queues (`requestQueueConfig.rate/capacity = 1`) when you need to observe spinners.
+
+## Interpreting extension DOM state
+
+- Bilingual mode: original text stays; wrapper `.read-frog-translated-content-wrapper` inserted next to it.
+- translationOnly, in-place swap (preferred since #1846): **no wrapper remains**; the run's parent carries `data-read-frog-translation-only` and the site's own text nodes hold Chinese.
+- translationOnly, fallback: wrapper holds the translation, originals detached but retained for restore.
+- After "show original": zero wrappers AND zero `[data-read-frog-translation-only]` anchors; walk labels remain — that's normal, not a leak.
+
+## Related skills
+
+- **extension-real-browser-testing** — Playwright + Edge variant, popup/options-page evaluation, screenshot evidence rules.
+- **extension-perf-forensics** — when the symptom is leak/freeze/CPU, not wrong DOM: attribution ladder, CDP metrics, tracing.

--- a/.agents/skills/extension-puppeteer-debugging/references/harness-template.js
+++ b/.agents/skills/extension-puppeteer-debugging/references/harness-template.js
@@ -1,0 +1,149 @@
+/* Puppeteer harness template for driving the built read-frog extension.
+ * Proven working 2026-07-13 (issue #1846 E2E). Adapt EXT_PATH, PORT, fixture
+ * dir, and the assertions; the extension-control plumbing below is the part
+ * that is easy to get wrong — keep it.
+ *
+ * Setup: npm i puppeteer   (Chrome comes from ~/.cache/puppeteer)
+ * Run:   node harness.js   (headed on purpose — watch it while it runs)
+ */
+const http = require('node:http')
+const path = require('node:path')
+const fs = require('node:fs')
+const puppeteer = require('puppeteer')
+
+const EXT_PATH = '/ABS/PATH/TO/read-frog/.output/chrome-mv3' // test -f manifest.json first!
+const PAGE_DIR = path.join(__dirname, 'page') // your fixture; served over http, NEVER file://
+const PORT = 8931
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+function serve() {
+  const MIME = { '.html': 'text/html', '.js': 'text/javascript' }
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const file = path.join(PAGE_DIR, req.url === '/' ? 'index.html' : req.url)
+      try {
+        res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'text/plain' })
+        res.end(fs.readFileSync(file))
+      } catch {
+        res.writeHead(404)
+        res.end()
+      }
+    })
+    server.listen(PORT, () => resolve(server))
+  })
+}
+
+async function getServiceWorker(browser) {
+  for (let i = 0; i < 60; i++) {
+    const sw = browser
+      .targets()
+      .find((t) => t.type() === 'service_worker' && t.url().includes('background'))
+    if (sw) return sw.worker()
+    await sleep(500)
+  }
+  throw new Error('extension service worker not found — did installExtension succeed?')
+}
+
+/* Patch the extension config. TRAPS this encodes:
+ * - background init/migration clobbers early writes -> patch, wait, re-patch
+ * - onboarding overwrites targetCode with the browser UI language -> force cmn
+ *   or the same-language skip silently translates nothing on English fixtures */
+async function patchConfig(browser, mutate) {
+  const worker = await getServiceWorker(browser)
+  const patch = () =>
+    worker.evaluate(async (mutateSrc) => {
+      const { config } = await chrome.storage.local.get('config')
+      if (!config) return 'no-config-yet'
+      config.language.targetCode = 'cmn'
+      config.language.sourceCode = 'auto'
+      // eslint-disable-next-line no-new-func
+      new Function('config', mutateSrc)(config)
+      await chrome.storage.local.set({ config })
+      return `ok mode=${config.translate.mode} target=${config.language.targetCode}`
+    }, mutate)
+  let result = await patch()
+  for (let i = 0; i < 20 && result === 'no-config-yet'; i++) {
+    await sleep(500)
+    result = await patch()
+  }
+  await sleep(4000) // let init/migration finish, then make the write stick
+  result = await patch()
+  console.log('[config]', result)
+}
+
+/* Toggle page translation exactly like the popup does. TRAP: do NOT synthesize
+ * Alt+E — on macOS Option+E is a dead key and the hotkey never fires. */
+async function setTranslation(browser, enabled) {
+  const worker = await getServiceWorker(browser)
+  return worker.evaluate(
+    async (on, port) => {
+      const tabs = await chrome.tabs.query({ url: `http://localhost:${port}/*` })
+      if (!tabs.length) return 'no-tab'
+      await chrome.tabs.sendMessage(tabs[0].id, {
+        id: Math.floor(Math.random() * 1e9), // webext-core envelope
+        type: 'askManagerToTogglePageTranslation',
+        data: { enabled: on },
+        timestamp: Date.now(),
+      })
+      return `sent enabled=${on}`
+    },
+    enabled,
+    PORT,
+  )
+}
+
+async function main() {
+  const server = await serve()
+  const browser = await puppeteer.launch({
+    headless: false,
+    pipe: true, // required for installExtension
+    enableExtensions: true, // Chrome 137+ ignores --load-extension; this is the way
+    args: ['--no-first-run', '--window-size=1200,900'],
+  })
+
+  try {
+    await browser.installExtension(EXT_PATH)
+    await patchConfig(browser, `config.translate.mode = 'translationOnly'`)
+
+    const page = await browser.newPage()
+    const errors = []
+    page.on('console', (m) => /Minified React error|NotFoundError/.test(m.text()) && errors.push(m.text()))
+    page.on('pageerror', (e) => errors.push(String(e)))
+    await page.goto(`http://localhost:${PORT}/`, { waitUntil: 'networkidle0' })
+    await sleep(1500)
+
+    console.log('[toggle]', await setTranslation(browser, true))
+    // Poll for CJK instead of a fixed sleep — provider latency varies
+    for (let i = 0; i < 40; i++) {
+      await sleep(500)
+      const text = await page.evaluate(() => document.body.textContent ?? '')
+      if (/[一-鿿]/.test(text)) break
+    }
+
+    // Extension DOM state: wrappers = fallback strategy, anchors = in-place swap
+    console.log(
+      await page.evaluate(() => ({
+        wrappers: document.querySelectorAll('.read-frog-translated-content-wrapper').length,
+        anchors: document.querySelectorAll('[data-read-frog-translation-only]').length,
+      })),
+    )
+
+    console.log('[toggle]', await setTranslation(browser, false))
+    await sleep(2500)
+
+    // Restore assertions: compare innerHTML MODULO walk labels — the walker's
+    // data-read-frog-* marks persist after restore by design in every mode.
+    // const clean = (html) => html.replace(/\s*data-read-frog-[a-z-]+="[^"]*"/g, '')
+
+    console.log('[page errors]', errors)
+  } finally {
+    await browser.close().catch(() => {})
+    server.close()
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(2)
+})

--- a/.claude/skills/extension-puppeteer-debugging
+++ b/.claude/skills/extension-puppeteer-debugging
@@ -1,0 +1,1 @@
+../../.agents/skills/extension-puppeteer-debugging

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -22,11 +22,14 @@ import { deepQueryTopLevelSelector } from "@/utils/host/dom/find"
 import { walkAndLabelElement } from "@/utils/host/dom/traversal"
 import {
   findStaleBilingualLayoutSource,
+  findStaleTranslationOnlyAnchor,
+  getTranslationOnlyAnchorState,
   wasCharacterDataChangeExtensionDriven,
   wasNodeRemovedByExtension,
 } from "@/utils/host/translate/core/translation-state"
 import {
   removeAllTranslatedWrapperNodes,
+  translateNodes,
   translateNodesBilingualMode,
   translateWalkedElement,
 } from "@/utils/host/translate/node-manipulation"
@@ -682,6 +685,10 @@ export class PageTranslationManager implements IPageTranslationManager {
     for (const record of hostRecords) {
       const staleSource = findStaleBilingualLayoutSource(record.target)
       if (staleSource) staleTranslatedSources.add(staleSource)
+      // In-place-swapped anchors (translationOnly): host re-renders such as an
+      // expand/"show more" must retranslate, not stay in the source language.
+      const staleAnchor = findStaleTranslationOnlyAnchor(record.target)
+      if (staleAnchor) staleTranslatedSources.add(staleAnchor)
     }
     staleTranslatedSources.forEach((source) => {
       const nextVersion = (this.translatedSourceMutationVersions.get(source) ?? 0) + 1
@@ -752,8 +759,15 @@ export class PageTranslationManager implements IPageTranslationManager {
         }
         passes += 1
         handledVersion = mutationVersions.get(source) ?? 0
-        walkAndLabelElement(source, walkId, config)
-        await translateNodesBilingualMode([source], walkId, config)
+        if (getTranslationOnlyAnchorState(source)) {
+          // In-place-swapped anchor: translateNodes routes to the
+          // translationOnly path, which restores surviving swaps first so the
+          // provider sees current host text, then re-swaps.
+          await translateNodes([source], walkId, false, config)
+        } else {
+          walkAndLabelElement(source, walkId, config)
+          await translateNodesBilingualMode([source], walkId, config)
+        }
       } while (
         this.isPageTranslating &&
         this.translationSessionVersion === sessionVersion &&

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -23,7 +23,6 @@ import { walkAndLabelElement } from "@/utils/host/dom/traversal"
 import {
   findStaleBilingualLayoutSource,
   findStaleTranslationOnlyAnchor,
-  getTranslationOnlyAnchorState,
   wasCharacterDataChangeExtensionDriven,
   wasNodeRemovedByExtension,
 } from "@/utils/host/translate/core/translation-state"
@@ -759,10 +758,12 @@ export class PageTranslationManager implements IPageTranslationManager {
         }
         passes += 1
         handledVersion = mutationVersions.get(source) ?? 0
-        if (getTranslationOnlyAnchorState(source)) {
-          // In-place-swapped anchor: translateNodes routes to the
+        if (config.translate.mode === "translationOnly") {
+          // Swapped-anchor staleness: translateNodes routes to the
           // translationOnly path, which restores surviving swaps first so the
-          // provider sees current host text, then re-swaps.
+          // provider sees current host text, then re-swaps. Keyed on the MODE,
+          // not on anchor-state presence — a scheduled retry must never insert
+          // bilingual wrappers into a translationOnly session.
           await translateNodes([source], walkId, false, config)
         } else {
           walkAndLabelElement(source, walkId, config)

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -22,6 +22,7 @@ import { deepQueryTopLevelSelector } from "@/utils/host/dom/find"
 import { walkAndLabelElement } from "@/utils/host/dom/traversal"
 import {
   findStaleBilingualLayoutSource,
+  wasCharacterDataChangeExtensionDriven,
   wasNodeRemovedByExtension,
 } from "@/utils/host/translate/core/translation-state"
 import {
@@ -625,6 +626,11 @@ export class PageTranslationManager implements IPageTranslationManager {
     // Wrapper classes/styles are set before insertion and data-read-frog-*
     // labels are not observed, so attribute records are never self-caused.
     if (record.type === "attributes") return false
+    // In-place swaps/restores write the site's own text nodes (no wrapper
+    // ancestor); classify by the exact value the extension last wrote.
+    if (record.type === "characterData" && wasCharacterDataChangeExtensionDriven(record.target)) {
+      return true
+    }
     const targetElement = isHTMLElement(record.target) ? record.target : record.target.parentElement
     if (targetElement?.closest(`.${CONTENT_WRAPPER_CLASS}`)) return true
     if (record.type !== "childList") return false

--- a/src/utils/constants/dom-labels.ts
+++ b/src/utils/constants/dom-labels.ts
@@ -11,6 +11,10 @@ export const INLINE_ATTRIBUTE = "data-read-frog-inline-node"
 
 export const TRANSLATION_MODE_ATTRIBUTE = "data-read-frog-translation-mode"
 export const VIRTUAL_PARAGRAPH_ATTRIBUTE = "data-read-frog-virtual-paragraph"
+// Marks an element whose own text nodes hold translated values (in-place swap,
+// translationOnly mode) — the queryable handle for restore, since no wrapper
+// remains in the DOM after a successful swap.
+export const TRANSLATION_ONLY_ATTRIBUTE = "data-read-frog-translation-only"
 
 export const MARK_ATTRIBUTES = new Set([
   WALKED_ATTRIBUTE,

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -13,18 +13,21 @@ import {
   INLINE_CONTENT_CLASS,
   PARAGRAPH_ATTRIBUTE,
   TRANSLATION_ERROR_CONTAINER_CLASS,
+  TRANSLATION_ONLY_ATTRIBUTE,
   VIRTUAL_PARAGRAPH_ATTRIBUTE,
   WALKED_ATTRIBUTE,
 } from "@/utils/constants/dom-labels"
 import { flushBatchedOperations } from "@/utils/host/dom/batch-dom"
 import { walkAndLabelElement } from "@/utils/host/dom/traversal"
 import {
+  removeAllTranslatedWrapperNodes,
   translateNodeTranslationOnlyMode,
   translateNodesBilingualMode,
   translateWalkedElement,
 } from "@/utils/host/translate/node-manipulation"
 import { translateTextForPage } from "@/utils/host/translate/translate-variants"
 import {
+  expectInPlaceTranslation,
   expectNodeLabels,
   expectTranslatedContent,
   expectTranslationWrapper,
@@ -183,17 +186,17 @@ describe("translate", () => {
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
         expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
       })
-      it("translation only mode: should replace original text with translation wrapper", async () => {
+      it("translation only mode: should swap original text in place", async () => {
         render(<div data-testid="test-node">{MOCK_ORIGINAL_TEXT}</div>)
         const node = screen.getByTestId("test-node")
         await removeOrShowPageTranslation("translationOnly", true)
 
         expectNodeLabels(node, [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
-        const wrapper = expectTranslationWrapper(node, "translationOnly")
-        expect(wrapper).toBe(node.childNodes[0])
+        expectInPlaceTranslation(node)
 
         await removeOrShowPageTranslation("translationOnly", true)
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+        expect(node).not.toHaveAttribute(TRANSLATION_ONLY_ATTRIBUTE)
         expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
       })
     })
@@ -217,7 +220,7 @@ describe("translate", () => {
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
         expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
       })
-      it("translation only mode: should replace inline node content with translation wrapper", async () => {
+      it("translation only mode: should swap inline node text in place", async () => {
         render(
           <div data-testid="test-node">
             <span style={{ display: "inline" }}>{MOCK_ORIGINAL_TEXT}</span>
@@ -228,11 +231,11 @@ describe("translate", () => {
 
         expectNodeLabels(node, [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
         expectNodeLabels(node.children[0], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
-        const wrapper = expectTranslationWrapper(node, "translationOnly")
-        expect(wrapper).toBe(node.childNodes[0].childNodes[0])
+        expectInPlaceTranslation(node.children[0])
 
         await removeOrShowPageTranslation("translationOnly", true)
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+        expect(node.querySelector(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)).toBeFalsy()
         expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
       })
     })
@@ -256,7 +259,7 @@ describe("translate", () => {
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
         expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
       })
-      it("translation only mode: should replace child block node content with translation wrapper", async () => {
+      it("translation only mode: should swap child block node text in place", async () => {
         render(
           <div data-testid="test-node">
             <div>{MOCK_ORIGINAL_TEXT}</div>
@@ -267,11 +270,11 @@ describe("translate", () => {
 
         expectNodeLabels(node, [BLOCK_ATTRIBUTE])
         expectNodeLabels(node.children[0], [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
-        const wrapper = expectTranslationWrapper(node, "translationOnly")
-        expect(wrapper).toBe(node.childNodes[0].childNodes[0])
+        expectInPlaceTranslation(node.children[0])
 
         await removeOrShowPageTranslation("translationOnly", true)
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+        expect(node.querySelector(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)).toBeFalsy()
         expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
       })
     })
@@ -298,7 +301,7 @@ describe("translate", () => {
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
         expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
       })
-      it("translation only mode: should replace deepest inline node content with translation wrapper", async () => {
+      it("translation only mode: should swap deepest inline node text in place", async () => {
         render(
           <div data-testid="test-node">
             <div>
@@ -312,11 +315,11 @@ describe("translate", () => {
         expectNodeLabels(node, [BLOCK_ATTRIBUTE])
         expectNodeLabels(node.children[0], [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
         expectNodeLabels(node.children[0].children[0], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
-        const wrapper = expectTranslationWrapper(node, "translationOnly")
-        expect(wrapper).toBe(node.childNodes[0].childNodes[0].childNodes[0])
+        expectInPlaceTranslation(node.children[0].children[0])
 
         await removeOrShowPageTranslation("translationOnly", true)
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+        expect(node.querySelector(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)).toBeFalsy()
         expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
       })
     })
@@ -343,7 +346,7 @@ describe("translate", () => {
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
         expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
       })
-      it("translation only mode: should replace deepest block node content with translation wrapper", async () => {
+      it("translation only mode: should swap deepest block node text in place", async () => {
         render(
           <div data-testid="test-node">
             <div style={{ display: "inline" }}>
@@ -357,11 +360,11 @@ describe("translate", () => {
         expectNodeLabels(node, [BLOCK_ATTRIBUTE])
         expectNodeLabels(node.children[0], [INLINE_ATTRIBUTE])
         expectNodeLabels(node.children[0].children[0], [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
-        const wrapper = expectTranslationWrapper(node, "translationOnly")
-        expect(wrapper).toBe(node.childNodes[0].childNodes[0].childNodes[0])
+        expectInPlaceTranslation(node.children[0].children[0])
 
         await removeOrShowPageTranslation("translationOnly", true)
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+        expect(node.querySelector(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)).toBeFalsy()
         expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
       })
     })
@@ -388,7 +391,7 @@ describe("translate", () => {
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
         expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
       })
-      it("translation only mode: should replace nested inline node content with translation wrapper", async () => {
+      it("translation only mode: should swap nested inline node text in place", async () => {
         render(
           <div data-testid="test-node">
             <div style={{ display: "inline" }}>
@@ -402,11 +405,11 @@ describe("translate", () => {
         expectNodeLabels(node, [BLOCK_ATTRIBUTE])
         expectNodeLabels(node.children[0], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
         expectNodeLabels(node.children[0].children[0], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
-        const wrapper = expectTranslationWrapper(node, "translationOnly")
-        expect(wrapper).toBe(node.childNodes[0].childNodes[0].childNodes[0])
+        expectInPlaceTranslation(node.children[0].children[0])
 
         await removeOrShowPageTranslation("translationOnly", true)
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+        expect(node.querySelector(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)).toBeFalsy()
         expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
       })
     })
@@ -1481,7 +1484,7 @@ describe("translate", () => {
           `${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}`,
         )
       })
-      it("translation only mode: should replace inline groups and block node with separate wrappers", async () => {
+      it("translation only mode: should wrap the mixed inline group and swap block/text runs in place", async () => {
         render(
           <div data-testid="test-node">
             {MOCK_ORIGINAL_TEXT}
@@ -1494,15 +1497,22 @@ describe("translate", () => {
         await removeOrShowPageTranslation("translationOnly", true)
 
         expectNodeLabels(node, [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
+        // Run [text, span]: mixed inline run cannot be paired against the
+        // plain-text translation, so the wrapper fallback keeps applying.
         const wrapper1 = expectTranslationWrapper(node, "translationOnly")
         expect(wrapper1).toBe(node.childNodes[0])
-        const wrapper2 = expectTranslationWrapper(node.children[1], "translationOnly")
-        expect(wrapper2).toBe(node.childNodes[1].childNodes[0])
-        const wrapper3 = node.lastChild
-        expect(wrapper3).toHaveClass(CONTENT_WRAPPER_CLASS)
+        // Run inside the block <div>: single text node, swapped in place.
+        expectInPlaceTranslation(node.children[1])
+        // Trailing text run: swapped in place; its anchor is the paragraph.
+        expect(node).toHaveAttribute(TRANSLATION_ONLY_ATTRIBUTE)
+        const lastChild = node.lastChild as Text
+        expect(lastChild.nodeType).toBe(Node.TEXT_NODE)
+        expect(lastChild.data).toBe(MOCK_TRANSLATION)
 
         await removeOrShowPageTranslation("translationOnly", true)
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+        expect(node.querySelector(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)).toBeFalsy()
+        expect(node).not.toHaveAttribute(TRANSLATION_ONLY_ATTRIBUTE)
         expect(node.textContent).toBe(
           `${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}`,
         )
@@ -1776,7 +1786,7 @@ describe("translate", () => {
           `${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}`,
         )
       })
-      it("translation only mode: should replace inline groups separated by br with wrappers", async () => {
+      it("translation only mode: should swap single-span groups in place and wrap the mixed group between br", async () => {
         render(
           <div data-testid="test-node">
             <span style={{ display: "inline" }}>{MOCK_ORIGINAL_TEXT}</span>
@@ -1791,16 +1801,18 @@ describe("translate", () => {
         await removeOrShowPageTranslation("translationOnly", true)
 
         expectNodeLabels(node, [BLOCK_ATTRIBUTE])
+        // Run [span]: descends to its single text node, swapped in place.
         expectNodeLabels(node.children[0], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
-        const wrapper1 = expectTranslationWrapper(node.children[0], "translationOnly")
-        expect(wrapper1).toBe(node.childNodes[0].childNodes[0])
+        expectInPlaceTranslation(node.children[0])
+        // Run [span, text]: mixed inline run keeps the wrapper fallback.
         const wrapper2 = node.childNodes[2]
         expect(wrapper2).toHaveClass(CONTENT_WRAPPER_CLASS)
-        const wrapper3 = expectTranslationWrapper(node.children[4], "translationOnly")
-        expect(wrapper3).toBe(node.childNodes[4].childNodes[0])
+        // Run [span]: swapped in place.
+        expectInPlaceTranslation(node.children[4])
 
         await removeOrShowPageTranslation("translationOnly", true)
         expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+        expect(node.querySelector(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)).toBeFalsy()
         expect(node.textContent).toBe(
           `${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}${MOCK_ORIGINAL_TEXT}`,
         )
@@ -2018,7 +2030,7 @@ describe("translate", () => {
       expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
       expect(node.textContent).toContain(MOCK_ORIGINAL_TEXT)
     })
-    it("translation only mode: should filter out SVG and style siblings and replace inline div content", async () => {
+    it("translation only mode: should filter out SVG and style siblings and swap inline div text in place", async () => {
       render(
         <div data-testid="test-node">
           <svg viewBox="0 0 24 24">
@@ -2034,11 +2046,11 @@ describe("translate", () => {
 
       expectNodeLabels(node, [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
       expectNodeLabels(node.children[2], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
-      const wrapper = expectTranslationWrapper(node.children[2], "translationOnly")
-      expect(wrapper).toBe(node.children[2].childNodes[0])
+      expectInPlaceTranslation(node.children[2])
 
       await removeOrShowPageTranslation("translationOnly", true)
       expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+      expect(node.querySelector(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)).toBeFalsy()
       expect(node.textContent).toContain(MOCK_ORIGINAL_TEXT)
     })
   })
@@ -2089,7 +2101,7 @@ describe("translate", () => {
       expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
       expect(node.textContent).toBe(` ${MOCK_ORIGINAL_TEXT}\n `)
     })
-    it("translation only mode: should have translation wrapper in inline node", async () => {
+    it("translation only mode: should swap text in place inside the inline node", async () => {
       render(
         <div data-testid="test-node">
           {" "}
@@ -2101,11 +2113,11 @@ describe("translate", () => {
       await removeOrShowPageTranslation("translationOnly", true)
 
       expectNodeLabels(node.children[0], [INLINE_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
-      const wrapper = expectTranslationWrapper(node.children[0], "translationOnly")
-      expect(wrapper).toBe(node.children[0].childNodes[0])
+      expectInPlaceTranslation(node.children[0])
 
       await removeOrShowPageTranslation("translationOnly", true)
       expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+      expect(node.querySelector(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)).toBeFalsy()
       expect(node.textContent).toBe(` ${MOCK_ORIGINAL_TEXT}\n `)
     })
   })
@@ -2128,8 +2140,8 @@ describe("translate", () => {
       expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
       expect(node.textContent).toBe(` ${MOCK_TRANSLATION} `)
     })
-    it("translation only mode: should have translation wrapper", async () => {
-      // Mock translateTextForPage to return the exact HTML string with spaces
+    it("translation only mode: should swap provider HTML as plain text in place", async () => {
+      // Mock translateTextForPage to return structural HTML around the text
       const TRANSLATED_TEXT = `<div>${MOCK_TRANSLATION}</div>`
       vi.mocked(translateTextForPage).mockResolvedValueOnce(TRANSLATED_TEXT)
 
@@ -2141,12 +2153,16 @@ describe("translate", () => {
       const node = screen.getByTestId("test-node")
       await removeOrShowPageTranslation("translationOnly", true)
 
-      const wrapper = node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)
-      expect(wrapper).toBeTruthy()
-      expect(wrapper?.innerHTML).toBe(TRANSLATED_TEXT)
+      // Single-text-node run: the provider's hallucinated <div> is flattened
+      // to plain text and swapped into the site's own text node.
+      const anchor = node.children[0]
+      expectInPlaceTranslation(anchor)
+      expect(anchor.children).toHaveLength(0)
 
       await removeOrShowPageTranslation("translationOnly", true)
       expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+      expect(node.querySelector(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)).toBeFalsy()
+      expect(node.textContent).toBe(MOCK_TRANSLATION)
     })
   })
   describe("switching between translation modes", () => {
@@ -2163,8 +2179,21 @@ describe("translate", () => {
       render(<div data-testid="test-node">{MOCK_ORIGINAL_TEXT}</div>)
       const node = screen.getByTestId("test-node")
       await removeOrShowPageTranslation("translationOnly", true)
-      await removeOrShowPageTranslation("bilingual", true)
+      expectInPlaceTranslation(node)
 
+      // An in-place swap leaves no wrapper for the bilingual walk to detect,
+      // so a real mode switch restarts page translation and its stop step
+      // (PageTranslationManager.stopInternal) restores the swapped text via
+      // removeAllTranslatedWrapperNodes before the next walk starts.
+      removeAllTranslatedWrapperNodes()
+      expect(node).not.toHaveAttribute(TRANSLATION_ONLY_ATTRIBUTE)
+      expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
+
+      await removeOrShowPageTranslation("bilingual", true)
+      const wrapper = expectTranslationWrapper(node, "bilingual")
+      expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
+
+      await removeOrShowPageTranslation("bilingual", true)
       expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
       expect(node.textContent).toBe(MOCK_ORIGINAL_TEXT)
     })
@@ -2235,7 +2264,7 @@ describe("translate", () => {
       ).toBe(true)
     })
 
-    it("sends a compact HTML skeleton and restores attributes after translated tag movement", async () => {
+    it("sends a compact HTML skeleton and swaps translated text into the untouched source elements", async () => {
       const longClassName = `place ${"utility-class-".repeat(40)}`
       vi.mocked(translateTextForPage).mockImplementation(async (text) => {
         if (text.includes("data-rf-attr")) {
@@ -2254,6 +2283,7 @@ describe("translate", () => {
         </div>,
       )
       const node = screen.getByTestId("test-node")
+      const originalStrong = node.querySelector("strong")
 
       await removeOrShowPageTranslation("translationOnly", true)
 
@@ -2264,20 +2294,31 @@ describe("translate", () => {
       expect(requestHtml).not.toContain(longClassName)
       expect(requestHtml).not.toContain("data-place")
 
-      const wrapper = expectTranslationWrapper(node, "translationOnly")
-      const translatedStrong = wrapper?.querySelector("strong")
+      // The structural response pairs 1:1 with the source run, so the text is
+      // swapped into the site's own text nodes: no wrapper, and the original
+      // <strong> element object stays in place with structural attributes
+      // untouched. Human-visible attributes the provider translated (title)
+      // are swapped alongside the text and restored with the same guard.
+      expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+      expect(node).toHaveAttribute(TRANSLATION_ONLY_ATTRIBUTE)
+      const translatedStrong = node.querySelector("strong")
+      expect(translatedStrong).toBe(originalStrong)
       expect(translatedStrong?.className).toBe(longClassName)
-      expect((translatedStrong as HTMLElement | null)?.style.color).toBe("red")
+      expect(translatedStrong?.style.color).toBe("red")
       expect(translatedStrong?.getAttribute("data-place")).toBe("yvr")
       expect(translatedStrong?.getAttribute("title")).toBe("城市")
       expect(translatedStrong?.hasAttribute("data-rf-attr")).toBe(false)
       expect(translatedStrong?.hasAttribute("onclick")).toBe(false)
-      expect(wrapper?.textContent).toBe("这个星期一我去了温哥华。")
+      expect(translatedStrong?.textContent).toBe("温哥华")
+      expect(node.textContent).toBe("这个星期一我去了温哥华。")
 
       await removeOrShowPageTranslation("translationOnly", true)
+      expect(node).not.toHaveAttribute(TRANSLATION_ONLY_ATTRIBUTE)
       const restoredStrong = node.querySelector("strong")
+      expect(restoredStrong).toBe(originalStrong)
       expect(restoredStrong?.className).toBe(longClassName)
       expect(restoredStrong?.getAttribute("data-place")).toBe("yvr")
+      expect(restoredStrong?.getAttribute("title")).toBe("City")
       expect(restoredStrong?.textContent).toBe("Vancouver")
     })
 
@@ -2846,9 +2887,9 @@ describe("translate", () => {
         const node = screen.getByTestId("test-node")
         await removeOrShowPageTranslation("translationOnly", true)
 
-        // Should have translation wrapper since it contains text
-        const wrapper = expectTranslationWrapper(node, "translationOnly")
-        expect(wrapper).toBeTruthy()
+        // Should be translated (swapped in place) since it contains text
+        expectInPlaceTranslation(node)
+        expect(node.textContent).toBe(MOCK_TRANSLATION)
       })
     })
 

--- a/src/utils/host/__tests__/utils.ts
+++ b/src/utils/host/__tests__/utils.ts
@@ -4,6 +4,7 @@ import {
   CONTENT_WRAPPER_CLASS,
   NOTRANSLATE_CLASS,
   TRANSLATION_MODE_ATTRIBUTE,
+  TRANSLATION_ONLY_ATTRIBUTE,
 } from "@/utils/constants/dom-labels"
 
 export const MOCK_TRANSLATION = "translation"
@@ -27,6 +28,17 @@ export function expectTranslatedContent(
   expect(content).toHaveTextContent(text)
   expect(content).toHaveClass(NOTRANSLATE_CLASS)
   return content
+}
+
+/**
+ * Assert a successful in-place text swap (translationOnly Strategy A): the
+ * translation lives in the site's own text nodes, no wrapper remains, and the
+ * run's anchor element carries the restore marker attribute.
+ */
+export function expectInPlaceTranslation(anchor: Element, text: string = MOCK_TRANSLATION) {
+  expect(anchor).toHaveAttribute(TRANSLATION_ONLY_ATTRIBUTE)
+  expect(anchor.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+  expect(anchor).toHaveTextContent(text)
 }
 
 export function expectNodeLabels(node: Element, attributes: string[]) {

--- a/src/utils/host/dom/find.ts
+++ b/src/utils/host/dom/find.ts
@@ -126,6 +126,51 @@ export function deepQueryTopLevelSelector(
   return result
 }
 
+/**
+ * Collect EVERY matching element under the root (shadow roots included),
+ * without stopping at the first match the way deepQueryTopLevelSelector does —
+ * nested matches (e.g. in-place-swap anchors inside each other) must all be
+ * returned.
+ */
+export function deepQueryAllSelector(
+  element: HTMLElement | ShadowRoot | Document,
+  selectorFn: (element: HTMLElement) => boolean,
+): HTMLElement[] {
+  if (element instanceof Document) {
+    return element.body ? deepQueryAllSelector(element.body, selectorFn) : []
+  }
+
+  const result: HTMLElement[] = []
+  if (element instanceof ShadowRoot) {
+    for (const child of element.children) {
+      if (isHTMLElement(child)) {
+        result.push(...deepQueryAllSelector(child, selectorFn))
+      }
+    }
+    return result
+  }
+
+  if (selectorFn(element)) {
+    result.push(element)
+  }
+
+  if (element.shadowRoot) {
+    for (const child of element.shadowRoot.children) {
+      if (isHTMLElement(child)) {
+        result.push(...deepQueryAllSelector(child, selectorFn))
+      }
+    }
+  }
+
+  for (const child of element.children) {
+    if (isHTMLElement(child)) {
+      result.push(...deepQueryAllSelector(child, selectorFn))
+    }
+  }
+
+  return result
+}
+
 export function unwrapDeepestOnlyHTMLChild(element: HTMLElement, config: Config) {
   let currentElement = element
   while (currentElement) {

--- a/src/utils/host/translate/__tests__/translation-text-swap.test.ts
+++ b/src/utils/host/translate/__tests__/translation-text-swap.test.ts
@@ -75,6 +75,46 @@ describe("planInPlaceTextSwap", () => {
     expect(planInPlaceTextSwap(run, "<b>粗体</b>", document)).toBeNull()
   })
 
+  it("returns null when the provider reorders same-tag siblings (identity attributes differ)", () => {
+    const { run } = buildRun('Click <a href="/a">here</a> and <a href="/b">there</a> now.')
+    // Provider legitimately reorders the links for target grammar — positional
+    // pairing would cross-bind text onto the wrong hrefs.
+    const plan = planInPlaceTextSwap(
+      run,
+      '点击<a href="/b">那里</a>和<a href="/a">这里</a>就现在',
+      document,
+    )
+    expect(plan).toBeNull()
+  })
+
+  it("carries a provider-inserted whitespace separator between adjacent inline elements", () => {
+    const { container, run } = buildRun("<span>苹果</span><span>橙子</span>")
+    const plan = planInPlaceTextSwap(run, "<span>Apples</span> <span>Oranges</span>", document)
+    expect(plan).not.toBeNull()
+    const first = plan!.pairs.find((pair) => pair.node === container.children[0].firstChild)
+    const second = plan!.pairs.find((pair) => pair.node === container.children[1].firstChild)
+    expect(first!.translatedValue).toBe("Apples ")
+    expect(second!.translatedValue).toBe("Oranges")
+  })
+
+  it("collects the full protection-layer attribute set, including input value", () => {
+    const { container, run } = buildRun(
+      '<span aria-valuetext="fifty percent">progress</span> <input type="submit" value="Send">x',
+    )
+    const plan = planInPlaceTextSwap(
+      run,
+      '<span aria-valuetext="百分之五十">进度</span> <input type="submit" value="发送">乙',
+      document,
+    )
+    expect(plan).not.toBeNull()
+    expect(plan!.attributePairs).toEqual(
+      expect.arrayContaining([
+        { element: container.children[0], name: "aria-valuetext", translatedValue: "百分之五十" },
+        { element: container.children[1], name: "value", translatedValue: "发送" },
+      ]),
+    )
+  })
+
   it("collects translated human-visible attributes as attribute pairs", () => {
     const { container, run } = buildRun('<a href="/x" title="City">link</a> tail')
     const plan = planInPlaceTextSwap(run, '<a href="/x" title="城市">链接</a> 尾部', document)

--- a/src/utils/host/translate/__tests__/translation-text-swap.test.ts
+++ b/src/utils/host/translate/__tests__/translation-text-swap.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+// Pairing logic for the translationOnly in-place text swap (issue #1846).
+
+import type { TransNode } from "@/types/dom"
+import { describe, expect, it } from "vitest"
+import { planInPlaceTextSwap } from "../dom/translation-text-swap"
+
+function buildRun(html: string): { container: HTMLElement; run: TransNode[] } {
+  const container = document.createElement("div")
+  container.innerHTML = html
+  return { container, run: [...container.childNodes] as TransNode[] }
+}
+
+describe("planInPlaceTextSwap", () => {
+  it("pairs a single bare text node with the whole translation (trivial path)", () => {
+    const { run } = buildRun("Hello world")
+    const plan = planInPlaceTextSwap(run, "你好世界", document)
+    expect(plan).not.toBeNull()
+    expect(plan!.pairs).toHaveLength(1)
+    expect(plan!.pairs[0].node).toBe(run[0])
+    expect(plan!.pairs[0].translatedValue).toBe("你好世界")
+  })
+
+  it("flattens hallucinated tags in the trivial path", () => {
+    const { run } = buildRun("Hello world")
+    const plan = planInPlaceTextSwap(run, "<div><b>你好</b>世界</div>", document)
+    expect(plan).not.toBeNull()
+    expect(plan!.pairs[0].translatedValue).toBe("你好世界")
+  })
+
+  it("aligns mixed text and inline elements structurally", () => {
+    const { container, run } = buildRun('lead <a href="/x">link</a> tail')
+    const plan = planInPlaceTextSwap(run, '前缀 <a href="/x">链接</a> 后缀', document)
+    expect(plan).not.toBeNull()
+    const valueFor = (node: Node) => plan!.pairs.find((pair) => pair.node === node)?.translatedValue
+    expect(plan!.pairs).toHaveLength(3)
+    expect(valueFor(container.childNodes[0])).toBe("前缀 ")
+    expect(valueFor(container.childNodes[1].firstChild!)).toBe("链接")
+    expect(valueFor(container.childNodes[2])).toBe(" 后缀")
+  })
+
+  it("merges provider-split gap text into the first source node and blanks the rest", () => {
+    const container = document.createElement("div")
+    const t1 = document.createTextNode("part one ")
+    const t2 = document.createTextNode("part two")
+    container.append(t1, document.createElement("br"), document.createTextNode("x"))
+    container.insertBefore(t2, container.childNodes[1])
+    // container: [t1, t2, <br>, "x"] — two source text nodes in one gap
+    const run = [...container.childNodes] as TransNode[]
+    const plan = planInPlaceTextSwap(run, "合并译文<br>甲", document)
+    expect(plan).not.toBeNull()
+    const gapPairs = plan!.pairs.filter((pair) => pair.node === t1 || pair.node === t2)
+    expect(gapPairs.find((pair) => pair.node === t1)!.translatedValue).toBe("合并译文")
+    expect(gapPairs.find((pair) => pair.node === t2)!.translatedValue).toBe("")
+  })
+
+  it("returns null when the provider drops an element", () => {
+    const { run } = buildRun("lead <b>bold</b> tail")
+    expect(planInPlaceTextSwap(run, "前缀 粗体 后缀", document)).toBeNull()
+  })
+
+  it("returns null when the provider changes an element's tag", () => {
+    const { run } = buildRun("lead <b>bold</b> tail")
+    expect(planInPlaceTextSwap(run, "前缀 <i>粗体</i> 后缀", document)).toBeNull()
+  })
+
+  it("returns null when translated text has no source slot (orphan target)", () => {
+    const { run } = buildRun("<b>bold</b>")
+    // Target adds loose text before the element where source had none
+    expect(planInPlaceTextSwap(run, "多余 <b>粗体</b>", document)).toBeNull()
+  })
+
+  it("returns null when source text goes untranslated (uncovered gap)", () => {
+    const { run } = buildRun("lead <b>bold</b> tail")
+    expect(planInPlaceTextSwap(run, "<b>粗体</b>", document)).toBeNull()
+  })
+
+  it("collects translated human-visible attributes as attribute pairs", () => {
+    const { container, run } = buildRun('<a href="/x" title="City">link</a> tail')
+    const plan = planInPlaceTextSwap(run, '<a href="/x" title="城市">链接</a> 尾部', document)
+    expect(plan).not.toBeNull()
+    expect(plan!.attributePairs).toEqual([
+      { element: container.children[0], name: "title", translatedValue: "城市" },
+    ])
+  })
+
+  it("does not create attribute pairs when the target drops or keeps the attribute", () => {
+    const { run } = buildRun('<a href="/x" title="City">link</a> tail')
+    const plan = planInPlaceTextSwap(run, '<a href="/x">链接</a> 尾部', document)
+    expect(plan).not.toBeNull()
+    expect(plan!.attributePairs).toEqual([])
+  })
+})

--- a/src/utils/host/translate/core/__tests__/translation-only-restore.test.ts
+++ b/src/utils/host/translate/core/__tests__/translation-only-restore.test.ts
@@ -12,6 +12,7 @@ import {
   removeTranslatedWrapperWithRestore,
 } from "../../dom/translation-cleanup"
 import { translateNodeTranslationOnlyMode } from "../translation-modes"
+import { findStaleTranslationOnlyAnchor } from "../translation-state"
 
 const { mockShouldFilterSmallParagraph, mockTranslateTextForPage, mockShouldSkipAsTargetLanguage } =
   vi.hoisted(() => ({
@@ -331,6 +332,53 @@ describe("translationOnly node-identity restore (#1846)", () => {
     expect(link.getAttribute("title")).toBe("City")
     expect(link.textContent).toBe("link")
     expect(p.textContent).toBe("prefix link suffix")
+  })
+
+  it("detects host expansion of swapped content and retranslates it (X show-more)", async () => {
+    const p = document.createElement("p")
+    p.textContent = "Short truncated tweet"
+    const textNode = p.firstChild as Text
+    document.body.append(p)
+
+    await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+    expect(textNode.data).toBe("中文译文")
+    // Untouched anchor is NOT stale
+    expect(findStaleTranslationOnlyAnchor(textNode)).toBeUndefined()
+
+    // Host expands the tweet ("show more"): rewrites the swapped node
+    textNode.data = "Short truncated tweet plus the long expanded remainder"
+    expect(findStaleTranslationOnlyAnchor(textNode)).toBe(p)
+
+    // What the manager's retranslation pipeline runs for a stale anchor
+    mockTranslateTextForPage.mockResolvedValue("完整中文译文")
+    await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+
+    // Provider saw the CURRENT host text, not the old translation
+    const lastRequest = String(mockTranslateTextForPage.mock.calls.at(-1)![0])
+    expect(lastRequest).toContain("expanded remainder")
+    expect(p.textContent).toBe("完整中文译文")
+    expect(findStaleTranslationOnlyAnchor(textNode)).toBeUndefined()
+
+    // Show original returns the host's EXPANDED text, not the stale short one
+    removeAllTranslatedWrapperNodes(document)
+    flushBatchedOperations()
+    expect(p.textContent).toBe("Short truncated tweet plus the long expanded remainder")
+    expect(p.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(false)
+  })
+
+  it("detects text nodes the host appended into a swapped anchor", async () => {
+    const p = document.createElement("p")
+    p.textContent = "Existing sentence"
+    document.body.append(p)
+
+    await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+
+    const appended = document.createTextNode(" Newly appended sentence.")
+    p.append(appended)
+    expect(findStaleTranslationOnlyAnchor(appended)).toBe(p)
   })
 
   it("keeps originals when the provider returns an empty translation", async () => {

--- a/src/utils/host/translate/core/__tests__/translation-only-restore.test.ts
+++ b/src/utils/host/translate/core/__tests__/translation-only-restore.test.ts
@@ -11,7 +11,7 @@ import {
   removeAllTranslatedWrapperNodes,
   removeTranslatedWrapperWithRestore,
 } from "../../dom/translation-cleanup"
-import { translateNodeTranslationOnlyMode } from "../translation-modes"
+import { translateNodesBilingualMode, translateNodeTranslationOnlyMode } from "../translation-modes"
 import { findStaleTranslationOnlyAnchor } from "../translation-state"
 
 const { mockShouldFilterSmallParagraph, mockTranslateTextForPage, mockShouldSkipAsTargetLanguage } =
@@ -366,6 +366,67 @@ describe("translationOnly node-identity restore (#1846)", () => {
     flushBatchedOperations()
     expect(p.textContent).toBe("Short truncated tweet plus the long expanded remainder")
     expect(p.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(false)
+  })
+
+  it("toggle-off converges for a container mixing a swapped run and a nested wrapper run", async () => {
+    // Adversarial-review finding: the loose-text run's toggle must restore its
+    // OWN swap, not steal the nested li's wrapper and re-translate forever.
+    const container = document.createElement("div")
+    const introText = document.createTextNode("Intro paragraph text. ")
+    const ul = document.createElement("ul")
+    const li = document.createElement("li")
+    const bold = document.createElement("b")
+    bold.textContent = "Keep any of them"
+    li.append(bold, document.createTextNode(" by setting its key to false"))
+    ul.append(li)
+    container.append(introText, ul)
+    document.body.append(container)
+    const originalHTML = container.innerHTML
+
+    // Press 1: translate (walker order — loose run first, then the li)
+    await translateNodeTranslationOnlyMode([introText], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+    await translateNodeTranslationOnlyMode([li], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+    expect(mockTranslateTextForPage).toHaveBeenCalledTimes(2)
+    expect(container.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(true)
+    expect(getWrappers(container).length).toBe(1)
+
+    // Press 2 ("hide"): same walker order, fresh walkId, toggle=true
+    await translateNodeTranslationOnlyMode([introText], "walk-2", DEFAULT_CONFIG, true)
+    flushBatchedOperations()
+    await translateNodeTranslationOnlyMode([li], "walk-2", DEFAULT_CONFIG, true)
+    flushBatchedOperations()
+
+    expect(container.innerHTML).toBe(originalHTML)
+    expect(container.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(false)
+    expect(getWrappers().length).toBe(0)
+    // No extra provider calls: the hide press translated nothing
+    expect(mockTranslateTextForPage).toHaveBeenCalledTimes(2)
+  })
+
+  it("bilingual toggle restores an in-place swap left by a translationOnly session", async () => {
+    const p = document.createElement("p")
+    p.textContent = "Original sentence"
+    const originalText = p.firstChild
+    document.body.append(p)
+
+    await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+    expect(p.textContent).toBe("中文译文")
+
+    // Mode switched to bilingual without a full cleanup; node-level toggle
+    const bilingualConfig = {
+      ...DEFAULT_CONFIG,
+      translate: { ...DEFAULT_CONFIG.translate, mode: "bilingual" as const },
+    }
+    await translateNodesBilingualMode([p], "walk-2", bilingualConfig, true)
+    flushBatchedOperations()
+
+    expect(p.textContent).toBe("Original sentence")
+    expect(p.firstChild).toBe(originalText)
+    expect(p.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(false)
+    expect(mockTranslateTextForPage).toHaveBeenCalledTimes(1)
   })
 
   it("detects text nodes the host appended into a swapped anchor", async () => {

--- a/src/utils/host/translate/core/__tests__/translation-only-restore.test.ts
+++ b/src/utils/host/translate/core/__tests__/translation-only-restore.test.ts
@@ -1,0 +1,251 @@
+// @vitest-environment jsdom
+// Node-identity restore for translationOnly mode (#1846): originals displaced by
+// a translation wrapper are retained as ChildNode objects and re-inserted on
+// restore — never rebuilt from an ancestor innerHTML snapshot.
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { CONTENT_WRAPPER_CLASS } from "@/utils/constants/dom-labels"
+import { flushBatchedOperations } from "../../../dom/batch-dom"
+import {
+  removeAllTranslatedWrapperNodes,
+  removeTranslatedWrapperWithRestore,
+} from "../../dom/translation-cleanup"
+import { translateNodeTranslationOnlyMode } from "../translation-modes"
+
+const { mockShouldFilterSmallParagraph, mockTranslateTextForPage, mockShouldSkipAsTargetLanguage } =
+  vi.hoisted(() => ({
+    mockShouldFilterSmallParagraph: vi.fn<(...args: any[]) => any>(),
+    mockTranslateTextForPage: vi.fn<(...args: any[]) => any>(),
+    mockShouldSkipAsTargetLanguage: vi.fn<(...args: any[]) => any>(),
+  }))
+
+vi.mock("@/utils/host/translate/filter-small-paragraph", () => ({
+  shouldFilterSmallParagraph: mockShouldFilterSmallParagraph,
+}))
+
+vi.mock("@/utils/host/translate/translate-variants", () => ({
+  translateTextForPage: mockTranslateTextForPage,
+}))
+
+vi.mock("@/utils/host/translate/target-language-skip", () => ({
+  shouldSkipAsTargetLanguage: mockShouldSkipAsTargetLanguage,
+}))
+
+function getWrappers(root: ParentNode = document): HTMLElement[] {
+  return [...root.querySelectorAll<HTMLElement>(`.${CONTENT_WRAPPER_CLASS}`)]
+}
+
+describe("translationOnly node-identity restore (#1846)", () => {
+  beforeEach(() => {
+    document.body.replaceChildren()
+    mockShouldFilterSmallParagraph.mockReset().mockResolvedValue(false)
+    mockShouldSkipAsTargetLanguage.mockReset().mockResolvedValue(false)
+    mockTranslateTextForPage.mockReset().mockResolvedValue("中文译文")
+  })
+
+  it("restores every original node when units were translated inner-first (issue repro)", async () => {
+    // Mimics the NexusMods description: loose text plus a nested list under one
+    // container, translated as separate units in inner-first order. The old
+    // snapshot mechanism skipped saving the container (a wrapper already
+    // existed inside it) and lost the loose text forever.
+    const container = document.createElement("div")
+    const introText = document.createTextNode("Intro paragraph text. ")
+    const ul = document.createElement("ul")
+    const li = document.createElement("li")
+    const bold = document.createElement("b")
+    bold.textContent = "Keep any of them"
+    li.append(bold, document.createTextNode(" by setting its key to false"))
+    ul.append(li)
+    container.append(introText, ul)
+    document.body.append(container)
+
+    const originalHTML = container.innerHTML
+
+    await translateNodeTranslationOnlyMode([li], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+    await translateNodeTranslationOnlyMode([introText], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+
+    expect(getWrappers(container).length).toBe(2)
+    expect(container.textContent).not.toContain("Intro paragraph text.")
+
+    removeAllTranslatedWrapperNodes(document)
+    flushBatchedOperations()
+
+    expect(container.innerHTML).toBe(originalHTML)
+    // Node identity, not just markup: the same Text object is back in place
+    expect(container.firstChild).toBe(introText)
+    expect(li.firstChild).toBe(bold)
+  })
+
+  it("re-inserts the same element objects for a multi-node inline run", async () => {
+    const container = document.createElement("div")
+    const spanA = document.createElement("span")
+    spanA.textContent = "First part"
+    const textB = document.createTextNode(" and second part")
+    container.append(spanA, textB)
+    document.body.append(container)
+
+    await translateNodeTranslationOnlyMode([spanA, textB], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+    expect(container.contains(spanA)).toBe(false)
+
+    removeAllTranslatedWrapperNodes(document)
+    flushBatchedOperations()
+
+    expect(container.children[0]).toBe(spanA)
+    expect(spanA.nextSibling).toBe(textB)
+    expect(getWrappers().length).toBe(0)
+  })
+
+  it("never touches untranslated siblings (no ancestor blast radius)", async () => {
+    const container = document.createElement("div")
+    const pA = document.createElement("p")
+    pA.textContent = "Translate me"
+    const pB = document.createElement("p")
+    pB.textContent = "Leave me alone"
+    const pBText = pB.firstChild
+    container.append(pA, pB)
+    document.body.append(container)
+
+    await translateNodeTranslationOnlyMode([pA], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+    removeAllTranslatedWrapperNodes(document)
+    flushBatchedOperations()
+
+    // The old code rewrote the shared parent's innerHTML, cloning pB
+    expect(container.children[1]).toBe(pB)
+    expect(pB.firstChild).toBe(pBText)
+  })
+
+  it("toggle removes the translation and restores originals without retranslating", async () => {
+    const p = document.createElement("p")
+    p.textContent = "Original sentence"
+    const originalText = p.firstChild
+    document.body.append(p)
+
+    await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+    expect(p.textContent).toContain("中文译文")
+
+    await translateNodeTranslationOnlyMode([p], "walk-2", DEFAULT_CONFIG, true)
+    flushBatchedOperations()
+
+    expect(p.textContent).toBe("Original sentence")
+    expect(p.firstChild).toBe(originalText)
+    expect(getWrappers().length).toBe(0)
+    expect(mockTranslateTextForPage).toHaveBeenCalledTimes(1)
+  })
+
+  it("retranslate (non-toggle) restores then translates the same nodes again", async () => {
+    const p = document.createElement("p")
+    p.textContent = "Original sentence"
+    document.body.append(p)
+
+    await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+
+    await translateNodeTranslationOnlyMode([p], "walk-2", DEFAULT_CONFIG, false)
+    await vi.waitFor(() => {
+      flushBatchedOperations()
+      expect(mockTranslateTextForPage).toHaveBeenCalledTimes(2)
+    })
+    flushBatchedOperations()
+
+    expect(getWrappers(p).length).toBe(1)
+    expect(p.textContent).toContain("中文译文")
+
+    removeAllTranslatedWrapperNodes(document)
+    flushBatchedOperations()
+    expect(p.textContent).toBe("Original sentence")
+  })
+
+  it("does not remove originals when cleanup ran while translation was in flight", async () => {
+    const p = document.createElement("p")
+    p.textContent = "Original sentence"
+    document.body.append(p)
+
+    let resolveTranslation!: (value: string) => void
+    mockTranslateTextForPage.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveTranslation = resolve
+      }),
+    )
+
+    const translation = translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    await vi.waitFor(() =>
+      expect(getWrappers(p).length + getWrappers(document).length).toBeGreaterThan(0),
+    )
+    flushBatchedOperations()
+
+    removeAllTranslatedWrapperNodes(document)
+    flushBatchedOperations()
+
+    resolveTranslation("中文译文")
+    await translation
+    flushBatchedOperations()
+
+    expect(p.textContent).toBe("Original sentence")
+    expect(getWrappers().length).toBe(0)
+  })
+
+  it("returns nothing and leaves the DOM alone when the host removed the wrapper", async () => {
+    const p = document.createElement("p")
+    p.textContent = "Original sentence"
+    document.body.append(p)
+
+    await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+
+    const wrapper = getWrappers(p)[0]
+    expect(wrapper).toBeDefined()
+    // Host (framework re-render) removes the wrapper wholesale
+    wrapper.remove()
+    const htmlAfterHostRemoval = document.body.innerHTML
+
+    const restored = removeTranslatedWrapperWithRestore(wrapper)
+    flushBatchedOperations()
+
+    expect(restored).toEqual([])
+    expect(document.body.innerHTML).toBe(htmlAfterHostRemoval)
+  })
+
+  it("does not duplicate an original the host already re-attached", async () => {
+    const p = document.createElement("p")
+    const originalText = document.createTextNode("Original sentence")
+    p.append(originalText)
+    document.body.append(p)
+
+    await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+
+    // Host re-attaches the original text node on its own (framework re-render)
+    p.append(originalText)
+
+    removeAllTranslatedWrapperNodes(document)
+    flushBatchedOperations()
+
+    expect(p.textContent).toBe("Original sentence")
+    expect([...p.childNodes].filter((n) => n === originalText).length).toBe(1)
+  })
+
+  it("keeps originals when the provider returns an empty translation", async () => {
+    mockTranslateTextForPage.mockResolvedValue("")
+    const p = document.createElement("p")
+    p.textContent = "Original sentence"
+    const originalText = p.firstChild
+    document.body.append(p)
+
+    await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+
+    expect(p.textContent).toBe("Original sentence")
+    expect(p.firstChild).toBe(originalText)
+    expect(getWrappers().length).toBe(0)
+
+    removeAllTranslatedWrapperNodes(document)
+    flushBatchedOperations()
+    expect(p.textContent).toBe("Original sentence")
+  })
+})

--- a/src/utils/host/translate/core/__tests__/translation-only-restore.test.ts
+++ b/src/utils/host/translate/core/__tests__/translation-only-restore.test.ts
@@ -5,7 +5,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
-import { CONTENT_WRAPPER_CLASS } from "@/utils/constants/dom-labels"
+import { CONTENT_WRAPPER_CLASS, TRANSLATION_ONLY_ATTRIBUTE } from "@/utils/constants/dom-labels"
 import { flushBatchedOperations } from "../../../dom/batch-dom"
 import {
   removeAllTranslatedWrapperNodes,
@@ -67,13 +67,17 @@ describe("translationOnly node-identity restore (#1846)", () => {
     await translateNodeTranslationOnlyMode([introText], "walk-1", DEFAULT_CONFIG)
     flushBatchedOperations()
 
-    expect(getWrappers(container).length).toBe(2)
+    // The structural li run falls back to a wrapper (plain-text mock can't be
+    // paired); the loose text run swaps in place on the container anchor.
+    expect(getWrappers(container).length).toBe(1)
+    expect(container.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(true)
     expect(container.textContent).not.toContain("Intro paragraph text.")
 
     removeAllTranslatedWrapperNodes(document)
     flushBatchedOperations()
 
     expect(container.innerHTML).toBe(originalHTML)
+    expect(container.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(false)
     // Node identity, not just markup: the same Text object is back in place
     expect(container.firstChild).toBe(introText)
     expect(li.firstChild).toBe(bold)
@@ -138,27 +142,29 @@ describe("translationOnly node-identity restore (#1846)", () => {
     expect(mockTranslateTextForPage).toHaveBeenCalledTimes(1)
   })
 
-  it("retranslate (non-toggle) restores then translates the same nodes again", async () => {
+  it("retranslate (non-toggle) restores the swap then translates again", async () => {
     const p = document.createElement("p")
     p.textContent = "Original sentence"
+    const originalText = p.firstChild
     document.body.append(p)
 
     await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
     flushBatchedOperations()
+    expect(p.textContent).toBe("中文译文")
 
     await translateNodeTranslationOnlyMode([p], "walk-2", DEFAULT_CONFIG, false)
-    await vi.waitFor(() => {
-      flushBatchedOperations()
-      expect(mockTranslateTextForPage).toHaveBeenCalledTimes(2)
-    })
     flushBatchedOperations()
 
-    expect(getWrappers(p).length).toBe(1)
-    expect(p.textContent).toContain("中文译文")
+    expect(mockTranslateTextForPage).toHaveBeenCalledTimes(2)
+    expect(getWrappers(p).length).toBe(0)
+    expect(p.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(true)
+    expect(p.firstChild).toBe(originalText)
+    expect(p.textContent).toBe("中文译文")
 
     removeAllTranslatedWrapperNodes(document)
     flushBatchedOperations()
     expect(p.textContent).toBe("Original sentence")
+    expect(p.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(false)
   })
 
   it("does not remove originals when cleanup ran while translation was in flight", async () => {
@@ -191,8 +197,11 @@ describe("translationOnly node-identity restore (#1846)", () => {
   })
 
   it("returns nothing and leaves the DOM alone when the host removed the wrapper", async () => {
+    // Structural content so the plain-text mock forces the wrapper fallback
     const p = document.createElement("p")
-    p.textContent = "Original sentence"
+    const bold = document.createElement("b")
+    bold.textContent = "Bold lead"
+    p.append(bold, document.createTextNode(" tail text"))
     document.body.append(p)
 
     await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
@@ -228,6 +237,100 @@ describe("translationOnly node-identity restore (#1846)", () => {
 
     expect(p.textContent).toBe("Original sentence")
     expect([...p.childNodes].filter((n) => n === originalText).length).toBe(1)
+  })
+
+  it("swaps a single-text paragraph in place, preserving node identity", async () => {
+    const p = document.createElement("p")
+    p.textContent = "Original sentence"
+    const originalText = p.firstChild as Text
+    document.body.append(p)
+
+    await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+
+    expect(getWrappers().length).toBe(0)
+    expect(p.firstChild).toBe(originalText)
+    expect(originalText.data).toBe("中文译文")
+    expect(p.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(true)
+
+    removeAllTranslatedWrapperNodes(document)
+    flushBatchedOperations()
+    expect(p.firstChild).toBe(originalText)
+    expect(originalText.data).toBe("Original sentence")
+    expect(p.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(false)
+  })
+
+  it("guarded restore never clobbers text the framework rewrote after the swap", async () => {
+    const p = document.createElement("p")
+    p.textContent = "Original sentence"
+    const originalText = p.firstChild as Text
+    document.body.append(p)
+
+    await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+    expect(originalText.data).toBe("中文译文")
+
+    // Framework re-render rewrites the swapped node with fresh host content
+    originalText.data = "Fresh host content"
+
+    removeAllTranslatedWrapperNodes(document)
+    flushBatchedOperations()
+
+    expect(originalText.data).toBe("Fresh host content")
+    expect(p.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(false)
+  })
+
+  it("drops the translation when the host mutated the run while the request was in flight", async () => {
+    const p = document.createElement("p")
+    p.textContent = "Original sentence"
+    const originalText = p.firstChild as Text
+    document.body.append(p)
+
+    let resolveTranslation!: (value: string) => void
+    mockTranslateTextForPage.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveTranslation = resolve
+      }),
+    )
+
+    const translation = translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    // Wait until the request is actually in flight (snapshot already taken),
+    // then let the host rewrite the text before the response lands
+    await vi.waitFor(() => expect(mockTranslateTextForPage).toHaveBeenCalled())
+    originalText.data = "Host changed this mid-flight"
+
+    resolveTranslation("中文译文")
+    await translation
+    flushBatchedOperations()
+
+    expect(originalText.data).toBe("Host changed this mid-flight")
+    expect(getWrappers().length).toBe(0)
+    expect(p.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(false)
+  })
+
+  it("swaps translated human-visible attributes and restores them guardedly", async () => {
+    mockTranslateTextForPage.mockResolvedValue('前缀 <a href="/x" title="城市">链接</a> 后缀')
+    const p = document.createElement("p")
+    const link = document.createElement("a")
+    link.setAttribute("href", "/x")
+    link.setAttribute("title", "City")
+    link.textContent = "link"
+    p.append(document.createTextNode("prefix "), link, document.createTextNode(" suffix"))
+    document.body.append(p)
+
+    await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+
+    expect(getWrappers().length).toBe(0)
+    expect(p.children[0]).toBe(link)
+    expect(link.getAttribute("title")).toBe("城市")
+    expect(link.textContent).toBe("链接")
+
+    removeAllTranslatedWrapperNodes(document)
+    flushBatchedOperations()
+    expect(link.getAttribute("title")).toBe("City")
+    expect(link.textContent).toBe("link")
+    expect(p.textContent).toBe("prefix link suffix")
   })
 
   it("keeps originals when the provider returns an empty translation", async () => {

--- a/src/utils/host/translate/core/__tests__/translation-only-restore.test.ts
+++ b/src/utils/host/translate/core/__tests__/translation-only-restore.test.ts
@@ -429,7 +429,7 @@ describe("translationOnly node-identity restore (#1846)", () => {
     expect(mockTranslateTextForPage).toHaveBeenCalledTimes(1)
   })
 
-  it("detects text nodes the host appended into a swapped anchor", async () => {
+  it("detects a host replacement of a swapped run's text node", async () => {
     const p = document.createElement("p")
     p.textContent = "Existing sentence"
     document.body.append(p)
@@ -437,9 +437,90 @@ describe("translationOnly node-identity restore (#1846)", () => {
     await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
     flushBatchedOperations()
 
-    const appended = document.createTextNode(" Newly appended sentence.")
-    p.append(appended)
-    expect(findStaleTranslationOnlyAnchor(appended)).toBe(p)
+    // Framework re-render swaps the text node object for a fresh one
+    p.replaceChildren(document.createTextNode("Expanded replacement sentence"))
+    expect(findStaleTranslationOnlyAnchor(p)).toBe(p)
+  })
+
+  it("nested anchors never make an ancestor anchor falsely stale (per-record staleness)", async () => {
+    // div[looseText, p[text]] — both runs swap, anchors nest (div ⊃ p). The
+    // old anchor-wide aggregate went permanently stale when the nested anchor
+    // registered/unregistered; per-record staleness must stay quiet.
+    const container = document.createElement("div")
+    const looseText = document.createTextNode("Loose intro text. ")
+    const inner = document.createElement("p")
+    inner.textContent = "Nested paragraph text"
+    container.append(looseText, inner)
+    document.body.append(container)
+
+    // Outer run swaps FIRST (its expected text computed while inner is
+    // unregistered — the old design's poison window)
+    await translateNodeTranslationOnlyMode([looseText], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+    await translateNodeTranslationOnlyMode([inner], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+
+    expect(findStaleTranslationOnlyAnchor(looseText)).toBeUndefined()
+    expect(findStaleTranslationOnlyAnchor(inner.firstChild!)).toBeUndefined()
+
+    // Toggling the nested run off must not flip the ancestor stale either
+    await translateNodeTranslationOnlyMode([inner], "walk-2", DEFAULT_CONFIG, true)
+    flushBatchedOperations()
+    expect(findStaleTranslationOnlyAnchor(looseText)).toBeUndefined()
+    expect(findStaleTranslationOnlyAnchor(inner)).toBeUndefined()
+  })
+
+  it("keeps monitoring a run whose retranslation was dropped by the mid-flight guard", async () => {
+    const p = document.createElement("p")
+    p.textContent = "Original sentence"
+    document.body.append(p)
+
+    await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+    expect(p.textContent).toBe("中文译文")
+
+    // Host rewrite triggers a retranslation pass; the host rewrites AGAIN
+    // while that pass's request is in flight, so the re-swap is dropped.
+    const textNode = p.firstChild as Text
+    textNode.data = "Expanded sentence one"
+    let resolveTranslation!: (value: string) => void
+    mockTranslateTextForPage.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveTranslation = resolve
+      }),
+    )
+    const retranslation = translateNodeTranslationOnlyMode([p], "walk-2", DEFAULT_CONFIG)
+    await vi.waitFor(() => expect(mockTranslateTextForPage).toHaveBeenCalledTimes(2))
+    textNode.data = "Expanded sentence two (host rewrote mid-flight)"
+    resolveTranslation("过期译文")
+    await retranslation
+    flushBatchedOperations()
+
+    // The stale translation was dropped, but the anchor is still registered
+    // and reads as stale — the budgeted pipeline will retry with fresh text.
+    expect(p.textContent).toBe("Expanded sentence two (host rewrote mid-flight)")
+    expect(p.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(true)
+    expect(findStaleTranslationOnlyAnchor(textNode)).toBe(p)
+  })
+
+  it("prunes unrestorable records so a toggled-off anchor releases its marker", async () => {
+    const p = document.createElement("p")
+    p.textContent = "Original sentence"
+    document.body.append(p)
+
+    await translateNodeTranslationOnlyMode([p], "walk-1", DEFAULT_CONFIG)
+    flushBatchedOperations()
+
+    // Host replaces the entire content: every node the record references is
+    // disconnected, nothing is restorable.
+    p.replaceChildren(document.createTextNode("Host rebuilt everything"))
+
+    await translateNodeTranslationOnlyMode([p], "walk-2", DEFAULT_CONFIG, true)
+    flushBatchedOperations()
+
+    expect(p.textContent).toBe("Host rebuilt everything")
+    expect(p.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)).toBe(false)
+    expect(findStaleTranslationOnlyAnchor(p)).toBeUndefined()
   })
 
   it("keeps originals when the provider returns an empty translation", async () => {

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -44,8 +44,8 @@ import {
   isVirtualParagraphGroupCurrent,
   markExtensionDrivenNodeRemoval,
   markVirtualParagraphGroupInserted,
-  originalContentMap,
   registerBilingualTranslationState,
+  registerTranslationOnlyOriginals,
   registerVirtualParagraphGroup,
   registerVirtualParagraphWrapper,
   translatingNodes,
@@ -532,24 +532,6 @@ export async function translateNodeTranslationOnlyMode(
     return
   }
 
-  // snapshot the outer parent element, to prevent lose it if we go to deeper by unwrapDeepestOnlyHTMLChild
-  // test case is:
-  // <div data-testid="test-node">
-  //   <span style={{ display: 'inline' }}>原文</span> // get the outer parent snapshot before go to inner element
-  //   <br />
-  //   <span style={{ display: 'inline' }}>原文</span>
-  //   原文
-  //   <br />
-  //   <span style={{ display: 'inline' }}>原文</span>
-  // </div>,
-  // Only save originalContent when there's no existing translation wrapper
-  // If wrapper exists, we're removing translation and should restore from saved content
-  const outerParentElement = outerTransNodes[0].parentElement
-  const hasExistingWrapper = outerParentElement?.querySelector(`.${CONTENT_WRAPPER_CLASS}`)
-  if (outerParentElement && !originalContentMap.has(outerParentElement) && !hasExistingWrapper) {
-    originalContentMap.set(outerParentElement, outerParentElement.innerHTML)
-  }
-
   let transNodes: TransNode[] = []
   let allChildNodes: ChildNode[] = []
   if (outerTransNodes.length === 1 && isHTMLElement(outerTransNodes[0])) {
@@ -588,18 +570,23 @@ export async function translateNodeTranslationOnlyMode(
 
     const finalTranslatedWrapper = existedTranslatedWrapperOutside ?? existedTranslatedWrapper
     if (finalTranslatedWrapper && isHTMLElement(finalTranslatedWrapper)) {
-      removeTranslatedWrapperWithRestore(finalTranslatedWrapper)
+      const restoredNodes = removeTranslatedWrapperWithRestore(finalTranslatedWrapper)
       if (toggle) {
         return
       }
-      // In translationOnly mode, removeTranslatedWrapperWithRestore uses innerHTML to restore content,
-      // which destroys the original DOM nodes and creates new ones. The 'nodes' array still references
-      // the old detached nodes, and targetNode can't reference to the new dom added by innerHTML anymore.
-      // Therefore, by recursively calling translateNodeTranslationOnlyMode here with the
-      // same nodes array, we ensure the translation uses the newly created DOM elements since the
-      // function will re-query and find the correct parent and child nodes from the restored DOM.
+      // The restore synchronously re-inserted the SAME original node objects,
+      // so when `nodes` are still connected they remain the correct
+      // retranslation input. When they referenced the removed wrapper or its
+      // translated content (both detached now), retranslate the restored
+      // originals instead. Neither side connected means the host rebuilt the
+      // region — leave it alone rather than loop.
       nodes.forEach((node) => translatingNodes.delete(node))
-      void translateNodeTranslationOnlyMode(nodes, walkId, config, toggle)
+      const retryNodes = nodes.some((node) => node.isConnected)
+        ? nodes
+        : restoredNodes.filter((node) => node.isConnected)
+      if (retryNodes.length > 0) {
+        void translateNodeTranslationOnlyMode(retryNodes, walkId, config, toggle)
+      }
       return
     }
 
@@ -611,12 +598,6 @@ export async function translateNodeTranslationOnlyMode(
     // Check the plain text, not the HTML string sent to the provider — franc
     // on markup is noise. Runs before the wrapper is inserted into the DOM.
     if (await shouldSkipAsTargetLanguage(innerTextContent, config)) return
-
-    // Only save originalContent when there's no existing translation wrapper
-    const hasExistingWrapperInParent = parentNode.querySelector(`.${CONTENT_WRAPPER_CLASS}`)
-    if (!originalContentMap.has(parentNode) && !hasExistingWrapperInParent) {
-      originalContentMap.set(parentNode, parentNode.innerHTML)
-    }
 
     const ownerDoc = getOwnerDocument(targetNode)
     const protectedHtml = protectTranslationHtmlAttributes(transNodes, ownerDoc)
@@ -727,11 +708,18 @@ export async function translateNodeTranslationOnlyMode(
 
     // Batch final DOM mutations to reduce layout thrashing
     batchDOMOperation(() => {
+      // Wrapper gone from the document: a global cleanup ran while the provider
+      // call was in flight, or the host re-rendered the region. The originals
+      // are the live content — don't remove them to apply a stale translation.
+      if (!translatedWrapperNode.isConnected) return
+
       // Insert translated content after the last node
       const lastChildNode = allChildNodes.at(-1)!
       lastChildNode.parentNode?.insertBefore(translatedWrapperNode, lastChildNode.nextSibling)
 
-      // Remove all original nodes
+      // Displace the originals, retaining the node objects so restore can
+      // re-insert the same nodes (#1846)
+      registerTranslationOnlyOriginals(translatedWrapperNode, allChildNodes)
       allChildNodes.forEach((childNode) => childNode.remove())
     })
   } finally {

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -20,6 +20,7 @@ import { extractTextContent } from "../../dom/traversal"
 import { buildVirtualParagraphPlan, type VirtualParagraphUnit } from "../dom/paragraph-segmentation"
 import {
   disposeVirtualParagraphGroup,
+  dropTranslationOnlySwapRecordsForNodes,
   dropVirtualParagraphWrapper,
   removeOrphanVirtualParagraphWrappers,
   removeTranslatedWrapperWithRestore,
@@ -637,9 +638,16 @@ export async function translateNodeTranslationOnlyMode(
     // own swap, never let an unrelated nested run's wrapper stand in for it.
     // Also runs before the filter/language checks below so they (and a
     // retranslation) see original text, not the previous translation.
+    // Non-toggle (retranslation) keeps the records registered so the anchor
+    // stays monitored through the provider round-trip — a re-swap dropped by
+    // the mid-flight snapshot guard must not leave the region unwatched.
     const swapAnchor = parentNode.closest<HTMLElement>(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)
     const restoredOwnSwap = swapAnchor
-      ? restoreTranslationOnlySwapsForAnchor(swapAnchor, transNodes)
+      ? restoreTranslationOnlySwapsForAnchor(
+          swapAnchor,
+          transNodes,
+          toggle ? undefined : { keepRecords: true },
+        )
       : false
 
     // Own-run wrapper discovery is scoped to the run itself: the fallback
@@ -807,8 +815,17 @@ export async function translateNodeTranslationOnlyMode(
         markExtensionDrivenNodeRemoval(translatedWrapperNode)
         translatedWrapperNode.remove()
         // Host mutated the run mid-flight: the translation is stale, drop it.
+        // Any kept (restore-first) records still reference the run, so the
+        // staleness pipeline retries with the host's fresh text.
         if (!verifySourceSnapshot(transNodes, sourceSnapshot)) return
-        applyInPlaceTextSwap(swapPlan, parentNode, walkId, config, getTranslationOnlyAnchorState)
+        applyInPlaceTextSwap(
+          swapPlan,
+          transNodes,
+          parentNode,
+          walkId,
+          config,
+          getTranslationOnlyAnchorState,
+        )
       })
       return
     }
@@ -830,6 +847,10 @@ export async function translateNodeTranslationOnlyMode(
 
       registerTranslationOnlyOriginals(translatedWrapperNode, allChildNodes)
       allChildNodes.forEach((childNode) => childNode.remove())
+      // The wrapper now owns this run; kept swap records (restore-first
+      // retranslation) would reference displaced nodes and read as
+      // permanently stale — drop them.
+      if (swapAnchor) dropTranslationOnlySwapRecordsForNodes(swapAnchor, transNodes)
     })
   } finally {
     nodes.forEach((node) => translatingNodes.delete(node))

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -410,6 +410,20 @@ export async function translateNodesBilingualMode(
       return translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
     }
 
+    // After a translationOnly session, an in-place-swapped paragraph has no
+    // wrapper — only the anchor marker. A bilingual toggle over it must undo
+    // the swap (and a bilingual translate must see the original text).
+    const swappedAnchor = (
+      isHTMLElement(insertionTarget) ? insertionTarget : insertionTarget.parentElement
+    )?.closest<HTMLElement>(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)
+    if (
+      swappedAnchor &&
+      restoreTranslationOnlySwapsForAnchor(swappedAnchor, transNodes) &&
+      toggle
+    ) {
+      return
+    }
+
     const sourceTextBeforeFilter = isHTMLElement(layoutSource)
       ? collectSourceTextExcludingWrappers(layoutSource)
       : null
@@ -525,6 +539,33 @@ export async function translateNodesBilingualMode(
   }
 }
 
+/**
+ * A run's own translationOnly wrapper, scoped to the run: the insertion code
+ * only ever places the wrapper as a sibling within the run or appends it into
+ * a single-element run, so nested runs' wrappers (a li's inside this run's
+ * subtree) are out of reach by construction.
+ */
+function findRunTranslationOnlyWrapper(
+  allChildNodes: ChildNode[],
+  walkId: string,
+): HTMLElement | null {
+  // Any-mode wrapper: a bilingual wrapper here is this run's own previous
+  // translation too (node-level translate, then a mode switch, then toggle).
+  const isForeignWrapper = (element: HTMLElement) =>
+    element.classList.contains(CONTENT_WRAPPER_CLASS) &&
+    element.getAttribute(WALKED_ATTRIBUTE) !== walkId
+
+  for (const node of allChildNodes) {
+    if (!isHTMLElement(node)) continue
+    if (isForeignWrapper(node)) return node
+    // Spinner phase of a single-element run: wrapper appended INSIDE it
+    for (const child of node.children) {
+      if (isHTMLElement(child) && isForeignWrapper(child)) return child
+    }
+  }
+  return null
+}
+
 export async function translateNodeTranslationOnlyMode(
   nodes: ChildNode[],
   walkId: string,
@@ -553,6 +594,28 @@ export async function translateNodeTranslationOnlyMode(
   }
 
   if (transNodes.length === 0) {
+    // The run may be nothing but a fallback wrapper whose originals were
+    // displaced (e.g. a <li> holding only the translation). Its toggle must
+    // still restore, so handle the wrapper before giving up on the run.
+    const runWrappers = allChildNodes.filter(
+      (node): node is HTMLElement =>
+        isHTMLElement(node) &&
+        node.classList.contains(CONTENT_WRAPPER_CLASS) &&
+        node.getAttribute(TRANSLATION_MODE_ATTRIBUTE) ===
+          ("translationOnly" satisfies TranslationMode) &&
+        node.getAttribute(WALKED_ATTRIBUTE) !== walkId,
+    )
+    if (runWrappers.length === 0) return
+    const restored: ChildNode[] = []
+    for (const wrapper of runWrappers) {
+      restored.push(...removeTranslatedWrapperWithRestore(wrapper))
+    }
+    if (!toggle) {
+      const retryNodes = restored.filter((node) => node.isConnected)
+      if (retryNodes.length > 0) {
+        void translateNodeTranslationOnlyMode(retryNodes, walkId, config, toggle)
+      }
+    }
     return
   }
 
@@ -569,15 +632,25 @@ export async function translateNodeTranslationOnlyMode(
       console.error("targetNode.parentElement is not HTMLElement", targetNode.parentElement)
       return
     }
-    const existedTranslatedWrapper = findPreviousTranslatedWrapperInside(
-      targetNode.parentElement,
-      walkId,
-    )
+    // An in-place swap leaves no wrapper — the anchor marker is the handle.
+    // Restore FIRST (before any wrapper handling): a swapped run must undo its
+    // own swap, never let an unrelated nested run's wrapper stand in for it.
+    // Also runs before the filter/language checks below so they (and a
+    // retranslation) see original text, not the previous translation.
+    const swapAnchor = parentNode.closest<HTMLElement>(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)
+    const restoredOwnSwap = swapAnchor
+      ? restoreTranslationOnlySwapsForAnchor(swapAnchor, transNodes)
+      : false
+
+    // Own-run wrapper discovery is scoped to the run itself: the fallback
+    // wrapper is always inserted as a sibling within the run or appended into
+    // a single-element run — a deep subtree query would steal a NESTED run's
+    // wrapper (e.g. a li's) and leave this run's state untouched (#1846 review).
     const existedTranslatedWrapperOutside = targetNode.parentElement.closest(
       `.${CONTENT_WRAPPER_CLASS}`,
     )
-
-    const finalTranslatedWrapper = existedTranslatedWrapperOutside ?? existedTranslatedWrapper
+    const finalTranslatedWrapper =
+      existedTranslatedWrapperOutside ?? findRunTranslationOnlyWrapper(allChildNodes, walkId)
     if (finalTranslatedWrapper && isHTMLElement(finalTranslatedWrapper)) {
       const restoredNodes = removeTranslatedWrapperWithRestore(finalTranslatedWrapper)
       if (toggle) {
@@ -599,11 +672,7 @@ export async function translateNodeTranslationOnlyMode(
       return
     }
 
-    // An in-place swap leaves no wrapper — the anchor marker is the handle.
-    // Restore BEFORE the filter/language checks below so they (and a
-    // retranslation) see original text, not the previous translation.
-    const swapAnchor = parentNode.closest<HTMLElement>(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)
-    if (swapAnchor && restoreTranslationOnlySwapsForAnchor(swapAnchor, transNodes) && toggle) {
+    if (restoredOwnSwap && toggle) {
       return
     }
 

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -8,6 +8,7 @@ import {
   NOTRANSLATE_CLASS,
   TRANSLATION_ERROR_CONTAINER_CLASS,
   TRANSLATION_MODE_ATTRIBUTE,
+  TRANSLATION_ONLY_ATTRIBUTE,
   VIRTUAL_PARAGRAPH_ATTRIBUTE,
   WALKED_ATTRIBUTE,
 } from "../../../constants/dom-labels"
@@ -22,9 +23,16 @@ import {
   dropVirtualParagraphWrapper,
   removeOrphanVirtualParagraphWrappers,
   removeTranslatedWrapperWithRestore,
+  restoreTranslationOnlySwapsForAnchor,
 } from "../dom/translation-cleanup"
 import { protectTranslationHtmlAttributes } from "../dom/translation-html-attributes"
 import { insertTranslatedNodeIntoWrapper } from "../dom/translation-insertion"
+import {
+  applyInPlaceTextSwap,
+  planInPlaceTextSwap,
+  snapshotSourceTextNodes,
+  verifySourceSnapshot,
+} from "../dom/translation-text-swap"
 import { findPreviousTranslatedWrapperInside } from "../dom/translation-wrapper"
 import { insertVirtualParagraphWrappers } from "../dom/virtual-paragraph-insertion"
 import { shouldFilterSmallParagraph } from "../filter-small-paragraph"
@@ -39,6 +47,7 @@ import {
   attachBilingualTranslationWrapper,
   collectSourceTextExcludingWrappers,
   getBilingualTranslationStateForSource,
+  getTranslationOnlyAnchorState,
   getVirtualParagraphGroupForSource,
   isBilingualTranslationStateCurrent,
   isVirtualParagraphGroupCurrent,
@@ -590,6 +599,14 @@ export async function translateNodeTranslationOnlyMode(
       return
     }
 
+    // An in-place swap leaves no wrapper — the anchor marker is the handle.
+    // Restore BEFORE the filter/language checks below so they (and a
+    // retranslation) see original text, not the previous translation.
+    const swapAnchor = parentNode.closest<HTMLElement>(`[${TRANSLATION_ONLY_ATTRIBUTE}]`)
+    if (swapAnchor && restoreTranslationOnlySwapsForAnchor(swapAnchor, transNodes) && toggle) {
+      return
+    }
+
     const innerTextContent = transNodes.map((node) => extractTextContent(node, config)).join("")
     if (!innerTextContent.trim() || isNumericContent(innerTextContent)) return
 
@@ -603,6 +620,11 @@ export async function translateNodeTranslationOnlyMode(
     const protectedHtml = protectTranslationHtmlAttributes(transNodes, ownerDoc)
     const textContent = protectedHtml.sourceHtml
     if (!textContent) return
+
+    // Taken before the provider request; the response handler compares against
+    // it to detect host mutations that happened while the request was in
+    // flight (never swap over content the host has since rewritten).
+    const sourceSnapshot = snapshotSourceTextNodes(transNodes)
 
     const translatedWrapperNode = ownerDoc.createElement("span")
     translatedWrapperNode.className = `${NOTRANSLATE_CLASS} ${CONTENT_WRAPPER_CLASS}`
@@ -704,6 +726,26 @@ export async function translateNodeTranslationOnlyMode(
       return
     }
 
+    // Preferred strategy: swap the translation into the site's OWN text nodes,
+    // leaving element identity (framework fibers, listeners) untouched. The
+    // wrapper was only the spinner vehicle and is removed.
+    const swapPlan = planInPlaceTextSwap(transNodes, translatedText, ownerDoc)
+    if (swapPlan) {
+      batchDOMOperation(() => {
+        // Wrapper gone: a global cleanup ran while the provider call was in
+        // flight, or the host re-rendered the region — leave originals alone.
+        if (!translatedWrapperNode.isConnected) return
+        markExtensionDrivenNodeRemoval(translatedWrapperNode)
+        translatedWrapperNode.remove()
+        // Host mutated the run mid-flight: the translation is stale, drop it.
+        if (!verifySourceSnapshot(transNodes, sourceSnapshot)) return
+        applyInPlaceTextSwap(swapPlan, parentNode, walkId, config, getTranslationOnlyAnchorState)
+      })
+      return
+    }
+
+    // Fallback strategy: render into the wrapper and displace the originals,
+    // retaining the node objects so restore can re-insert the same nodes (#1846).
     translatedWrapperNode.innerHTML = translatedText
 
     // Batch final DOM mutations to reduce layout thrashing
@@ -717,8 +759,6 @@ export async function translateNodeTranslationOnlyMode(
       const lastChildNode = allChildNodes.at(-1)!
       lastChildNode.parentNode?.insertBefore(translatedWrapperNode, lastChildNode.nextSibling)
 
-      // Displace the originals, retaining the node objects so restore can
-      // re-insert the same nodes (#1846)
       registerTranslationOnlyOriginals(translatedWrapperNode, allChildNodes)
       allChildNodes.forEach((childNode) => childNode.remove())
     })

--- a/src/utils/host/translate/core/translation-state.ts
+++ b/src/utils/host/translate/core/translation-state.ts
@@ -95,9 +95,65 @@ export interface TranslationOnlyAnchorState {
   // guardedly when the last swap is undone.
   attributeAdjustments: { name: string; previousValue: string | null }[]
   swaps: TranslationOnlySwapRecord[]
+  // Aggregate anchor text right after our last swap/restore write. Deviation
+  // means the HOST changed content inside the anchor (e.g. an expand/"show
+  // more" re-render) and the anchor needs retranslation (mirrors the bilingual
+  // sourceTextContent staleness contract).
+  expectedTextContent: string
 }
 
 const translationOnlyAnchorStates = new WeakMap<HTMLElement, TranslationOnlyAnchorState>()
+
+/**
+ * Aggregate comparable text under an anchor: non-whitespace text nodes,
+ * excluding translated-wrapper subtrees and NESTED anchors (those track their
+ * own expected text).
+ */
+export function collectTranslationOnlyAnchorText(anchor: HTMLElement): string {
+  const parts: string[] = []
+  const visit = (node: Node): void => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const data = (node as Text).data
+      if (data.trim()) parts.push(data)
+      return
+    }
+    if (!(node instanceof HTMLElement)) return
+    if (node !== anchor) {
+      if (isTranslatedWrapperNode(node)) return
+      if (translationOnlyAnchorStates.has(node)) return
+    }
+    for (const child of node.childNodes) visit(child)
+  }
+  visit(anchor)
+  return parts.join("")
+}
+
+export function refreshTranslationOnlyAnchorExpectedText(state: TranslationOnlyAnchorState): void {
+  state.expectedTextContent = collectTranslationOnlyAnchorText(state.anchor)
+}
+
+function isTranslationOnlyAnchorCurrent(state: TranslationOnlyAnchorState): boolean {
+  return (
+    state.anchor.isConnected &&
+    collectTranslationOnlyAnchorText(state.anchor) === state.expectedTextContent
+  )
+}
+
+/**
+ * Nearest ancestor anchor whose content the host changed since our swap —
+ * the translationOnly counterpart of findStaleBilingualLayoutSource. Feeds the
+ * same budgeted retranslation pipeline so expand/"show more" re-renders get
+ * translated instead of staying in the source language.
+ */
+export function findStaleTranslationOnlyAnchor(node: Node): HTMLElement | undefined {
+  let current = node.nodeType === Node.ELEMENT_NODE ? (node as HTMLElement) : node.parentElement
+  while (current) {
+    const state = translationOnlyAnchorStates.get(current)
+    if (state && !isTranslationOnlyAnchorCurrent(state)) return current
+    current = current.parentElement
+  }
+  return undefined
+}
 
 export function getTranslationOnlyAnchorState(
   anchor: HTMLElement,

--- a/src/utils/host/translate/core/translation-state.ts
+++ b/src/utils/host/translate/core/translation-state.ts
@@ -85,6 +85,15 @@ export interface TranslationOnlySwapAttributeItem {
 
 export interface TranslationOnlySwapRecord {
   walkId: string
+  // The run's top-level nodes at swap time. Staleness is judged per record
+  // against exactly these nodes — NEVER against an anchor-wide text aggregate,
+  // which would couple the record to unrelated nested content (a descendant
+  // anchor registering/unregistering, a sibling run's fallback displacement)
+  // and produce permanent false staleness (adversarial-review finding).
+  runNodes: ChildNode[]
+  // Aggregate run text right after our swap wrote it; host deviation means
+  // this run needs retranslation (expand/"show more" re-renders).
+  expectedRunText: string
   items: TranslationOnlySwapItem[]
   attributeItems: TranslationOnlySwapAttributeItem[]
 }
@@ -95,53 +104,44 @@ export interface TranslationOnlyAnchorState {
   // guardedly when the last swap is undone.
   attributeAdjustments: { name: string; previousValue: string | null }[]
   swaps: TranslationOnlySwapRecord[]
-  // Aggregate anchor text right after our last swap/restore write. Deviation
-  // means the HOST changed content inside the anchor (e.g. an expand/"show
-  // more" re-render) and the anchor needs retranslation (mirrors the bilingual
-  // sourceTextContent staleness contract).
-  expectedTextContent: string
 }
 
 const translationOnlyAnchorStates = new WeakMap<HTMLElement, TranslationOnlyAnchorState>()
 
-/**
- * Aggregate comparable text under an anchor: non-whitespace text nodes,
- * excluding translated-wrapper subtrees and NESTED anchors (those track their
- * own expected text).
- */
-export function collectTranslationOnlyAnchorText(anchor: HTMLElement): string {
-  const parts: string[] = []
-  const visit = (node: Node): void => {
-    if (node.nodeType === Node.TEXT_NODE) {
-      const data = (node as Text).data
-      if (data.trim()) parts.push(data)
-      return
-    }
-    if (!(node instanceof HTMLElement)) return
-    if (node !== anchor) {
-      if (isTranslatedWrapperNode(node)) return
-      if (translationOnlyAnchorStates.has(node)) return
-    }
-    for (const child of node.childNodes) visit(child)
+function collectRunText(node: Node, parts: string[]): void {
+  if (node.nodeType === Node.TEXT_NODE) {
+    const data = (node as Text).data
+    if (data.trim()) parts.push(data)
+    return
   }
-  visit(anchor)
+  if (!(node instanceof HTMLElement)) return
+  if (isTranslatedWrapperNode(node)) return
+  for (const child of node.childNodes) collectRunText(child, parts)
+}
+
+/** Aggregate comparable text of a swap record's run, in document order. */
+export function collectTranslationOnlyRunText(runNodes: readonly ChildNode[]): string {
+  const parts: string[] = []
+  for (const node of runNodes) collectRunText(node, parts)
   return parts.join("")
 }
 
-export function refreshTranslationOnlyAnchorExpectedText(state: TranslationOnlyAnchorState): void {
-  state.expectedTextContent = collectTranslationOnlyAnchorText(state.anchor)
-}
-
-function isTranslationOnlyAnchorCurrent(state: TranslationOnlyAnchorState): boolean {
-  return (
-    state.anchor.isConnected &&
-    collectTranslationOnlyAnchorText(state.anchor) === state.expectedTextContent
+export function refreshTranslationOnlySwapRecordExpectedText(
+  record: TranslationOnlySwapRecord,
+): void {
+  record.expectedRunText = collectTranslationOnlyRunText(
+    record.runNodes.filter((node) => node.isConnected),
   )
 }
 
+export function isTranslationOnlySwapRecordCurrent(record: TranslationOnlySwapRecord): boolean {
+  if (record.runNodes.some((node) => !node.isConnected)) return false
+  return collectTranslationOnlyRunText(record.runNodes) === record.expectedRunText
+}
+
 /**
- * Nearest ancestor anchor whose content the host changed since our swap —
- * the translationOnly counterpart of findStaleBilingualLayoutSource. Feeds the
+ * Nearest ancestor anchor one of whose swapped runs the host changed — the
+ * translationOnly counterpart of findStaleBilingualLayoutSource. Feeds the
  * same budgeted retranslation pipeline so expand/"show more" re-renders get
  * translated instead of staying in the source language.
  */
@@ -149,10 +149,45 @@ export function findStaleTranslationOnlyAnchor(node: Node): HTMLElement | undefi
   let current = node.nodeType === Node.ELEMENT_NODE ? (node as HTMLElement) : node.parentElement
   while (current) {
     const state = translationOnlyAnchorStates.get(current)
-    if (state && !isTranslationOnlyAnchorCurrent(state)) return current
+    if (
+      state?.anchor.isConnected &&
+      state.swaps.some((record) => !isTranslationOnlySwapRecordCurrent(record))
+    ) {
+      return current
+    }
     current = current.parentElement
   }
   return undefined
+}
+
+/** A record every one of whose nodes the host disconnected: nothing restorable. */
+export function isTranslationOnlySwapRecordDead(record: TranslationOnlySwapRecord): boolean {
+  return (
+    record.runNodes.every((node) => !node.isConnected) &&
+    record.items.every((item) => !item.node.isConnected)
+  )
+}
+
+export function swapRecordIntersectsNodes(
+  record: TranslationOnlySwapRecord,
+  nodes: readonly ChildNode[],
+): boolean {
+  const touches = (candidate: ChildNode) =>
+    nodes.some(
+      (node) =>
+        node === candidate ||
+        (node instanceof HTMLElement && node.contains(candidate)) ||
+        (candidate instanceof HTMLElement && candidate.contains(node)),
+    )
+  return record.runNodes.some(touches) || record.items.some((item) => touches(item.node))
+}
+
+export function dropTranslationOnlySwapRecords(
+  state: TranslationOnlyAnchorState,
+  records: readonly TranslationOnlySwapRecord[],
+): void {
+  if (records.length === 0) return
+  state.swaps = state.swaps.filter((record) => !records.includes(record))
 }
 
 export function getTranslationOnlyAnchorState(

--- a/src/utils/host/translate/core/translation-state.ts
+++ b/src/utils/host/translate/core/translation-state.ts
@@ -44,9 +44,23 @@ export interface BilingualTranslationState {
 
 // State management for translation operations
 export const translatingNodes = new WeakSet<ChildNode>()
-// WeakMap so elements removed by the site (SPA re-renders, infinite scroll)
-// don't pin themselves and their innerHTML snapshots for the page's lifetime.
-export const originalContentMap = new WeakMap<Element, string>()
+// Original ChildNode objects a translationOnly wrapper displaced, keyed by that
+// wrapper. Restore re-inserts these SAME node objects at the wrapper's position
+// (node-identity restore) — never an ancestor innerHTML rewrite, which destroys
+// framework-owned node identity and untouched sibling content (#1846).
+// WeakMap so a wrapper deleted by the site (SPA re-renders) releases its
+// retained originals instead of pinning them for the page's lifetime.
+const translationOnlyOriginalNodes = new WeakMap<HTMLElement, ChildNode[]>()
+
+export function registerTranslationOnlyOriginals(wrapper: HTMLElement, nodes: ChildNode[]): void {
+  translationOnlyOriginalNodes.set(wrapper, nodes)
+}
+
+export function takeTranslationOnlyOriginals(wrapper: HTMLElement): ChildNode[] | undefined {
+  const nodes = translationOnlyOriginalNodes.get(wrapper)
+  if (nodes) translationOnlyOriginalNodes.delete(wrapper)
+  return nodes
+}
 
 const virtualParagraphGroupsBySource = new WeakMap<HTMLElement, VirtualParagraphGroup>()
 const virtualParagraphGroupsByWrapper = new WeakMap<HTMLElement, VirtualParagraphGroup>()

--- a/src/utils/host/translate/core/translation-state.ts
+++ b/src/utils/host/translate/core/translation-state.ts
@@ -62,6 +62,72 @@ export function takeTranslationOnlyOriginals(wrapper: HTMLElement): ChildNode[] 
   return nodes
 }
 
+// ---- In-place text swap state (translationOnly preferred strategy) ----
+// A successful swap leaves NO wrapper in the DOM: the site's own text nodes
+// hold the translated values. The anchor element (the swapped run's parent)
+// carries TRANSLATION_ONLY_ATTRIBUTE as the queryable handle and this WeakMap
+// holds the restore payload.
+
+export interface TranslationOnlySwapItem {
+  node: Text
+  originalValue: string
+  translatedValue: string
+}
+
+// Human-visible attributes the provider translated (title, alt, …) — swapped
+// on the source element alongside its text, restored with the same guard.
+export interface TranslationOnlySwapAttributeItem {
+  element: Element
+  name: string
+  originalValue: string | null
+  translatedValue: string
+}
+
+export interface TranslationOnlySwapRecord {
+  walkId: string
+  items: TranslationOnlySwapItem[]
+  attributeItems: TranslationOnlySwapAttributeItem[]
+}
+
+export interface TranslationOnlyAnchorState {
+  anchor: HTMLElement
+  // Attribute values before we touched the anchor (dir/lang/marker), restored
+  // guardedly when the last swap is undone.
+  attributeAdjustments: { name: string; previousValue: string | null }[]
+  swaps: TranslationOnlySwapRecord[]
+}
+
+const translationOnlyAnchorStates = new WeakMap<HTMLElement, TranslationOnlyAnchorState>()
+
+export function getTranslationOnlyAnchorState(
+  anchor: HTMLElement,
+): TranslationOnlyAnchorState | undefined {
+  return translationOnlyAnchorStates.get(anchor)
+}
+
+export function registerTranslationOnlyAnchorState(state: TranslationOnlyAnchorState): void {
+  translationOnlyAnchorStates.set(state.anchor, state)
+}
+
+export function unregisterTranslationOnlyAnchorState(anchor: HTMLElement): void {
+  translationOnlyAnchorStates.delete(anchor)
+}
+
+// Extension-written text-node values, so the mutation observer can classify
+// characterData records from in-place swaps/restores as self-inflicted. Value
+// comparison rather than membership: a later SITE write to the same node must
+// still count as a host mutation.
+const extensionDrivenCharacterData = new WeakMap<Node, string>()
+
+export function markExtensionDrivenCharacterData(node: Node, writtenValue: string): void {
+  extensionDrivenCharacterData.set(node, writtenValue)
+}
+
+export function wasCharacterDataChangeExtensionDriven(node: Node): boolean {
+  const written = extensionDrivenCharacterData.get(node)
+  return written !== undefined && written === (node as CharacterData).data
+}
+
 const virtualParagraphGroupsBySource = new WeakMap<HTMLElement, VirtualParagraphGroup>()
 const virtualParagraphGroupsByWrapper = new WeakMap<HTMLElement, VirtualParagraphGroup>()
 const bilingualTranslationsBySource = new WeakMap<HTMLElement, BilingualTranslationState>()

--- a/src/utils/host/translate/core/translation-walker.ts
+++ b/src/utils/host/translate/core/translation-walker.ts
@@ -3,6 +3,7 @@ import {
   BLOCK_ATTRIBUTE,
   CONTENT_WRAPPER_CLASS,
   PARAGRAPH_ATTRIBUTE,
+  TRANSLATION_ONLY_ATTRIBUTE,
   WALKED_ATTRIBUTE,
 } from "../../../constants/dom-labels"
 import { isBlockTransNode, isHTMLElement, isTextNode, isTransNode } from "../../dom/filter"
@@ -14,7 +15,16 @@ export async function translateWalkedElement(
   config: Config,
   toggle: boolean = false,
 ): Promise<void> {
-  if (!toggle && element.querySelector(`.${CONTENT_WRAPPER_CLASS}`)) return
+  // Translated regions are skipped on non-toggle walks. In-place-swapped
+  // paragraphs leave no wrapper, so also check the anchor marker attribute.
+  if (
+    !toggle &&
+    (element.querySelector(`.${CONTENT_WRAPPER_CLASS}`) ||
+      element.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE) ||
+      element.querySelector(`[${TRANSLATION_ONLY_ATTRIBUTE}]`))
+  ) {
+    return
+  }
 
   // if the walkId is not the same, return
   if (element.getAttribute(WALKED_ATTRIBUTE) !== walkId) return

--- a/src/utils/host/translate/core/translation-walker.ts
+++ b/src/utils/host/translate/core/translation-walker.ts
@@ -8,6 +8,25 @@ import {
 } from "../../../constants/dom-labels"
 import { isBlockTransNode, isHTMLElement, isTextNode, isTransNode } from "../../dom/filter"
 import { translateNodes } from "./translation-modes"
+import { getTranslationOnlyAnchorState } from "./translation-state"
+
+/**
+ * Marker attributes can outlive their WeakMap state (extension reload on a
+ * live tab). A ghost marker must not block walks forever — heal it and treat
+ * the region as untranslated.
+ */
+function hasLiveTranslationOnlyAnchor(element: HTMLElement): boolean {
+  const candidates: HTMLElement[] = element.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE)
+    ? [element]
+    : []
+  candidates.push(...element.querySelectorAll<HTMLElement>(`[${TRANSLATION_ONLY_ATTRIBUTE}]`))
+  let live = false
+  for (const candidate of candidates) {
+    if (getTranslationOnlyAnchorState(candidate)) live = true
+    else candidate.removeAttribute(TRANSLATION_ONLY_ATTRIBUTE)
+  }
+  return live
+}
 
 export async function translateWalkedElement(
   element: HTMLElement,
@@ -19,9 +38,7 @@ export async function translateWalkedElement(
   // paragraphs leave no wrapper, so also check the anchor marker attribute.
   if (
     !toggle &&
-    (element.querySelector(`.${CONTENT_WRAPPER_CLASS}`) ||
-      element.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE) ||
-      element.querySelector(`[${TRANSLATION_ONLY_ATTRIBUTE}]`))
+    (element.querySelector(`.${CONTENT_WRAPPER_CLASS}`) || hasLiveTranslationOnlyAnchor(element))
   ) {
     return
   }

--- a/src/utils/host/translate/dom/translation-cleanup.ts
+++ b/src/utils/host/translate/dom/translation-cleanup.ts
@@ -1,5 +1,6 @@
 import type {
   TextSplitRecord,
+  TranslationOnlyAnchorState,
   TranslationOnlySwapRecord,
   VirtualParagraphGroup,
 } from "../core/translation-state"
@@ -15,15 +16,18 @@ import { removeReactShadowHost } from "../../../react-shadow-host/create-shadow-
 import { isHTMLElement, isTranslatedWrapperNode } from "../../dom/filter"
 import { deepQueryAllSelector, deepQueryTopLevelSelector } from "../../dom/find"
 import {
+  dropTranslationOnlySwapRecords,
   getBilingualTranslationStateForWrapper,
   getPendingBilingualTranslationStates,
   getPendingVirtualParagraphGroups,
   getTranslationOnlyAnchorState,
   getVirtualParagraphGroupForSource,
   getVirtualParagraphGroupForWrapper,
+  isTranslationOnlySwapRecordDead,
   markExtensionDrivenCharacterData,
   markExtensionDrivenNodeRemoval,
-  refreshTranslationOnlyAnchorExpectedText,
+  refreshTranslationOnlySwapRecordExpectedText,
+  swapRecordIntersectsNodes,
   takeTranslationOnlyOriginals,
   unregisterBilingualTranslationState,
   unregisterTranslationOnlyAnchorState,
@@ -232,15 +236,52 @@ function restoreSwapRecord(record: TranslationOnlySwapRecord): void {
   }
 }
 
+function finalizeTranslationOnlyAnchorIfEmpty(state: TranslationOnlyAnchorState): void {
+  if (state.swaps.length > 0) return
+  for (const { name, previousValue } of state.attributeAdjustments) {
+    if (previousValue === null) state.anchor.removeAttribute(name)
+    else state.anchor.setAttribute(name, previousValue)
+  }
+  unregisterTranslationOnlyAnchorState(state.anchor)
+}
+
+/**
+ * Drop an anchor's swap records touching the given nodes WITHOUT writing any
+ * values back — used when the fallback wrapper strategy takes over a run whose
+ * previous swap was already restored (the displaced nodes now belong to the
+ * wrapper's node-identity registry).
+ */
+export function dropTranslationOnlySwapRecordsForNodes(
+  anchor: HTMLElement,
+  nodes: readonly ChildNode[],
+): void {
+  const state = getTranslationOnlyAnchorState(anchor)
+  if (!state) return
+  dropTranslationOnlySwapRecords(
+    state,
+    state.swaps.filter(
+      (record) =>
+        swapRecordIntersectsNodes(record, nodes) || isTranslationOnlySwapRecordDead(record),
+    ),
+  )
+  finalizeTranslationOnlyAnchorIfEmpty(state)
+}
+
 /**
  * Undo in-place text swaps registered on an anchor. With `filterNodes`, only
- * swap records whose text nodes intersect those nodes are restored (the
- * walker toggles one run at a time); without it, everything is restored.
+ * swap records whose nodes intersect those nodes are restored (the walker
+ * toggles one run at a time); without it, everything is restored.
+ * `keepRecords` is the retranslation mode: values return to source but the
+ * records stay registered (expected text refreshed) so the anchor keeps being
+ * monitored through the provider round-trip — a dropped re-swap must not
+ * leave the region untranslated AND unwatched. The incoming swap replaces the
+ * kept records.
  * @returns true when at least one swap record was restored
  */
 export function restoreTranslationOnlySwapsForAnchor(
   anchor: HTMLElement,
   filterNodes?: readonly ChildNode[],
+  options?: { keepRecords?: boolean },
 ): boolean {
   const state = getTranslationOnlyAnchorState(anchor)
   if (!state) {
@@ -250,28 +291,29 @@ export function restoreTranslationOnlySwapsForAnchor(
     return false
   }
 
-  const intersects = (record: TranslationOnlySwapRecord) =>
-    !filterNodes ||
-    record.items.some((item) =>
-      filterNodes.some(
-        (node) => node === item.node || (isHTMLElement(node) && node.contains(item.node)),
-      ),
-    )
+  // Records whose every node the host disconnected are unrestorable debris;
+  // letting them linger would pin detached subtrees and hold the marker (and
+  // the walker skip) forever.
+  const deadRecords = state.swaps.filter(isTranslationOnlySwapRecordDead)
+  dropTranslationOnlySwapRecords(state, deadRecords)
 
-  const toRestore = state.swaps.filter(intersects)
-  if (toRestore.length === 0) return false
+  const toRestore = state.swaps.filter(
+    (record) => !filterNodes || swapRecordIntersectsNodes(record, filterNodes),
+  )
+  if (toRestore.length === 0) {
+    finalizeTranslationOnlyAnchorIfEmpty(state)
+    // Pruning emptied the anchor: the host rebuilt the translated content, so
+    // a toggle pressing "hide" here has nothing left to hide — report the
+    // clear so the caller flips OFF instead of translating the fresh content.
+    return deadRecords.length > 0 && state.swaps.length === 0
+  }
 
   toRestore.forEach(restoreSwapRecord)
-  state.swaps = state.swaps.filter((record) => !toRestore.includes(record))
-
-  if (state.swaps.length === 0) {
-    for (const { name, previousValue } of state.attributeAdjustments) {
-      if (previousValue === null) anchor.removeAttribute(name)
-      else anchor.setAttribute(name, previousValue)
-    }
-    unregisterTranslationOnlyAnchorState(anchor)
+  if (options?.keepRecords) {
+    toRestore.forEach(refreshTranslationOnlySwapRecordExpectedText)
   } else {
-    refreshTranslationOnlyAnchorExpectedText(state)
+    dropTranslationOnlySwapRecords(state, toRestore)
+    finalizeTranslationOnlyAnchorIfEmpty(state)
   }
   return true
 }

--- a/src/utils/host/translate/dom/translation-cleanup.ts
+++ b/src/utils/host/translate/dom/translation-cleanup.ts
@@ -1,12 +1,12 @@
 import type { TextSplitRecord, VirtualParagraphGroup } from "../core/translation-state"
 import {
+  CONTENT_WRAPPER_CLASS,
   REACT_SHADOW_HOST_CLASS,
   SPINNER_CLASS,
   TRANSLATION_MODE_ATTRIBUTE,
   VIRTUAL_PARAGRAPH_ATTRIBUTE,
 } from "../../../constants/dom-labels"
 import { removeReactShadowHost } from "../../../react-shadow-host/create-shadow-host"
-import { batchDOMOperation } from "../../dom/batch-dom"
 import { isHTMLElement, isTranslatedWrapperNode } from "../../dom/filter"
 import { deepQueryTopLevelSelector } from "../../dom/find"
 import {
@@ -16,7 +16,7 @@ import {
   getVirtualParagraphGroupForSource,
   getVirtualParagraphGroupForWrapper,
   markExtensionDrivenNodeRemoval,
-  originalContentMap,
+  takeTranslationOnlyOriginals,
   unregisterBilingualTranslationState,
   unregisterVirtualParagraphGroup,
   unregisterVirtualParagraphWrapper,
@@ -161,16 +161,63 @@ export function removeVirtualParagraphWrapper(wrapper: HTMLElement): void {
 }
 
 /**
+ * Restore the original ChildNode objects a translationOnly wrapper displaced,
+ * re-inserting the SAME nodes at the wrapper's position (node-identity restore).
+ * Synchronous on purpose: the walker can issue several translate calls against
+ * one parent in a single tick, and a deferred restore would let a later call
+ * find a wrapper whose registry entry is already consumed.
+ * @returns the original nodes this call re-inserted
+ */
+function restoreTranslationOnlyWrapper(wrapper: HTMLElement): ChildNode[] {
+  const originals = takeTranslationOnlyOriginals(wrapper)
+  if (!originals) {
+    // Translation never completed (spinner / error UI / empty result), so the
+    // originals were never removed — removing the wrapper IS the restore.
+    wrapper.remove()
+    return []
+  }
+
+  const parent = wrapper.parentNode
+  if (!parent) {
+    // The host rebuilt the region that owned the wrapper; never force stale
+    // nodes back into a framework-rebuilt DOM.
+    return []
+  }
+
+  const restored: ChildNode[] = []
+  for (const node of originals) {
+    if (node.isConnected) continue // the host re-attached this original itself
+    parent.insertBefore(node, wrapper)
+    restored.push(node)
+  }
+  wrapper.remove()
+
+  // Restored originals may carry wrappers from an older walk (cross-walk
+  // nesting); finish those restores so "show original" leaves no translation.
+  for (const node of restored) {
+    if (!isHTMLElement(node)) continue
+    const nested = node.classList.contains(CONTENT_WRAPPER_CLASS)
+      ? [node]
+      : [...node.querySelectorAll<HTMLElement>(`.${CONTENT_WRAPPER_CLASS}`)]
+    for (const nestedWrapper of nested) {
+      if (nestedWrapper.isConnected) removeTranslatedWrapperWithRestore(nestedWrapper)
+    }
+  }
+  return restored
+}
+
+/**
  * Remove translated wrapper and restore original content based on translation mode
  * @param wrapper - The translated wrapper element to remove
+ * @returns for translationOnly wrappers, the original nodes re-inserted by the restore
  */
-export function removeTranslatedWrapperWithRestore(wrapper: HTMLElement): void {
-  // Every path below removes the wrapper (directly or via an innerHTML restore).
+export function removeTranslatedWrapperWithRestore(wrapper: HTMLElement): ChildNode[] {
+  // Every path below removes the wrapper (directly or via restore).
   markExtensionDrivenNodeRemoval(wrapper)
   const virtualParagraphGroup = getVirtualParagraphGroupForWrapper(wrapper)
   if (virtualParagraphGroup) {
     disposeVirtualParagraphGroup(virtualParagraphGroup)
-    return
+    return []
   }
 
   const bilingualState = getBilingualTranslationStateForWrapper(wrapper)
@@ -181,30 +228,11 @@ export function removeTranslatedWrapperWithRestore(wrapper: HTMLElement): void {
   const translationMode = wrapper.getAttribute(TRANSLATION_MODE_ATTRIBUTE)
 
   if (translationMode === "translationOnly") {
-    // For translation-only mode, find nearest ancestor in originalContentMap and restore
-    let currentNode = wrapper.parentNode
-
-    while (currentNode && isHTMLElement(currentNode)) {
-      const originalContent = originalContentMap.get(currentNode)
-      if (originalContent) {
-        const nodeToRestore = currentNode
-        batchDOMOperation(() => {
-          nodeToRestore.innerHTML = originalContent
-        })
-        originalContentMap.delete(currentNode)
-        return
-      }
-      currentNode = currentNode.parentNode
-    }
+    return restoreTranslationOnlyWrapper(wrapper)
   }
 
-  if (translationMode === "bilingual") {
-    wrapper.remove()
-    return
-  }
-
-  // When no original content is found, just remove the wrapper.
-  batchDOMOperation(() => wrapper.remove())
+  wrapper.remove()
+  return []
 }
 
 export function removeAllTranslatedWrapperNodes(root: Document | ShadowRoot = document): void {

--- a/src/utils/host/translate/dom/translation-cleanup.ts
+++ b/src/utils/host/translate/dom/translation-cleanup.ts
@@ -1,23 +1,31 @@
-import type { TextSplitRecord, VirtualParagraphGroup } from "../core/translation-state"
+import type {
+  TextSplitRecord,
+  TranslationOnlySwapRecord,
+  VirtualParagraphGroup,
+} from "../core/translation-state"
 import {
   CONTENT_WRAPPER_CLASS,
   REACT_SHADOW_HOST_CLASS,
   SPINNER_CLASS,
   TRANSLATION_MODE_ATTRIBUTE,
+  TRANSLATION_ONLY_ATTRIBUTE,
   VIRTUAL_PARAGRAPH_ATTRIBUTE,
 } from "../../../constants/dom-labels"
 import { removeReactShadowHost } from "../../../react-shadow-host/create-shadow-host"
 import { isHTMLElement, isTranslatedWrapperNode } from "../../dom/filter"
-import { deepQueryTopLevelSelector } from "../../dom/find"
+import { deepQueryAllSelector, deepQueryTopLevelSelector } from "../../dom/find"
 import {
   getBilingualTranslationStateForWrapper,
   getPendingBilingualTranslationStates,
   getPendingVirtualParagraphGroups,
+  getTranslationOnlyAnchorState,
   getVirtualParagraphGroupForSource,
   getVirtualParagraphGroupForWrapper,
+  markExtensionDrivenCharacterData,
   markExtensionDrivenNodeRemoval,
   takeTranslationOnlyOriginals,
   unregisterBilingualTranslationState,
+  unregisterTranslationOnlyAnchorState,
   unregisterVirtualParagraphGroup,
   unregisterVirtualParagraphWrapper,
 } from "../core/translation-state"
@@ -206,6 +214,65 @@ function restoreTranslationOnlyWrapper(wrapper: HTMLElement): ChildNode[] {
   return restored
 }
 
+function restoreSwapRecord(record: TranslationOnlySwapRecord): void {
+  for (const item of record.items) {
+    if (!item.node.isConnected) continue
+    // The framework rewrote this node since we swapped it — its current value
+    // is host-owned content; never clobber it with our stale original.
+    if (item.node.data.trim() !== item.translatedValue.trim()) continue
+    markExtensionDrivenCharacterData(item.node, item.originalValue)
+    item.node.data = item.originalValue
+  }
+  for (const item of record.attributeItems) {
+    if (!item.element.isConnected) continue
+    if (item.element.getAttribute(item.name) !== item.translatedValue) continue
+    if (item.originalValue === null) item.element.removeAttribute(item.name)
+    else item.element.setAttribute(item.name, item.originalValue)
+  }
+}
+
+/**
+ * Undo in-place text swaps registered on an anchor. With `filterNodes`, only
+ * swap records whose text nodes intersect those nodes are restored (the
+ * walker toggles one run at a time); without it, everything is restored.
+ * @returns true when at least one swap record was restored
+ */
+export function restoreTranslationOnlySwapsForAnchor(
+  anchor: HTMLElement,
+  filterNodes?: readonly ChildNode[],
+): boolean {
+  const state = getTranslationOnlyAnchorState(anchor)
+  if (!state) {
+    // Stale marker from a previous content-script realm: the payload is gone,
+    // so the marker is the only thing left to clean up.
+    anchor.removeAttribute(TRANSLATION_ONLY_ATTRIBUTE)
+    return false
+  }
+
+  const intersects = (record: TranslationOnlySwapRecord) =>
+    !filterNodes ||
+    record.items.some((item) =>
+      filterNodes.some(
+        (node) => node === item.node || (isHTMLElement(node) && node.contains(item.node)),
+      ),
+    )
+
+  const toRestore = state.swaps.filter(intersects)
+  if (toRestore.length === 0) return false
+
+  toRestore.forEach(restoreSwapRecord)
+  state.swaps = state.swaps.filter((record) => !toRestore.includes(record))
+
+  if (state.swaps.length === 0) {
+    for (const { name, previousValue } of state.attributeAdjustments) {
+      if (previousValue === null) anchor.removeAttribute(name)
+      else anchor.setAttribute(name, previousValue)
+    }
+    unregisterTranslationOnlyAnchorState(anchor)
+  }
+  return true
+}
+
 /**
  * Remove translated wrapper and restore original content based on translation mode
  * @param wrapper - The translated wrapper element to remove
@@ -251,4 +318,10 @@ export function removeAllTranslatedWrapperNodes(root: Document | ShadowRoot = do
   translatedNodes.forEach((contentWrapperNode) => {
     removeTranslatedWrapperWithRestore(contentWrapperNode)
   })
+  // In-place-swapped paragraphs have no wrapper; their anchors are found by
+  // marker attribute. Collect ALL matches — nested anchors are independent.
+  const swapAnchors = deepQueryAllSelector(root, (element) =>
+    element.hasAttribute(TRANSLATION_ONLY_ATTRIBUTE),
+  )
+  swapAnchors.forEach((anchor) => restoreTranslationOnlySwapsForAnchor(anchor))
 }

--- a/src/utils/host/translate/dom/translation-cleanup.ts
+++ b/src/utils/host/translate/dom/translation-cleanup.ts
@@ -23,6 +23,7 @@ import {
   getVirtualParagraphGroupForWrapper,
   markExtensionDrivenCharacterData,
   markExtensionDrivenNodeRemoval,
+  refreshTranslationOnlyAnchorExpectedText,
   takeTranslationOnlyOriginals,
   unregisterBilingualTranslationState,
   unregisterTranslationOnlyAnchorState,
@@ -269,6 +270,8 @@ export function restoreTranslationOnlySwapsForAnchor(
       else anchor.setAttribute(name, previousValue)
     }
     unregisterTranslationOnlyAnchorState(anchor)
+  } else {
+    refreshTranslationOnlyAnchorExpectedText(state)
   }
   return true
 }

--- a/src/utils/host/translate/dom/translation-html-attributes.ts
+++ b/src/utils/host/translate/dom/translation-html-attributes.ts
@@ -6,7 +6,7 @@ import {
   HtmlAttributeMarkerIntegrityError,
 } from "../html-attribute-markers"
 
-const TRANSLATABLE_ATTRIBUTE_NAMES = new Set([
+export const TRANSLATABLE_ATTRIBUTE_NAMES = new Set([
   "abbr",
   "alt",
   "aria-description",
@@ -19,7 +19,7 @@ const TRANSLATABLE_ATTRIBUTE_NAMES = new Set([
   "title",
 ])
 
-const TRANSLATABLE_INPUT_VALUE_TYPES = new Set(["button", "reset", "submit"])
+export const TRANSLATABLE_INPUT_VALUE_TYPES = new Set(["button", "reset", "submit"])
 const SHOW_COMMENT = 128
 const ELEMENT_NODE = 1
 

--- a/src/utils/host/translate/dom/translation-text-swap.ts
+++ b/src/utils/host/translate/dom/translation-text-swap.ts
@@ -11,6 +11,10 @@ import {
   type TranslationOnlySwapItem,
 } from "../core/translation-state"
 import { setTranslationDirAndLang } from "../translation-attributes"
+import {
+  TRANSLATABLE_ATTRIBUTE_NAMES,
+  TRANSLATABLE_INPUT_VALUE_TYPES,
+} from "./translation-html-attributes"
 
 // All-or-nothing for now: a partially swapped paragraph mixes languages, and
 // the detach-with-node-refs fallback is acceptable. Named so it can be relaxed
@@ -100,10 +104,11 @@ export function verifySourceSnapshot(
   )
 }
 
-// Human-visible attributes the provider may legitimately translate. The
-// placeholder protection keeps structural attributes (href, class, …) intact,
-// so only these need swapping onto the source element.
-const TRANSLATABLE_ATTRIBUTES = ["title", "alt", "placeholder", "aria-label"]
+// Element identity attributes: pairing is positional, so when a provider
+// legitimately reorders same-tag siblings (links for target grammar), these
+// must still match pairwise or the plan would cross-bind text onto the wrong
+// element (wrong link text on the wrong href). Mismatch -> fallback strategy.
+const IDENTITY_ATTRIBUTES = ["href", "src", "id"]
 
 interface AlignmentAccumulator {
   pairs: TextSwapPair[]
@@ -111,12 +116,17 @@ interface AlignmentAccumulator {
   coveredChars: number
   totalChars: number
   orphanTargetText: boolean
+  // Last document-ordered text pair, used to carry provider-inserted
+  // whitespace separators between adjacent inline elements.
+  lastTextPair: TextSwapPair | null
 }
 
 function partitionLevel(nodes: readonly Node[]): {
   sequence: (Element | Text[])[]
 } {
   // A level is a sequence of elements with text-node "gaps" between them.
+  // Whitespace-only text nodes stay in the gaps: the provider may emit one as
+  // the only word separator between adjacent inline elements.
   const sequence: (Element | Text[])[] = []
   let gap: Text[] = []
   for (const node of nodes) {
@@ -124,35 +134,47 @@ function partitionLevel(nodes: readonly Node[]): {
       sequence.push(gap)
       gap = []
       sequence.push(node)
-    } else if (isSwapRelevantText(node)) {
+    } else if (isTextNode(node)) {
       gap.push(node)
     }
-    // comments / whitespace-only text / wrappers don't participate
+    // comments / wrappers don't participate
   }
   sequence.push(gap)
   return { sequence }
 }
 
 function alignGap(sourceGap: Text[], targetGap: Text[], acc: AlignmentAccumulator): void {
-  const gapChars = sourceGap.reduce((sum, node) => sum + node.data.length, 0)
+  const relevantSource = sourceGap.filter((node) => node.data.trim())
+  const gapChars = relevantSource.reduce((sum, node) => sum + node.data.length, 0)
   acc.totalChars += gapChars
 
-  if (sourceGap.length === 0) {
-    if (targetGap.some((node) => node.data.trim())) {
+  const joinedTarget = targetGap.map((node) => node.data).join("")
+
+  if (relevantSource.length === 0) {
+    if (joinedTarget.trim()) {
       // Translated text with no source slot would be dropped silently — bail.
       acc.orphanTargetText = true
+    } else if (joinedTarget.length > 0 && acc.lastTextPair) {
+      // Provider inserted a pure-whitespace separator where the source had
+      // none (adjacent inline elements in CJK markup translated to a
+      // Latin-script target). Carry it on the preceding text so words don't
+      // jam together ("ApplesOranges").
+      if (!/\s$/.test(acc.lastTextPair.translatedValue)) {
+        acc.lastTextPair.translatedValue += " "
+      }
     }
     return
   }
-  if (targetGap.length === 0) return // uncovered source text
+  if (!joinedTarget) return // uncovered source text
 
-  const joinedTarget = targetGap.map((node) => node.data).join("")
-  acc.pairs.push({ node: sourceGap[0], translatedValue: joinedTarget })
+  const pair: TextSwapPair = { node: relevantSource[0], translatedValue: joinedTarget }
+  acc.pairs.push(pair)
   // Provider merged several source fragments: the first node carries the whole
   // translation, the rest are blanked (same parent, so visually identical).
-  for (const extra of sourceGap.slice(1)) {
+  for (const extra of relevantSource.slice(1)) {
     acc.pairs.push({ node: extra, translatedValue: "" })
   }
+  acc.lastTextPair = pair
   acc.coveredChars += gapChars
 }
 
@@ -169,29 +191,54 @@ function alignLevel(
   if (sourceElements.length !== targetElements.length) return false
   for (let i = 0; i < sourceElements.length; i++) {
     if (sourceElements[i].localName !== targetElements[i].localName) return false
-  }
-  for (let i = 0; i < sourceElements.length; i++) {
-    for (const name of TRANSLATABLE_ATTRIBUTES) {
-      const translatedValue = targetElements[i].getAttribute(name)
-      if (translatedValue !== null && translatedValue !== sourceElements[i].getAttribute(name)) {
-        acc.attributePairs.push({ element: sourceElements[i], name, translatedValue })
+    for (const name of IDENTITY_ATTRIBUTES) {
+      if (sourceElements[i].getAttribute(name) !== targetElements[i].getAttribute(name)) {
+        return false
       }
     }
   }
 
-  // With equal element counts both sequences interleave identically:
-  // gap, el, gap, el, ..., gap
-  const sourceGaps = source.sequence.filter((item): item is Text[] => Array.isArray(item))
-  const targetGaps = target.sequence.filter((item): item is Text[] => Array.isArray(item))
-  for (let i = 0; i < sourceGaps.length; i++) {
-    alignGap(sourceGaps[i], targetGaps[i] ?? [], acc)
-  }
-  for (let i = 0; i < sourceElements.length; i++) {
-    if (!alignLevel([...sourceElements[i].childNodes], [...targetElements[i].childNodes], acc)) {
+  // Both sequences strictly alternate gap, el, gap, el, ..., gap and element
+  // counts are equal, so positions line up. Walk them interleaved in document
+  // order so lastTextPair (the whitespace-separator carrier) is correct.
+  for (let i = 0; i < source.sequence.length; i++) {
+    const sourceItem = source.sequence[i]
+    const targetItem = target.sequence[i]
+    if (Array.isArray(sourceItem)) {
+      alignGap(sourceItem, Array.isArray(targetItem) ? targetItem : [], acc)
+      continue
+    }
+    const targetElement = targetItem as Element
+    collectTranslatedAttributePairs(sourceItem, targetElement, acc)
+    if (!alignLevel([...sourceItem.childNodes], [...targetElement.childNodes], acc)) {
       return false
     }
   }
   return true
+}
+
+function collectTranslatedAttributePairs(
+  source: Element,
+  target: Element,
+  acc: AlignmentAccumulator,
+): void {
+  // Same attribute set the protection layer exposes to providers for
+  // translation — anything narrower silently drops translated values.
+  for (const name of TRANSLATABLE_ATTRIBUTE_NAMES) {
+    const translatedValue = target.getAttribute(name)
+    if (translatedValue !== null && translatedValue !== source.getAttribute(name)) {
+      acc.attributePairs.push({ element: source, name, translatedValue })
+    }
+  }
+  if (
+    source.localName === "input" &&
+    TRANSLATABLE_INPUT_VALUE_TYPES.has((source.getAttribute("type") ?? "").toLowerCase())
+  ) {
+    const translatedValue = target.getAttribute("value")
+    if (translatedValue !== null && translatedValue !== source.getAttribute("value")) {
+      acc.attributePairs.push({ element: source, name: "value", translatedValue })
+    }
+  }
 }
 
 /**
@@ -229,6 +276,7 @@ export function planInPlaceTextSwap(
     coveredChars: 0,
     totalChars: 0,
     orphanTargetText: false,
+    lastTextPair: null,
   }
   if (!alignLevel(transNodes, targetNodes, acc)) return null
   if (acc.orphanTargetText) return null

--- a/src/utils/host/translate/dom/translation-text-swap.ts
+++ b/src/utils/host/translate/dom/translation-text-swap.ts
@@ -1,0 +1,291 @@
+import type { Config } from "@/types/config/config"
+import type { TransNode } from "@/types/dom"
+import { CONTENT_WRAPPER_CLASS, TRANSLATION_ONLY_ATTRIBUTE } from "../../../constants/dom-labels"
+import { isHTMLElement, isTextNode } from "../../dom/filter"
+import {
+  markExtensionDrivenCharacterData,
+  registerTranslationOnlyAnchorState,
+  type TranslationOnlyAnchorState,
+  type TranslationOnlySwapAttributeItem,
+  type TranslationOnlySwapItem,
+} from "../core/translation-state"
+import { setTranslationDirAndLang } from "../translation-attributes"
+
+// All-or-nothing for now: a partially swapped paragraph mixes languages, and
+// the detach-with-node-refs fallback is acceptable. Named so it can be relaxed
+// once fallback-frequency data exists.
+const IN_PLACE_SWAP_COVERAGE_THRESHOLD = 1
+
+export interface TextSwapPair {
+  node: Text
+  translatedValue: string
+}
+
+export interface AttributeSwapPair {
+  element: Element
+  name: string
+  translatedValue: string
+}
+
+export interface TextSwapPlan {
+  pairs: TextSwapPair[]
+  attributePairs: AttributeSwapPair[]
+  coverage: number
+}
+
+export interface SourceTextSnapshotEntry {
+  node: Text
+  parent: Node | null
+  value: string
+}
+
+function isSwapRelevantText(node: Node): node is Text {
+  return isTextNode(node) && !!node.data.trim()
+}
+
+function isWrapperElement(node: Node): boolean {
+  return isHTMLElement(node) && node.classList.contains(CONTENT_WRAPPER_CLASS)
+}
+
+function collectTextNodes(node: Node, into: Text[]): void {
+  if (isSwapRelevantText(node)) {
+    into.push(node)
+    return
+  }
+  if (!isHTMLElement(node) || isWrapperElement(node)) return
+  for (const child of node.childNodes) collectTextNodes(child, into)
+}
+
+/** Source text nodes of a run, in document order, excluding wrapper subtrees. */
+export function collectSourceTextNodes(transNodes: readonly TransNode[]): Text[] {
+  const result: Text[] = []
+  for (const node of transNodes) collectTextNodes(node, result)
+  return result
+}
+
+/**
+ * Snapshot the run's text nodes before the provider request so the response
+ * handler can detect host mutations that happened while the request was in
+ * flight (never swap against content the host has since rewritten).
+ */
+export function snapshotSourceTextNodes(
+  transNodes: readonly TransNode[],
+): SourceTextSnapshotEntry[] {
+  return collectSourceTextNodes(transNodes).map((node) => ({
+    node,
+    parent: node.parentNode,
+    value: node.data,
+  }))
+}
+
+/**
+ * The snapshot still describes the live DOM exactly: same text-node objects in
+ * the same order under the same parents with the same values, and no new text
+ * appeared inside the run.
+ */
+export function verifySourceSnapshot(
+  transNodes: readonly TransNode[],
+  snapshot: readonly SourceTextSnapshotEntry[],
+): boolean {
+  const connectedTransNodes = transNodes.filter((node) => node.isConnected)
+  if (connectedTransNodes.length !== transNodes.length) return false
+  const current = collectSourceTextNodes(transNodes)
+  if (current.length !== snapshot.length) return false
+  return snapshot.every(
+    (entry, index) =>
+      current[index] === entry.node &&
+      entry.node.parentNode === entry.parent &&
+      entry.node.data === entry.value,
+  )
+}
+
+// Human-visible attributes the provider may legitimately translate. The
+// placeholder protection keeps structural attributes (href, class, …) intact,
+// so only these need swapping onto the source element.
+const TRANSLATABLE_ATTRIBUTES = ["title", "alt", "placeholder", "aria-label"]
+
+interface AlignmentAccumulator {
+  pairs: TextSwapPair[]
+  attributePairs: AttributeSwapPair[]
+  coveredChars: number
+  totalChars: number
+  orphanTargetText: boolean
+}
+
+function partitionLevel(nodes: readonly Node[]): {
+  sequence: (Element | Text[])[]
+} {
+  // A level is a sequence of elements with text-node "gaps" between them.
+  const sequence: (Element | Text[])[] = []
+  let gap: Text[] = []
+  for (const node of nodes) {
+    if (isHTMLElement(node) && !isWrapperElement(node)) {
+      sequence.push(gap)
+      gap = []
+      sequence.push(node)
+    } else if (isSwapRelevantText(node)) {
+      gap.push(node)
+    }
+    // comments / whitespace-only text / wrappers don't participate
+  }
+  sequence.push(gap)
+  return { sequence }
+}
+
+function alignGap(sourceGap: Text[], targetGap: Text[], acc: AlignmentAccumulator): void {
+  const gapChars = sourceGap.reduce((sum, node) => sum + node.data.length, 0)
+  acc.totalChars += gapChars
+
+  if (sourceGap.length === 0) {
+    if (targetGap.some((node) => node.data.trim())) {
+      // Translated text with no source slot would be dropped silently — bail.
+      acc.orphanTargetText = true
+    }
+    return
+  }
+  if (targetGap.length === 0) return // uncovered source text
+
+  const joinedTarget = targetGap.map((node) => node.data).join("")
+  acc.pairs.push({ node: sourceGap[0], translatedValue: joinedTarget })
+  // Provider merged several source fragments: the first node carries the whole
+  // translation, the rest are blanked (same parent, so visually identical).
+  for (const extra of sourceGap.slice(1)) {
+    acc.pairs.push({ node: extra, translatedValue: "" })
+  }
+  acc.coveredChars += gapChars
+}
+
+function alignLevel(
+  sourceNodes: readonly Node[],
+  targetNodes: readonly Node[],
+  acc: AlignmentAccumulator,
+): boolean {
+  const source = partitionLevel(sourceNodes)
+  const target = partitionLevel(targetNodes)
+
+  const sourceElements = source.sequence.filter((item): item is Element => !Array.isArray(item))
+  const targetElements = target.sequence.filter((item): item is Element => !Array.isArray(item))
+  if (sourceElements.length !== targetElements.length) return false
+  for (let i = 0; i < sourceElements.length; i++) {
+    if (sourceElements[i].localName !== targetElements[i].localName) return false
+  }
+  for (let i = 0; i < sourceElements.length; i++) {
+    for (const name of TRANSLATABLE_ATTRIBUTES) {
+      const translatedValue = targetElements[i].getAttribute(name)
+      if (translatedValue !== null && translatedValue !== sourceElements[i].getAttribute(name)) {
+        acc.attributePairs.push({ element: sourceElements[i], name, translatedValue })
+      }
+    }
+  }
+
+  // With equal element counts both sequences interleave identically:
+  // gap, el, gap, el, ..., gap
+  const sourceGaps = source.sequence.filter((item): item is Text[] => Array.isArray(item))
+  const targetGaps = target.sequence.filter((item): item is Text[] => Array.isArray(item))
+  for (let i = 0; i < sourceGaps.length; i++) {
+    alignGap(sourceGaps[i], targetGaps[i] ?? [], acc)
+  }
+  for (let i = 0; i < sourceElements.length; i++) {
+    if (!alignLevel([...sourceElements[i].childNodes], [...targetElements[i].childNodes], acc)) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Pair the run's live source text nodes against the provider's translated
+ * HTML. Returns null when the structures cannot be aligned confidently — the
+ * caller then falls back to the detach-with-node-refs strategy.
+ */
+export function planInPlaceTextSwap(
+  transNodes: readonly TransNode[],
+  translatedHtml: string,
+  ownerDoc: Document,
+): TextSwapPlan | null {
+  const sourceTextNodes = collectSourceTextNodes(transNodes)
+  if (sourceTextNodes.length === 0) return null
+
+  const template = ownerDoc.createElement("template")
+  template.innerHTML = translatedHtml
+  const targetNodes = [...template.content.childNodes]
+
+  // Dominant trivial case: a single source text node takes the whole
+  // translation as plain text, which also neutralizes hallucinated tags.
+  if (sourceTextNodes.length === 1 && transNodes.every((node) => isTextNode(node))) {
+    const translatedText = template.content.textContent ?? ""
+    if (!translatedText.trim()) return null
+    return {
+      pairs: [{ node: sourceTextNodes[0], translatedValue: translatedText }],
+      attributePairs: [],
+      coverage: 1,
+    }
+  }
+
+  const acc: AlignmentAccumulator = {
+    pairs: [],
+    attributePairs: [],
+    coveredChars: 0,
+    totalChars: 0,
+    orphanTargetText: false,
+  }
+  if (!alignLevel(transNodes, targetNodes, acc)) return null
+  if (acc.orphanTargetText) return null
+  if (acc.totalChars === 0) return null
+
+  const coverage = acc.coveredChars / acc.totalChars
+  if (coverage < IN_PLACE_SWAP_COVERAGE_THRESHOLD) return null
+  return { pairs: acc.pairs, attributePairs: acc.attributePairs, coverage }
+}
+
+/**
+ * Write the paired translated values into the site's own text nodes and
+ * register the guarded-restore state on the anchor.
+ */
+export function applyInPlaceTextSwap(
+  plan: TextSwapPlan,
+  anchor: HTMLElement,
+  walkId: string,
+  config: Config,
+  getAnchorState: (anchor: HTMLElement) => TranslationOnlyAnchorState | undefined,
+): void {
+  const items: TranslationOnlySwapItem[] = []
+  for (const { node, translatedValue } of plan.pairs) {
+    items.push({ node, originalValue: node.data, translatedValue })
+    markExtensionDrivenCharacterData(node, translatedValue)
+    node.data = translatedValue
+  }
+
+  const attributeItems: TranslationOnlySwapAttributeItem[] = []
+  for (const { element, name, translatedValue } of plan.attributePairs) {
+    attributeItems.push({
+      element,
+      name,
+      originalValue: element.getAttribute(name),
+      translatedValue,
+    })
+    element.setAttribute(name, translatedValue)
+  }
+
+  const existingState = getAnchorState(anchor)
+  if (existingState) {
+    existingState.swaps.push({ walkId, items, attributeItems })
+    return
+  }
+
+  const attributeAdjustments = [
+    {
+      name: TRANSLATION_ONLY_ATTRIBUTE,
+      previousValue: anchor.getAttribute(TRANSLATION_ONLY_ATTRIBUTE),
+    },
+    { name: "dir", previousValue: anchor.getAttribute("dir") },
+    { name: "lang", previousValue: anchor.getAttribute("lang") },
+  ]
+  anchor.setAttribute(TRANSLATION_ONLY_ATTRIBUTE, "")
+  setTranslationDirAndLang(anchor, config)
+  registerTranslationOnlyAnchorState({
+    anchor,
+    attributeAdjustments,
+    swaps: [{ walkId, items, attributeItems }],
+  })
+}

--- a/src/utils/host/translate/dom/translation-text-swap.ts
+++ b/src/utils/host/translate/dom/translation-text-swap.ts
@@ -4,6 +4,7 @@ import { CONTENT_WRAPPER_CLASS, TRANSLATION_ONLY_ATTRIBUTE } from "../../../cons
 import { isHTMLElement, isTextNode } from "../../dom/filter"
 import {
   markExtensionDrivenCharacterData,
+  refreshTranslationOnlyAnchorExpectedText,
   registerTranslationOnlyAnchorState,
   type TranslationOnlyAnchorState,
   type TranslationOnlySwapAttributeItem,
@@ -270,6 +271,7 @@ export function applyInPlaceTextSwap(
   const existingState = getAnchorState(anchor)
   if (existingState) {
     existingState.swaps.push({ walkId, items, attributeItems })
+    refreshTranslationOnlyAnchorExpectedText(existingState)
     return
   }
 
@@ -283,9 +285,13 @@ export function applyInPlaceTextSwap(
   ]
   anchor.setAttribute(TRANSLATION_ONLY_ATTRIBUTE, "")
   setTranslationDirAndLang(anchor, config)
-  registerTranslationOnlyAnchorState({
+  const state: TranslationOnlyAnchorState = {
     anchor,
     attributeAdjustments,
     swaps: [{ walkId, items, attributeItems }],
-  })
+    expectedTextContent: "",
+  }
+  registerTranslationOnlyAnchorState(state)
+  // After registration so nested-anchor exclusion sees a consistent registry
+  refreshTranslationOnlyAnchorExpectedText(state)
 }

--- a/src/utils/host/translate/dom/translation-text-swap.ts
+++ b/src/utils/host/translate/dom/translation-text-swap.ts
@@ -3,12 +3,15 @@ import type { TransNode } from "@/types/dom"
 import { CONTENT_WRAPPER_CLASS, TRANSLATION_ONLY_ATTRIBUTE } from "../../../constants/dom-labels"
 import { isHTMLElement, isTextNode } from "../../dom/filter"
 import {
+  dropTranslationOnlySwapRecords,
   markExtensionDrivenCharacterData,
-  refreshTranslationOnlyAnchorExpectedText,
+  refreshTranslationOnlySwapRecordExpectedText,
   registerTranslationOnlyAnchorState,
+  swapRecordIntersectsNodes,
   type TranslationOnlyAnchorState,
   type TranslationOnlySwapAttributeItem,
   type TranslationOnlySwapItem,
+  type TranslationOnlySwapRecord,
 } from "../core/translation-state"
 import { setTranslationDirAndLang } from "../translation-attributes"
 import {
@@ -289,10 +292,12 @@ export function planInPlaceTextSwap(
 
 /**
  * Write the paired translated values into the site's own text nodes and
- * register the guarded-restore state on the anchor.
+ * register the guarded-restore state on the anchor. An existing record for
+ * the same run (a retranslation pass) is replaced, not appended.
  */
 export function applyInPlaceTextSwap(
   plan: TextSwapPlan,
+  runNodes: readonly TransNode[],
   anchor: HTMLElement,
   walkId: string,
   config: Config,
@@ -316,10 +321,25 @@ export function applyInPlaceTextSwap(
     element.setAttribute(name, translatedValue)
   }
 
+  const record: TranslationOnlySwapRecord = {
+    walkId,
+    runNodes: [...runNodes],
+    expectedRunText: "",
+    items,
+    attributeItems,
+  }
+  refreshTranslationOnlySwapRecordExpectedText(record)
+
   const existingState = getAnchorState(anchor)
   if (existingState) {
-    existingState.swaps.push({ walkId, items, attributeItems })
-    refreshTranslationOnlyAnchorExpectedText(existingState)
+    // A retranslation pass replaces its run's previous record — appending
+    // would leave a dead record whose stale references keep flagging the
+    // anchor as host-changed.
+    dropTranslationOnlySwapRecords(
+      existingState,
+      existingState.swaps.filter((existing) => swapRecordIntersectsNodes(existing, runNodes)),
+    )
+    existingState.swaps.push(record)
     return
   }
 
@@ -333,13 +353,9 @@ export function applyInPlaceTextSwap(
   ]
   anchor.setAttribute(TRANSLATION_ONLY_ATTRIBUTE, "")
   setTranslationDirAndLang(anchor, config)
-  const state: TranslationOnlyAnchorState = {
+  registerTranslationOnlyAnchorState({
     anchor,
     attributeAdjustments,
-    swaps: [{ walkId, items, attributeItems }],
-    expectedTextContent: "",
-  }
-  registerTranslationOnlyAnchorState(state)
-  // After registration so nested-anchor exclusion sees a consistent registry
-  refreshTranslationOnlyAnchorExpectedText(state)
+    swaps: [record],
+  })
 }


### PR DESCRIPTION
Fixes #1846

## Root cause

Translation-only mode was destructive with lossy recovery: translating **removed the original nodes** and "show original" rewrote the nearest snapshotted ancestor's `innerHTML` from a string kept in `originalContentMap`. The snapshot was skipped whenever any wrapper already existed inside the parent (routine with inner-first/overlapping walk units), so restore silently deleted the wrapper and **lost the original text forever**; when a snapshot did exist, the ancestor rewrite **destroyed untouched siblings and framework node identity**. On logged-in NexusMods (Next.js/React, client re-renders) this produced the reported empty list items and scattered buttons. Reproduced in jsdom before fixing.

## Design (ported from Immersive Translate 1.31.2, reverse-engineered)

1. **In-place text swap (preferred)** — pair the provider's translated HTML against the run's source text nodes (structural alignment, identity-attribute checks, all-or-nothing coverage gate) and write translations into the site's OWN text nodes. Element identity, listeners, and React fibers stay untouched; no wrapper remains. Restore writes originals back only when a node still holds the value we wrote — never clobbering framework re-renders. Translated human-visible attributes (title/alt/placeholder/aria-*/button value) swap and restore under the same guard.
2. **Node-identity fallback** — when pairing fails, the wrapper strategy retains the displaced `ChildNode` objects per wrapper and restore re-inserts those same nodes. No string snapshots anywhere.
3. **Staleness retranslation** — swapped runs record their expected text; host re-renders (X "show more" expansions) flag the run stale per record and route through the existing budgeted retranslation pipeline, so expanded content gets translated instead of staying in the source language. Bilingual mode already had this contract; translation-only now matches it.

## Hardening (multi-agent adversarial review, 12 confirmed findings fixed)

- toggle scoping: a run restores its OWN swap/wrapper; nested runs' wrappers and sibling in-flight spinners can no longer be stolen (toggle now converges instead of re-translating on every press)
- bilingual node-toggle recognizes swapped anchors after a mode switch
- positional pairing bails to the fallback when same-tag siblings are reordered (no cross-bound link text), provider whitespace separators are preserved, and the attribute set matches the protection layer
- per-record staleness (timing-independent w.r.t. nested anchors), mid-flight-drop keeps the region monitored, dead records are pruned, ghost markers self-heal after extension reloads, scheduled retries dispatch by mode

## Verification

- 1766 unit/integration tests green (36 new), lint clean
- Real-browser E2E (built extension + Microsoft endpoint + a React fixture simulating logged-in NexusMods and X "show more"): translate → React re-render + clicks survive → expansion retranslates through the live MutationObserver pipeline → restore is content-identical with zero artifacts and zero React/DOM exceptions
- NexusMods logged-in final confirmation needs an account — please verify on the reported page before release

Note: the freeze discussed in the issue comments (ad-heavy pages) is tracked separately in #1601 and is out of scope here. The `chore(skills)` commit adds the Puppeteer E2E harness skill used for verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)