### PR TITLE
feat(guide): expose extension status protocol

### DIFF
--- a/src/entrypoints/guide.content/extension-status.test.ts
+++ b/src/entrypoints/guide.content/extension-status.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+import {
+  createExtensionStatusResponse,
+  EXTENSION_STATUS_REQUEST_SOURCE,
+  EXTENSION_STATUS_REQUEST_TYPE,
+} from "./extension-status"
+
+describe("extension status bridge", () => {
+  const pageWindow = {}
+
+  it("echoes a valid request id with the extension version", () => {
+    expect(
+      createExtensionStatusResponse(
+        {
+          source: pageWindow,
+          data: {
+            source: EXTENSION_STATUS_REQUEST_SOURCE,
+            type: EXTENSION_STATUS_REQUEST_TYPE,
+            requestId: "request-1",
+          },
+        },
+        pageWindow,
+        "1.33.12",
+      ),
+    ).toEqual({
+      source: "read-frog-ext",
+      type: "extensionStatus",
+      requestId: "request-1",
+      data: { version: "1.33.12" },
+    })
+  })
+
+  it("ignores messages from another window", () => {
+    expect(
+      createExtensionStatusResponse(
+        {
+          source: {},
+          data: {
+            source: EXTENSION_STATUS_REQUEST_SOURCE,
+            type: EXTENSION_STATUS_REQUEST_TYPE,
+            requestId: "request-1",
+          },
+        },
+        pageWindow,
+        "1.33.12",
+      ),
+    ).toBeNull()
+  })
+
+  it("ignores malformed and unrelated messages", () => {
+    expect(
+      createExtensionStatusResponse(
+        {
+          source: pageWindow,
+          data: {
+            source: EXTENSION_STATUS_REQUEST_SOURCE,
+            type: "getPinState",
+            requestId: "request-1",
+          },
+        },
+        pageWindow,
+        "1.33.12",
+      ),
+    ).toBeNull()
+
+    expect(
+      createExtensionStatusResponse(
+        {
+          source: pageWindow,
+          data: {
+            source: EXTENSION_STATUS_REQUEST_SOURCE,
+            type: EXTENSION_STATUS_REQUEST_TYPE,
+          },
+        },
+        pageWindow,
+        "1.33.12",
+      ),
+    ).toBeNull()
+  })
+})

--- a/src/entrypoints/guide.content/extension-status.ts
+++ b/src/entrypoints/guide.content/extension-status.ts
@@ -1,0 +1,49 @@
+export const EXTENSION_STATUS_REQUEST_SOURCE = "read-frog-page"
+export const EXTENSION_STATUS_RESPONSE_SOURCE = "read-frog-ext"
+export const EXTENSION_STATUS_REQUEST_TYPE = "getExtensionStatus"
+export const EXTENSION_STATUS_RESPONSE_TYPE = "extensionStatus"
+
+interface ExtensionStatusMessageEvent {
+  data: unknown
+  source: unknown
+}
+
+export interface ExtensionStatusResponse {
+  source: typeof EXTENSION_STATUS_RESPONSE_SOURCE
+  type: typeof EXTENSION_STATUS_RESPONSE_TYPE
+  requestId: string
+  data: {
+    version: string
+  }
+}
+
+export function createExtensionStatusResponse(
+  event: ExtensionStatusMessageEvent,
+  pageWindow: unknown,
+  version: string,
+): ExtensionStatusResponse | null {
+  if (event.source !== pageWindow || !isRecord(event.data)) {
+    return null
+  }
+
+  const { requestId, source, type } = event.data
+  if (
+    source !== EXTENSION_STATUS_REQUEST_SOURCE ||
+    type !== EXTENSION_STATUS_REQUEST_TYPE ||
+    typeof requestId !== "string" ||
+    requestId.length === 0
+  ) {
+    return null
+  }
+
+  return {
+    source: EXTENSION_STATUS_RESPONSE_SOURCE,
+    type: EXTENSION_STATUS_RESPONSE_TYPE,
+    requestId,
+    data: { version },
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}

--- a/src/entrypoints/guide.content/index.ts
+++ b/src/entrypoints/guide.content/index.ts
@@ -3,7 +3,7 @@ import { kebabCase } from "case-anything"
 import { defineContentScript, storage } from "#imports"
 import { env } from "@/env"
 import { getLocalConfig } from "@/utils/config/storage"
-import { APP_NAME } from "@/utils/constants/app"
+import { APP_NAME, EXTENSION_VERSION } from "@/utils/constants/app"
 import { CONFIG_STORAGE_KEY } from "@/utils/constants/config"
 import {
   getGuideDictionaryNotebaseState,
@@ -12,6 +12,7 @@ import {
 import { resolveGuideTargetLanguage } from "@/utils/guide/target-language"
 import { logger } from "@/utils/logger"
 import { onMessage, sendMessage } from "@/utils/message"
+import { createExtensionStatusResponse } from "./extension-status"
 
 export default defineContentScript({
   matches: env.WXT_OFFICIAL_SITE_ORIGINS.map((origin: string) => `${origin}/*`),
@@ -26,6 +27,13 @@ export default defineContentScript({
 
     window.addEventListener("message", async (e) => {
       if (e.source !== window) return
+
+      const extensionStatusResponse = createExtensionStatusResponse(e, window, EXTENSION_VERSION)
+      if (extensionStatusResponse) {
+        window.postMessage(extensionStatusResponse, window.location.origin)
+        return
+      }
+
       const { source, type } = e.data || {}
       if (source !== "read-frog-page") return
 


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)

## Description

Adds a dedicated page-to-extension status handshake for the official website. The guide content script now responds to `getExtensionStatus` with the matching `requestId` and current extension version before reading local configuration, so detection also works before user settings are initialized.

The protocol is intentionally version-gated: older extension releases without this handler are treated as unavailable by the website.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Additional validation:

- Full repository format check
- Full type-aware lint/type check
- Full extension test suite
- Chrome MV3 production build

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

This extension release should reach most users before the corresponding website install-prompt PR is deployed.