### PR TITLE
fix(selection-toolbar): keep toolbar anchored while scrolling

### DIFF
--- a/.changeset/bright-frogs-scroll.md
+++ b/.changeset/bright-frogs-scroll.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection-toolbar): keep the selection toolbar anchored across custom scroll containers

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/positioning.test.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/positioning.test.ts
@@ -1,0 +1,244 @@
+// @vitest-environment jsdom
+import type { SelectionRangeSnapshot } from "../../utils"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  collectSelectionScrollTargets,
+  collectSelectionShadowRoots,
+  createSelectionAnchorTracker,
+  getSelectionDirection,
+  getToolbarViewportPosition,
+  getViewportRect,
+  measureSelectionAnchor,
+  SelectionDirection,
+  viewportPointToHostPoint,
+} from "../positioning"
+
+function createRect({
+  left,
+  top,
+  width,
+  height,
+}: {
+  left: number
+  top: number
+  width: number
+  height: number
+}) {
+  return {
+    x: left,
+    y: top,
+    top,
+    right: left + width,
+    bottom: top + height,
+    left,
+    width,
+    height,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
+const viewport = {
+  top: 0,
+  right: 1200,
+  bottom: 800,
+  left: 0,
+  width: 1200,
+  height: 800,
+}
+
+describe("selection toolbar positioning", () => {
+  let rangeRects: DOMRect[]
+  let rangeInvalid: boolean
+  let rangeSnapshot: SelectionRangeSnapshot
+  let visualViewportDescriptor: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    document.body.textContent = "Selected text"
+    const textNode = document.body.firstChild as Text
+    rangeSnapshot = {
+      startContainer: textNode,
+      startOffset: 0,
+      endContainer: textNode,
+      endOffset: textNode.length,
+    }
+    rangeRects = [createRect({ left: 100, top: 100, width: 120, height: 24 })]
+    rangeInvalid = false
+    visualViewportDescriptor = Object.getOwnPropertyDescriptor(window, "visualViewport")
+
+    vi.spyOn(document, "createRange").mockImplementation(
+      () =>
+        ({
+          setStart: () => {
+            if (rangeInvalid) throw new Error("detached range")
+          },
+          setEnd: () => {
+            if (rangeInvalid) throw new Error("detached range")
+          },
+          getClientRects: () => {
+            if (rangeInvalid) throw new Error("detached range")
+            return rangeRects as unknown as DOMRectList
+          },
+          getBoundingClientRect: () =>
+            rangeRects[0] ?? createRect({ left: 0, top: 0, width: 0, height: 0 }),
+        }) as unknown as Range,
+    )
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    if (visualViewportDescriptor) {
+      Object.defineProperty(window, "visualViewport", visualViewportDescriptor)
+    } else {
+      Reflect.deleteProperty(window, "visualViewport")
+    }
+  })
+
+  it("reads visual viewport offsets and dimensions", () => {
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: Object.assign(new EventTarget(), {
+        offsetLeft: 12,
+        offsetTop: 34,
+        width: 900,
+        height: 600,
+      }),
+    })
+
+    expect(getViewportRect()).toEqual({
+      top: 34,
+      right: 912,
+      bottom: 634,
+      left: 12,
+      width: 900,
+      height: 600,
+    })
+  })
+
+  it.each([
+    [100, 100, 200, 200, SelectionDirection.BOTTOM_RIGHT],
+    [200, 100, 100, 200, SelectionDirection.BOTTOM_LEFT],
+    [100, 200, 200, 100, SelectionDirection.TOP_RIGHT],
+    [200, 200, 100, 100, SelectionDirection.TOP_LEFT],
+  ])("detects all selection directions", (startX, startY, endX, endY, direction) => {
+    expect(getSelectionDirection(startX, startY, endX, endY)).toBe(direction)
+  })
+
+  it("positions and clamps a toolbar inside the viewport", () => {
+    expect(
+      getToolbarViewportPosition(
+        SelectionDirection.BOTTOM_RIGHT,
+        { x: 1190, y: 790 },
+        { width: 200, height: 50 },
+        viewport,
+        25,
+      ),
+    ).toEqual({ x: 975, y: 725 })
+  })
+
+  it("converts viewport coordinates through a translated and scaled host", () => {
+    const host = {
+      offsetWidth: 1200,
+      offsetHeight: 800,
+      getBoundingClientRect: () => createRect({ left: -100, top: -200, width: 600, height: 400 }),
+    }
+
+    expect(viewportPointToHostPoint({ x: 200, y: 100 }, host)).toEqual({ x: 600, y: 600 })
+  })
+
+  it("keeps the pointer offset while the selected range moves", () => {
+    const tracker = createSelectionAnchorTracker([rangeSnapshot], { x: 210, y: 124 })
+    expect(tracker).not.toBeNull()
+
+    rangeRects = [createRect({ left: 100, top: 40, width: 120, height: 24 })]
+    const measurement = measureSelectionAnchor(tracker!, viewport)
+
+    expect(measurement).toMatchObject({
+      status: "visible",
+      anchor: { x: 210, y: 64 },
+    })
+  })
+
+  it("falls back to the nearest visible rect when wrapping changes", () => {
+    rangeRects = [
+      createRect({ left: 100, top: 100, width: 120, height: 24 }),
+      createRect({ left: 100, top: 130, width: 80, height: 24 }),
+    ]
+    const tracker = createSelectionAnchorTracker([rangeSnapshot], { x: 175, y: 150 })
+    expect(tracker?.reference.rectIndex).toBe(1)
+
+    rangeRects = [createRect({ left: 100, top: 80, width: 160, height: 24 })]
+    const measurement = measureSelectionAnchor(tracker!, viewport)
+
+    expect(measurement).toMatchObject({
+      status: "visible",
+      tracker: { reference: { rectIndex: 0 } },
+    })
+  })
+
+  it("reports when the selection is completely outside the viewport", () => {
+    const tracker = createSelectionAnchorTracker([rangeSnapshot], { x: 210, y: 124 })
+    rangeRects = [createRect({ left: 100, top: -100, width: 120, height: 24 })]
+
+    expect(measureSelectionAnchor(tracker!, viewport)).toEqual({ status: "offscreen" })
+  })
+
+  it("reports invalid detached ranges", () => {
+    const tracker = createSelectionAnchorTracker([rangeSnapshot], { x: 210, y: 124 })
+    rangeInvalid = true
+
+    expect(measureSelectionAnchor(tracker!, viewport)).toEqual({ status: "invalid" })
+  })
+
+  it("reports invalid ranges when their boundary nodes are removed", () => {
+    const tracker = createSelectionAnchorTracker([rangeSnapshot], { x: 210, y: 124 })
+    document.body.textContent = ""
+
+    expect(measureSelectionAnchor(tracker!, viewport)).toEqual({ status: "invalid" })
+  })
+
+  it("collects every nested shadow root containing the selection", () => {
+    vi.restoreAllMocks()
+    document.body.textContent = ""
+    const outerHost = document.createElement("div")
+    const outerRoot = outerHost.attachShadow({ mode: "open" })
+    const innerHost = document.createElement("div")
+    const innerRoot = innerHost.attachShadow({ mode: "open" })
+    const textNode = document.createTextNode("Shadow selection")
+    innerRoot.append(textNode)
+    outerRoot.append(innerHost)
+    document.body.append(outerHost)
+
+    const roots = collectSelectionShadowRoots([
+      {
+        startContainer: textNode,
+        startOffset: 0,
+        endContainer: textNode,
+        endOffset: textNode.length,
+      },
+    ])
+
+    expect(roots).toEqual([innerRoot, outerRoot])
+  })
+
+  it("collects the complete ancestor chain as direct scroll targets", () => {
+    vi.restoreAllMocks()
+    document.body.textContent = ""
+    const scroller = document.createElement("div")
+    const paragraph = document.createElement("p")
+    const textNode = document.createTextNode("Nested selection")
+    paragraph.append(textNode)
+    scroller.append(paragraph)
+    document.body.append(scroller)
+
+    const targets = collectSelectionScrollTargets([
+      {
+        startContainer: textNode,
+        startOffset: 0,
+        endContainer: textNode,
+        endOffset: textNode.length,
+      },
+    ])
+
+    expect(targets).toEqual([paragraph, scroller, document.body, document.documentElement])
+  })
+})

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
@@ -1,11 +1,17 @@
 // @vitest-environment jsdom
 import { act, cleanup, render, screen, waitFor } from "@testing-library/react"
-import { atom } from "jotai"
+import { atom, useAtomValue } from "jotai"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { SELECTION_CONTENT_OVERLAY_ROOT_ATTRIBUTE } from "@/entrypoints/selection.content/overlay-layers"
+import { selectionSessionAtom } from "../atoms"
 import { SelectionToolbar } from "../index"
 
 const MOCK_SELECTED_TEXT = "Selected Text"
+
+function SelectionSessionProbe() {
+  const session = useAtomValue(selectionSessionAtom)
+  return <div data-testid="selection-session">{session?.selectionSnapshot.text ?? "empty"}</div>
+}
 
 // Mock child components
 vi.mock("../translate-button", () => ({
@@ -563,6 +569,35 @@ describe("selectionToolbar - isInputOrTextarea logic", () => {
 describe("selectionToolbar - positioning logic", () => {
   let originalRequestAnimationFrame: typeof requestAnimationFrame
   let rafCallbacks: FrameRequestCallback[]
+  let selectionRects: DOMRect[]
+  let rangeInvalid: boolean
+  let getClientRectsDescriptor: PropertyDescriptor | undefined
+  let getBoundingClientRectDescriptor: PropertyDescriptor | undefined
+  let visualViewportDescriptor: PropertyDescriptor | undefined
+  let resizeObserverDescriptor: PropertyDescriptor | undefined
+
+  const createRect = ({
+    left,
+    top,
+    width,
+    height,
+  }: {
+    left: number
+    top: number
+    width: number
+    height: number
+  }) =>
+    ({
+      x: left,
+      y: top,
+      top,
+      right: left + width,
+      bottom: top + height,
+      left,
+      width,
+      height,
+      toJSON: () => ({}),
+    }) as DOMRect
 
   beforeEach(() => {
     // Mock requestAnimationFrame to execute callbacks synchronously
@@ -587,6 +622,31 @@ describe("selectionToolbar - positioning logic", () => {
       containsNode: vi.fn<(...args: any[]) => any>(() => true),
     }))
 
+    selectionRects = [createRect({ left: 100, top: 100, width: 100, height: 20 })]
+    rangeInvalid = false
+    getClientRectsDescriptor = Object.getOwnPropertyDescriptor(Range.prototype, "getClientRects")
+    getBoundingClientRectDescriptor = Object.getOwnPropertyDescriptor(
+      Range.prototype,
+      "getBoundingClientRect",
+    )
+    visualViewportDescriptor = Object.getOwnPropertyDescriptor(window, "visualViewport")
+    resizeObserverDescriptor = Object.getOwnPropertyDescriptor(globalThis, "ResizeObserver")
+    Reflect.deleteProperty(window, "visualViewport")
+    Object.defineProperty(Range.prototype, "getClientRects", {
+      configurable: true,
+      value: () => {
+        if (rangeInvalid) throw new Error("detached range")
+        return selectionRects
+      },
+    })
+    Object.defineProperty(Range.prototype, "getBoundingClientRect", {
+      configurable: true,
+      value: () => {
+        if (rangeInvalid) throw new Error("detached range")
+        return selectionRects[0] ?? createRect({ left: 0, top: 0, width: 0, height: 0 })
+      },
+    })
+
     // Mock window dimensions
     Object.defineProperty(window, "innerHeight", {
       writable: true,
@@ -594,20 +654,19 @@ describe("selectionToolbar - positioning logic", () => {
       value: 800,
     })
 
-    Object.defineProperty(document.documentElement, "clientWidth", {
+    Object.defineProperty(window, "innerWidth", {
       writable: true,
       configurable: true,
       value: 1200,
     })
 
-    // Mock scrollY and scrollX
-    Object.defineProperty(window, "scrollY", {
+    Object.defineProperty(window, "scrollX", {
       writable: true,
       configurable: true,
       value: 0,
     })
 
-    Object.defineProperty(window, "scrollX", {
+    Object.defineProperty(window, "scrollY", {
       writable: true,
       configurable: true,
       value: 0,
@@ -618,6 +677,30 @@ describe("selectionToolbar - positioning logic", () => {
     cleanup()
     window.requestAnimationFrame = originalRequestAnimationFrame
     rafCallbacks = []
+    if (getClientRectsDescriptor) {
+      Object.defineProperty(Range.prototype, "getClientRects", getClientRectsDescriptor)
+    } else {
+      Reflect.deleteProperty(Range.prototype, "getClientRects")
+    }
+    if (getBoundingClientRectDescriptor) {
+      Object.defineProperty(
+        Range.prototype,
+        "getBoundingClientRect",
+        getBoundingClientRectDescriptor,
+      )
+    } else {
+      Reflect.deleteProperty(Range.prototype, "getBoundingClientRect")
+    }
+    if (visualViewportDescriptor) {
+      Object.defineProperty(window, "visualViewport", visualViewportDescriptor)
+    } else {
+      Reflect.deleteProperty(window, "visualViewport")
+    }
+    if (resizeObserverDescriptor) {
+      Object.defineProperty(globalThis, "ResizeObserver", resizeObserverDescriptor)
+    } else {
+      Reflect.deleteProperty(globalThis, "ResizeObserver")
+    }
     vi.clearAllMocks()
   })
 
@@ -628,14 +711,25 @@ describe("selectionToolbar - positioning logic", () => {
     endX: number,
     endY: number,
   ) => {
+    selectionRects = [
+      createRect({
+        left: Math.min(startX, endX),
+        top: Math.min(startY, endY),
+        width: Math.max(Math.abs(endX - startX), 1),
+        height: Math.max(Math.abs(endY - startY), 20),
+      }),
+    ]
+
     const mouseDownEvent = new MouseEvent("mousedown", {
       bubbles: true,
+      composed: true,
       clientX: startX,
       clientY: startY,
     })
 
     const mouseUpEvent = new MouseEvent("mouseup", {
       bubbles: true,
+      composed: true,
       clientX: endX,
       clientY: endY,
     })
@@ -705,6 +799,12 @@ describe("selectionToolbar - positioning logic", () => {
       expect(topValue).toBeGreaterThanOrEqual(175) // Allow some margin for clamping
       expect(topValue).toBeLessThanOrEqual(225) // Allow some margin for clamping
     })
+  })
+
+  it("renders inside a fixed viewport host", () => {
+    render(<SelectionToolbar />)
+
+    expect(getToolbarElement().parentElement).toHaveClass("fixed", "inset-0", "pointer-events-none")
   })
 
   it("should keep the bottom-right toolbar below the cursor to reduce accidental clicks", async () => {
@@ -929,9 +1029,8 @@ describe("selectionToolbar - positioning logic", () => {
       const mockToolbarHeight = 50
       mockToolbarDimensions(toolbar, 200, mockToolbarHeight)
 
-      // Trigger position update with mocked dimensions
-      // Simulate what updatePosition does: bottomBoundary = scrollY + viewportHeight - tooltipHeight - MARGIN = 0 + 800 - 50 - 25 = 725
-      // Since mouseUp is at y=795, toolbar should be clamped to top <= 725
+      // Trigger position update with mocked dimensions. The viewport bottom boundary is
+      // 800 - 50 - 25 = 725, so a mouseup at y=795 must be clamped.
       // Manually trigger updatePosition by dispatching a scroll event
       act(() => {
         window.dispatchEvent(new Event("scroll"))
@@ -945,8 +1044,7 @@ describe("selectionToolbar - positioning logic", () => {
       const toolbar = getToolbarElement()
       const topValue = Number.parseInt(toolbar.style.top, 10)
       const toolbarHeight = toolbar.offsetHeight
-      // Should be clamped within bottom boundary
-      // bottomBoundary = scrollY + viewportHeight - tooltipHeight - MARGIN = 0 + 800 - 50 - 25 = 725
+      // Should be clamped within the visual viewport bottom boundary.
       expect(topValue).toBeLessThanOrEqual(725)
       expect(topValue + toolbarHeight + 25).toBeLessThanOrEqual(800) // top + height + margin <= innerHeight
     })
@@ -962,7 +1060,6 @@ describe("selectionToolbar - positioning logic", () => {
 
     const target = screen.getByTestId("test-element")
 
-    // Initial selection at client position (100, 100) with scrollY = 0
     await triggerMouseDownAndUp(target, 100, 100, 200, 200)
 
     await waitFor(() => {
@@ -971,13 +1068,8 @@ describe("selectionToolbar - positioning logic", () => {
     })
 
     const toolbar = getToolbarElement()
-
-    // Simulate scroll down by 100px
-    Object.defineProperty(window, "scrollY", {
-      writable: true,
-      configurable: true,
-      value: 100,
-    })
+    const initialTop = Number.parseInt(toolbar.style.top, 10)
+    selectionRects = [createRect({ left: 100, top: 0, width: 100, height: 100 })]
 
     await act(async () => {
       window.dispatchEvent(new Event("scroll"))
@@ -986,14 +1078,11 @@ describe("selectionToolbar - positioning logic", () => {
       callbacks.forEach((cb) => cb(0))
     })
 
-    // After scrolling, the toolbar position should be updated
     const updatedTop = Number.parseInt(toolbar.style.top, 10)
-    // The toolbar should be clamped to at least scrollY + MARGIN (100 + 10 = 110)
-    expect(updatedTop).toBeGreaterThanOrEqual(110)
+    expect(updatedTop).toBe(initialTop - 100)
   })
 
-  it("should account for scroll offset when positioning toolbar", async () => {
-    // Set initial scroll position
+  it("should keep client coordinates independent from window scroll offsets", async () => {
     Object.defineProperty(window, "scrollY", {
       writable: true,
       configurable: true,
@@ -1015,18 +1104,226 @@ describe("selectionToolbar - positioning logic", () => {
 
     const target = screen.getByTestId("test-element")
 
-    // Select at client position (100, 100)
-    // Document position should be (150, 300) considering scroll
     await triggerMouseDownAndUp(target, 100, 100, 100, 100)
 
     await waitFor(() => {
       const toolbar = getToolbarElement()
       expect(toolbar).toBeTruthy()
-      // Toolbar position should account for scroll offset
       const topValue = Number.parseInt(toolbar.style.top, 10)
-      // Should be at least scrollY + MARGIN (200 + 10 = 210)
-      expect(topValue).toBeGreaterThanOrEqual(210)
+      expect(topValue).toBe(120)
     })
+  })
+
+  it("should follow a selection when body is the scroll container", async () => {
+    render(
+      <div>
+        <SelectionToolbar />
+        <div data-testid="test-element">Test content</div>
+      </div>,
+    )
+
+    await triggerMouseDownAndUp(screen.getByTestId("test-element"), 100, 100, 200, 200)
+    const toolbar = getToolbarElement()
+    const initialTop = Number.parseInt(toolbar.style.top, 10)
+    selectionRects = [createRect({ left: 100, top: 50, width: 100, height: 100 })]
+
+    await act(async () => {
+      document.body.dispatchEvent(new Event("scroll"))
+      const callbacks = [...rafCallbacks]
+      rafCallbacks = []
+      callbacks.forEach((callback) => callback(0))
+    })
+
+    expect(Number.parseInt(toolbar.style.top, 10)).toBe(initialTop - 50)
+  })
+
+  it("should follow a selection inside a nested scroll container", async () => {
+    render(
+      <div>
+        <SelectionToolbar />
+        <div data-testid="scroller">
+          <div data-testid="test-element">Test content</div>
+        </div>
+      </div>,
+    )
+
+    await triggerMouseDownAndUp(screen.getByTestId("test-element"), 100, 100, 200, 200)
+    const toolbar = getToolbarElement()
+    const initialTop = Number.parseInt(toolbar.style.top, 10)
+    selectionRects = [createRect({ left: 100, top: 25, width: 100, height: 100 })]
+
+    await act(async () => {
+      screen.getByTestId("scroller").dispatchEvent(new Event("scroll"))
+      const callbacks = [...rafCallbacks]
+      rafCallbacks = []
+      callbacks.forEach((callback) => callback(0))
+    })
+
+    expect(Number.parseInt(toolbar.style.top, 10)).toBe(initialTop - 75)
+  })
+
+  it("should follow a selection when a scroller lives inside shadow DOM", async () => {
+    const shadowHost = document.createElement("div")
+    const shadowRoot = shadowHost.attachShadow({ mode: "open" })
+    const target = document.createElement("span")
+    const textNode = document.createTextNode("Shadow selection")
+    target.append(textNode)
+    shadowRoot.append(target)
+    document.body.append(shadowHost)
+    window.getSelection = vi.fn<(...args: any[]) => any>(() => ({
+      toString: () => MOCK_SELECTED_TEXT,
+      getRangeAt: () => ({
+        startContainer: textNode,
+        startOffset: 0,
+        endContainer: textNode,
+        endOffset: textNode.length,
+      }),
+      containsNode: () => true,
+    }))
+
+    render(<SelectionToolbar />)
+    await triggerMouseDownAndUp(target, 100, 100, 200, 200)
+    const toolbar = getToolbarElement()
+    const initialTop = Number.parseInt(toolbar.style.top, 10)
+    selectionRects = [createRect({ left: 100, top: 20, width: 100, height: 100 })]
+
+    await act(async () => {
+      shadowRoot.dispatchEvent(new Event("scroll"))
+      const callbacks = [...rafCallbacks]
+      rafCallbacks = []
+      callbacks.forEach((callback) => callback(0))
+    })
+
+    expect(Number.parseInt(toolbar.style.top, 10)).toBe(initialTop - 80)
+  })
+
+  it("should close after the selection leaves the viewport and stay closed", async () => {
+    render(
+      <div>
+        <SelectionToolbar />
+        <SelectionSessionProbe />
+        <div data-testid="test-element">Test content</div>
+      </div>,
+    )
+
+    await triggerMouseDownAndUp(screen.getByTestId("test-element"), 100, 100, 200, 200)
+    const toolbar = getToolbarElement()
+    selectionRects = [createRect({ left: 100, top: -200, width: 100, height: 100 })]
+
+    await act(async () => {
+      document.body.dispatchEvent(new Event("scroll"))
+      const callbacks = [...rafCallbacks]
+      rafCallbacks = []
+      callbacks.forEach((callback) => callback(0))
+    })
+
+    expect(toolbar).toHaveClass("pointer-events-none", "opacity-0")
+    expect(screen.getByTestId("selection-session")).toHaveTextContent(MOCK_SELECTED_TEXT)
+
+    selectionRects = [createRect({ left: 100, top: 100, width: 100, height: 100 })]
+    await act(async () => {
+      document.body.dispatchEvent(new Event("scroll"))
+      const callbacks = [...rafCallbacks]
+      rafCallbacks = []
+      callbacks.forEach((callback) => callback(0))
+    })
+
+    expect(toolbar).toHaveClass("pointer-events-none", "opacity-0")
+  })
+
+  it("should clear a selection session when its range becomes invalid", async () => {
+    render(
+      <div>
+        <SelectionToolbar />
+        <SelectionSessionProbe />
+        <div data-testid="test-element">Test content</div>
+      </div>,
+    )
+
+    await triggerMouseDownAndUp(screen.getByTestId("test-element"), 100, 100, 200, 200)
+    expect(screen.getByTestId("selection-session")).toHaveTextContent(MOCK_SELECTED_TEXT)
+    rangeInvalid = true
+
+    await act(async () => {
+      document.body.dispatchEvent(new Event("scroll"))
+      const callbacks = [...rafCallbacks]
+      rafCallbacks = []
+      callbacks.forEach((callback) => callback(0))
+    })
+
+    expect(getToolbarElement()).toHaveClass("pointer-events-none", "opacity-0")
+    expect(screen.getByTestId("selection-session")).toHaveTextContent("empty")
+  })
+
+  it("should remeasure and clamp when the visual viewport is resized", async () => {
+    const visualViewport = Object.assign(new EventTarget(), {
+      offsetLeft: 0,
+      offsetTop: 0,
+      width: 1200,
+      height: 800,
+    })
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: visualViewport,
+    })
+    render(
+      <div>
+        <SelectionToolbar />
+        <div data-testid="test-element">Test content</div>
+      </div>,
+    )
+
+    await triggerMouseDownAndUp(screen.getByTestId("test-element"), 800, 500, 850, 570)
+    const toolbar = getToolbarElement()
+    mockToolbarDimensions(toolbar, 200, 50)
+    visualViewport.width = 860
+    visualViewport.height = 600
+
+    await act(async () => {
+      visualViewport.dispatchEvent(new Event("resize"))
+      const callbacks = [...rafCallbacks]
+      rafCallbacks = []
+      callbacks.forEach((callback) => callback(0))
+    })
+
+    expect(toolbar.style.left).toBe("635px")
+    expect(toolbar.style.top).toBe("525px")
+  })
+
+  it("should re-clamp when ResizeObserver reports a toolbar size change", async () => {
+    let resizeCallback: ResizeObserverCallback | null = null
+    class ResizeObserverMock {
+      constructor(callback: ResizeObserverCallback) {
+        resizeCallback = callback
+      }
+
+      observe() {}
+      disconnect() {}
+    }
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: ResizeObserverMock,
+    })
+    render(
+      <div>
+        <SelectionToolbar />
+        <div data-testid="test-element">Test content</div>
+      </div>,
+    )
+
+    await triggerMouseDownAndUp(screen.getByTestId("test-element"), 900, 600, 1100, 700)
+    const toolbar = getToolbarElement()
+    mockToolbarDimensions(toolbar, 300, 100)
+
+    await act(async () => {
+      resizeCallback?.([], {} as ResizeObserver)
+      const callbacks = [...rafCallbacks]
+      rafCallbacks = []
+      callbacks.forEach((callback) => callback(0))
+    })
+
+    expect(toolbar.style.left).toBe("875px")
+    expect(toolbar.style.top).toBe("675px")
   })
 
   it("should maintain toolbar visibility when window is resized", async () => {

--- a/src/entrypoints/selection.content/selection-toolbar/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/index.tsx
@@ -17,15 +17,18 @@ import {
 } from "./atoms"
 import { CloseButton, DropEvent } from "./close-button"
 import { SelectionToolbarCustomActionButtons } from "./custom-action-button"
+import {
+  collectSelectionScrollTargets,
+  createSelectionAnchorTracker,
+  getSelectionDirection,
+  getToolbarViewportPosition,
+  getViewportRect,
+  measureSelectionAnchor,
+  SelectionDirection,
+  viewportPointToHostPoint,
+} from "./positioning"
 import { SpeakButton } from "./speak-button"
 import { TranslateButton } from "./translate-button"
-
-enum SelectionDirection {
-  TOP_LEFT = "TOP_LEFT",
-  TOP_RIGHT = "TOP_RIGHT",
-  BOTTOM_LEFT = "BOTTOM_LEFT",
-  BOTTOM_RIGHT = "BOTTOM_RIGHT",
-}
 
 const SELECTION_GUARD_INTERACTIVE_SELECTOR = [
   "button",
@@ -174,51 +177,14 @@ function isMouseEventInsideSelectionOverlay(
   )
 }
 
-function getSelectionDirection(
-  startX: number,
-  startY: number,
-  endX: number,
-  endY: number,
-): SelectionDirection {
-  const DOWNWARD_TOLERANCE = 8
-
-  const isRightward = startX <= endX
-  const isDownward = startY - DOWNWARD_TOLERANCE <= endY
-
-  if (isRightward && isDownward) return SelectionDirection.BOTTOM_RIGHT
-  if (isRightward && !isDownward) return SelectionDirection.TOP_RIGHT
-  if (!isRightward && isDownward) return SelectionDirection.BOTTOM_LEFT
-  return SelectionDirection.TOP_LEFT
-}
-
-function applyDirectionOffset(
-  direction: SelectionDirection,
-  baseX: number,
-  baseY: number,
-  tooltipWidth: number,
-  tooltipHeight: number,
-): { x: number; y: number } {
-  const CURSOR_CLEARANCE = 20
-  switch (direction) {
-    case SelectionDirection.BOTTOM_RIGHT:
-      return { x: baseX, y: baseY + CURSOR_CLEARANCE }
-    case SelectionDirection.BOTTOM_LEFT:
-      return { x: baseX - tooltipWidth, y: baseY + CURSOR_CLEARANCE }
-    case SelectionDirection.TOP_RIGHT:
-      return { x: baseX, y: baseY - tooltipHeight - CURSOR_CLEARANCE }
-    case SelectionDirection.TOP_LEFT:
-      return { x: baseX - tooltipWidth, y: baseY - tooltipHeight - CURSOR_CLEARANCE }
-    default:
-      return { x: baseX, y: baseY + CURSOR_CLEARANCE }
-  }
-}
-
 export function SelectionToolbar() {
   const tooltipRef = useRef<HTMLDivElement>(null)
   const tooltipContainerRef = useRef<HTMLDivElement>(null)
   const selectionPositionRef = useRef<{ x: number; y: number } | null>(null) // store selection position (base position without direction offset)
   const selectionStartRef = useRef<{ x: number; y: number } | null>(null) // store selection start position
   const selectionDirectionRef = useRef<SelectionDirection>(SelectionDirection.BOTTOM_RIGHT) // store selection direction
+  const selectionAnchorTrackerRef = useRef<ReturnType<typeof createSelectionAnchorTracker>>(null)
+  const selectionScrollTargetsRef = useRef<Array<Element | ShadowRoot>>([])
   const isPointerDownInsideOverlayRef = useRef(false)
   const preserveSelectionStateRef = useRef(false)
   const [isSelectionToolbarVisible, setIsSelectionToolbarVisible] = useAtom(
@@ -229,46 +195,124 @@ export function SelectionToolbar() {
   const selectionToolbar = useAtomValue(configFieldsAtomMap.selectionToolbar)
   const dropdownOpenRef = useRef(false)
 
-  const updatePosition = useCallback(() => {
-    if (!isSelectionToolbarVisible || !tooltipRef.current || !selectionPositionRef.current) return
+  const updatePosition = useCallback(
+    ({ remeasureSelection = false }: { remeasureSelection?: boolean } = {}) => {
+      const tooltip = tooltipRef.current
+      const viewportHost = tooltipContainerRef.current
+      const selectionPosition = selectionPositionRef.current
 
-    const scrollY = window.scrollY
-    const viewportHeight = window.innerHeight
-    const clientWidth = document.documentElement.clientWidth
-    const tooltipWidth = tooltipRef.current.offsetWidth
-    const tooltipHeight = tooltipRef.current.offsetHeight
+      if (!isSelectionToolbarVisible || !tooltip || !viewportHost || !selectionPosition) {
+        return
+      }
 
-    // Apply direction offset based on selection direction and tooltip dimensions
-    const { x: offsetX, y: offsetY } = applyDirectionOffset(
-      selectionDirectionRef.current,
-      selectionPositionRef.current.x,
-      selectionPositionRef.current.y,
-      tooltipWidth,
-      tooltipHeight,
-    )
+      const viewport = getViewportRect()
+      const tracker = selectionAnchorTrackerRef.current
 
-    // calculate strict boundaries
-    const topBoundary = scrollY + MARGIN
-    const bottomBoundary = scrollY + viewportHeight - tooltipHeight - MARGIN
-    const leftBoundary = MARGIN
-    const rightBoundary = clientWidth - tooltipWidth - MARGIN
+      if (remeasureSelection && tracker) {
+        const measurement = measureSelectionAnchor(tracker, viewport)
 
-    // calculate the position of the tooltip, but strictly limit it within the boundaries
-    const clampedX = Math.max(leftBoundary, Math.min(rightBoundary, offsetX))
-    const clampedY = Math.max(topBoundary, Math.min(bottomBoundary, offsetY))
+        if (measurement.status === "invalid") {
+          selectionAnchorTrackerRef.current = null
+          selectionScrollTargetsRef.current = []
+          selectionPositionRef.current = null
+          clearSelectionState()
+          setIsSelectionToolbarVisible(false)
+          return
+        }
 
-    // directly operate the DOM, avoid React re-rendering
-    tooltipRef.current.style.top = `${clampedY}px`
-    tooltipRef.current.style.left = `${clampedX}px`
-  }, [isSelectionToolbarVisible])
+        if (measurement.status === "offscreen") {
+          selectionAnchorTrackerRef.current = null
+          selectionScrollTargetsRef.current = []
+          selectionPositionRef.current = null
+          setIsSelectionToolbarVisible(false)
+          return
+        }
+
+        selectionAnchorTrackerRef.current = measurement.tracker
+        selectionPositionRef.current = measurement.anchor
+      }
+
+      const nextSelectionPosition = selectionPositionRef.current
+      if (!nextSelectionPosition) {
+        return
+      }
+
+      const tooltipRect = tooltip.getBoundingClientRect()
+      const viewportPosition = getToolbarViewportPosition(
+        selectionDirectionRef.current,
+        nextSelectionPosition,
+        {
+          width: tooltipRect.width || tooltip.offsetWidth,
+          height: tooltipRect.height || tooltip.offsetHeight,
+        },
+        viewport,
+        MARGIN,
+      )
+      const hostPosition = viewportPointToHostPoint(viewportPosition, viewportHost)
+
+      tooltip.style.top = `${hostPosition.y}px`
+      tooltip.style.left = `${hostPosition.x}px`
+    },
+    [clearSelectionState, isSelectionToolbarVisible, setIsSelectionToolbarVisible],
+  )
 
   useLayoutEffect(() => {
-    updatePosition()
+    updatePosition({ remeasureSelection: true })
   }, [updatePosition])
 
   useEffect(() => {
-    let animationFrameId: number
+    if (!isSelectionToolbarVisible) {
+      return undefined
+    }
 
+    let animationFrameId: number | null = null
+    const schedulePositionUpdate = () => {
+      if (animationFrameId !== null) {
+        return
+      }
+
+      animationFrameId = requestAnimationFrame(() => {
+        animationFrameId = null
+        updatePosition({ remeasureSelection: true })
+      })
+    }
+
+    const captureScrollOptions: AddEventListenerOptions = { capture: true, passive: true }
+    const passiveOptions: AddEventListenerOptions = { passive: true }
+    const selectionScrollTargets = selectionScrollTargetsRef.current
+    const visualViewport = window.visualViewport
+    const resizeObserver =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(schedulePositionUpdate)
+
+    document.addEventListener("scroll", schedulePositionUpdate, captureScrollOptions)
+    window.addEventListener("scroll", schedulePositionUpdate, passiveOptions)
+    window.addEventListener("resize", schedulePositionUpdate)
+    visualViewport?.addEventListener("scroll", schedulePositionUpdate, passiveOptions)
+    visualViewport?.addEventListener("resize", schedulePositionUpdate)
+    selectionScrollTargets.forEach((target) =>
+      target.addEventListener("scroll", schedulePositionUpdate, captureScrollOptions),
+    )
+    if (tooltipRef.current) {
+      resizeObserver?.observe(tooltipRef.current)
+    }
+
+    return () => {
+      document.removeEventListener("scroll", schedulePositionUpdate, true)
+      window.removeEventListener("scroll", schedulePositionUpdate)
+      window.removeEventListener("resize", schedulePositionUpdate)
+      visualViewport?.removeEventListener("scroll", schedulePositionUpdate)
+      visualViewport?.removeEventListener("resize", schedulePositionUpdate)
+      selectionScrollTargets.forEach((target) =>
+        target.removeEventListener("scroll", schedulePositionUpdate, true),
+      )
+      resizeObserver?.disconnect()
+      if (animationFrameId !== null) {
+        cancelAnimationFrame(animationFrameId)
+      }
+    }
+  }, [isSelectionToolbarVisible, updatePosition])
+
+  useEffect(() => {
     const handleMouseUp = (e: MouseEvent) => {
       if (isPointerDownInsideOverlayRef.current) {
         isPointerDownInsideOverlayRef.current = false
@@ -322,10 +366,6 @@ export function SelectionToolbar() {
             selection: selectionSnapshot,
             context: buildContextSnapshot(selectionSnapshot),
           })
-          // calculate the position relative to the document
-          const scrollY = window.scrollY
-          const scrollX = window.scrollX
-
           if (selectionStartRef.current) {
             // Get selection start and end positions
             const startX = selectionStartRef.current.x
@@ -339,11 +379,15 @@ export function SelectionToolbar() {
             selectionDirectionRef.current = SelectionDirection.BOTTOM_RIGHT
           }
 
-          const docX = e.clientX + scrollX
-          const docY = e.clientY + scrollY
-
-          // Store pending position for useLayoutEffect to process
-          selectionPositionRef.current = { x: docX, y: docY }
+          const selectionPosition = { x: e.clientX, y: e.clientY }
+          selectionPositionRef.current = selectionPosition
+          selectionAnchorTrackerRef.current = createSelectionAnchorTracker(
+            selectionSnapshot.ranges,
+            selectionPosition,
+          )
+          selectionScrollTargetsRef.current = collectSelectionScrollTargets(
+            selectionSnapshot.ranges,
+          )
           setIsSelectionToolbarVisible(true)
         }
       })
@@ -370,6 +414,9 @@ export function SelectionToolbar() {
 
       // Record selection start position
       selectionStartRef.current = { x: e.clientX, y: e.clientY }
+      selectionPositionRef.current = null
+      selectionAnchorTrackerRef.current = null
+      selectionScrollTargetsRef.current = []
 
       clearSelectionState()
       setIsSelectionToolbarVisible(false)
@@ -393,43 +440,25 @@ export function SelectionToolbar() {
         }
 
         clearSelectionState()
+        selectionPositionRef.current = null
+        selectionAnchorTrackerRef.current = null
+        selectionScrollTargetsRef.current = []
         // Don't hide toolbar when dropdown is open to prevent unwanted dismissal
         // (Firefox clears selection when dropdown gains focus)
         if (!dropdownOpenRef.current) setIsSelectionToolbarVisible(false)
       }
     }
 
-    const handleScroll = () => {
-      // cancel the previous animation frame
-      if (animationFrameId) {
-        cancelAnimationFrame(animationFrameId)
-      }
-
-      // use requestAnimationFrame to ensure rendering synchronization
-      animationFrameId = requestAnimationFrame(updatePosition)
-    }
-
     document.addEventListener("mouseup", handleMouseUp)
     document.addEventListener("mousedown", handleMouseDown)
     document.addEventListener("selectionchange", handleSelectionChange)
-    window.addEventListener("scroll", handleScroll, { passive: true })
 
     return () => {
       document.removeEventListener("mouseup", handleMouseUp)
       document.removeEventListener("mousedown", handleMouseDown)
       document.removeEventListener("selectionchange", handleSelectionChange)
-      window.removeEventListener("scroll", handleScroll)
-      if (animationFrameId) {
-        cancelAnimationFrame(animationFrameId)
-      }
     }
-  }, [
-    clearSelectionState,
-    isSelectionToolbarVisible,
-    setIsSelectionToolbarVisible,
-    setSelectionState,
-    updatePosition,
-  ])
+  }, [clearSelectionState, setIsSelectionToolbarVisible, setSelectionState])
 
   useEffect(() => {
     const handler = (e: Event) => {
@@ -453,7 +482,7 @@ export function SelectionToolbar() {
   return (
     <div
       ref={tooltipContainerRef}
-      className={NOTRANSLATE_CLASS}
+      className={`${NOTRANSLATE_CLASS} pointer-events-none fixed inset-0`}
       {...{ [SELECTION_CONTENT_OVERLAY_ROOT_ATTRIBUTE]: "" }}
     >
       {selectionToolbar.enabled && !isSiteDisabled && hasAnyEnabledFeature && (

--- a/src/entrypoints/selection.content/selection-toolbar/positioning.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/positioning.ts
@@ -1,0 +1,346 @@
+import type { SelectionRangeSnapshot } from "../utils"
+import { toLiveRange } from "../utils"
+
+export interface ViewportPoint {
+  x: number
+  y: number
+}
+
+export interface ViewportRect {
+  top: number
+  right: number
+  bottom: number
+  left: number
+  width: number
+  height: number
+}
+
+export interface SelectionAnchorTracker {
+  ranges: SelectionRangeSnapshot[]
+  reference: {
+    rangeIndex: number
+    rectIndex: number
+    offsetX: number
+    offsetY: number
+  }
+  lastAnchor: ViewportPoint
+}
+
+export type SelectionAnchorMeasurement =
+  | {
+      status: "visible"
+      anchor: ViewportPoint
+      tracker: SelectionAnchorTracker
+    }
+  | { status: "offscreen" }
+  | { status: "invalid" }
+
+export enum SelectionDirection {
+  TOP_LEFT = "TOP_LEFT",
+  TOP_RIGHT = "TOP_RIGHT",
+  BOTTOM_LEFT = "BOTTOM_LEFT",
+  BOTTOM_RIGHT = "BOTTOM_RIGHT",
+}
+
+interface IndexedClientRect {
+  rangeIndex: number
+  rectIndex: number
+  rect: DOMRect
+}
+
+interface ViewportHost {
+  offsetWidth: number
+  offsetHeight: number
+  getBoundingClientRect: () => DOMRect
+}
+
+const DOWNWARD_TOLERANCE = 8
+const CURSOR_CLEARANCE = 20
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value))
+}
+
+function hasArea(rect: DOMRect) {
+  return rect.width > 0 || rect.height > 0
+}
+
+function getPointToRectDistanceSquared(point: ViewportPoint, rect: DOMRect) {
+  const deltaX = point.x < rect.left ? rect.left - point.x : Math.max(point.x - rect.right, 0)
+  const deltaY = point.y < rect.top ? rect.top - point.y : Math.max(point.y - rect.bottom, 0)
+
+  return deltaX * deltaX + deltaY * deltaY
+}
+
+function getNearestRect(rects: IndexedClientRect[], point: ViewportPoint) {
+  let nearestRect: IndexedClientRect | null = null
+  let nearestDistance = Number.POSITIVE_INFINITY
+
+  for (const rect of rects) {
+    const distance = getPointToRectDistanceSquared(point, rect.rect)
+    if (distance < nearestDistance) {
+      nearestRect = rect
+      nearestDistance = distance
+    }
+  }
+
+  return nearestRect
+}
+
+function readIndexedClientRects(ranges: SelectionRangeSnapshot[]) {
+  const rects: IndexedClientRect[] = []
+
+  for (const [rangeIndex, rangeSnapshot] of ranges.entries()) {
+    if (!rangeSnapshot.startContainer.isConnected || !rangeSnapshot.endContainer.isConnected) {
+      return null
+    }
+
+    let range: Range
+
+    try {
+      range = toLiveRange(rangeSnapshot)
+    } catch {
+      return null
+    }
+
+    let clientRects: DOMRect[]
+
+    try {
+      clientRects = Array.from(range.getClientRects()).filter(hasArea)
+      if (clientRects.length === 0) {
+        const boundingRect = range.getBoundingClientRect()
+        if (hasArea(boundingRect)) {
+          clientRects.push(boundingRect)
+        }
+      }
+    } catch {
+      return null
+    }
+
+    for (const [rectIndex, rect] of clientRects.entries()) {
+      rects.push({ rangeIndex, rectIndex, rect })
+    }
+  }
+
+  return rects
+}
+
+function isRectVisible(rect: DOMRect, viewport: ViewportRect) {
+  return (
+    rect.right > viewport.left &&
+    rect.left < viewport.right &&
+    rect.bottom > viewport.top &&
+    rect.top < viewport.bottom
+  )
+}
+
+export function getViewportRect(): ViewportRect {
+  const visualViewport = window.visualViewport
+  const left = visualViewport?.offsetLeft ?? 0
+  const top = visualViewport?.offsetTop ?? 0
+  const width = visualViewport?.width ?? window.innerWidth
+  const height = visualViewport?.height ?? window.innerHeight
+
+  return {
+    top,
+    right: left + width,
+    bottom: top + height,
+    left,
+    width,
+    height,
+  }
+}
+
+export function getSelectionDirection(startX: number, startY: number, endX: number, endY: number) {
+  const isRightward = startX <= endX
+  const isDownward = startY - DOWNWARD_TOLERANCE <= endY
+
+  if (isRightward && isDownward) return SelectionDirection.BOTTOM_RIGHT
+  if (isRightward && !isDownward) return SelectionDirection.TOP_RIGHT
+  if (!isRightward && isDownward) return SelectionDirection.BOTTOM_LEFT
+  return SelectionDirection.TOP_LEFT
+}
+
+export function getToolbarViewportPosition(
+  direction: SelectionDirection,
+  anchor: ViewportPoint,
+  toolbarSize: { width: number; height: number },
+  viewport: ViewportRect,
+  margin: number,
+) {
+  let left = anchor.x
+  let top = anchor.y
+
+  switch (direction) {
+    case SelectionDirection.BOTTOM_RIGHT:
+      top += CURSOR_CLEARANCE
+      break
+    case SelectionDirection.BOTTOM_LEFT:
+      left -= toolbarSize.width
+      top += CURSOR_CLEARANCE
+      break
+    case SelectionDirection.TOP_RIGHT:
+      top -= toolbarSize.height + CURSOR_CLEARANCE
+      break
+    case SelectionDirection.TOP_LEFT:
+      left -= toolbarSize.width
+      top -= toolbarSize.height + CURSOR_CLEARANCE
+      break
+    default:
+      break
+  }
+
+  const minLeft = viewport.left + margin
+  const maxLeft = Math.max(minLeft, viewport.right - toolbarSize.width - margin)
+  const minTop = viewport.top + margin
+  const maxTop = Math.max(minTop, viewport.bottom - toolbarSize.height - margin)
+
+  return {
+    x: clamp(left, minLeft, maxLeft),
+    y: clamp(top, minTop, maxTop),
+  }
+}
+
+export function viewportPointToHostPoint(point: ViewportPoint, host: ViewportHost) {
+  const hostRect = host.getBoundingClientRect()
+  const scaleX = host.offsetWidth > 0 && hostRect.width > 0 ? hostRect.width / host.offsetWidth : 1
+  const scaleY =
+    host.offsetHeight > 0 && hostRect.height > 0 ? hostRect.height / host.offsetHeight : 1
+
+  return {
+    x: (point.x - hostRect.left) / scaleX,
+    y: (point.y - hostRect.top) / scaleY,
+  }
+}
+
+export function createSelectionAnchorTracker(
+  ranges: SelectionRangeSnapshot[],
+  anchor: ViewportPoint,
+): SelectionAnchorTracker | null {
+  const rects = readIndexedClientRects(ranges)
+  if (!rects || rects.length === 0) {
+    return null
+  }
+
+  const referenceRect = getNearestRect(rects, anchor)
+  if (!referenceRect) {
+    return null
+  }
+
+  return {
+    ranges,
+    reference: {
+      rangeIndex: referenceRect.rangeIndex,
+      rectIndex: referenceRect.rectIndex,
+      offsetX: anchor.x - referenceRect.rect.left,
+      offsetY: anchor.y - referenceRect.rect.top,
+    },
+    lastAnchor: anchor,
+  }
+}
+
+export function measureSelectionAnchor(
+  tracker: SelectionAnchorTracker,
+  viewport: ViewportRect,
+): SelectionAnchorMeasurement {
+  const rects = readIndexedClientRects(tracker.ranges)
+  if (!rects) {
+    return { status: "invalid" }
+  }
+
+  const visibleRects = rects.filter(({ rect }) => isRectVisible(rect, viewport))
+  if (visibleRects.length === 0) {
+    return { status: "offscreen" }
+  }
+
+  const referenceRect = visibleRects.find(
+    ({ rangeIndex, rectIndex }) =>
+      rangeIndex === tracker.reference.rangeIndex && rectIndex === tracker.reference.rectIndex,
+  )
+
+  if (referenceRect) {
+    const anchor = {
+      x: referenceRect.rect.left + tracker.reference.offsetX,
+      y: referenceRect.rect.top + tracker.reference.offsetY,
+    }
+
+    return {
+      status: "visible",
+      anchor,
+      tracker: {
+        ...tracker,
+        lastAnchor: anchor,
+      },
+    }
+  }
+
+  const fallbackRect = getNearestRect(visibleRects, tracker.lastAnchor)
+  if (!fallbackRect) {
+    return { status: "offscreen" }
+  }
+
+  const anchor = {
+    x: clamp(tracker.lastAnchor.x, fallbackRect.rect.left, fallbackRect.rect.right),
+    y: clamp(tracker.lastAnchor.y, fallbackRect.rect.top, fallbackRect.rect.bottom),
+  }
+
+  return {
+    status: "visible",
+    anchor,
+    tracker: {
+      ranges: tracker.ranges,
+      reference: {
+        rangeIndex: fallbackRect.rangeIndex,
+        rectIndex: fallbackRect.rectIndex,
+        offsetX: anchor.x - fallbackRect.rect.left,
+        offsetY: anchor.y - fallbackRect.rect.top,
+      },
+      lastAnchor: anchor,
+    },
+  }
+}
+
+export function collectSelectionShadowRoots(ranges: SelectionRangeSnapshot[]) {
+  return collectSelectionScrollTargets(ranges).filter(isShadowRoot)
+}
+
+function isElement(node: Node): node is Element {
+  return node.nodeType === 1
+}
+
+function isShadowRoot(node: Node): node is ShadowRoot {
+  return node.nodeType === 11 && "host" in node
+}
+
+export function collectSelectionScrollTargets(ranges: SelectionRangeSnapshot[]) {
+  const scrollTargets = new Set<Element | ShadowRoot>()
+
+  for (const range of ranges) {
+    for (const boundaryNode of [range.startContainer, range.endContainer]) {
+      let current: Node | null = boundaryNode
+
+      while (current) {
+        if (isElement(current)) {
+          scrollTargets.add(current)
+        }
+
+        if (isShadowRoot(current)) {
+          scrollTargets.add(current)
+          current = current.host
+          continue
+        }
+
+        const root = current.getRootNode()
+        if (current.parentElement) {
+          current = current.parentElement
+        } else if (isShadowRoot(root)) {
+          current = root
+        } else {
+          current = null
+        }
+      }
+    }
+  }
+
+  return [...scrollTargets]
+}


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

- Position the selection toolbar in viewport coordinates so body, window, nested element, and Shadow DOM scrolling no longer moves it away from the selected text.
- Track the selected live range across scroll and viewport changes, including wrapped text fallback, visual viewport offsets, transformed fixed containing blocks, and toolbar resize boundary clamping.
- Hide the toolbar when the selection leaves the viewport without discarding the selection session, while still clearing the session when its DOM range becomes invalid.
- Coalesce scroll and resize measurements into a single animation frame and add a patch changeset for `@read-frog/extension`.

## Related Issue

<!-- No linked issue. -->

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

- `SKIP_FREE_API=true pnpm test` — 192 files and 1813 tests passed; the live free API test file was intentionally skipped.
- `pnpm type-check`
- `pnpm fmt:check`
- Chrome MV3 and Firefox MV3 production builds with non-sensitive test environment values.
- Built-extension Puppeteer checks on the OpenAI Developers page and local body, nested scroller, and Shadow DOM fixtures; the toolbar followed the selection and stayed closed after the selection moved fully offscreen.

## Screenshots

Not applicable; behavior is covered by automated positioning assertions and built-extension browser checks.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- iframe selection behavior is intentionally unchanged; this fix applies to scrolling contexts in the current document.
- The fixed-host correction supports translation and scaling. Rotated or skewed root transforms remain outside this change's scope.
