### PR TITLE
fix(subtitles): bound AI segmentation to the look-ahead window

### DIFF
--- a/.changeset/subtitles-segmentation-lookahead-bound.md
+++ b/.changeset/subtitles-segmentation-lookahead-bound.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(subtitles): bound AI segmentation to the look-ahead window

--- a/src/entrypoints/subtitles.content/__tests__/segmentation-pipeline.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/segmentation-pipeline.test.ts
@@ -52,11 +52,48 @@ describe("segmentation pipeline", () => {
     await (pipeline as any).runLoop()
 
     const segmentedStarts = (pipeline as any).segmentedRawStarts as Set<number>
-    const furthestSegmented = Math.max(...segmentedStarts)
 
-    // Only the look-ahead window ahead of the current position should be segmented,
-    // not the whole remaining video. The rest waits until playback advances.
-    expect(furthestSegmented).toBeLessThanOrEqual(2 * PROCESS_LOOK_AHEAD_MS)
+    // The window ahead of the playhead is segmented...
+    expect(segmentedStarts.has(0)).toBe(true)
+
+    // ...and nothing beyond it. Chunks are kept a whole PROCESS_LOOK_AHEAD_MS wide and are
+    // only started while their first fragment is within the look-ahead window, so the buffer
+    // reaches at most two windows ahead of the playhead — not the rest of the video.
+    const furthestSegmented = Math.max(...segmentedStarts)
+    expect(furthestSegmented).toBeLessThan(2 * PROCESS_LOOK_AHEAD_MS)
     expect(pipeline.hasUnprocessedChunks()).toBe(true)
+  })
+
+  it("segments the next window once playback advances into it", async () => {
+    const rawFragments = Array.from({ length: 600 }, (_, i) => ({
+      text: `w${i}`,
+      start: i * 1000,
+      end: i * 1000 + 1000,
+    }))
+
+    let currentTime = 0
+    const pipeline = new SegmentationPipeline({
+      rawFragments,
+      getVideoElement: () =>
+        ({
+          get currentTime() {
+            return currentTime
+          },
+        }) as HTMLVideoElement,
+      getSourceLanguage: () => "en",
+      preSegmented: true,
+    })
+
+    await (pipeline as any).runLoop()
+    const afterStart = Math.max(...((pipeline as any).segmentedRawStarts as Set<number>))
+
+    // Playback moves into the buffered region; the pipeline should top the window back up
+    // rather than stay starved behind its own bound.
+    currentTime = 150
+    await (pipeline as any).runLoop()
+    const afterAdvance = Math.max(...((pipeline as any).segmentedRawStarts as Set<number>))
+
+    expect(afterAdvance).toBeGreaterThan(afterStart)
+    expect(afterAdvance).toBeLessThan(150_000 + 2 * PROCESS_LOOK_AHEAD_MS)
   })
 })

--- a/src/entrypoints/subtitles.content/__tests__/segmentation-pipeline.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/segmentation-pipeline.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
+import { PROCESS_LOOK_AHEAD_MS } from "@/utils/constants/subtitles"
 import { SegmentationPipeline } from "../segmentation-pipeline"
 
 vi.mock("@/utils/config/storage", () => ({
@@ -30,5 +31,32 @@ describe("segmentation pipeline", () => {
     await (pipeline as any).processNextChunk(0)
 
     expect(pipeline.processedFragments).toEqual([{ text: "hello world", start: 0, end: 1000 }])
+  })
+
+  it("does not segment past the look-ahead window from the current position", async () => {
+    // 10 minutes of word-level fragments, one per second.
+    const rawFragments = Array.from({ length: 600 }, (_, i) => ({
+      text: `w${i}`,
+      start: i * 1000,
+      end: i * 1000 + 1000,
+    }))
+
+    const pipeline = new SegmentationPipeline({
+      rawFragments,
+      // Playback stays at the very beginning (e.g. paused right after enabling).
+      getVideoElement: () => ({ currentTime: 0 }) as HTMLVideoElement,
+      getSourceLanguage: () => "en",
+      preSegmented: true,
+    })
+
+    await (pipeline as any).runLoop()
+
+    const segmentedStarts = (pipeline as any).segmentedRawStarts as Set<number>
+    const furthestSegmented = Math.max(...segmentedStarts)
+
+    // Only the look-ahead window ahead of the current position should be segmented,
+    // not the whole remaining video. The rest waits until playback advances.
+    expect(furthestSegmented).toBeLessThanOrEqual(2 * PROCESS_LOOK_AHEAD_MS)
+    expect(pipeline.hasUnprocessedChunks()).toBe(true)
   })
 })

--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -125,6 +125,14 @@ export class SegmentationPipeline {
     )
     if (!firstUnprocessed) return []
 
+    // Only segment chunks within the look-ahead window ahead of the current
+    // position. Without this bound the loop keeps segmenting until the end of
+    // the video regardless of how far playback has actually reached, which
+    // eagerly sends the entire remaining video to the AI segmentation model.
+    // Chunks further ahead are picked up later, once playback advances and the
+    // translation coordinator restarts the pipeline.
+    if (firstUnprocessed.start > currentTimeMs + PROCESS_LOOK_AHEAD_MS) return []
+
     const windowEnd = firstUnprocessed.start + PROCESS_LOOK_AHEAD_MS
     return this.rawFragments.filter(
       (f) =>


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

When AI subtitle segmentation is enabled, `SegmentationPipeline` is meant to segment only the fragments shortly ahead of the current playback position (`PROCESS_LOOK_AHEAD_MS`, 60s). In practice it segments the **entire remaining video** as soon as subtitles are enabled:

- `findNextChunk` bounds its window relative to the first *unprocessed* fragment, not to the current playback position.
- `runLoop` keeps going `while (hasUnprocessedChunks())`, and doesn't check whether playback has actually advanced (it keeps running even while paused).

So from the moment subtitles are turned on, the pipeline walks 60s chunks back-to-back to the end of the track, regardless of how much is actually watched. YouTube auto-captions are word-level and every chunk re-sends the full segmentation system prompt, so token cost scales with **total video length instead of watched length**. Watching a few minutes of a multi-hour video can fire hundreds of segmentation calls; the segmentation cache is keyed on exact chunk content, so a later seek/reload that shifts chunk boundaries misses the cache and re-segments.

Reproduction (before the fix): a 10-minute, one-fragment-per-second track with playback held at 0s segments all 600 fragments in a single `runLoop`.

This PR bounds `findNextChunk` so it returns nothing once the next unprocessed fragment is beyond `currentTime + PROCESS_LOOK_AHEAD_MS`. `runLoop` then stops, and the existing restart-on-`timeupdate` logic in `TranslationCoordinator` resumes segmentation as playback advances — the on-demand behavior the look-ahead constant was designed for. Cost now scales with watched time.

## Related Issue

No linked issue — reported by a user.

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

**Unit test** — new case in `segmentation-pipeline.test.ts`: a 10-minute track with playback held at the start is only segmented within the look-ahead window, and the rest stays queued. Before the fix `furthestSegmented` is `599000`; after, it is bounded to the look-ahead window. All 137 subtitle-related unit tests pass (`vitest run src/entrypoints/subtitles.content src/utils/subtitles`, `SKIP_FREE_API=true`).

**Real browser A/B** — built both revisions, loaded each into real Chrome 150 (CDP `installExtension`), same config (AI segmentation on, DeepSeek provider), same video — a 30-hour lecture with English ASR captions ([SQL Full Course, 29.8h](https://www.youtube.com/watch?v=SSKVgrwhzus)). Enabled subtitles, then **paused at 0s** so playback never advances, and counted segmentation requests leaving the background service worker (classified by prompt body, since translation hits the same endpoint):

| Build | Segmentation requests, 60s paused | Trend |
|---|---|---|
| before | **183** | steady ~25 per 10s, never stops |
| after | **2** | issued once, then **+0 for the remaining 50s** |

Paused at 0s the pipeline should be idle once the look-ahead window is filled. Before the fix it marches toward the end of a 30-hour video at ~2.5 req/s; after, it fills the window and stops.

Checked the other direction too — that the bound doesn't starve segmentation. Same setup, AI segmentation on, playing normally at 1x against a local mock provider calibrated to DeepSeek V4 Flash's measured latency (1.16s TTFT + 105 tok/s):

| Playback reaches | Cumulative segmentation requests |
|---|---|
| 15s / 30s / 45s / 60s | 2 |
| 75s | 3 |
| 90s | 3 |

It buffers the look-ahead window ahead of the playhead and tops it up as playback crosses into the next window — segmentation still covers everything watched, it just no longer runs ahead of the viewer by hours.

(The A/B used a deliberately invalid API key: whether a request is *issued* is independent of key validity, and both builds fail identically, so the difference is attributable to the look-ahead bound alone — and no tokens were spent reproducing a token-cost bug.)

## Checklist

- [x] I have tested these changes locally (unit tests)
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

**Known trade-off, needs a maintainer call: seeks land on unsegmented cues.**

Not pre-segmenting the whole track and having a seek instantly land on AI-segmented cues are in direct tension — `main` only manages the latter *because* of the runaway this PR fixes.

`TranslationCoordinator.start()` already starts segmentation fire-and-forget and then calls `handleTranslationTick()` synchronously, so cues in a not-yet-segmented region get translated from the baseline fragments `SegmentationPipeline` was seeded with, and are replaced when the AI chunk lands. Measured by wiring the real pipeline and coordinator together and tagging baseline vs AI output:

| | `main` | this PR |
|---|---|---|
| at startup, before the first chunk lands | 5 × baseline | 5 × baseline |
| normal playback | 0 × baseline, 14 × AI | 0 × baseline, 14 × AI |
| AI-segmented fragments after 3s | 360 (whole 30min track) | 24 (two windows) |
| seek to 900s | 0 × baseline | **5 × baseline** |

- The startup race is pre-existing and unchanged — that code path isn't touched here.
- Normal playback never hits it: segmentation buffers ~2 windows (~120s) ahead while `TRANSLATE_LOOK_AHEAD_MS` only reaches 30s.
- Seeks do regress: a seek now behaves like startup — ~5 cues render from baseline for one segmentation round-trip, then get swapped and retranslated. It self-heals, costing a handful of translation calls per seek against the hundreds of segmentation calls saved.

The clean fix is to hide unsegmented fragments from translation, but that also makes the *first* subtitle wait a full segmentation round-trip (~4-9s of `loading`) instead of showing baseline immediately — which looks like a deliberate choice in the current design, so I didn't flip it in a PR scoped to the cost bug. Happy to implement it here if you'd prefer that behaviour, or leave it as a follow-up.
