### PR TITLE
fix(translation): experiment with preserving replaced translations

### DIFF
--- a/.changeset/steady-frogs-translate.md
+++ b/.changeset/steady-frogs-translate.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): preserve completed translations across DOM replacements

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -3,6 +3,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import {
+  getBilingualTranslationStateForSource,
   markExtensionDrivenNodeRemoval,
   registerBilingualTranslationState,
   unregisterBilingualTranslationState,
@@ -207,6 +208,42 @@ function walkAndLabelVisibleParagraphs(element: HTMLElement, walkId: string) {
   }
 }
 
+function attachBilingualTranslationState(
+  source: HTMLElement,
+  translatedText: string,
+  options: {
+    error?: boolean
+    insertionParent?: HTMLElement
+    phase?: BilingualTranslationState["phase"]
+  } = {},
+): { state: BilingualTranslationState; wrapper: HTMLElement } {
+  const wrapper = document.createElement("span")
+  wrapper.className = "notranslate read-frog-translated-content-wrapper"
+  wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+  wrapper.setAttribute("data-read-frog-walked", "walk-id")
+  const translated = document.createElement("span")
+  translated.className = "notranslate read-frog-translated-block-content"
+  translated.textContent = translatedText
+  wrapper.append(document.createElement("br"), translated)
+  if (options.error) {
+    const error = document.createElement("span")
+    error.className = "read-frog-translation-error-container"
+    wrapper.append(error)
+  }
+  ;(options.insertionParent ?? source).append(wrapper)
+
+  const state: BilingualTranslationState = {
+    layoutSource: source,
+    sourceTextContent: source.textContent?.replace(translatedText, "").trim() ?? "",
+    phase: options.phase ?? "complete",
+    status: "active",
+    walkId: "walk-id",
+    wrapper,
+  }
+  registerBilingualTranslationState(state)
+  return { state, wrapper }
+}
+
 describe("pageTranslationManager mutation re-walk", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -239,6 +276,300 @@ describe("pageTranslationManager mutation re-walk", () => {
     mockTranslateNodesBilingualMode.mockReset().mockResolvedValue(undefined)
     mockValidateTranslationConfigAndToast.mockReturnValue(true)
     mockSendMessage.mockResolvedValue(undefined)
+  })
+
+  it("moves a completed translation to an equivalent replacement before config lookup resolves (#1854)", async () => {
+    document.body.innerHTML = `<main id="lesson"><p id="source">Python variables</p></main>`
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const lesson = document.getElementById("lesson") as HTMLElement
+    const oldSource = document.getElementById("source") as HTMLElement
+    const { wrapper } = attachBilingualTranslationState(oldSource, "Python 变量")
+    await flushDomUpdates()
+    mockTranslateWalkedElement.mockClear()
+
+    let resolveConfig!: (config: typeof DEFAULT_CONFIG) => void
+    mockGetLocalConfig.mockReturnValue(
+      new Promise<typeof DEFAULT_CONFIG>((resolve) => {
+        resolveConfig = resolve
+      }),
+    )
+
+    const newSource = document.createElement("p")
+    newSource.id = "source"
+    newSource.textContent = "Python variables"
+    lesson.replaceChild(newSource, oldSource)
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(newSource.querySelector(".read-frog-translated-content-wrapper")).toBe(wrapper)
+    expect(getBilingualTranslationStateForSource(newSource)).toMatchObject({
+      phase: "complete",
+      sourceTextContent: "Python variables",
+      walkId: "walk-id",
+    })
+    expect(mockTranslateWalkedElement).not.toHaveBeenCalled()
+
+    resolveConfig(DEFAULT_CONFIG)
+    await flushDomUpdates()
+    manager.stop()
+  })
+
+  it("restores a cached translation when removal and insertion arrive separately (#1854)", async () => {
+    document.body.innerHTML = `<main id="lesson"><p id="source">Python lists</p></main>`
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const lesson = document.getElementById("lesson") as HTMLElement
+    const oldSource = document.getElementById("source") as HTMLElement
+    const { wrapper: oldWrapper } = attachBilingualTranslationState(oldSource, "Python 列表")
+    await flushDomUpdates()
+
+    oldSource.remove()
+    await flushDomUpdates()
+
+    const newSource = document.createElement("p")
+    newSource.id = "source"
+    newSource.textContent = "Python lists"
+    lesson.append(newSource)
+    await flushDomUpdates()
+
+    const restoredWrapper = newSource.querySelector<HTMLElement>(
+      ".read-frog-translated-content-wrapper",
+    )
+    expect(restoredWrapper).not.toBeNull()
+    expect(restoredWrapper).not.toBe(oldWrapper)
+    expect(restoredWrapper?.textContent).toContain("Python 列表")
+    expect(getBilingualTranslationStateForSource(newSource)?.phase).toBe("complete")
+    expect(mockTranslateNodesBilingualMode).not.toHaveBeenCalled()
+
+    manager.stop()
+  })
+
+  it("does not reuse a translation when source text or host structure changed (#1854)", async () => {
+    document.body.innerHTML = `
+      <main id="lesson">
+        <p id="changed-text">Python tuples</p>
+        <p id="changed-structure"><span>Python dictionaries</span></p>
+      </main>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const lesson = document.getElementById("lesson") as HTMLElement
+    const changedText = document.getElementById("changed-text") as HTMLElement
+    const changedStructure = document.getElementById("changed-structure") as HTMLElement
+    attachBilingualTranslationState(changedText, "Python 元组")
+    attachBilingualTranslationState(changedStructure, "Python 字典", {
+      insertionParent: changedStructure.firstElementChild as HTMLElement,
+    })
+    await flushDomUpdates()
+
+    const newTextSource = document.createElement("p")
+    newTextSource.textContent = "Python sets"
+    lesson.replaceChild(newTextSource, changedText)
+
+    const newStructureSource = document.createElement("p")
+    newStructureSource.innerHTML = "<em><span>Python dictionaries</span></em>"
+    lesson.replaceChild(newStructureSource, changedStructure)
+    await flushDomUpdates()
+
+    expect(newTextSource.querySelector(".read-frog-translated-content-wrapper")).toBeNull()
+    expect(newStructureSource.querySelector(".read-frog-translated-content-wrapper")).toBeNull()
+
+    manager.stop()
+  })
+
+  it("does not cache pending or error translations (#1854)", async () => {
+    document.body.innerHTML = `
+      <main id="lesson">
+        <p id="pending">Pending paragraph</p>
+        <p id="error">Error paragraph</p>
+      </main>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const lesson = document.getElementById("lesson") as HTMLElement
+    const pending = document.getElementById("pending") as HTMLElement
+    const error = document.getElementById("error") as HTMLElement
+    attachBilingualTranslationState(pending, "等待中的译文", { phase: "pending" })
+    attachBilingualTranslationState(error, "错误译文", { error: true })
+    await flushDomUpdates()
+
+    const newPending = document.createElement("p")
+    newPending.textContent = "Pending paragraph"
+    const newError = document.createElement("p")
+    newError.textContent = "Error paragraph"
+    lesson.replaceChildren(newPending, newError)
+    await flushDomUpdates()
+
+    expect(newPending.querySelector(".read-frog-translated-content-wrapper")).toBeNull()
+    expect(newError.querySelector(".read-frog-translated-content-wrapper")).toBeNull()
+
+    manager.stop()
+  })
+
+  it("counts pending generations toward the cross-node circuit breaker without copying them (#1854)", async () => {
+    document.body.innerHTML = `<main id="lesson"><p>Pending loop</p></main>`
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const lesson = document.getElementById("lesson") as HTMLElement
+    let current = lesson.firstElementChild as HTMLElement
+    attachBilingualTranslationState(current, "未完成", { phase: "pending" })
+    await flushDomUpdates()
+
+    for (let index = 0; index < 6; index++) {
+      const replacement = document.createElement("p")
+      replacement.textContent = "Pending loop"
+      lesson.replaceChild(replacement, current)
+      current = replacement
+      await flushDomUpdates()
+      expect(current.querySelector(".read-frog-translated-content-wrapper")).toBeNull()
+      attachBilingualTranslationState(current, "未完成", { phase: "pending" })
+      await flushDomUpdates()
+    }
+
+    const suppressed = document.createElement("p")
+    suppressed.textContent = "Pending loop"
+    lesson.replaceChild(suppressed, current)
+    current = suppressed
+    await flushDomUpdates()
+
+    expect(current.querySelector(".read-frog-translated-content-wrapper")).toBeNull()
+    expect(intersectionObservers[0].observe.mock.calls.some(([target]) => target === current)).toBe(
+      false,
+    )
+
+    manager.stop()
+  })
+
+  it("restores repeated identical paragraphs without duplicating wrappers (#1854)", async () => {
+    document.body.innerHTML = `
+      <main id="lesson">
+        <p>Shared paragraph</p>
+        <p>Shared paragraph</p>
+      </main>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const lesson = document.getElementById("lesson") as HTMLElement
+    const oldSources = [...lesson.querySelectorAll<HTMLElement>("p")]
+    oldSources.forEach((source) => attachBilingualTranslationState(source, "重复段落"))
+    await flushDomUpdates()
+
+    const replacements = [document.createElement("p"), document.createElement("p")]
+    replacements.forEach((source) => {
+      source.textContent = "Shared paragraph"
+    })
+    lesson.replaceChildren(...replacements)
+    await flushDomUpdates()
+
+    expect(
+      replacements.map(
+        (source) => source.querySelectorAll(".read-frog-translated-content-wrapper").length,
+      ),
+    ).toEqual([1, 1])
+    expect(replacements.map((source) => source.textContent)).toEqual([
+      "Shared paragraph重复段落",
+      "Shared paragraph重复段落",
+    ])
+
+    manager.stop()
+  })
+
+  it("stops restoring one logical paragraph after six rapid replacements and resets on restart (#1854)", async () => {
+    document.body.innerHTML = `<main id="lesson"><p>Looping paragraph</p></main>`
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const lesson = document.getElementById("lesson") as HTMLElement
+    let current = lesson.firstElementChild as HTMLElement
+    attachBilingualTranslationState(current, "循环段落")
+    await flushDomUpdates()
+
+    for (let index = 0; index < 6; index++) {
+      const replacement = document.createElement("p")
+      replacement.textContent = "Looping paragraph"
+      lesson.replaceChild(replacement, current)
+      current = replacement
+      await flushDomUpdates()
+      expect(current.querySelectorAll(".read-frog-translated-content-wrapper")).toHaveLength(1)
+    }
+
+    const suppressed = document.createElement("p")
+    suppressed.textContent = "Looping paragraph"
+    lesson.replaceChild(suppressed, current)
+    current = suppressed
+    await flushDomUpdates()
+
+    expect(current.querySelector(".read-frog-translated-content-wrapper")).toBeNull()
+    expect(intersectionObservers[0].observe.mock.calls.some(([target]) => target === current)).toBe(
+      false,
+    )
+
+    const stillSuppressed = document.createElement("p")
+    stillSuppressed.textContent = "Looping paragraph"
+    lesson.replaceChild(stillSuppressed, current)
+    current = stillSuppressed
+    await flushDomUpdates()
+    expect(current.querySelector(".read-frog-translated-content-wrapper")).toBeNull()
+
+    current.textContent = "Looping paragraph changed"
+    await flushDomUpdates()
+    expect(intersectionObservers[0].observe.mock.calls.some(([target]) => target === current)).toBe(
+      true,
+    )
+
+    manager.stop()
+    await manager.start()
+    await flushDomUpdates()
+    expect(intersectionObservers[1].observe).toHaveBeenCalledWith(current)
+
+    manager.stop()
+  })
+
+  it("does not spend the autonomous-loop budget while the user is actively scrolling (#1854)", async () => {
+    document.body.innerHTML = `<main id="lesson"><p>Scrolling paragraph</p></main>`
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const lesson = document.getElementById("lesson") as HTMLElement
+    let current = lesson.firstElementChild as HTMLElement
+    attachBilingualTranslationState(current, "滚动段落")
+    await flushDomUpdates()
+
+    for (let index = 0; index < 10; index++) {
+      document.dispatchEvent(new WheelEvent("wheel"))
+      const replacement = document.createElement("p")
+      replacement.textContent = "Scrolling paragraph"
+      lesson.replaceChild(replacement, current)
+      current = replacement
+      await flushDomUpdates()
+      expect(current.querySelectorAll(".read-frog-translated-content-wrapper")).toHaveLength(1)
+    }
+
+    manager.stop()
   })
 
   it("observes and translates hidden accordion content after it becomes visible", async () => {
@@ -349,6 +680,7 @@ describe("pageTranslationManager mutation re-walk", () => {
     const state: BilingualTranslationState = {
       layoutSource: tweet,
       sourceTextContent: "Truncated tweet",
+      phase: "complete",
       status: "active",
       walkId: "walk-id",
       wrapper,
@@ -388,6 +720,7 @@ describe("pageTranslationManager mutation re-walk", () => {
       const state: BilingualTranslationState = {
         layoutSource: tweet,
         sourceTextContent: source.data,
+        phase: "complete",
         status: "active",
         walkId: "walk-id",
         wrapper,
@@ -448,6 +781,7 @@ describe("pageTranslationManager mutation re-walk", () => {
       const state: BilingualTranslationState = {
         layoutSource: tweet,
         sourceTextContent: source.data,
+        phase: "complete",
         status: "active",
         walkId,
         wrapper,
@@ -542,6 +876,7 @@ describe("pageTranslationManager mutation re-walk", () => {
     const state: BilingualTranslationState = {
       layoutSource: tweet,
       sourceTextContent: "Original tweet",
+      phase: "complete",
       status: "active",
       walkId: "walk-id",
       wrapper,
@@ -588,6 +923,7 @@ describe("pageTranslationManager mutation re-walk", () => {
       const state: BilingualTranslationState = {
         layoutSource: tweet,
         sourceTextContent: sourceText,
+        phase: "complete",
         status: "active",
         walkId: "walk-id",
         wrapper,
@@ -645,6 +981,7 @@ describe("pageTranslationManager mutation re-walk", () => {
     const state: BilingualTranslationState = {
       layoutSource: tweet,
       sourceTextContent: "Original content",
+      phase: "complete",
       status: "active",
       walkId: "walk-id",
       wrapper,
@@ -696,6 +1033,7 @@ describe("pageTranslationManager mutation re-walk", () => {
       const state: BilingualTranslationState = {
         layoutSource: tweet,
         sourceTextContent: "never matches",
+        phase: "complete",
         status: "active",
         walkId: "walk-id",
         wrapper,

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -21,6 +21,15 @@ import {
 import { deepQueryTopLevelSelector } from "@/utils/host/dom/find"
 import { walkAndLabelElement } from "@/utils/host/dom/traversal"
 import {
+  captureBilingualReplacements,
+  isBilingualReplacementMatchCurrent,
+  matchBilingualReplacement,
+  restoreCompletedBilingualReplacement,
+  type BilingualReplacementMatch,
+  type BilingualReplacementSnapshot,
+} from "@/utils/host/translate/core/bilingual-replacement"
+import {
+  collectSourceTextExcludingWrappers,
   findStaleBilingualLayoutSource,
   findStaleTranslationOnlyAnchor,
   wasCharacterDataChangeExtensionDriven,
@@ -50,6 +59,17 @@ type DebouncedRetry = (() => void) & { clear: () => void }
 interface RetranslationBudget {
   windowStart: number
   passes: number
+}
+
+interface CachedBilingualReplacement {
+  budget?: RetranslationBudget
+  snapshot: BilingualReplacementSnapshot
+  suppressed: boolean
+}
+
+interface SuppressedBilingualReplacement {
+  match: BilingualReplacementMatch
+  snapshot: BilingualReplacementSnapshot
 }
 
 interface IPageTranslationManager {
@@ -91,6 +111,8 @@ export class PageTranslationManager implements IPageTranslationManager {
   private static readonly RETRANSLATE_WINDOW_MS = 10_000
   private static readonly MAX_PASSES_PER_WINDOW = 6
   private static readonly RETRANSLATE_RETRY_DEBOUNCE_MS = 1_000
+  private static readonly MAX_BILINGUAL_REPLACEMENT_CACHE_ENTRIES = 500
+  private static readonly USER_SCROLL_INTENT_GRACE_MS = 1_000
   private static readonly DEFAULT_INTERSECTION_OPTIONS: SimpleIntersectionOptions = {
     root: null,
     rootMargin: "600px",
@@ -108,6 +130,11 @@ export class PageTranslationManager implements IPageTranslationManager {
   private translatedSourceMutationVersions = new WeakMap<HTMLElement, number>()
   private retranslationBudgets = new WeakMap<HTMLElement, RetranslationBudget>()
   private retranslateRetries = new WeakMap<HTMLElement, DebouncedRetry>()
+  private bilingualReplacementCache = new Map<string, CachedBilingualReplacement>()
+  private suppressedBilingualReplacements = new WeakMap<
+    HTMLElement,
+    SuppressedBilingualReplacement
+  >()
   // Strong and enumerable so stop() can cancel in-flight retries; entries are
   // removed when a retry fires, so the set only holds armed timers.
   private pendingRetranslateRetries = new Set<DebouncedRetry>()
@@ -116,6 +143,8 @@ export class PageTranslationManager implements IPageTranslationManager {
   private lastSourceTitle: string | null = null
   private lastAppliedTranslatedTitle: string | null = null
   private titleRequestVersion = 0
+  private lastUserScrollIntentAt = 0
+  private removeScrollIntentListeners: (() => void) | null = null
 
   constructor(intersectionOptions: SimpleIntersectionOptions = {}) {
     if (intersectionOptions.threshold !== undefined) {
@@ -180,6 +209,7 @@ export class PageTranslationManager implements IPageTranslationManager {
 
       this.isPageTranslating = true
       this.translationSessionVersion += 1
+      this.startUserScrollIntentTracking()
 
       const siteRule = getEffectiveSiteRule(config, window.location.href)
       if (siteRule.injectedCss) {
@@ -199,6 +229,10 @@ export class PageTranslationManager implements IPageTranslationManager {
           if (entry.isIntersecting) {
             if (isHTMLElement(entry.target)) {
               if (!entry.target.closest(`.${CONTENT_WRAPPER_CLASS}`)) {
+                if (this.isBilingualReplacementSuppressed(entry.target)) {
+                  observer.unobserve(entry.target)
+                  continue
+                }
                 const currentConfig = await getLocalConfig()
                 if (!currentConfig) {
                   logger.error("Global config is not initialized")
@@ -273,6 +307,9 @@ export class PageTranslationManager implements IPageTranslationManager {
     this.pendingRetranslateRetries.clear()
     this.retranslateRetries = new WeakMap()
     this.retranslationBudgets = new WeakMap()
+    this.bilingualReplacementCache.clear()
+    this.suppressedBilingualReplacements = new WeakMap()
+    this.stopUserScrollIntentTracking()
     this.stopDocumentTitleTracking()
 
     if (this.intersectionObserver) {
@@ -490,7 +527,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       container.hasAttribute("data-read-frog-paragraph") &&
       container.getAttribute("data-read-frog-walked") === this.walkId
     ) {
-      observer.observe(container)
+      if (!this.isBilingualReplacementSuppressed(container)) observer.observe(container)
       return
     }
 
@@ -502,7 +539,9 @@ export class PageTranslationManager implements IPageTranslationManager {
       //  • the ancestor is *not* inside container
       return !ancestor || !container.contains(ancestor)
     })
-    topLevelParagraphs.forEach((el) => observer.observe(el))
+    topLevelParagraphs.forEach((el) => {
+      if (!this.isBilingualReplacementSuppressed(el)) observer.observe(el)
+    })
   }
 
   /**
@@ -673,14 +712,18 @@ export class PageTranslationManager implements IPageTranslationManager {
     const sessionVersion = this.translationSessionVersion
     const hostRecords: MutationRecord[] = []
     for (const record of records) {
+      if (!this.isSelfInflictedRecord(record)) hostRecords.push(record)
+    }
+    this.restoreReplacedBilingualTranslations(hostRecords)
+    for (const record of records) {
       if (record.type === "childList") {
         this.cleanupDetachedTranslationArtifacts(record.removedNodes)
       }
-      if (!this.isSelfInflictedRecord(record)) hostRecords.push(record)
     }
     if (hostRecords.length === 0) return
 
     const staleTranslatedSources = new Set<HTMLElement>()
+    const releasedSuppressedSources = new Set<HTMLElement>()
     for (const record of hostRecords) {
       const staleSource = findStaleBilingualLayoutSource(record.target)
       if (staleSource) staleTranslatedSources.add(staleSource)
@@ -688,13 +731,17 @@ export class PageTranslationManager implements IPageTranslationManager {
       // expand/"show more" must retranslate, not stay in the source language.
       const staleAnchor = findStaleTranslationOnlyAnchor(record.target)
       if (staleAnchor) staleTranslatedSources.add(staleAnchor)
+      const releasedSource = this.releaseChangedBilingualReplacementSuppression(record.target)
+      if (releasedSource) releasedSuppressedSources.add(releasedSource)
     }
     staleTranslatedSources.forEach((source) => {
       const nextVersion = (this.translatedSourceMutationVersions.get(source) ?? 0) + 1
       this.translatedSourceMutationVersions.set(source, nextVersion)
     })
 
-    const needsTraversalHandling = hostRecords.some((record) => record.type !== "characterData")
+    const needsTraversalHandling =
+      releasedSuppressedSources.size > 0 ||
+      hostRecords.some((record) => record.type !== "characterData")
     if (staleTranslatedSources.size === 0 && !needsTraversalHandling) return
 
     const config = await getLocalConfig()
@@ -720,6 +767,9 @@ export class PageTranslationManager implements IPageTranslationManager {
         }
       }
     }
+    for (const source of releasedSuppressedSources) {
+      if (source.isConnected) void this.observeTopLevelParagraphs(source, config)
+    }
 
     await Promise.all(
       [...staleTranslatedSources].map((source) =>
@@ -741,6 +791,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       this.translationSessionVersion !== sessionVersion ||
       !walkId ||
       !source.isConnected ||
+      this.isBilingualReplacementSuppressed(source) ||
       refreshingSources.has(source)
     ) {
       return
@@ -825,13 +876,186 @@ export class PageTranslationManager implements IPageTranslationManager {
     source: HTMLElement,
     sessionVersion: number,
   ): Promise<void> {
-    if (!this.isPageTranslating || this.translationSessionVersion !== sessionVersion) return
+    if (
+      !this.isPageTranslating ||
+      this.translationSessionVersion !== sessionVersion ||
+      this.isBilingualReplacementSuppressed(source)
+    ) {
+      return
+    }
     // No pending mutation version means the source converged in the meantime.
     if (this.translatedSourceMutationVersions.get(source) === undefined) return
     const config = await getLocalConfig()
     if (!config) return
     if (!this.isPageTranslating || this.translationSessionVersion !== sessionVersion) return
     await this.retranslateChangedSource(source, config, sessionVersion)
+  }
+
+  private rememberBilingualReplacement(
+    snapshot: BilingualReplacementSnapshot,
+  ): CachedBilingualReplacement {
+    const existing = this.bilingualReplacementCache.get(snapshot.key)
+    const entry: CachedBilingualReplacement = existing
+      ? { ...existing, snapshot }
+      : { snapshot, suppressed: false }
+
+    this.bilingualReplacementCache.delete(snapshot.key)
+    this.bilingualReplacementCache.set(snapshot.key, entry)
+    while (
+      this.bilingualReplacementCache.size >
+      PageTranslationManager.MAX_BILINGUAL_REPLACEMENT_CACHE_ENTRIES
+    ) {
+      const oldestKey = this.bilingualReplacementCache.keys().next().value
+      if (oldestKey === undefined) break
+      this.bilingualReplacementCache.delete(oldestKey)
+    }
+    return entry
+  }
+
+  private consumeBilingualReplacementBudget(entry: CachedBilingualReplacement): boolean {
+    const now = Date.now()
+    if (now - this.lastUserScrollIntentAt < PageTranslationManager.USER_SCROLL_INTENT_GRACE_MS) {
+      entry.budget = undefined
+      return true
+    }
+    if (
+      !entry.budget ||
+      now - entry.budget.windowStart > PageTranslationManager.RETRANSLATE_WINDOW_MS
+    ) {
+      entry.budget = { windowStart: now, passes: 1 }
+      return true
+    }
+    if (entry.budget.passes >= PageTranslationManager.MAX_PASSES_PER_WINDOW) return false
+    entry.budget.passes += 1
+    return true
+  }
+
+  /**
+   * Frameworks may replace a translated paragraph with an equivalent fresh
+   * node. Move/clone the completed wrapper before the first await in the
+   * mutation pipeline so layout never observes a source-only intermediate
+   * state. Exact host structure and source text matching prevents stale reuse.
+   */
+  private restoreReplacedBilingualTranslations(records: MutationRecord[]): void {
+    const walkId = this.walkId
+    if (!this.isPageTranslating || !walkId) return
+
+    const capturedEntries = new Set<CachedBilingualReplacement>()
+    for (const record of records) {
+      if (record.type !== "childList") continue
+      for (const removedNode of record.removedNodes) {
+        if (!isHTMLElement(removedNode)) continue
+        for (const snapshot of captureBilingualReplacements(removedNode, walkId)) {
+          capturedEntries.add(this.rememberBilingualReplacement(snapshot))
+        }
+      }
+    }
+    if (this.bilingualReplacementCache.size === 0) return
+
+    const entries = [...this.bilingualReplacementCache.values()].reverse()
+    const handledSources = new Set<HTMLElement>()
+    for (const record of records) {
+      if (record.type !== "childList") continue
+      for (const addedNode of record.addedNodes) {
+        if (!isHTMLElement(addedNode)) continue
+        const addedRootTextContent = collectSourceTextExcludingWrappers(addedNode)
+        for (const entry of entries) {
+          const match = matchBilingualReplacement(addedNode, addedRootTextContent, entry.snapshot)
+          if (!match || handledSources.has(match.source)) continue
+
+          handledSources.add(match.source)
+          if (entry.suppressed || !this.consumeBilingualReplacementBudget(entry)) {
+            entry.suppressed = true
+            this.suppressedBilingualReplacements.set(match.source, {
+              match,
+              snapshot: entry.snapshot,
+            })
+            continue
+          }
+
+          // Pending/error generations contribute to the logical replacement
+          // budget but are never copied. The fresh node proceeds through the
+          // normal translation path unless the circuit breaker trips.
+          if (!entry.snapshot.reusable) continue
+
+          restoreCompletedBilingualReplacement(
+            match,
+            entry.snapshot,
+            walkId,
+            capturedEntries.has(entry),
+          )
+          this.bilingualReplacementCache.delete(entry.snapshot.key)
+          this.bilingualReplacementCache.set(entry.snapshot.key, entry)
+        }
+      }
+    }
+    for (const entry of capturedEntries) entry.snapshot.detachedWrapper = undefined
+  }
+
+  private isBilingualReplacementSuppressed(source: HTMLElement): boolean {
+    const suppressed = this.suppressedBilingualReplacements.get(source)
+    if (!suppressed) return false
+    if (isBilingualReplacementMatchCurrent(suppressed.match, suppressed.snapshot)) return true
+    this.suppressedBilingualReplacements.delete(source)
+    return false
+  }
+
+  private startUserScrollIntentTracking(): void {
+    this.stopUserScrollIntentTracking()
+
+    const markIntent = () => {
+      this.lastUserScrollIntentAt = Date.now()
+    }
+    const markPointerDrag = (event: PointerEvent) => {
+      if (event.buttons !== 0) markIntent()
+    }
+    const markScrollKey = (event: KeyboardEvent) => {
+      if (
+        [
+          "ArrowDown",
+          "ArrowLeft",
+          "ArrowRight",
+          "ArrowUp",
+          "End",
+          "Home",
+          "PageDown",
+          "PageUp",
+          " ",
+        ].includes(event.key)
+      ) {
+        markIntent()
+      }
+    }
+
+    document.addEventListener("wheel", markIntent, { capture: true, passive: true })
+    document.addEventListener("touchmove", markIntent, { capture: true, passive: true })
+    document.addEventListener("pointerdown", markIntent, { capture: true, passive: true })
+    document.addEventListener("pointermove", markPointerDrag, { capture: true, passive: true })
+    document.addEventListener("keydown", markScrollKey, true)
+    this.removeScrollIntentListeners = () => {
+      document.removeEventListener("wheel", markIntent, true)
+      document.removeEventListener("touchmove", markIntent, true)
+      document.removeEventListener("pointerdown", markIntent, true)
+      document.removeEventListener("pointermove", markPointerDrag, true)
+      document.removeEventListener("keydown", markScrollKey, true)
+    }
+  }
+
+  private stopUserScrollIntentTracking(): void {
+    this.removeScrollIntentListeners?.()
+    this.removeScrollIntentListeners = null
+    this.lastUserScrollIntentAt = 0
+  }
+
+  private releaseChangedBilingualReplacementSuppression(node: Node): HTMLElement | undefined {
+    let current = isHTMLElement(node) ? node : node.parentElement
+    while (current) {
+      if (this.suppressedBilingualReplacements.has(current)) {
+        return this.isBilingualReplacementSuppressed(current) ? undefined : current
+      }
+      current = current.parentElement
+    }
+    return undefined
   }
 
   private isWalkabilityAttributeMutation(record: MutationRecord): boolean {

--- a/src/utils/host/translate/core/__tests__/translation-modes-pending.test.ts
+++ b/src/utils/host/translate/core/__tests__/translation-modes-pending.test.ts
@@ -52,6 +52,17 @@ describe("legacy bilingual pending lifecycle", () => {
     removeAllTranslatedWrapperNodes(document)
   })
 
+  it("marks the state complete only after final translated content is inserted", async () => {
+    const source = createSource()
+    mockShouldFilterSmallParagraph.mockResolvedValue(false)
+
+    await translateNodesBilingualMode([source], "completed", DEFAULT_CONFIG)
+
+    const state = getBilingualTranslationStateForSource(source)
+    expect(state?.phase).toBe("complete")
+    expect(state?.wrapper?.textContent).toContain("translated")
+  })
+
   it("does not insert a wrapper after global cleanup while filtering is pending", async () => {
     const source = createSource()
     const filter = deferredFilter()

--- a/src/utils/host/translate/core/bilingual-replacement.ts
+++ b/src/utils/host/translate/core/bilingual-replacement.ts
@@ -1,0 +1,290 @@
+import {
+  BLOCK_CONTENT_CLASS,
+  CONTENT_WRAPPER_CLASS,
+  INLINE_CONTENT_CLASS,
+  SPINNER_CLASS,
+  TRANSLATION_ERROR_CONTAINER_CLASS,
+  WALKED_ATTRIBUTE,
+} from "@/utils/constants/dom-labels"
+import { isTranslatedWrapperNode } from "../../dom/filter"
+import {
+  collectSourceTextExcludingWrappers,
+  getBilingualTranslationStateForSource,
+  getBilingualTranslationStateForWrapper,
+  getPendingBilingualTranslationStates,
+  registerBilingualTranslationState,
+  unregisterBilingualTranslationState,
+} from "./translation-state"
+
+type TranslationPresentation = "block" | "inline" | "pending"
+
+interface HostElementPathStep {
+  index: number
+  tagName: string
+}
+
+export interface BilingualReplacementSnapshot {
+  key: string
+  rootTagName: string
+  rootTextContent: string
+  sourceTagName: string
+  sourceTextContent: string
+  sourcePath: HostElementPathStep[]
+  insertionParentPath: HostElementPathStep[]
+  presentation: TranslationPresentation
+  reusable: boolean
+  wrapperTemplate?: HTMLElement
+  detachedWrapper?: HTMLElement
+}
+
+export interface BilingualReplacementMatch {
+  insertionParent: HTMLElement
+  source: HTMLElement
+}
+
+function getHostElementChildren(parent: HTMLElement): HTMLElement[] {
+  return [...parent.children].filter(
+    (child): child is HTMLElement =>
+      child instanceof HTMLElement && !isTranslatedWrapperNode(child),
+  )
+}
+
+function getHostElementPath(
+  root: HTMLElement,
+  target: HTMLElement,
+): HostElementPathStep[] | undefined {
+  if (root === target) return []
+
+  const path: HostElementPathStep[] = []
+  let current: HTMLElement | null = target
+  while (current && current !== root) {
+    const parent: HTMLElement | null = current.parentElement
+    if (!parent) return undefined
+    const index = getHostElementChildren(parent).indexOf(current)
+    if (index < 0) return undefined
+    path.unshift({ index, tagName: current.tagName })
+    current = parent
+  }
+  return current === root ? path : undefined
+}
+
+function resolveHostElementPath(
+  root: HTMLElement,
+  path: readonly HostElementPathStep[],
+): HTMLElement | undefined {
+  let current = root
+  for (const step of path) {
+    const next = getHostElementChildren(current)[step.index]
+    if (!next || next.tagName !== step.tagName) return undefined
+    current = next
+  }
+  return current
+}
+
+function getPresentation(wrapper: HTMLElement): TranslationPresentation | undefined {
+  const hasBlock = wrapper.querySelector(`.${BLOCK_CONTENT_CLASS}`) !== null
+  const hasInline = wrapper.querySelector(`.${INLINE_CONTENT_CLASS}`) !== null
+  if (hasBlock === hasInline) return undefined
+  return hasBlock ? "block" : "inline"
+}
+
+function createSnapshotKey(
+  rootTagName: string,
+  rootTextContent: string,
+  sourceTagName: string,
+  sourceTextContent: string,
+  sourcePath: readonly HostElementPathStep[],
+  insertionParentPath: readonly HostElementPathStep[],
+  presentation: TranslationPresentation,
+): string {
+  return JSON.stringify([
+    rootTagName,
+    rootTextContent,
+    sourceTagName,
+    sourceTextContent,
+    sourcePath,
+    insertionParentPath,
+    presentation,
+  ])
+}
+
+/**
+ * Capture ordinary bilingual generations owned by a subtree the host page
+ * removed. Completed wrappers can be restored; pending/error generations only
+ * contribute a logical fingerprint for the cross-node circuit breaker.
+ * Virtual paragraphs use a separate lifecycle and intentionally fall through.
+ */
+export function captureBilingualReplacements(
+  removedRoot: HTMLElement,
+  walkId: string,
+): BilingualReplacementSnapshot[] {
+  const wrappers = [
+    ...(removedRoot.classList.contains(CONTENT_WRAPPER_CLASS) ? [removedRoot] : []),
+    ...removedRoot.querySelectorAll<HTMLElement>(`.${CONTENT_WRAPPER_CLASS}`),
+  ]
+  const snapshots: BilingualReplacementSnapshot[] = []
+  const rootTagName = removedRoot.tagName
+  const rootTextContent = collectSourceTextExcludingWrappers(removedRoot)
+
+  for (const wrapper of wrappers) {
+    const state = getBilingualTranslationStateForWrapper(wrapper)
+    if (
+      !state ||
+      state.walkId !== walkId ||
+      !removedRoot.contains(state.layoutSource) ||
+      !state.layoutSource.contains(wrapper)
+    ) {
+      continue
+    }
+
+    const sourceTextContent = collectSourceTextExcludingWrappers(state.layoutSource)
+    if (sourceTextContent !== state.sourceTextContent) continue
+
+    const sourcePath = getHostElementPath(removedRoot, state.layoutSource)
+    const insertionParent = wrapper.parentElement
+    const insertionParentPath = insertionParent
+      ? getHostElementPath(state.layoutSource, insertionParent)
+      : undefined
+    const finalPresentation = getPresentation(wrapper)
+    const reusable =
+      state.phase === "complete" &&
+      finalPresentation !== undefined &&
+      !wrapper.querySelector(`.${SPINNER_CLASS}, .${TRANSLATION_ERROR_CONTAINER_CLASS}`)
+    const presentation = finalPresentation ?? "pending"
+    if (!sourcePath || !insertionParentPath) continue
+
+    const sourceTagName = state.layoutSource.tagName
+    snapshots.push({
+      key: createSnapshotKey(
+        rootTagName,
+        rootTextContent,
+        sourceTagName,
+        sourceTextContent,
+        sourcePath,
+        insertionParentPath,
+        presentation,
+      ),
+      rootTagName,
+      rootTextContent,
+      sourceTagName,
+      sourceTextContent,
+      sourcePath,
+      insertionParentPath,
+      presentation,
+      reusable,
+      wrapperTemplate: reusable ? (wrapper.cloneNode(true) as HTMLElement) : undefined,
+      detachedWrapper: reusable ? wrapper : undefined,
+    })
+    unregisterBilingualTranslationState(state)
+  }
+
+  for (const state of getPendingBilingualTranslationStates()) {
+    if (
+      state.wrapper !== null ||
+      state.walkId !== walkId ||
+      !removedRoot.contains(state.layoutSource)
+    ) {
+      continue
+    }
+    const sourceTextContent = collectSourceTextExcludingWrappers(state.layoutSource)
+    if (sourceTextContent !== state.sourceTextContent) {
+      unregisterBilingualTranslationState(state)
+      continue
+    }
+    const sourcePath = getHostElementPath(removedRoot, state.layoutSource)
+    if (!sourcePath) {
+      unregisterBilingualTranslationState(state)
+      continue
+    }
+    const sourceTagName = state.layoutSource.tagName
+    const insertionParentPath: HostElementPathStep[] = []
+    const presentation = "pending" as const
+    snapshots.push({
+      key: createSnapshotKey(
+        rootTagName,
+        rootTextContent,
+        sourceTagName,
+        sourceTextContent,
+        sourcePath,
+        insertionParentPath,
+        presentation,
+      ),
+      rootTagName,
+      rootTextContent,
+      sourceTagName,
+      sourceTextContent,
+      sourcePath,
+      insertionParentPath,
+      presentation,
+      reusable: false,
+    })
+    unregisterBilingualTranslationState(state)
+  }
+
+  return snapshots
+}
+
+export function matchBilingualReplacement(
+  addedRoot: HTMLElement,
+  addedRootTextContent: string,
+  snapshot: BilingualReplacementSnapshot,
+): BilingualReplacementMatch | undefined {
+  if (
+    addedRoot.tagName !== snapshot.rootTagName ||
+    addedRootTextContent !== snapshot.rootTextContent
+  ) {
+    return undefined
+  }
+  const source = resolveHostElementPath(addedRoot, snapshot.sourcePath)
+  if (
+    !source ||
+    source.tagName !== snapshot.sourceTagName ||
+    getBilingualTranslationStateForSource(source) ||
+    collectSourceTextExcludingWrappers(source) !== snapshot.sourceTextContent
+  ) {
+    return undefined
+  }
+
+  const insertionParent = resolveHostElementPath(source, snapshot.insertionParentPath)
+  if (!insertionParent) return undefined
+
+  return { insertionParent, source }
+}
+
+export function isBilingualReplacementMatchCurrent(
+  match: BilingualReplacementMatch,
+  snapshot: BilingualReplacementSnapshot,
+): boolean {
+  return (
+    match.source.tagName === snapshot.sourceTagName &&
+    collectSourceTextExcludingWrappers(match.source) === snapshot.sourceTextContent &&
+    resolveHostElementPath(match.source, snapshot.insertionParentPath) === match.insertionParent
+  )
+}
+
+export function restoreCompletedBilingualReplacement(
+  match: BilingualReplacementMatch,
+  snapshot: BilingualReplacementSnapshot,
+  walkId: string,
+  reuseDetachedWrapper: boolean,
+): HTMLElement {
+  if (!snapshot.reusable || !snapshot.wrapperTemplate) {
+    throw new Error("Cannot restore an incomplete bilingual translation")
+  }
+  const wrapper =
+    reuseDetachedWrapper && snapshot.detachedWrapper
+      ? snapshot.detachedWrapper
+      : (snapshot.wrapperTemplate.cloneNode(true) as HTMLElement)
+  snapshot.detachedWrapper = undefined
+  wrapper.setAttribute(WALKED_ATTRIBUTE, walkId)
+  match.insertionParent.append(wrapper)
+  registerBilingualTranslationState({
+    layoutSource: match.source,
+    sourceTextContent: snapshot.sourceTextContent,
+    phase: "complete",
+    status: "active",
+    walkId,
+    wrapper,
+  })
+  return wrapper
+}

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -439,6 +439,7 @@ export async function translateNodesBilingualMode(
       bilingualState = {
         layoutSource,
         sourceTextContent: sourceTextBeforeFilter,
+        phase: "pending",
         status: "active",
         walkId,
         wrapper: null,
@@ -534,7 +535,11 @@ export async function translateNodesBilingualMode(
       config,
       forceBlockTranslation,
     )
-    if (!isCurrent()) removeTranslatedWrapperWithRestore(translatedWrapperNode)
+    if (!isCurrent()) {
+      removeTranslatedWrapperWithRestore(translatedWrapperNode)
+    } else if (bilingualState) {
+      bilingualState.phase = "complete"
+    }
   } finally {
     transNodes.forEach((node) => translatingNodes.delete(node))
   }

--- a/src/utils/host/translate/core/translation-state.ts
+++ b/src/utils/host/translate/core/translation-state.ts
@@ -37,6 +37,7 @@ export interface VirtualParagraphGroup {
 export interface BilingualTranslationState {
   layoutSource: HTMLElement
   sourceTextContent: string
+  phase: "pending" | "complete"
   status: "active" | "disposed"
   walkId: string
   wrapper: HTMLElement | null

--- a/src/utils/host/translate/dom/__tests__/virtual-paragraph-lifecycle.test.ts
+++ b/src/utils/host/translate/dom/__tests__/virtual-paragraph-lifecycle.test.ts
@@ -297,6 +297,7 @@ describe("virtual paragraph lifecycle", () => {
     const state: BilingualTranslationState = {
       layoutSource,
       sourceTextContent: "Pending source",
+      phase: "pending",
       status: "active",
       walkId: "pending-legacy",
       wrapper: null,
@@ -320,6 +321,7 @@ describe("virtual paragraph lifecycle", () => {
     const state: BilingualTranslationState = {
       layoutSource,
       sourceTextContent: "Host paragraph text",
+      phase: "complete",
       status: "active",
       walkId: "foreign-wrapper",
       wrapper: ownWrapper,
@@ -372,6 +374,7 @@ describe("virtual paragraph lifecycle", () => {
     const state: BilingualTranslationState = {
       layoutSource,
       sourceTextContent: collectSourceTextExcludingWrappers(layoutSource),
+      phase: "complete",
       status: "active",
       walkId: "snapshot-symmetry",
       wrapper: null,


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

This is an experimental investigation for #1854, not a change intended for merge.

Coddy replaces translated lesson paragraphs with fresh DOM nodes while scrolling. The experiment records completed bilingual translations and restores them synchronously when an exactly matching paragraph is recreated, with structural matching, a bounded cache, and a cross-node circuit breaker.

It stabilizes repeated scrolling in the lesson panel, but it is not a complete solution: typing in the code editor can still cause Coddy to rebuild related content and remove some translations. Reliably restoring every mutation without interfering with the editor or page layout would require unsafe site-specific behavior, so this approach is not suitable for release.

## Related Issue

Related to #1854

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation performed:

- `SKIP_FREE_API=true pnpm test` — 190 files passed, 1 intentionally skipped; 1,772 tests passed
- `pnpm fmt:check`
- `pnpm type-check`
- Chrome and Edge MV3 production builds
- Real Chrome on the Coddy reproduction page: 10 scrolls reached the bottom and remained stable for 10 seconds
- Follow-up editing test: typing in the code editor still removed some translations

## Screenshots

Not applicable.

## Checklist

- [x] I have tested these changes locally
- [x] Documentation changes are not required for this experiment
- [x] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This draft PR is being opened only to preserve the experimental implementation and test evidence. It will be closed immediately and should not be merged.
