### PR TITLE
fix(translate): keep trailing emoji with source paragraphs

### DIFF
--- a/.changeset/fuzzy-hearts-stay.md
+++ b/.changeset/fuzzy-hearts-stay.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): keep trailing emoji with source paragraphs

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -618,6 +618,137 @@ describe("translate", () => {
         })
       })
 
+      it("keeps trailing twemoji images before a single bilingual translation", async () => {
+        await withHost("x.com", async () => {
+          const sourceText = "Finish the job"
+          const translatedText = "完成这项工作"
+          vi.mocked(translateTextForPage).mockResolvedValue(translatedText)
+          render(
+            <div data-testid="tweetText">
+              <span>{sourceText}</span>{" "}
+              {[
+                ["👍", "thumbs-up.svg"],
+                ["🇺🇸", "flag-us.svg"],
+                ["💪", "flexed-biceps.svg"],
+                ["❤️", "red-heart.svg"],
+              ].map(([alt, src]) => (
+                <img key={alt} alt={alt} src={src} style={{ display: "inline-block" }} />
+              ))}
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const sourceSpan = tweet.querySelector("span")!
+          const emojiImages = [...tweet.querySelectorAll("img")]
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(translateTextForPage).toHaveBeenCalledTimes(1)
+          expect(translateTextForPage).toHaveBeenCalledWith(sourceText, "plain")
+          const [wrapper] = expectBlockTranslations(tweet, [translatedText])
+          expect(sourceSpan.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+          expect([...tweet.children]).toEqual([sourceSpan, ...emojiImages, wrapper])
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(getTranslationWrappers(tweet)).toHaveLength(0)
+          expect([...tweet.children]).toEqual([sourceSpan, ...emojiImages])
+        })
+      })
+
+      it("keeps trailing twemoji images after translation-only swaps and restore", async () => {
+        await withHost("x.com", async () => {
+          const sourceText = "Finish the job"
+          const translatedText = "完成这项工作"
+          vi.mocked(translateTextForPage).mockResolvedValue(translatedText)
+          render(
+            <div data-testid="tweetText">
+              <span>{sourceText}</span>
+              {[
+                ["👍", "thumbs-up.svg"],
+                ["🇺🇸", "flag-us.svg"],
+                ["💪", "flexed-biceps.svg"],
+                ["❤️", "red-heart.svg"],
+              ].map(([alt, src]) => (
+                <img key={alt} alt={alt} src={src} style={{ display: "inline-block" }} />
+              ))}
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const sourceSpan = tweet.querySelector("span")!
+          const sourceTextNode = sourceSpan.firstChild
+          const emojiImages = [...tweet.querySelectorAll("img")]
+
+          await removeOrShowPageTranslation("translationOnly", true)
+
+          expect(translateTextForPage).toHaveBeenCalledTimes(1)
+          expect(translateTextForPage).toHaveBeenCalledWith(sourceText, "html")
+          expectInPlaceTranslation(sourceSpan, translatedText)
+          expect(sourceSpan.firstChild).toBe(sourceTextNode)
+          expect([...tweet.children]).toEqual([sourceSpan, ...emojiImages])
+
+          await removeOrShowPageTranslation("translationOnly", true)
+
+          expect(sourceSpan).not.toHaveAttribute(TRANSLATION_ONLY_ATTRIBUTE)
+          expect(sourceSpan.firstChild).toBe(sourceTextNode)
+          expect(sourceSpan).toHaveTextContent(sourceText)
+          expect([...tweet.children]).toEqual([sourceSpan, ...emojiImages])
+        })
+      })
+
+      it("places the final virtual translation after trailing twemoji images", async () => {
+        await withHost("x.com", async () => {
+          const paragraphs = [
+            "The U.S. is destroying all Iranian military bases.",
+            "Finish The Job, Remove & Replace This Iranian Tyranny Terror Regime!\nFree Iran\nGod Bless The U.S. Troops & The Israeli Troops",
+          ]
+          const translations = ["【军事基地译文】", "【完成任务与祝福译文】"]
+          const translationByParagraph = new Map(
+            paragraphs.map((paragraph, index) => [paragraph, translations[index]]),
+          )
+          vi.mocked(translateTextForPage).mockImplementation(async (text) => {
+            const translatedText = translationByParagraph.get(text)
+            if (!translatedText) throw new Error(`Unexpected paragraph: ${text}`)
+            return translatedText
+          })
+
+          render(
+            <div data-testid="tweetText" style={{ whiteSpace: "pre-wrap" }}>
+              <img alt="🇺🇸" src="leading-flag.svg" style={{ display: "inline-block" }} />
+              <span>{paragraphs[0]}</span>
+              <img alt="🇺🇸" src="first-paragraph-flag.svg" style={{ display: "inline-block" }} />
+              <span>{`\n\n${paragraphs[1]} `}</span>
+              {[
+                ["✡️", "star-of-david.svg"],
+                ["✝️", "cross.svg"],
+                ["🙏🏻", "folded-hands.svg"],
+                ["♥️", "heart-suit.svg"],
+              ].map(([alt, src]) => (
+                <img key={alt} alt={alt} src={src} style={{ display: "inline-block" }} />
+              ))}
+            </div>,
+          )
+          const tweet = screen.getByTestId("tweetText")
+          const originalChildren = [...tweet.childNodes]
+          const emojiImages = [...tweet.querySelectorAll("img")]
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(translateTextForPage).toHaveBeenCalledTimes(2)
+          paragraphs.forEach((paragraph, index) => {
+            expect(translateTextForPage).toHaveBeenNthCalledWith(index + 1, paragraph, "plain")
+          })
+          const wrappers = expectBlockTranslations(tweet, translations)
+          expect(wrappers[0].previousSibling).toBe(emojiImages[1])
+          expect(wrappers[1]).toBe(tweet.lastElementChild)
+          expect(wrappers[1].previousSibling).toBe(emojiImages.at(-1))
+
+          await removeOrShowPageTranslation("bilingual", true)
+
+          expect(getTranslationWrappers(tweet)).toHaveLength(0)
+          expect([...tweet.childNodes]).toEqual(originalChildren)
+        })
+      })
+
       it("removes orphan virtual wrappers on toggle without changing source fragments", async () => {
         await withHost("x.com", async () => {
           const sourceText = "First paragraph.\n\nSecond paragraph."

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -17,7 +17,11 @@ import { isBlockTransNode, isHTMLElement, isTextNode, isTransNode } from "../../
 import { unwrapDeepestOnlyHTMLChild } from "../../dom/find"
 import { getOwnerDocument } from "../../dom/node"
 import { extractTextContent } from "../../dom/traversal"
-import { buildVirtualParagraphPlan, type VirtualParagraphUnit } from "../dom/paragraph-segmentation"
+import {
+  buildVirtualParagraphPlan,
+  moveParagraphInsertionBoundaryAfterTrailingInlineImages,
+  type VirtualParagraphUnit,
+} from "../dom/paragraph-segmentation"
 import {
   disposeVirtualParagraphGroup,
   dropTranslationOnlySwapRecordsForNodes,
@@ -481,7 +485,16 @@ export async function translateNodesBilingualMode(
       config,
     )
 
-    if (isTextNode(insertionTarget) || transNodes.length > 1) {
+    if (transNodes.length === 1 && isHTMLElement(layoutSource) && isHTMLElement(insertionTarget)) {
+      const insertionBoundary = moveParagraphInsertionBoundaryAfterTrailingInlineImages(
+        { container: insertionTarget, offset: insertionTarget.childNodes.length },
+        layoutSource,
+      )
+      insertionBoundary.container.insertBefore(
+        translatedWrapperNode,
+        insertionBoundary.container.childNodes[insertionBoundary.offset] ?? null,
+      )
+    } else if (isTextNode(insertionTarget) || transNodes.length > 1) {
       insertionTarget.parentNode?.insertBefore(translatedWrapperNode, insertionTarget.nextSibling)
     } else {
       insertionTarget.appendChild(translatedWrapperNode)

--- a/src/utils/host/translate/dom/__tests__/paragraph-segmentation.test.ts
+++ b/src/utils/host/translate/dom/__tests__/paragraph-segmentation.test.ts
@@ -6,6 +6,7 @@ import { CONTENT_WRAPPER_CLASS } from "@/utils/constants/dom-labels"
 import {
   buildVirtualParagraphUnits,
   liftParagraphInsertionBoundary,
+  moveParagraphInsertionBoundaryAfterTrailingInlineImages,
   type DOMBoundary,
 } from "../paragraph-segmentation"
 
@@ -113,6 +114,118 @@ describe("buildVirtualParagraphUnits", () => {
     expect(units[1].sourceFragments).toEqual([
       { source: secondText, startOffset: 1, endOffset: 7, atomic: false },
     ])
+  })
+
+  it("places the final virtual paragraph after trailing inline images with alt text", () => {
+    const root = createRoot()
+    const source = document.createElement("span")
+    source.textContent = "First paragraph\n\nSecond paragraph"
+    const emojiImages = ["✡️", "✝️", "🙏🏻", "♥️"].map((alt) => {
+      const image = document.createElement("img")
+      image.alt = alt
+      image.style.display = "inline-block"
+      return image
+    })
+    root.append(
+      source,
+      " ",
+      emojiImages[0],
+      "\t",
+      emojiImages[1],
+      "  ",
+      emojiImages[2],
+      emojiImages[3],
+      " ",
+    )
+
+    const units = buildVirtualParagraphUnits(root, DEFAULT_CONFIG)
+
+    expect(units.map((unit) => unit.text)).toEqual(["First paragraph", "Second paragraph"])
+    expect(units[1].insertionBoundary).toEqual({
+      container: root,
+      offset: root.childNodes.length,
+    })
+    expect(
+      units.flatMap((unit) => unit.sourceFragments).map((fragment) => fragment.source),
+    ).not.toEqual(expect.arrayContaining(emojiImages))
+  })
+
+  it.each([
+    {
+      label: "a block image",
+      createTrailingNode: () => {
+        const image = document.createElement("img")
+        image.alt = "♥️"
+        image.style.display = "block"
+        return image
+      },
+    },
+    {
+      label: "an inline image without alt text",
+      createTrailingNode: () => {
+        const image = document.createElement("img")
+        image.style.display = "inline-block"
+        return image
+      },
+    },
+    {
+      label: "an inline SVG",
+      createTrailingNode: () => {
+        const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg")
+        svg.style.display = "inline-block"
+        return svg
+      },
+    },
+    {
+      label: "a hidden inline image",
+      createTrailingNode: () => {
+        const image = document.createElement("img")
+        image.alt = "♥️"
+        image.style.display = "inline-block"
+        image.style.visibility = "hidden"
+        return image
+      },
+    },
+  ])("does not move the final boundary past $label", ({ createTrailingNode }) => {
+    const root = createRoot()
+    const source = document.createElement("span")
+    source.textContent = "First paragraph\n\nSecond paragraph"
+    root.append(source, createTrailingNode())
+
+    const units = buildVirtualParagraphUnits(root, DEFAULT_CONFIG)
+
+    expect(units[1].insertionBoundary).toEqual({ container: root, offset: 1 })
+  })
+
+  it("does not move a paragraph boundary past a trailing control", () => {
+    const root = createRoot()
+    const source = document.createElement("span")
+    source.textContent = "Paragraph"
+    const button = document.createElement("button")
+    button.textContent = "Show more"
+    root.append(source, button)
+
+    expect(
+      moveParagraphInsertionBoundaryAfterTrailingInlineImages(
+        { container: source, offset: source.childNodes.length },
+        root,
+      ),
+    ).toEqual({ container: source, offset: source.childNodes.length })
+  })
+
+  it.each([
+    ["a newline", "\n"],
+    ["real text", "next paragraph"],
+  ])("does not move a paragraph boundary past %s", (_label, trailingText) => {
+    const root = createRoot()
+    const source = document.createElement("span")
+    source.textContent = "Paragraph"
+    root.append(source, document.createTextNode(trailingText))
+    const originalBoundary = { container: source, offset: source.childNodes.length }
+
+    expect(moveParagraphInsertionBoundaryAfterTrailingInlineImages(originalBoundary, root)).toEqual(
+      originalBoundary,
+    )
   })
 
   it("keeps a preserve-text mention atomic inside its surrounding paragraph", () => {

--- a/src/utils/host/translate/dom/paragraph-segmentation.ts
+++ b/src/utils/host/translate/dom/paragraph-segmentation.ts
@@ -15,6 +15,8 @@ const BLANK_LINE_DELIMITER_RE = /(?:\r\n?|\n)[^\S\r\n]*(?:\r\n?|\n)(?:[^\S\r\n]*
 
 const PROTECTED_INSERTION_TAGS = new Set(["A", "BUTTON"])
 
+const HORIZONTAL_WHITESPACE_RE = /^[^\S\r\n]*$/
+
 export interface DOMBoundary {
   container: Node
   offset: number
@@ -358,6 +360,84 @@ export function liftParagraphInsertionBoundary(
   return liftEdgeBoundary(outsideProtected, layoutSource)
 }
 
+function isHorizontalWhitespaceText(node: Node): node is Text {
+  return isTextNode(node) && HORIZONTAL_WHITESPACE_RE.test(node.data)
+}
+
+function isVisibleInlineImageWithAlt(node: Node): node is HTMLImageElement {
+  if (!isHTMLElement(node) || node.tagName !== "IMG" || !node.getAttribute("alt")?.trim()) {
+    return false
+  }
+
+  const computedStyle = window.getComputedStyle(node)
+  return (
+    computedStyle.visibility !== "hidden" &&
+    computedStyle.display.trim().toLowerCase().startsWith("inline")
+  )
+}
+
+/**
+ * Keep textless inline images such as X/Twitter's twemoji with the source
+ * paragraph for layout purposes. Their alt text is intentionally not added to
+ * the translation stream: this only moves the bilingual wrapper boundary.
+ */
+export function moveParagraphInsertionBoundaryAfterTrailingInlineImages(
+  boundary: DOMBoundary,
+  layoutSource: HTMLElement,
+): DOMBoundary {
+  const originalBoundary = boundary
+  let container = boundary.container
+  let offset = boundary.offset
+  let committedBoundary = originalBoundary
+  let sawInlineImage = false
+
+  if (isTextNode(container)) {
+    if (offset !== container.data.length) return originalBoundary
+    const parent = container.parentNode
+    if (!parent) return originalBoundary
+    const index = [...parent.childNodes].indexOf(container)
+    if (index === -1) return originalBoundary
+    container = parent
+    offset = index + 1
+  }
+
+  while (container === layoutSource || layoutSource.contains(container)) {
+    const children = [...container.childNodes]
+    let index = offset
+
+    while (index < children.length) {
+      const child = children[index]
+
+      if (isHorizontalWhitespaceText(child)) {
+        if (sawInlineImage) {
+          committedBoundary = { container, offset: index + 1 }
+        }
+        index += 1
+        continue
+      }
+
+      if (!isVisibleInlineImageWithAlt(child)) {
+        return sawInlineImage ? committedBoundary : originalBoundary
+      }
+
+      sawInlineImage = true
+      committedBoundary = { container, offset: index + 1 }
+      index += 1
+    }
+
+    if (container === layoutSource) break
+
+    const parent = container.parentNode
+    if (!parent) break
+    const indexInParent = [...parent.childNodes].indexOf(container as ChildNode)
+    if (indexInParent === -1) break
+    container = parent
+    offset = indexInParent + 1
+  }
+
+  return sawInlineImage ? committedBoundary : originalBoundary
+}
+
 /**
  * Build virtual bilingual paragraphs from literal blank lines without changing
  * the host DOM. An empty result means the caller should use the existing
@@ -393,11 +473,15 @@ export function buildVirtualParagraphPlan(
     const contentStart = segment.start + (rawText.length - rawText.trimStart().length)
     const contentEnd = segment.end - (rawText.length - rawText.trimEnd().length)
     const boundary = boundaryAtStreamOffset(state.chunks, segment.insertionIndex, layoutSource)
+    const liftedBoundary = liftParagraphInsertionBoundary(boundary, layoutSource, config)
 
     units.push({
       id: units.length,
       text,
-      insertionBoundary: liftParagraphInsertionBoundary(boundary, layoutSource, config),
+      insertionBoundary: moveParagraphInsertionBoundaryAfterTrailingInlineImages(
+        liftedBoundary,
+        layoutSource,
+      ),
       sourceFragments: createSourceFragments(state.chunks, contentStart, contentEnd),
     })
   }


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

- Treat visible trailing inline `img[alt]` nodes as paragraph layout attachments when choosing bilingual translation insertion boundaries.
- Reuse the boundary rule for both single-element translations and blank-line virtual paragraphs without adding emoji alt text to translation requests.
- Stop boundary movement at newlines, real text, block or hidden images, empty alt text, SVG, controls, and other elements.
- Keep translation-only in-place swapping unchanged so emoji image identity and ordering remain stable.
- Add a patch changeset for `@read-frog/extension`.

## Related Issue

fix: https://x.com/ArmandKleinX/status/2076717608091471899

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation performed:

- `SKIP_FREE_API=true pnpm test`
- `pnpm type-check`
- `pnpm fmt:check`
- `pnpm build`
- Pre-push extension checks: formatting, type-aware lint, and 1,778 tests passed
- Built-extension headed Chrome fixture covering bilingual single/multi-paragraph placement, translation-only image preservation, and restore

## Screenshots

N/A — this changes DOM insertion order without changing translation styling.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The issue was reproduced from X/Twitter DOM where emoji are separate inline-block images with empty `textContent`. Fresh-profile live X automation did not render `tweetText` due X access gating, so the built-extension browser verification uses a fixture matching the observed live DOM structure.
