### PR TITLE
fix(translate): restore the active toolbar icon after page refresh

### DIFF
--- a/.changeset/green-frogs-refresh.md
+++ b/.changeset/green-frogs-refresh.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): restore the active toolbar icon after page refresh

--- a/src/entrypoints/background/__tests__/browser-action-icon.test.ts
+++ b/src/entrypoints/background/__tests__/browser-action-icon.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { browser, storage } from "#imports"
+import { getTranslationStateKey } from "@/utils/constants/storage-keys"
+
+const setIconMock = vi.fn<(...args: any[]) => any>()
+const storageGetItemMock = vi.fn<(...args: any[]) => any>()
+const storageOnChangedAddListenerMock = vi.fn<(...args: any[]) => any>()
+const webNavigationOnCommittedAddListenerMock = vi.fn<(...args: any[]) => any>()
+
+const DEFAULT_ACTION_ICON_PATHS = {
+  16: "/icon/16.png",
+  32: "/icon/32.png",
+  48: "/icon/48.png",
+}
+
+const ACTIVE_ACTION_ICON_PATHS = {
+  16: "/icon/16-active.png",
+  32: "/icon/32-active.png",
+  48: "/icon/48-active.png",
+}
+
+function getStorageChangeListener() {
+  const listener = storageOnChangedAddListenerMock.mock.calls.at(-1)?.[0]
+  if (!listener) {
+    throw new Error("Expected storage.session.onChanged listener to be registered")
+  }
+  return listener as (changes: Record<string, { newValue?: unknown }>) => Promise<void>
+}
+
+function getOnCommittedListener() {
+  const listener = webNavigationOnCommittedAddListenerMock.mock.calls.at(-1)?.[0]
+  if (!listener) {
+    throw new Error("Expected webNavigation.onCommitted listener to be registered")
+  }
+  return listener as (details: { tabId: number; frameId: number; url: string }) => Promise<void>
+}
+
+async function setupSubject() {
+  const { registerActionIconListeners } = await import("../browser-action-icon")
+  registerActionIconListeners()
+}
+
+describe("browser action icon", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    browser.action.setIcon = setIconMock
+    browser.storage.session.onChanged.addListener = storageOnChangedAddListenerMock
+    browser.webNavigation.onCommitted.addListener = webNavigationOnCommittedAddListenerMock
+    storage.getItem = storageGetItemMock
+
+    setIconMock.mockResolvedValue(undefined)
+    storageGetItemMock.mockResolvedValue(undefined)
+  })
+
+  it("updates the tab icon when translation state changes", async () => {
+    await setupSubject()
+
+    await getStorageChangeListener()({
+      "translationState.42": {
+        newValue: { enabled: true, origin: "https://example.com" },
+      },
+    })
+
+    expect(setIconMock).toHaveBeenCalledWith({
+      tabId: 42,
+      path: ACTIVE_ACTION_ICON_PATHS,
+    })
+  })
+
+  it("restores the active icon after same-origin top-frame navigation", async () => {
+    await setupSubject()
+    storageGetItemMock.mockResolvedValue({
+      enabled: true,
+      origin: "https://example.com",
+    })
+
+    await getOnCommittedListener()({
+      tabId: 42,
+      frameId: 0,
+      url: "https://example.com/articles/2?from=feed#comments",
+    })
+
+    expect(storageGetItemMock).toHaveBeenCalledWith(getTranslationStateKey(42))
+    expect(setIconMock).toHaveBeenCalledWith({
+      tabId: 42,
+      path: ACTIVE_ACTION_ICON_PATHS,
+    })
+  })
+
+  it("uses the default icon after cross-origin top-frame navigation", async () => {
+    await setupSubject()
+    storageGetItemMock.mockResolvedValue({
+      enabled: true,
+      origin: "https://example.com",
+    })
+
+    await getOnCommittedListener()({
+      tabId: 42,
+      frameId: 0,
+      url: "https://other.example.com/articles/2",
+    })
+
+    expect(setIconMock).toHaveBeenCalledWith({
+      tabId: 42,
+      path: DEFAULT_ACTION_ICON_PATHS,
+    })
+  })
+
+  it.each([
+    ["disabled", { enabled: false }],
+    ["missing", undefined],
+  ])("uses the default icon when translation state is %s", async (_label, state) => {
+    await setupSubject()
+    storageGetItemMock.mockResolvedValue(state)
+
+    await getOnCommittedListener()({
+      tabId: 42,
+      frameId: 0,
+      url: "https://example.com/articles/2",
+    })
+
+    expect(setIconMock).toHaveBeenCalledWith({
+      tabId: 42,
+      path: DEFAULT_ACTION_ICON_PATHS,
+    })
+  })
+
+  it("ignores iframe navigation", async () => {
+    await setupSubject()
+
+    await getOnCommittedListener()({
+      tabId: 42,
+      frameId: 7,
+      url: "https://embed.example.net/frame",
+    })
+
+    expect(storageGetItemMock).not.toHaveBeenCalled()
+    expect(setIconMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/entrypoints/background/browser-action-icon.ts
+++ b/src/entrypoints/background/browser-action-icon.ts
@@ -5,7 +5,11 @@ import {
   TRANSLATION_STATE_KEY_PREFIX,
 } from "@/utils/constants/storage-keys"
 import { logger } from "@/utils/logger"
-import { getPageTranslationEnabled } from "./page-translation-state"
+import {
+  getPageTranslationEnabled,
+  getPageTranslationState,
+  isPageTranslationStateInUrlScope,
+} from "./page-translation-state"
 
 type ActionIconSize = 16 | 32 | 48
 type ActionIconPathMap = Record<ActionIconSize, string>
@@ -47,6 +51,23 @@ export function registerActionIconListeners() {
         await updateActionIconForPageTranslation(tabId, enabled)
       }),
     )
+  })
+
+  browser.webNavigation.onCommitted.addListener(async (details) => {
+    if (details.frameId !== 0) return
+
+    try {
+      const state = await getPageTranslationState(details.tabId)
+      await updateActionIconForPageTranslation(
+        details.tabId,
+        isPageTranslationStateInUrlScope(state, details.url),
+      )
+    } catch (error) {
+      logger.warn("Failed to restore action icon after navigation", {
+        error,
+        tabId: details.tabId,
+      })
+    }
   })
 }
 


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Restore the active browser action icon after a translated page is refreshed or navigates within the same origin.

The browser resets tab-specific action icons on navigation even though the canonical page translation state remains enabled. The background now listens for committed top-frame navigation, reuses the existing translation state and URL-scope helpers, and reapplies either the active or default icon. Iframe navigation remains ignored.

Adds focused unit coverage and a patch changeset for the extension.

## Related Issue

No linked issue.

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation completed:

- Full test suite: 193 files, 1801 tests passed
- Type-aware lint and type check
- Full formatting check
- Chrome MV3 build
- Firefox MV3 build
- Built extension in real Chrome: active icon restored after reload and same-origin navigation, iframe navigation ignored, cross-origin navigation reset to the default icon

## Screenshots

Not applicable.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The floating-button Jotai atom is unchanged. Both UI surfaces continue to share the canonical background translation state without introducing a second source of truth.