### PR TITLE
fix(translation): keep short bilingual UI labels inline

### DIFF
--- a/.changeset/short-ui-text-inline.md
+++ b/.changeset/short-ui-text-inline.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): keep short bilingual UI labels inline

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -2849,7 +2849,7 @@ describe("translate", () => {
 
         // Should have translation wrapper since it contains text
         const wrapper = expectTranslationWrapper(node, "bilingual")
-        expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
+        expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
       })
     })
 
@@ -2941,6 +2941,99 @@ describe("translate", () => {
         expectNodeLabels(node, [BLOCK_ATTRIBUTE])
         expectNodeLabels(node.children[0], [BLOCK_ATTRIBUTE])
         expectNodeLabels(node.children[1], [BLOCK_ATTRIBUTE])
+      })
+    })
+  })
+  describe("short single-line block content", () => {
+    it.each([
+      { flexDirection: "row", label: "Introduction" },
+      { flexDirection: "row", label: "Solution" },
+      { flexDirection: "column", label: "Output" },
+    ] as const)(
+      "keeps $label inline inside a flex-$flexDirection container",
+      async ({ flexDirection, label }) => {
+        render(
+          <div style={{ display: "flex", flexDirection }}>
+            <p data-testid="test-node">{label}</p>
+          </div>,
+        )
+
+        const node = screen.getByTestId("test-node")
+        await removeOrShowPageTranslation("bilingual", true)
+
+        expectNodeLabels(node, [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
+        const wrapper = expectTranslationWrapper(node, "bilingual")!
+        expect(wrapper).toBe(node.lastChild)
+        expect(wrapper.querySelector("br")).toBeFalsy()
+        expect(wrapper.firstChild?.textContent).toBe("\u00A0\u00A0")
+        expectTranslatedContent(wrapper, INLINE_CONTENT_CLASS)
+
+        await removeOrShowPageTranslation("bilingual", true)
+        expect(node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
+        expect(node.textContent).toBe(label)
+      },
+    )
+
+    it("keeps a long block paragraph on a separate line", async () => {
+      const text = "Python is one of the world's easiest and most popular programming languages."
+      render(<p data-testid="test-node">{text}</p>)
+
+      const node = screen.getByTestId("test-node")
+      await removeOrShowPageTranslation("bilingual", true)
+
+      const wrapper = expectTranslationWrapper(node, "bilingual")!
+      expect(wrapper.querySelector("br")).toBeTruthy()
+      expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
+    })
+
+    it("keeps structural force-block priority over the short-text heuristic", async () => {
+      render(
+        <div data-testid="test-node">
+          <div>
+            Introduction
+            <div>{MOCK_ORIGINAL_TEXT}</div>
+          </div>
+        </div>,
+      )
+
+      const node = screen.getByTestId("test-node")
+      await removeOrShowPageTranslation("bilingual", true)
+
+      const paragraph = node.children[0]
+      const wrapper = paragraph.childNodes[1] as Element
+      expect(wrapper).toHaveClass(CONTENT_WRAPPER_CLASS)
+      expect(wrapper.querySelector("br")).toBeTruthy()
+      expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
+    })
+
+    it("keeps a matching site force-block rule above the short-text heuristic", async () => {
+      const config: Config = {
+        ...BILINGUAL_CONFIG,
+        siteRules: {
+          ...BILINGUAL_CONFIG.siteRules,
+          userRules: [
+            {
+              id: "force-short-label-block",
+              matches: "example.com",
+              forceBlockSelectors: [".force-block"],
+            },
+          ],
+        },
+      }
+
+      await withHost("example.com", async () => {
+        render(
+          <p className="force-block" data-testid="test-node">
+            Introduction
+          </p>,
+        )
+
+        const node = screen.getByTestId("test-node")
+        await removeOrShowPageTranslation("bilingual", true, config)
+
+        const wrapper = expectTranslationWrapper(node, "bilingual")!
+        expect(wrapper.querySelector("br")).toBeTruthy()
+        expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
       })
     })
   })

--- a/src/utils/host/__tests__/utils.ts
+++ b/src/utils/host/__tests__/utils.ts
@@ -8,7 +8,8 @@ import {
 } from "@/utils/constants/dom-labels"
 
 export const MOCK_TRANSLATION = "translation"
-export const MOCK_ORIGINAL_TEXT = "原文"
+export const MOCK_ORIGINAL_TEXT =
+  "This is deliberately long source text for block translation layout tests"
 
 export function expectTranslationWrapper(node: Element, mode: TranslationMode) {
   const wrapper = node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -486,12 +486,20 @@ export async function translateNodesBilingualMode(
       walkId,
       config,
     )
+    let hasTrailingInlineImageAttachment = false
 
     if (transNodes.length === 1 && isHTMLElement(layoutSource) && isHTMLElement(insertionTarget)) {
+      const originalInsertionBoundary = {
+        container: insertionTarget,
+        offset: insertionTarget.childNodes.length,
+      }
       const insertionBoundary = moveParagraphInsertionBoundaryAfterTrailingInlineImages(
-        { container: insertionTarget, offset: insertionTarget.childNodes.length },
+        originalInsertionBoundary,
         layoutSource,
       )
+      hasTrailingInlineImageAttachment =
+        insertionBoundary.container !== originalInsertionBoundary.container ||
+        insertionBoundary.offset !== originalInsertionBoundary.offset
       insertionBoundary.container.insertBefore(
         translatedWrapperNode,
         insertionBoundary.container.childNodes[insertionBoundary.offset] ?? null,
@@ -547,7 +555,7 @@ export async function translateNodesBilingualMode(
       translatedText,
       config.translate.translationNodeStyle,
       config,
-      forceBlockTranslation,
+      forceBlockTranslation || hasTrailingInlineImageAttachment,
     )
     if (!isCurrent()) removeTranslatedWrapperWithRestore(translatedWrapperNode)
   } finally {

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -210,7 +210,7 @@ async function translateVirtualParagraph(
 
   await insertTranslatedNodeIntoWrapper(
     wrapper,
-    { flowSource, isCurrent, layoutSource: group.layoutSource },
+    { flowSource, isCurrent, layoutSource: group.layoutSource, sourceText: unit.text },
     translatedText,
     config.translate.translationNodeStyle,
     config,
@@ -383,6 +383,8 @@ export async function translateNodesBilingualMode(
     if (virtualLayoutSource) {
       const virtualParagraphPlan = buildVirtualParagraphPlan(virtualLayoutSource, config)
       if (virtualParagraphPlan.units.length >= 2) {
+        // Explicit blank-line boundaries represent block paragraphs even when
+        // an individual unit is short enough for the compact-label heuristic.
         await translateVirtualParagraphs(
           nodes,
           virtualParagraphPlan.units,
@@ -390,7 +392,7 @@ export async function translateNodesBilingualMode(
           virtualLayoutSource,
           walkId,
           config,
-          forceBlockTranslation,
+          true,
         )
         return
       }
@@ -528,7 +530,7 @@ export async function translateNodesBilingualMode(
 
     await insertTranslatedNodeIntoWrapper(
       translatedWrapperNode,
-      { flowSource: insertionTarget, isCurrent, layoutSource },
+      { flowSource: insertionTarget, isCurrent, layoutSource, sourceText: textContent },
       translatedText,
       config.translate.translationNodeStyle,
       config,

--- a/src/utils/host/translate/dom/translation-insertion.ts
+++ b/src/utils/host/translate/dom/translation-insertion.ts
@@ -17,11 +17,12 @@ import {
 } from "../../dom/filter"
 import { getOwnerDocument } from "../../dom/node"
 import { decorateTranslationNode } from "../ui/decorate-translation"
-import { isForceInlineTranslation } from "../ui/translation-utils"
+import { isForceInlineTranslation, isShortInlineTranslationText } from "../ui/translation-utils"
 
 interface TranslationInsertionContext {
   flowSource: TransNode
   layoutSource: TransNode
+  sourceText: string
   isCurrent?: () => boolean
 }
 
@@ -77,7 +78,7 @@ export function addInlineTranslation(
   translatedNode: HTMLElement,
 ): void {
   const spaceNode = ownerDoc.createElement("span")
-  spaceNode.textContent = "  "
+  spaceNode.textContent = "\u00A0\u00A0"
   translatedWrapperNode.appendChild(spaceNode)
   translatedNode.className = `${NOTRANSLATE_CLASS} ${INLINE_CONTENT_CLASS}`
 }
@@ -94,7 +95,7 @@ export function addBlockTranslation(
 
 export async function insertTranslatedNodeIntoWrapper(
   translatedWrapperNode: HTMLElement,
-  { flowSource, layoutSource, isCurrent }: TranslationInsertionContext,
+  { flowSource, layoutSource, sourceText, isCurrent }: TranslationInsertionContext,
   translatedText: string,
   translationNodeStyle: TranslationNodeStyleConfig,
   config: Config,
@@ -105,19 +106,28 @@ export async function insertTranslatedNodeIntoWrapper(
   // Use the wrapper's owner document
   const ownerDoc = getOwnerDocument(translatedWrapperNode)
   const translatedNode = ownerDoc.createElement("span")
+  const layoutSourceDisplay = isHTMLElement(layoutSource)
+    ? window.getComputedStyle(layoutSource).display
+    : undefined
   const siteRuleForceInline =
     isHTMLElement(layoutSource) && isSiteRuleForceInlineElement(layoutSource, config)
-  const forceInlineTranslation = isForceInlineTranslation(layoutSource) || siteRuleForceInline
+  const forceInlineTranslation =
+    isForceInlineTranslation(layoutSource, layoutSourceDisplay) || siteRuleForceInline
+  const shortInlineTranslation =
+    isShortInlineTranslationText(sourceText) && layoutSourceDisplay !== "contents"
   const siteRuleForceBlock =
     isHTMLElement(layoutSource) && isSiteRuleForceBlockElement(layoutSource, config)
 
-  // priority: siteRuleForceBlock > forceInlineTranslation > forceBlockTranslation > isInlineTransNode > isBlockTransNode
+  // priority: siteRuleForceBlock > forceInlineTranslation > forceBlockTranslation >
+  // shortInlineTranslation > isInlineTransNode > isBlockTransNode
   if (siteRuleForceBlock) {
     addBlockTranslation(ownerDoc, translatedWrapperNode, translatedNode)
   } else if (forceInlineTranslation) {
     addInlineTranslation(ownerDoc, translatedWrapperNode, translatedNode)
   } else if (forceBlockTranslation) {
     addBlockTranslation(ownerDoc, translatedWrapperNode, translatedNode)
+  } else if (shortInlineTranslation) {
+    addInlineTranslation(ownerDoc, translatedWrapperNode, translatedNode)
   } else if (isInlineTransNode(layoutSource)) {
     addInlineTranslation(ownerDoc, translatedWrapperNode, translatedNode)
   } else if (isBlockTransNode(layoutSource)) {

--- a/src/utils/host/translate/ui/__tests__/translation-utils.test.ts
+++ b/src/utils/host/translate/ui/__tests__/translation-utils.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import { isShortInlineTranslationText } from "../translation-utils"
+
+describe("isShortInlineTranslationText", () => {
+  it.each([
+    ["Introduction", true],
+    ["one two three four", true],
+    ["a".repeat(24), true],
+    ["短标签", true],
+    ["a".repeat(25), false],
+    ["one two three four five", false],
+    ["Introduction\nTitle", false],
+    ["Introduction\rTitle", false],
+    ["", false],
+    ["   ", false],
+  ])("classifies %j as %s", (text, expected) => {
+    expect(isShortInlineTranslationText(text)).toBe(expected)
+  })
+
+  it("normalizes surrounding and repeated horizontal whitespace", () => {
+    expect(isShortInlineTranslationText("  one\t two   three four  ")).toBe(true)
+  })
+})

--- a/src/utils/host/translate/ui/translation-utils.ts
+++ b/src/utils/host/translate/ui/translation-utils.ts
@@ -6,6 +6,9 @@ import { isHTMLElement } from "../../dom/filter"
 // Examples: "123", "1,234", "1,234.56", "1 234", "1.234,56" (European format)
 const NUMERIC_PATTERN = /^[\d\s,.-]+$/
 const CONTAINS_DIGIT_RE = /\d/
+const LINE_BREAK_PATTERN = /[\r\n]/
+const SHORT_INLINE_MAX_CHARACTERS = 24
+const SHORT_INLINE_MAX_WORDS = 4
 
 // Helper function to check if content is purely numeric
 export function isNumericContent(text: string): boolean {
@@ -20,12 +23,21 @@ export function isNumericContent(text: string): boolean {
   return CONTAINS_DIGIT_RE.test(cleanedText)
 }
 
-export function isForceInlineTranslation(targetNode: TransNode): boolean {
+export function isShortInlineTranslationText(text: string): boolean {
+  if (LINE_BREAK_PATTERN.test(text)) return false
+
+  const cleanedText = text.trim()
+  if (!cleanedText) return false
+
+  const wordCount = cleanedText.split(/\s+/u).length
+  return cleanedText.length <= SHORT_INLINE_MAX_CHARACTERS && wordCount <= SHORT_INLINE_MAX_WORDS
+}
+
+export function isForceInlineTranslation(targetNode: TransNode, display?: string): boolean {
   if (isHTMLElement(targetNode)) {
-    const computedStyle = window.getComputedStyle(targetNode)
     return (
       FORCE_INLINE_TRANSLATION_TAGS.has(targetNode.tagName) ||
-      computedStyle.display.includes("flex")
+      (display ?? window.getComputedStyle(targetNode).display).includes("flex")
     )
   }
   return false


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Short UI labels rendered in block elements, such as Coddy's `Introduction`, `Solution`, and `Output` paragraphs, were always given a block translation with a leading `<br>`. This made compact bilingual labels wrap onto a second line even when the surrounding UI was designed to show the source and translation together.

This change:

- classifies non-empty, single-line source text as a compact inline label when it is at most 24 characters and 4 whitespace-delimited words;
- preserves the existing layout priority: site force-block, forced inline layouts, structural force-block, compact-label heuristic, then DOM inline/block labels;
- inserts two non-breaking spaces before inline translations so spacing is not collapsed;
- keeps explicit blank-line virtual paragraphs and `display: contents` layout sources block-level;
- passes original source text through both regular and virtual bilingual insertion paths;
- adds a patch changeset for `@read-frog/extension`.

## Related Issue

No linked issue.

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Automated validation:

- `SKIP_FREE_API=true pnpm test` — 191 files passed, 1 intentionally skipped; 1780 tests passed, 4 skipped.
- Pre-push hook — 192 files and 1784 tests passed.
- `pnpm fmt:check`
- `pnpm lint`
- `WXT_SKIP_ENV_VALIDATION=true pnpm build`

Real-browser validation used the built extension in headed Chrome with Puppeteer on Coddy's Python lesson page. `Introduction`, `The Language`, `Challenge`, `Ask AI`, `Run Code`, `TEST CASES`, `CONSOLE`, `Output`, and `Expected Output` all used inline translation wrappers with no `<br>` and two NBSP characters. Long prose retained its block wrapper and leading `<br>`. Toggling translation off removed all wrappers and restored the original text.

The guest Coddy page does not render `Solution`, so its exact flex-row structure is covered by the deterministic integration fixture.

## Screenshots

Not included. The change was verified through computed DOM structure and live layout assertions in Puppeteer.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The heuristic is global rather than Coddy-specific. It intentionally does not make every child of a flex parent inline, which would risk squeezing long prose into navigation and button layouts.
