### PR TITLE
fix(subtitles): show original captions while translation is pending

### DIFF
--- a/.changeset/show-original-while-translating.md
+++ b/.changeset/show-original-while-translating.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(subtitles): show original captions while translation is pending

--- a/src/assets/styles/theme.css
+++ b/src/assets/styles/theme.css
@@ -304,7 +304,10 @@ body {
     .animate-toast-success-odd,
     .animate-toast-success-even,
     .animate-toast-error-odd,
-    .animate-toast-error-even
+    .animate-toast-error-even,
+    .animate-subtitle-pending-breath,
+    .animate-subtitle-pending-appear,
+    .animate-subtitle-fade-in
   ) {
     animation: none;
   }

--- a/src/assets/styles/theme.css
+++ b/src/assets/styles/theme.css
@@ -69,6 +69,37 @@
   --animate-toast-success-even: toast-success-even 0.32s cubic-bezier(0.5, 1, 0.89, 1);
   --animate-toast-error-odd: toast-error-odd 0.28s cubic-bezier(0.5, 1, 0.89, 1);
   --animate-toast-error-even: toast-error-even 0.28s cubic-bezier(0.5, 1, 0.89, 1);
+  --animate-subtitle-pending-breath: subtitle-pending-breath 2s ease-in-out infinite;
+  --animate-subtitle-pending-appear: subtitle-pending-appear 250ms ease-out both;
+  --animate-subtitle-fade-in: subtitle-fade-in 200ms ease-out both;
+
+  @keyframes subtitle-pending-breath {
+    0%,
+    100% {
+      opacity: 0.22;
+    }
+    50% {
+      opacity: 0.58;
+    }
+  }
+
+  @keyframes subtitle-pending-appear {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes subtitle-fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
 
   @keyframes toast-success-odd {
     0% {

--- a/src/entrypoints/subtitles.content/__tests__/display-subtitle-atom.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/display-subtitle-atom.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest"
+import { configAtom } from "@/utils/atoms/config"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import {
   adPlayingAtom,
   currentSubtitleAtom,
@@ -6,6 +8,8 @@ import {
   displaySubtitleAtom,
   sourceTrackAtom,
   subtitlesShowContentAtom,
+  subtitlesShowStateAtom,
+  subtitlesStateAtom,
   subtitlesStore,
   subtitlesVisibleAtom,
 } from "../atoms"
@@ -15,7 +19,9 @@ describe("displaySubtitleAtom", () => {
     subtitlesStore.set(adPlayingAtom, false)
     subtitlesStore.set(currentSubtitleAtom, null)
     subtitlesStore.set(sourceTrackAtom, [])
+    subtitlesStore.set(subtitlesStateAtom, null)
     subtitlesStore.set(subtitlesVisibleAtom, false)
+    subtitlesStore.set(configAtom, DEFAULT_CONFIG)
   })
 
   it("falls back to source track when no translated cue is scheduled", () => {
@@ -65,6 +71,37 @@ describe("displaySubtitleAtom", () => {
       start: 2000,
       end: 3000,
     })
+  })
+
+  it("does not render a stale scheduled translation in translation-only mode", () => {
+    subtitlesStore.set(configAtom, {
+      ...DEFAULT_CONFIG,
+      videoSubtitles: {
+        ...DEFAULT_CONFIG.videoSubtitles,
+        style: {
+          ...DEFAULT_CONFIG.videoSubtitles.style,
+          displayMode: "translationOnly",
+        },
+      },
+    })
+    subtitlesStore.set(currentTimeMsAtom, 2500)
+    subtitlesStore.set(subtitlesStateAtom, { state: "loading" })
+    subtitlesStore.set(subtitlesVisibleAtom, true)
+    subtitlesStore.set(sourceTrackAtom, [{ text: "later", start: 2000, end: 3000 }])
+    subtitlesStore.set(currentSubtitleAtom, {
+      text: "hello",
+      start: 0,
+      end: 1000,
+      translation: "你好",
+    })
+
+    expect(subtitlesStore.get(displaySubtitleAtom)).toEqual({
+      text: "later",
+      start: 2000,
+      end: 3000,
+    })
+    expect(subtitlesStore.get(subtitlesShowContentAtom)).toBe(false)
+    expect(subtitlesStore.get(subtitlesShowStateAtom)).toBe("loading")
   })
 
   it("hides main-video captions while an ad is playing", () => {

--- a/src/entrypoints/subtitles.content/__tests__/display-subtitle-atom.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/display-subtitle-atom.test.ts
@@ -46,6 +46,27 @@ describe("displaySubtitleAtom", () => {
     expect(subtitlesStore.get(displaySubtitleAtom)?.translation).toBe("你好")
   })
 
+  it("ignores a stale scheduled cue that no longer covers the current time", () => {
+    subtitlesStore.set(currentTimeMsAtom, 2500)
+    subtitlesStore.set(sourceTrackAtom, [
+      { text: "hello", start: 0, end: 1000 },
+      { text: "later", start: 2000, end: 3000 },
+    ])
+    // Scheduler atom lagging behind the clock.
+    subtitlesStore.set(currentSubtitleAtom, {
+      text: "hello",
+      start: 0,
+      end: 1000,
+      translation: "你好",
+    })
+
+    expect(subtitlesStore.get(displaySubtitleAtom)).toEqual({
+      text: "later",
+      start: 2000,
+      end: 3000,
+    })
+  })
+
   it("hides main-video captions while an ad is playing", () => {
     subtitlesStore.set(currentTimeMsAtom, 500)
     subtitlesStore.set(subtitlesVisibleAtom, true)

--- a/src/entrypoints/subtitles.content/__tests__/display-subtitle-atom.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/display-subtitle-atom.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import {
+  currentSubtitleAtom,
+  currentTimeMsAtom,
+  displaySubtitleAtom,
+  sourceTrackAtom,
+  subtitlesStore,
+} from "../atoms"
+
+describe("displaySubtitleAtom", () => {
+  it("falls back to source track when no translated cue is scheduled", () => {
+    subtitlesStore.set(currentTimeMsAtom, 500)
+    subtitlesStore.set(currentSubtitleAtom, null)
+    subtitlesStore.set(sourceTrackAtom, [
+      { text: "hello", start: 0, end: 1000 },
+      { text: "world", start: 1000, end: 2000 },
+    ])
+
+    expect(subtitlesStore.get(displaySubtitleAtom)).toEqual({
+      text: "hello",
+      start: 0,
+      end: 1000,
+    })
+  })
+
+  it("prefers the translated scheduler cue when present", () => {
+    subtitlesStore.set(currentTimeMsAtom, 500)
+    subtitlesStore.set(sourceTrackAtom, [{ text: "hello", start: 0, end: 1000 }])
+    subtitlesStore.set(currentSubtitleAtom, {
+      text: "hello",
+      start: 0,
+      end: 1000,
+      translation: "你好",
+    })
+
+    expect(subtitlesStore.get(displaySubtitleAtom)?.translation).toBe("你好")
+  })
+})

--- a/src/entrypoints/subtitles.content/__tests__/display-subtitle-atom.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/display-subtitle-atom.test.ts
@@ -1,13 +1,23 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it } from "vitest"
 import {
+  adPlayingAtom,
   currentSubtitleAtom,
   currentTimeMsAtom,
   displaySubtitleAtom,
   sourceTrackAtom,
+  subtitlesShowContentAtom,
   subtitlesStore,
+  subtitlesVisibleAtom,
 } from "../atoms"
 
 describe("displaySubtitleAtom", () => {
+  afterEach(() => {
+    subtitlesStore.set(adPlayingAtom, false)
+    subtitlesStore.set(currentSubtitleAtom, null)
+    subtitlesStore.set(sourceTrackAtom, [])
+    subtitlesStore.set(subtitlesVisibleAtom, false)
+  })
+
   it("falls back to source track when no translated cue is scheduled", () => {
     subtitlesStore.set(currentTimeMsAtom, 500)
     subtitlesStore.set(currentSubtitleAtom, null)
@@ -34,5 +44,23 @@ describe("displaySubtitleAtom", () => {
     })
 
     expect(subtitlesStore.get(displaySubtitleAtom)?.translation).toBe("你好")
+  })
+
+  it("hides main-video captions while an ad is playing", () => {
+    subtitlesStore.set(currentTimeMsAtom, 500)
+    subtitlesStore.set(subtitlesVisibleAtom, true)
+    subtitlesStore.set(sourceTrackAtom, [{ text: "hello", start: 0, end: 1000 }])
+    subtitlesStore.set(currentSubtitleAtom, {
+      text: "hello",
+      start: 0,
+      end: 1000,
+      translation: "你好",
+    })
+    subtitlesStore.set(adPlayingAtom, true)
+
+    expect(subtitlesStore.get(displaySubtitleAtom)).toBeNull()
+    expect(subtitlesStore.get(subtitlesShowContentAtom)).toBe(false)
+    // User toggle intent stays on.
+    expect(subtitlesStore.get(subtitlesVisibleAtom)).toBe(true)
   })
 })

--- a/src/entrypoints/subtitles.content/__tests__/segmentation-pipeline.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/segmentation-pipeline.test.ts
@@ -120,6 +120,31 @@ describe("segmentation pipeline", () => {
     ])
   })
 
+  it("falls back to local optimize when config is missing instead of orphaning the chunk", async () => {
+    const { getLocalConfig } = await import("@/utils/config/storage")
+    vi.mocked(getLocalConfig).mockResolvedValueOnce(null)
+
+    const rawFragments = [
+      { text: "hello", start: 0, end: 500 },
+      { text: "world", start: 500, end: 1000 },
+    ]
+    const onChunkSegmented = vi.fn<(...args: any[]) => any>()
+
+    const pipeline = new SegmentationPipeline({
+      baselineFragments: [{ text: "hello world", start: 0, end: 1000 }],
+      rawFragments,
+      getVideoElement: () => ({ currentTime: 0 }) as HTMLVideoElement,
+      getSourceLanguage: () => "en",
+      onChunkSegmented,
+    })
+
+    await (pipeline as any).processNextChunk(0)
+
+    expect(onChunkSegmented).toHaveBeenCalled()
+    // Starts must not remain "segmented" with no replacement applied.
+    expect(pipeline.processedFragments.length).toBeGreaterThan(0)
+  })
+
   it("replaceProcessedChunk drops cues that overlap the window by interval", () => {
     const pipeline = new SegmentationPipeline({
       baselineFragments: [

--- a/src/entrypoints/subtitles.content/__tests__/segmentation-pipeline.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/segmentation-pipeline.test.ts
@@ -119,4 +119,36 @@ describe("segmentation pipeline", () => {
       { text: "hello world", start: 0, end: 1000 },
     ])
   })
+
+  it("does not apply segmentation results after stop", async () => {
+    const rawFragments = [
+      { text: "hello", start: 0, end: 500 },
+      { text: "world", start: 500, end: 1000 },
+    ]
+    const onChunkSegmented = vi.fn<(...args: any[]) => any>()
+    let resolveAi: (value: any) => void
+    const aiPromise = new Promise((resolve) => {
+      resolveAi = resolve
+    })
+
+    const { aiSegmentBlock } = await import("@/utils/subtitles/processor/ai-segmentation")
+    vi.mocked(aiSegmentBlock).mockImplementationOnce(() => aiPromise as any)
+
+    const pipeline = new SegmentationPipeline({
+      baselineFragments: [{ text: "hello world", start: 0, end: 1000 }],
+      rawFragments,
+      getVideoElement: () => ({ currentTime: 0 }) as HTMLVideoElement,
+      getSourceLanguage: () => "en",
+      onChunkSegmented,
+    })
+
+    const pending = (pipeline as any).processNextChunk(0)
+    pipeline.stop()
+    resolveAi!([{ text: "hello world", start: 0, end: 1000 }])
+    await pending
+
+    expect(onChunkSegmented).not.toHaveBeenCalled()
+    // Baseline fragments remain untouched after stop mid-flight.
+    expect(pipeline.processedFragments).toEqual([{ text: "hello world", start: 0, end: 1000 }])
+  })
 })

--- a/src/entrypoints/subtitles.content/__tests__/segmentation-pipeline.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/segmentation-pipeline.test.ts
@@ -96,4 +96,27 @@ describe("segmentation pipeline", () => {
     expect(afterAdvance).toBeGreaterThan(afterStart)
     expect(afterAdvance).toBeLessThan(150_000 + 2 * PROCESS_LOOK_AHEAD_MS)
   })
+
+  it("notifies onChunkSegmented after replacing a processed chunk", async () => {
+    const rawFragments = [
+      { text: "hello", start: 0, end: 500 },
+      { text: "world", start: 500, end: 1000 },
+    ]
+    const onChunkSegmented = vi.fn<(...args: any[]) => any>()
+
+    const pipeline = new SegmentationPipeline({
+      baselineFragments: [{ text: "hello world", start: 0, end: 1000 }],
+      rawFragments,
+      getVideoElement: () => ({ currentTime: 0 }) as HTMLVideoElement,
+      getSourceLanguage: () => "en",
+      onChunkSegmented,
+    })
+
+    await (pipeline as any).processNextChunk(0)
+
+    expect(onChunkSegmented).toHaveBeenCalledTimes(1)
+    expect(onChunkSegmented).toHaveBeenCalledWith(rawFragments, [
+      { text: "hello world", start: 0, end: 1000 },
+    ])
+  })
 })

--- a/src/entrypoints/subtitles.content/__tests__/segmentation-pipeline.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/segmentation-pipeline.test.ts
@@ -120,6 +120,34 @@ describe("segmentation pipeline", () => {
     ])
   })
 
+  it("replaceProcessedChunk drops cues that overlap the window by interval", () => {
+    const pipeline = new SegmentationPipeline({
+      baselineFragments: [
+        { text: "spans into window", start: 0, end: 1500 },
+        { text: "after", start: 2000, end: 3000 },
+      ],
+      rawFragments: [
+        { text: "a", start: 1000, end: 1500 },
+        { text: "b", start: 1500, end: 2000 },
+      ],
+      getVideoElement: () => ({ currentTime: 0 }) as HTMLVideoElement,
+      getSourceLanguage: () => "en",
+    })
+
+    ;(pipeline as any).replaceProcessedChunk(
+      [
+        { text: "a", start: 1000, end: 1500 },
+        { text: "b", start: 1500, end: 2000 },
+      ],
+      [{ text: "recut", start: 1000, end: 2000 }],
+    )
+
+    expect(pipeline.processedFragments).toEqual([
+      { text: "recut", start: 1000, end: 2000 },
+      { text: "after", start: 2000, end: 3000 },
+    ])
+  })
+
   it("does not apply segmentation results after stop", async () => {
     const rawFragments = [
       { text: "hello", start: 0, end: 500 },

--- a/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
@@ -131,4 +131,32 @@ describe("subtitles scheduler", () => {
     ;(scheduler as any).updateSubtitles(2.1)
     expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("after")
   })
+
+  it("reconcileTranslatedCuesAfterRecut keeps translations for unchanged identities", () => {
+    const video = createVideo(0.25)
+    const scheduler = new SubtitlesScheduler({ videoElement: video })
+    scheduler.start()
+
+    scheduler.supplementSubtitles([
+      { text: "keep me", start: 0, end: 1000, translation: "保留" },
+      { text: "old cut", start: 1000, end: 2000, translation: "旧" },
+    ])
+
+    scheduler.reconcileTranslatedCuesAfterRecut(0, 2000, [
+      { text: "keep me", start: 0, end: 1000 },
+      { text: "new cut", start: 1000, end: 2000 },
+    ])
+
+    expect(subtitlesStore.get(currentSubtitleAtom)).toEqual({
+      text: "keep me",
+      start: 0,
+      end: 1000,
+      translation: "保留",
+    })
+
+    video.currentTime = 1.2
+    ;(scheduler as any).updateSubtitles(1.2)
+    // Recut line must not keep the old translation under a changed identity.
+    expect(subtitlesStore.get(currentSubtitleAtom)).toBeNull()
+  })
 })

--- a/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
@@ -1,27 +1,143 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { subtitlesStateAtom, subtitlesStore } from "../atoms"
+import { currentSubtitleAtom, subtitlesStateAtom, subtitlesStore } from "../atoms"
 import { SubtitlesScheduler } from "../subtitles-scheduler"
+
+function createVideo(currentTime = 0) {
+  return {
+    currentTime,
+    addEventListener: vi.fn<(...args: any[]) => any>(),
+    removeEventListener: vi.fn<(...args: any[]) => any>(),
+  } as unknown as HTMLVideoElement
+}
 
 describe("subtitles scheduler", () => {
   afterEach(() => {
     vi.useRealTimers()
+    subtitlesStore.set(currentSubtitleAtom, null)
+    subtitlesStore.set(subtitlesStateAtom, null)
   })
 
   it("auto-hides error state after a delay", () => {
     vi.useFakeTimers()
 
-    const videoElement = {
-      currentTime: 0,
-      addEventListener: vi.fn<(...args: any[]) => any>(),
-      removeEventListener: vi.fn<(...args: any[]) => any>(),
-    } as unknown as HTMLVideoElement
-
-    const scheduler = new SubtitlesScheduler({ videoElement })
+    const scheduler = new SubtitlesScheduler({ videoElement: createVideo() })
     scheduler.setState("error", { message: "boom" })
 
     expect(subtitlesStore.get(subtitlesStateAtom)?.state).toBe("error")
 
     vi.advanceTimersByTime(5_000)
     expect(subtitlesStore.get(subtitlesStateAtom)).toBeNull()
+  })
+
+  it("shows original fragments immediately after supplement without translation", () => {
+    const video = createVideo(0.25)
+    const scheduler = new SubtitlesScheduler({ videoElement: video })
+    scheduler.start()
+
+    scheduler.supplementSubtitles([{ text: "hello world", start: 0, end: 1000 }])
+
+    expect(subtitlesStore.get(currentSubtitleAtom)).toEqual({
+      text: "hello world",
+      start: 0,
+      end: 1000,
+    })
+  })
+
+  it("fills in translation on an existing original cue", () => {
+    const video = createVideo(0.25)
+    const scheduler = new SubtitlesScheduler({ videoElement: video })
+    scheduler.start()
+
+    scheduler.supplementSubtitles([{ text: "hello world", start: 0, end: 1000 }])
+    scheduler.supplementSubtitles(
+      [{ text: "hello world", start: 0, end: 1000, translation: "你好世界" }],
+      { mergeOnly: true },
+    )
+
+    expect(subtitlesStore.get(currentSubtitleAtom)).toEqual({
+      text: "hello world",
+      start: 0,
+      end: 1000,
+      translation: "你好世界",
+    })
+  })
+
+  it("applies empty-string translation in mergeOnly mode without re-inserting unknown starts", () => {
+    const video = createVideo(0.25)
+    const scheduler = new SubtitlesScheduler({ videoElement: video })
+    scheduler.start()
+
+    scheduler.supplementSubtitles([{ text: "hello world", start: 0, end: 1000 }])
+    scheduler.supplementSubtitles(
+      [
+        { text: "hello world", start: 0, end: 1000, translation: "" },
+        { text: "stale cue", start: 9999, end: 10_000, translation: "幽灵" },
+      ],
+      { mergeOnly: true },
+    )
+
+    expect(subtitlesStore.get(currentSubtitleAtom)).toEqual({
+      text: "hello world",
+      start: 0,
+      end: 1000,
+      translation: "",
+    })
+
+    video.currentTime = 10
+    ;(scheduler as any).updateSubtitles(10)
+    expect(subtitlesStore.get(currentSubtitleAtom)).toBeNull()
+  })
+
+  it("replaceTimeWindow removes cues in the window and inserts next fragments", () => {
+    // Start outside any cue so nothing is sticky-protected during replace.
+    const video = createVideo(10)
+    const scheduler = new SubtitlesScheduler({ videoElement: video })
+    scheduler.start()
+
+    scheduler.supplementSubtitles([
+      { text: "a", start: 0, end: 500 },
+      { text: "b", start: 500, end: 1000 },
+      { text: "c", start: 2000, end: 2500 },
+    ])
+
+    scheduler.replaceTimeWindow(0, 1000, [{ text: "ab", start: 0, end: 1000 }])
+
+    // Seek into the replaced window
+    video.currentTime = 0.25
+    ;(scheduler as any).updateSubtitles(0.25)
+
+    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("ab")
+
+    // Cue outside the window remains
+    video.currentTime = 2.1
+    ;(scheduler as any).updateSubtitles(2.1)
+    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("c")
+  })
+
+  it("keeps the active cue sticky when re-segmentation overlaps the current time", () => {
+    const video = createVideo(0.5)
+    const scheduler = new SubtitlesScheduler({ videoElement: video })
+    scheduler.start()
+
+    scheduler.supplementSubtitles([{ text: "hello world foo", start: 0, end: 2000 }])
+    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("hello world foo")
+
+    scheduler.replaceTimeWindow(0, 2000, [
+      { text: "hello world", start: 0, end: 1000 },
+      { text: "foo", start: 1000, end: 2000 },
+      { text: "after", start: 2000, end: 3000 },
+    ])
+
+    // Still inside the protected baseline cue — must not jump mid-line.
+    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("hello world foo")
+
+    video.currentTime = 1.5
+    ;(scheduler as any).updateSubtitles(1.5)
+    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("hello world foo")
+
+    // After the protected cue ends, use the next available cue.
+    video.currentTime = 2.1
+    ;(scheduler as any).updateSubtitles(2.1)
+    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("after")
   })
 })

--- a/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
@@ -140,4 +140,29 @@ describe("subtitles scheduler", () => {
     ;(scheduler as any).updateSubtitles(2.1)
     expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("after")
   })
+
+  it("does not merge a recut same-start translation onto a protected longer cue", () => {
+    const video = createVideo(0.5)
+    const scheduler = new SubtitlesScheduler({ videoElement: video })
+    scheduler.start()
+
+    scheduler.supplementSubtitles([{ text: "hello world foo", start: 0, end: 2000 }])
+    scheduler.replaceTimeWindow(0, 2000, [
+      { text: "hello world", start: 0, end: 1000 },
+      { text: "foo", start: 1000, end: 2000 },
+    ])
+
+    // Translation for the recut shorter cue (same start, different end/text).
+    scheduler.supplementSubtitles(
+      [{ text: "hello world", start: 0, end: 1000, translation: "你好世界" }],
+      { mergeOnly: true },
+    )
+
+    // Protected baseline must not pick up the recut line's translation.
+    expect(subtitlesStore.get(currentSubtitleAtom)).toEqual({
+      text: "hello world foo",
+      start: 0,
+      end: 2000,
+    })
+  })
 })

--- a/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
@@ -93,4 +93,27 @@ describe("subtitles scheduler", () => {
     ;(scheduler as any).updateSubtitles(2.1)
     expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("c")
   })
+
+  it("removeCuesInTimeWindow drops cues that span into the window", () => {
+    const video = createVideo(1.2)
+    const scheduler = new SubtitlesScheduler({ videoElement: video })
+    scheduler.start()
+
+    // start is before the window, but the cue overlaps [1000, 2000).
+    scheduler.supplementSubtitles([
+      { text: "span", start: 0, end: 1500, translation: "跨界" },
+      { text: "after", start: 2000, end: 3000, translation: "后" },
+    ])
+
+    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("span")
+
+    scheduler.removeCuesInTimeWindow(1000, 2000)
+
+    // Spanning translation must not remain preferred over the recut source track.
+    expect(subtitlesStore.get(currentSubtitleAtom)).toBeNull()
+
+    video.currentTime = 2.1
+    ;(scheduler as any).updateSubtitles(2.1)
+    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("after")
+  })
 })

--- a/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
@@ -30,6 +30,21 @@ describe("subtitles scheduler", () => {
     expect(subtitlesStore.get(currentTimeMsAtom)).toBe(12_500)
   })
 
+  it("resyncFromVideo refreshes the active cue from the live clock", () => {
+    const video = createVideo(0.25)
+    const scheduler = new SubtitlesScheduler({ videoElement: video })
+    scheduler.start()
+    scheduler.supplementSubtitles([
+      { text: "early", start: 0, end: 1000, translation: "早" },
+      { text: "later", start: 2000, end: 3000, translation: "晚" },
+    ])
+    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("early")
+
+    video.currentTime = 2.1
+    scheduler.resyncFromVideo()
+    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("later")
+  })
+
   it("auto-hides error state after a delay", () => {
     vi.useFakeTimers()
 

--- a/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
@@ -89,27 +89,7 @@ describe("subtitles scheduler", () => {
     expect(subtitlesStore.get(currentSubtitleAtom)?.translation).toBe("你好世界")
   })
 
-  it("removeCuesInTimeWindow drops translated cues in the window", () => {
-    const video = createVideo(0.25)
-    const scheduler = new SubtitlesScheduler({ videoElement: video })
-    scheduler.start()
-
-    scheduler.supplementSubtitles([
-      { text: "a", start: 0, end: 500, translation: "A" },
-      { text: "b", start: 500, end: 1000, translation: "B" },
-      { text: "c", start: 2000, end: 2500, translation: "C" },
-    ])
-
-    scheduler.removeCuesInTimeWindow(0, 1000)
-
-    expect(subtitlesStore.get(currentSubtitleAtom)).toBeNull()
-
-    video.currentTime = 2.1
-    ;(scheduler as any).updateSubtitles(2.1)
-    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("c")
-  })
-
-  it("removeCuesInTimeWindow drops cues that span into the window", () => {
+  it("reconcileTranslatedCuesAfterRecut drops cues that span into the window", () => {
     const video = createVideo(1.2)
     const scheduler = new SubtitlesScheduler({ videoElement: video })
     scheduler.start()
@@ -122,7 +102,9 @@ describe("subtitles scheduler", () => {
 
     expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("span")
 
-    scheduler.removeCuesInTimeWindow(1000, 2000)
+    scheduler.reconcileTranslatedCuesAfterRecut(1000, 2000, [
+      { text: "recut", start: 1000, end: 2000 },
+    ])
 
     // Spanning translation must not remain preferred over the recut source track.
     expect(subtitlesStore.get(currentSubtitleAtom)).toBeNull()

--- a/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { currentSubtitleAtom, subtitlesStateAtom, subtitlesStore } from "../atoms"
+import {
+  currentSubtitleAtom,
+  currentTimeMsAtom,
+  subtitlesStateAtom,
+  subtitlesStore,
+} from "../atoms"
 import { SubtitlesScheduler } from "../subtitles-scheduler"
 
 function createVideo(currentTime = 0) {
@@ -15,6 +20,14 @@ describe("subtitles scheduler", () => {
     vi.useRealTimers()
     subtitlesStore.set(currentSubtitleAtom, null)
     subtitlesStore.set(subtitlesStateAtom, null)
+    subtitlesStore.set(currentTimeMsAtom, 0)
+  })
+
+  it("syncs currentTimeMsAtom on start without waiting for timeupdate", () => {
+    subtitlesStore.set(currentTimeMsAtom, 0)
+    const scheduler = new SubtitlesScheduler({ videoElement: createVideo(12.5) })
+    scheduler.start()
+    expect(subtitlesStore.get(currentTimeMsAtom)).toBe(12_500)
   })
 
   it("auto-hides error state after a delay", () => {

--- a/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
@@ -29,30 +29,14 @@ describe("subtitles scheduler", () => {
     expect(subtitlesStore.get(subtitlesStateAtom)).toBeNull()
   })
 
-  it("shows original fragments immediately after supplement without translation", () => {
+  it("holds only translated cues via supplementSubtitles", () => {
     const video = createVideo(0.25)
     const scheduler = new SubtitlesScheduler({ videoElement: video })
     scheduler.start()
 
-    scheduler.supplementSubtitles([{ text: "hello world", start: 0, end: 1000 }])
-
-    expect(subtitlesStore.get(currentSubtitleAtom)).toEqual({
-      text: "hello world",
-      start: 0,
-      end: 1000,
-    })
-  })
-
-  it("fills in translation on an existing original cue", () => {
-    const video = createVideo(0.25)
-    const scheduler = new SubtitlesScheduler({ videoElement: video })
-    scheduler.start()
-
-    scheduler.supplementSubtitles([{ text: "hello world", start: 0, end: 1000 }])
-    scheduler.supplementSubtitles(
-      [{ text: "hello world", start: 0, end: 1000, translation: "你好世界" }],
-      { mergeOnly: true },
-    )
+    scheduler.supplementSubtitles([
+      { text: "hello world", start: 0, end: 1000, translation: "你好世界" },
+    ])
 
     expect(subtitlesStore.get(currentSubtitleAtom)).toEqual({
       text: "hello world",
@@ -62,132 +46,38 @@ describe("subtitles scheduler", () => {
     })
   })
 
-  it("applies empty-string translation in mergeOnly mode without re-inserting unknown starts", () => {
+  it("updates translation on an existing cue", () => {
     const video = createVideo(0.25)
     const scheduler = new SubtitlesScheduler({ videoElement: video })
     scheduler.start()
 
-    scheduler.supplementSubtitles([{ text: "hello world", start: 0, end: 1000 }])
-    scheduler.supplementSubtitles(
-      [
-        { text: "hello world", start: 0, end: 1000, translation: "" },
-        { text: "stale cue", start: 9999, end: 10_000, translation: "幽灵" },
-      ],
-      { mergeOnly: true },
-    )
+    scheduler.supplementSubtitles([
+      { text: "hello world", start: 0, end: 1000, translation: "你好" },
+    ])
+    scheduler.supplementSubtitles([
+      { text: "hello world", start: 0, end: 1000, translation: "你好世界" },
+    ])
 
-    expect(subtitlesStore.get(currentSubtitleAtom)).toEqual({
-      text: "hello world",
-      start: 0,
-      end: 1000,
-      translation: "",
-    })
-
-    video.currentTime = 10
-    ;(scheduler as any).updateSubtitles(10)
-    expect(subtitlesStore.get(currentSubtitleAtom)).toBeNull()
+    expect(subtitlesStore.get(currentSubtitleAtom)?.translation).toBe("你好世界")
   })
 
-  it("replaceTimeWindow removes cues in the window and inserts next fragments", () => {
-    // Start outside any cue so nothing is sticky-protected during replace.
-    const video = createVideo(10)
+  it("removeCuesInTimeWindow drops translated cues in the window", () => {
+    const video = createVideo(0.25)
     const scheduler = new SubtitlesScheduler({ videoElement: video })
     scheduler.start()
 
     scheduler.supplementSubtitles([
-      { text: "a", start: 0, end: 500 },
-      { text: "b", start: 500, end: 1000 },
-      { text: "c", start: 2000, end: 2500 },
+      { text: "a", start: 0, end: 500, translation: "A" },
+      { text: "b", start: 500, end: 1000, translation: "B" },
+      { text: "c", start: 2000, end: 2500, translation: "C" },
     ])
 
-    scheduler.replaceTimeWindow(0, 1000, [{ text: "ab", start: 0, end: 1000 }])
+    scheduler.removeCuesInTimeWindow(0, 1000)
 
-    // Seek into the replaced window
-    video.currentTime = 0.25
-    ;(scheduler as any).updateSubtitles(0.25)
+    expect(subtitlesStore.get(currentSubtitleAtom)).toBeNull()
 
-    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("ab")
-
-    // Cue outside the window remains
     video.currentTime = 2.1
     ;(scheduler as any).updateSubtitles(2.1)
     expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("c")
-  })
-
-  it("keeps the active cue sticky when re-segmentation overlaps the current time", () => {
-    const video = createVideo(0.5)
-    const scheduler = new SubtitlesScheduler({ videoElement: video })
-    scheduler.start()
-
-    scheduler.supplementSubtitles([{ text: "hello world foo", start: 0, end: 2000 }])
-    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("hello world foo")
-
-    scheduler.replaceTimeWindow(0, 2000, [
-      { text: "hello world", start: 0, end: 1000 },
-      { text: "foo", start: 1000, end: 2000 },
-      { text: "after", start: 2000, end: 3000 },
-    ])
-
-    // Still inside the protected baseline cue — must not jump mid-line.
-    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("hello world foo")
-
-    video.currentTime = 1.5
-    ;(scheduler as any).updateSubtitles(1.5)
-    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("hello world foo")
-
-    // After the protected cue ends, use the next available cue.
-    video.currentTime = 2.1
-    ;(scheduler as any).updateSubtitles(2.1)
-    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("after")
-  })
-
-  it("does not merge a recut same-start translation onto a protected longer cue", () => {
-    const video = createVideo(0.5)
-    const scheduler = new SubtitlesScheduler({ videoElement: video })
-    scheduler.start()
-
-    scheduler.supplementSubtitles([{ text: "hello world foo", start: 0, end: 2000 }])
-    scheduler.replaceTimeWindow(0, 2000, [
-      { text: "hello world", start: 0, end: 1000 },
-      { text: "foo", start: 1000, end: 2000 },
-    ])
-
-    // Translation for the recut shorter cue (same start, different end/text).
-    scheduler.supplementSubtitles(
-      [{ text: "hello world", start: 0, end: 1000, translation: "你好世界" }],
-      { mergeOnly: true },
-    )
-
-    // Protected baseline must not pick up the recut line's translation.
-    expect(subtitlesStore.get(currentSubtitleAtom)).toEqual({
-      text: "hello world foo",
-      start: 0,
-      end: 2000,
-    })
-  })
-
-  it("installs deferred same-start recut cue after the protected baseline expires", () => {
-    const video = createVideo(0.5)
-    const scheduler = new SubtitlesScheduler({ videoElement: video })
-    scheduler.start()
-
-    scheduler.supplementSubtitles([{ text: "hello world foo", start: 0, end: 2000 }])
-    scheduler.replaceTimeWindow(0, 2000, [
-      { text: "hello world", start: 0, end: 1000 },
-      { text: "foo", start: 1000, end: 2000 },
-    ])
-
-    // While protected, still the long baseline.
-    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("hello world foo")
-
-    // Leave the protected range — deferred recut should replace the baseline.
-    video.currentTime = 2.1
-    ;(scheduler as any).updateSubtitles(2.1)
-
-    // Seek back into the first recut segment.
-    video.currentTime = 0.5
-    ;(scheduler as any).updateSubtitles(0.5)
-    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("hello world")
-    expect(subtitlesStore.get(currentSubtitleAtom)?.end).toBe(1000)
   })
 })

--- a/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/subtitles-scheduler.test.ts
@@ -165,4 +165,29 @@ describe("subtitles scheduler", () => {
       end: 2000,
     })
   })
+
+  it("installs deferred same-start recut cue after the protected baseline expires", () => {
+    const video = createVideo(0.5)
+    const scheduler = new SubtitlesScheduler({ videoElement: video })
+    scheduler.start()
+
+    scheduler.supplementSubtitles([{ text: "hello world foo", start: 0, end: 2000 }])
+    scheduler.replaceTimeWindow(0, 2000, [
+      { text: "hello world", start: 0, end: 1000 },
+      { text: "foo", start: 1000, end: 2000 },
+    ])
+
+    // While protected, still the long baseline.
+    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("hello world foo")
+
+    // Leave the protected range — deferred recut should replace the baseline.
+    video.currentTime = 2.1
+    ;(scheduler as any).updateSubtitles(2.1)
+
+    // Seek back into the first recut segment.
+    video.currentTime = 0.5
+    ;(scheduler as any).updateSubtitles(0.5)
+    expect(subtitlesStore.get(currentSubtitleAtom)?.text).toBe("hello world")
+    expect(subtitlesStore.get(currentSubtitleAtom)?.end).toBe(1000)
+  })
 })

--- a/src/entrypoints/subtitles.content/__tests__/translation-coordinator.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/translation-coordinator.test.ts
@@ -101,7 +101,8 @@ describe("translation coordinator loading state", () => {
     expect(spy).toHaveBeenCalledTimes(1)
 
     coordinator.stop()
-    const batch = spy.mock.calls[0][0] as Array<{ text: string; start: number; end: number }>
+    const firstCall = spy.mock.calls[0]!
+    const batch = firstCall[0] as Array<{ text: string; start: number; end: number }>
     resolveTranslate(batch.map((f) => ({ ...f, translation: `t:${f.text}` })))
     await Promise.resolve()
     await Promise.resolve()
@@ -184,13 +185,13 @@ describe("translation coordinator loading state", () => {
     expect(spy).toHaveBeenCalledTimes(2)
 
     // Stale first-run result.
-    resolvers[0]([{ text: "a", start: 0, end: 1000, translation: "STALE" }])
+    resolvers[0]!([{ text: "a", start: 0, end: 1000, translation: "STALE" }])
     await Promise.resolve()
     await Promise.resolve()
     expect(onTranslated).not.toHaveBeenCalled()
 
     // Current-run result.
-    resolvers[1]([{ text: "a", start: 0, end: 1000, translation: "FRESH" }])
+    resolvers[1]!([{ text: "a", start: 0, end: 1000, translation: "FRESH" }])
     await Promise.resolve()
     await Promise.resolve()
     expect(onTranslated).toHaveBeenCalledWith([expect.objectContaining({ translation: "FRESH" })])

--- a/src/entrypoints/subtitles.content/__tests__/translation-coordinator.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/translation-coordinator.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest"
+import { TranslationCoordinator } from "../translation-coordinator"
+
+describe("translation coordinator loading state", () => {
+  it("sets loading for the active untranslated cue", () => {
+    const onStateChange = vi.fn<(...args: any[]) => any>()
+    const coordinator = new TranslationCoordinator({
+      getFragments: () => [{ text: "hello", start: 0, end: 1000 }],
+      getVideoElement: () => ({ currentTime: 0.5 }) as HTMLVideoElement,
+      getCurrentState: () => "idle",
+      segmentationPipeline: null,
+      onTranslated: vi.fn<(...args: any[]) => any>(),
+      onStateChange,
+    })
+
+    ;(coordinator as any).updateLoadingStateAt(500, [{ text: "hello", start: 0, end: 1000 }])
+
+    expect(onStateChange).toHaveBeenCalledWith("loading")
+  })
+
+  it("does not keep loading in a cue gap just because the next cue is untranslated", () => {
+    const onStateChange = vi.fn<(...args: any[]) => any>()
+    const coordinator = new TranslationCoordinator({
+      getFragments: () => [
+        { text: "hello", start: 0, end: 1000 },
+        { text: "world", start: 2000, end: 3000 },
+      ],
+      getVideoElement: () => ({ currentTime: 1.5 }) as HTMLVideoElement,
+      getCurrentState: () => "loading",
+      segmentationPipeline: null,
+      onTranslated: vi.fn<(...args: any[]) => any>(),
+      onStateChange,
+    })
+
+    // Pretend we were loading on the previous cue.
+    ;(coordinator as any).lastEmittedState = "loading"
+    ;(coordinator as any).updateLoadingStateAt(1500, [
+      { text: "hello", start: 0, end: 1000 },
+      { text: "world", start: 2000, end: 3000 },
+    ])
+
+    expect(onStateChange).toHaveBeenCalledWith("idle")
+  })
+
+  it("clears adapter loading during a music intro with no active cue", () => {
+    const onStateChange = vi.fn<(...args: any[]) => any>()
+    const coordinator = new TranslationCoordinator({
+      getFragments: () => [{ text: "lyrics start later", start: 30_000, end: 31_000 }],
+      getVideoElement: () => ({ currentTime: 5 }) as HTMLVideoElement,
+      // Scheduler was set to loading while source subtitles were fetched.
+      getCurrentState: () => "loading",
+      segmentationPipeline: null,
+      onTranslated: vi.fn<(...args: any[]) => any>(),
+      onStateChange,
+    })
+
+    // Coordinator starts with lastEmittedState = "idle", which previously skipped clear.
+    ;(coordinator as any).updateLoadingStateAt(5_000, [
+      { text: "lyrics start later", start: 30_000, end: 31_000 },
+    ])
+
+    expect(onStateChange).toHaveBeenCalledWith("idle")
+  })
+})

--- a/src/entrypoints/subtitles.content/__tests__/translation-coordinator.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/translation-coordinator.test.ts
@@ -62,18 +62,76 @@ describe("translation coordinator loading state", () => {
     expect(onStateChange).toHaveBeenCalledWith("idle")
   })
 
+  it("does not chain another translation tick after stop", async () => {
+    const onTranslated = vi.fn<(...args: any[]) => any>()
+    const onStateChange = vi.fn<(...args: any[]) => any>()
+    let resolveTranslate!: (value: any) => void
+    const translatePromise = new Promise((resolve) => {
+      resolveTranslate = resolve
+    })
+
+    const translator = await import("@/utils/subtitles/processor/translator")
+    const spy = vi
+      .spyOn(translator, "translateSubtitles")
+      .mockImplementation(() => translatePromise as any)
+
+    const coordinator = new TranslationCoordinator({
+      getFragments: () => [
+        { text: "a", start: 0, end: 1000 },
+        { text: "b", start: 1000, end: 2000 },
+        { text: "c", start: 2000, end: 3000 },
+        { text: "d", start: 3000, end: 4000 },
+        { text: "e", start: 4000, end: 5000 },
+        { text: "f", start: 5000, end: 6000 },
+      ],
+      getVideoElement: () =>
+        ({
+          currentTime: 0,
+          addEventListener: vi.fn<(...args: any[]) => any>(),
+          removeEventListener: vi.fn<(...args: any[]) => any>(),
+        }) as unknown as HTMLVideoElement,
+      getCurrentState: () => "idle",
+      segmentationPipeline: null,
+      onTranslated,
+      onStateChange,
+    })
+
+    coordinator.start()
+    await Promise.resolve()
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    coordinator.stop()
+    const batch = spy.mock.calls[0][0] as Array<{ text: string; start: number; end: number }>
+    resolveTranslate(batch.map((f) => ({ ...f, translation: `t:${f.text}` })))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // In-flight call may finish, but stop must not chain another nearby batch.
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(onTranslated).not.toHaveBeenCalled()
+
+    spy.mockRestore()
+  })
+
   it("invalidates translated bookkeeping when the same start is recut", () => {
     let fragments = [{ text: "hello world", start: 0, end: 2000 }]
     const onStateChange = vi.fn<(...args: any[]) => any>()
     const coordinator = new TranslationCoordinator({
       getFragments: () => fragments,
-      getVideoElement: () => ({ currentTime: 0.2 }) as HTMLVideoElement,
+      getVideoElement: () =>
+        ({
+          currentTime: 0.2,
+          addEventListener: vi.fn<(...args: any[]) => any>(),
+          removeEventListener: vi.fn<(...args: any[]) => any>(),
+        }) as unknown as HTMLVideoElement,
       getCurrentState: () => "idle",
       segmentationPipeline: null,
       onTranslated: vi.fn<(...args: any[]) => any>(),
       onStateChange,
     })
 
+    // noteFragmentListChanged is a no-op when inactive.
+    ;(coordinator as any).active = true
     ;(coordinator as any).translatedStarts.add(0)
     ;(coordinator as any).knownIdentities.set(0, "2000\0hello world")
 

--- a/src/entrypoints/subtitles.content/__tests__/translation-coordinator.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/translation-coordinator.test.ts
@@ -61,4 +61,32 @@ describe("translation coordinator loading state", () => {
 
     expect(onStateChange).toHaveBeenCalledWith("idle")
   })
+
+  it("invalidates translated bookkeeping when the same start is recut", () => {
+    let fragments = [{ text: "hello world", start: 0, end: 2000 }]
+    const onStateChange = vi.fn<(...args: any[]) => any>()
+    const coordinator = new TranslationCoordinator({
+      getFragments: () => fragments,
+      getVideoElement: () => ({ currentTime: 0.2 }) as HTMLVideoElement,
+      getCurrentState: () => "idle",
+      segmentationPipeline: null,
+      onTranslated: vi.fn<(...args: any[]) => any>(),
+      onStateChange,
+    })
+
+    ;(coordinator as any).translatedStarts.add(0)
+    ;(coordinator as any).knownIdentities.set(0, "2000\0hello world")
+
+    // AI re-segmentation keeps start=0 but shortens the cue.
+    fragments = [
+      { text: "hello", start: 0, end: 1000 },
+      { text: "world", start: 1000, end: 2000 },
+    ]
+    coordinator.noteFragmentListChanged()
+
+    // Old completion must be invalidated so the recut line can be translated again.
+    expect((coordinator as any).translatedStarts.has(0)).toBe(false)
+    // Old baseline identity must not stick around as if still valid.
+    expect((coordinator as any).knownIdentities.get(0)).not.toBe("2000\0hello world")
+  })
 })

--- a/src/entrypoints/subtitles.content/__tests__/translation-coordinator.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/translation-coordinator.test.ts
@@ -147,4 +147,58 @@ describe("translation coordinator loading state", () => {
     // Old baseline identity must not stick around as if still valid.
     expect((coordinator as any).knownIdentities.get(0)).not.toBe("2000\0hello world")
   })
+
+  it("does not publish stale batch cues on translation failure after a recut", async () => {
+    let fragments = [
+      { text: "hello world", start: 0, end: 2000 },
+      { text: "next", start: 2000, end: 3000 },
+    ]
+    const onTranslated = vi.fn<(...args: any[]) => any>()
+    const onStateChange = vi.fn<(...args: any[]) => any>()
+
+    const translator = await import("@/utils/subtitles/processor/translator")
+    const spy = vi
+      .spyOn(translator, "translateSubtitles")
+      .mockRejectedValue(new Error("translate failed"))
+
+    const config = await import("@/utils/config/storage")
+    const configSpy = vi.spyOn(config, "getLocalConfig").mockResolvedValue({
+      videoSubtitles: { style: { displayMode: "bilingual" } },
+    } as any)
+
+    const coordinator = new TranslationCoordinator({
+      getFragments: () => fragments,
+      getVideoElement: () =>
+        ({
+          currentTime: 0.2,
+          addEventListener: vi.fn<(...args: any[]) => any>(),
+          removeEventListener: vi.fn<(...args: any[]) => any>(),
+        }) as unknown as HTMLVideoElement,
+      getCurrentState: () => "idle",
+      segmentationPipeline: null,
+      onTranslated,
+      onStateChange,
+    })
+
+    coordinator.start()
+    await Promise.resolve()
+    // Recut mid-request: original cue is gone; only identity-valid fallbacks may publish.
+    fragments = [
+      { text: "hello", start: 0, end: 1000 },
+      { text: "world", start: 1000, end: 2000 },
+      { text: "next", start: 2000, end: 3000 },
+    ]
+    await vi.waitFor(() => {
+      expect(onStateChange).toHaveBeenCalledWith("error", { message: "translate failed" })
+    })
+
+    // Stale full-batch fallback would re-introduce the pre-recut cue as a zombie.
+    const published = onTranslated.mock.calls.flatMap((call) => call[0] as any[])
+    expect(published.every((f) => f.text !== "hello world")).toBe(true)
+    // Empty translation fallbacks for still-valid cues are fine; identity-mismatched are not.
+    expect(published.some((f) => f.start === 0 && f.end === 2000)).toBe(false)
+
+    spy.mockRestore()
+    configSpy.mockRestore()
+  })
 })

--- a/src/entrypoints/subtitles.content/__tests__/translation-coordinator.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/translation-coordinator.test.ts
@@ -148,6 +148,56 @@ describe("translation coordinator loading state", () => {
     expect((coordinator as any).knownIdentities.get(0)).not.toBe("2000\0hello world")
   })
 
+  it("does not apply in-flight results after stop then start", async () => {
+    const onTranslated = vi.fn<(...args: any[]) => any>()
+    const resolvers: Array<(value: any) => void> = []
+    const translator = await import("@/utils/subtitles/processor/translator")
+    const spy = vi.spyOn(translator, "translateSubtitles").mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvers.push(resolve)
+        }) as any,
+    )
+
+    const coordinator = new TranslationCoordinator({
+      getFragments: () => [{ text: "a", start: 0, end: 1000 }],
+      getVideoElement: () =>
+        ({
+          currentTime: 0.2,
+          addEventListener: vi.fn<(...args: any[]) => any>(),
+          removeEventListener: vi.fn<(...args: any[]) => any>(),
+        }) as unknown as HTMLVideoElement,
+      getCurrentState: () => "idle",
+      segmentationPipeline: null,
+      onTranslated,
+      onStateChange: vi.fn<(...args: any[]) => any>(),
+    })
+
+    coordinator.start()
+    await Promise.resolve()
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    coordinator.stop()
+    coordinator.start()
+    await Promise.resolve()
+    // Resume must be able to start a new batch (isTranslating not stuck).
+    expect(spy).toHaveBeenCalledTimes(2)
+
+    // Stale first-run result.
+    resolvers[0]([{ text: "a", start: 0, end: 1000, translation: "STALE" }])
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(onTranslated).not.toHaveBeenCalled()
+
+    // Current-run result.
+    resolvers[1]([{ text: "a", start: 0, end: 1000, translation: "FRESH" }])
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(onTranslated).toHaveBeenCalledWith([expect.objectContaining({ translation: "FRESH" })])
+
+    spy.mockRestore()
+  })
+
   it("does not publish stale batch cues on translation failure after a recut", async () => {
     let fragments = [
       { text: "hello world", start: 0, end: 2000 },

--- a/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
@@ -60,6 +60,7 @@ function attachScheduler(adapter: UniversalVideoAdapter, active: boolean, curren
     setState: vi.fn<(...args: any[]) => any>(),
     supplementSubtitles: vi.fn<(...args: any[]) => any>(),
     removeCuesInTimeWindow: vi.fn<(...args: any[]) => any>(),
+    reconcileTranslatedCuesAfterRecut: vi.fn<(...args: any[]) => any>(),
     getVideoElement: vi.fn<(...args: any[]) => any>(() => ({ currentTime })),
     getState: vi.fn<(...args: any[]) => any>(() => "idle"),
   }

--- a/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SUBTITLES_SOURCE } from "@/utils/constants/subtitles"
-import { sourceTrackAtom, subtitlesStore } from "../atoms"
+import { currentTimeMsAtom, sourceTrackAtom, subtitlesStore } from "../atoms"
 import { TranslationCoordinator } from "../translation-coordinator"
 import { UniversalVideoAdapter } from "../universal-adapter"
 
@@ -52,7 +52,7 @@ function createAdapter(fetchResult: Array<{ text: string; start: number; end: nu
   return { adapter, subtitlesFetcher }
 }
 
-function attachScheduler(adapter: UniversalVideoAdapter, active: boolean) {
+function attachScheduler(adapter: UniversalVideoAdapter, active: boolean, currentTime = 0) {
   const subtitlesScheduler = {
     isActive: vi.fn<(...args: any[]) => any>(() => active),
     reset: vi.fn<(...args: any[]) => any>(),
@@ -60,7 +60,7 @@ function attachScheduler(adapter: UniversalVideoAdapter, active: boolean) {
     setState: vi.fn<(...args: any[]) => any>(),
     supplementSubtitles: vi.fn<(...args: any[]) => any>(),
     removeCuesInTimeWindow: vi.fn<(...args: any[]) => any>(),
-    getVideoElement: vi.fn<(...args: any[]) => any>(() => ({ currentTime: 0 })),
+    getVideoElement: vi.fn<(...args: any[]) => any>(() => ({ currentTime })),
     getState: vi.fn<(...args: any[]) => any>(() => "idle"),
   }
 
@@ -72,6 +72,7 @@ describe("universalVideoAdapter", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     subtitlesStore.set(sourceTrackAtom, [])
+    subtitlesStore.set(currentTimeMsAtom, 0)
     vi.stubGlobal("document", {
       title: "Test video",
       querySelector: vi.fn<(...args: any[]) => any>(() => null),
@@ -277,5 +278,43 @@ describe("universalVideoAdapter", () => {
     expect(startSpy).toHaveBeenCalled()
 
     startSpy.mockRestore()
+  })
+
+  it("syncs currentTimeMsAtom from the video when publishing the source track", async () => {
+    const { adapter } = createAdapter([{ text: "hello", start: 0, end: 1000 }])
+    attachScheduler(adapter, true, 42.5)
+
+    await (adapter as any).getOrLoadSourceSubtitles()
+    ;(adapter as any).sessionSubtitles = (adapter as any).sourceSubtitles
+
+    const startSpy = vi
+      .spyOn(TranslationCoordinator.prototype, "start")
+      .mockImplementation(() => undefined)
+
+    await (adapter as any).processTranslatedSubtitles()
+
+    expect(subtitlesStore.get(currentTimeMsAtom)).toBe(42_500)
+
+    startSpy.mockRestore()
+  })
+
+  it("replaceSourceTrackWindow drops cues that overlap the window by interval", () => {
+    const { adapter } = createAdapter([])
+    attachScheduler(adapter, true)
+
+    // Spans into the replace window even though its start is before windowStart.
+    subtitlesStore.set(sourceTrackAtom, [
+      { text: "overlap", start: 0, end: 1500 },
+      { text: "after", start: 2000, end: 3000 },
+    ])
+
+    ;(adapter as any).replaceSourceTrackWindow(1000, 2000, [
+      { text: "recut", start: 1000, end: 2000 },
+    ])
+
+    expect(subtitlesStore.get(sourceTrackAtom)).toEqual([
+      { text: "recut", start: 1000, end: 2000 },
+      { text: "after", start: 2000, end: 3000 },
+    ])
   })
 })

--- a/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
@@ -1,10 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SUBTITLES_SOURCE } from "@/utils/constants/subtitles"
 import { subtitlesSourceAtom, subtitlesStore } from "../atoms"
+import { TranslationCoordinator } from "../translation-coordinator"
 import { UniversalVideoAdapter } from "../universal-adapter"
 
 const mocks = vi.hoisted(() => ({
   getLocalConfig: vi.fn<(...args: any[]) => any>(),
+  buildSubtitlesSummaryContextHash: vi.fn<(...args: any[]) => any>(() => null),
+  fetchSubtitlesSummary: vi.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
+  translateSubtitles: vi.fn<(...args: any[]) => any>(),
 }))
 
 vi.mock("@/utils/config/storage", async (importOriginal) => {
@@ -14,6 +18,12 @@ vi.mock("@/utils/config/storage", async (importOriginal) => {
     getLocalConfig: mocks.getLocalConfig,
   }
 })
+
+vi.mock("@/utils/subtitles/processor/translator", () => ({
+  buildSubtitlesSummaryContextHash: mocks.buildSubtitlesSummaryContextHash,
+  fetchSubtitlesSummary: mocks.fetchSubtitlesSummary,
+  translateSubtitles: mocks.translateSubtitles,
+}))
 
 function createAdapter(fetchResult: Array<{ text: string; start: number; end: number }>) {
   const subtitlesFetcher = {
@@ -48,6 +58,10 @@ function attachScheduler(adapter: UniversalVideoAdapter, active: boolean) {
     reset: vi.fn<(...args: any[]) => any>(),
     stop: vi.fn<(...args: any[]) => any>(),
     setState: vi.fn<(...args: any[]) => any>(),
+    supplementSubtitles: vi.fn<(...args: any[]) => any>(),
+    replaceTimeWindow: vi.fn<(...args: any[]) => any>(),
+    getVideoElement: vi.fn<(...args: any[]) => any>(() => ({ currentTime: 0 })),
+    getState: vi.fn<(...args: any[]) => any>(() => "idle"),
   }
 
   ;(adapter as any).subtitlesScheduler = subtitlesScheduler
@@ -57,7 +71,10 @@ function attachScheduler(adapter: UniversalVideoAdapter, active: boolean) {
 describe("universalVideoAdapter", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.stubGlobal("document", { title: "Test video" })
+    vi.stubGlobal("document", {
+      title: "Test video",
+      querySelector: vi.fn<(...args: any[]) => any>(() => null),
+    })
     mocks.getLocalConfig.mockResolvedValue({
       language: {},
       providersConfig: [],
@@ -222,5 +239,46 @@ describe("universalVideoAdapter", () => {
     ;(adapter as any).clearVisibleStateForNavigation()
 
     expect(downloader.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it("seeds original subtitles into the scheduler before starting translation", async () => {
+    const subtitles = [
+      { text: "I agree.", start: 0, end: 500 },
+      { text: "It is true.", start: 500, end: 1000 },
+    ]
+    const { adapter } = createAdapter(subtitles)
+    const subtitlesScheduler = attachScheduler(adapter, true)
+
+    mocks.getLocalConfig.mockResolvedValue({
+      language: { targetCode: "zh-CN" },
+      providersConfig: [],
+      videoSubtitles: {
+        aiSegmentation: false,
+        providerId: null,
+      },
+    })
+
+    await (adapter as any).getOrLoadSourceSubtitles()
+    ;(adapter as any).sessionSubtitles = (adapter as any).sourceSubtitles
+
+    const startSpy = vi
+      .spyOn(TranslationCoordinator.prototype, "start")
+      .mockImplementation(() => undefined)
+
+    await (adapter as any).processTranslatedSubtitles()
+
+    expect(subtitlesScheduler.supplementSubtitles).toHaveBeenCalled()
+    const seedCall = vi.mocked(subtitlesScheduler.supplementSubtitles).mock.calls[0]
+    const seeded = seedCall[0]
+    expect(seeded.length).toBeGreaterThan(0)
+    expect(seeded.every((fragment: { translation?: string }) => !fragment.translation)).toBe(true)
+    // Seed must upsert (not mergeOnly); translations later use mergeOnly.
+    expect(seedCall[1]?.mergeOnly).toBeFalsy()
+
+    const seedOrder = vi.mocked(subtitlesScheduler.supplementSubtitles).mock.invocationCallOrder[0]
+    const startOrder = startSpy.mock.invocationCallOrder[0]
+    expect(seedOrder).toBeLessThan(startOrder)
+
+    startSpy.mockRestore()
   })
 })

--- a/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
@@ -1,6 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { SUBTITLES_SOURCE } from "@/utils/constants/subtitles"
-import { currentTimeMsAtom, sourceTrackAtom, subtitlesStore } from "../atoms"
+import { adPlayingAtom, currentTimeMsAtom, sourceTrackAtom, subtitlesStore } from "../atoms"
 import { TranslationCoordinator } from "../translation-coordinator"
 import { UniversalVideoAdapter } from "../universal-adapter"
 
@@ -59,8 +59,8 @@ function attachScheduler(adapter: UniversalVideoAdapter, active: boolean, curren
     stop: vi.fn<(...args: any[]) => any>(),
     setState: vi.fn<(...args: any[]) => any>(),
     supplementSubtitles: vi.fn<(...args: any[]) => any>(),
-    removeCuesInTimeWindow: vi.fn<(...args: any[]) => any>(),
     reconcileTranslatedCuesAfterRecut: vi.fn<(...args: any[]) => any>(),
+    resyncFromVideo: vi.fn<(...args: any[]) => any>(),
     getVideoElement: vi.fn<(...args: any[]) => any>(() => ({ currentTime })),
     getState: vi.fn<(...args: any[]) => any>(() => "idle"),
   }
@@ -86,6 +86,61 @@ describe("universalVideoAdapter", () => {
         providerId: null,
       },
     })
+  })
+
+  afterEach(() => {
+    subtitlesStore.set(adPlayingAtom, false)
+    vi.unstubAllGlobals()
+  })
+
+  it("tracks ad state and resyncs subtitles when an ad ends", () => {
+    const { adapter } = createAdapter([])
+    const scheduler = attachScheduler(adapter, true)
+    const requestTick = vi.fn<(...args: any[]) => any>()
+    ;(adapter as any).translationCoordinator = { requestTick }
+
+    let playing = true
+    const player = {} as HTMLElement
+    vi.stubGlobal("document", {
+      title: "Test video",
+      querySelector: vi.fn<(selector: string) => Element | null>(() => player),
+    })
+    ;(adapter as any).config.isAdPlaying = vi.fn<() => boolean>(() => playing)
+
+    let observerCallback!: MutationCallback
+    const observe = vi.fn<(...args: any[]) => any>()
+    const disconnect = vi.fn<(...args: any[]) => any>()
+    class FakeMutationObserver {
+      constructor(callback: MutationCallback) {
+        observerCallback = callback
+      }
+
+      observe = observe
+      disconnect = disconnect
+    }
+    vi.stubGlobal("MutationObserver", FakeMutationObserver)
+
+    ;(adapter as any).setupAdObserver()
+
+    expect(subtitlesStore.get(adPlayingAtom)).toBe(true)
+    expect(observe).toHaveBeenCalledWith(player, {
+      attributes: true,
+      attributeFilter: ["class"],
+    })
+
+    playing = false
+    observerCallback([], {} as MutationObserver)
+
+    expect(subtitlesStore.get(adPlayingAtom)).toBe(false)
+    expect(scheduler.resyncFromVideo).toHaveBeenCalledTimes(1)
+    expect(requestTick).toHaveBeenCalledTimes(1)
+
+    playing = true
+    observerCallback([], {} as MutationObserver)
+    ;(adapter as any).teardownAdObserver()
+
+    expect(disconnect).toHaveBeenCalledTimes(1)
+    expect(subtitlesStore.get(adPlayingAtom)).toBe(false)
   })
 
   it("keeps raw source subtitles and rebuilds processed source subtitles", async () => {

--- a/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { SUBTITLES_SOURCE } from "@/utils/constants/subtitles"
-import { adPlayingAtom, currentTimeMsAtom, sourceTrackAtom, subtitlesStore } from "../atoms"
+import {
+  adPlayingAtom,
+  currentTimeMsAtom,
+  sourceTrackAtom,
+  subtitlesSourceAtom,
+  subtitlesStore,
+} from "../atoms"
 import { TranslationCoordinator } from "../translation-coordinator"
 import { UniversalVideoAdapter } from "../universal-adapter"
 

--- a/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
+++ b/src/entrypoints/subtitles.content/__tests__/universal-adapter.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SUBTITLES_SOURCE } from "@/utils/constants/subtitles"
-import { subtitlesSourceAtom, subtitlesStore } from "../atoms"
+import { sourceTrackAtom, subtitlesStore } from "../atoms"
 import { TranslationCoordinator } from "../translation-coordinator"
 import { UniversalVideoAdapter } from "../universal-adapter"
 
@@ -59,7 +59,7 @@ function attachScheduler(adapter: UniversalVideoAdapter, active: boolean) {
     stop: vi.fn<(...args: any[]) => any>(),
     setState: vi.fn<(...args: any[]) => any>(),
     supplementSubtitles: vi.fn<(...args: any[]) => any>(),
-    replaceTimeWindow: vi.fn<(...args: any[]) => any>(),
+    removeCuesInTimeWindow: vi.fn<(...args: any[]) => any>(),
     getVideoElement: vi.fn<(...args: any[]) => any>(() => ({ currentTime: 0 })),
     getState: vi.fn<(...args: any[]) => any>(() => "idle"),
   }
@@ -71,6 +71,7 @@ function attachScheduler(adapter: UniversalVideoAdapter, active: boolean) {
 describe("universalVideoAdapter", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    subtitlesStore.set(sourceTrackAtom, [])
     vi.stubGlobal("document", {
       title: "Test video",
       querySelector: vi.fn<(...args: any[]) => any>(() => null),
@@ -241,7 +242,7 @@ describe("universalVideoAdapter", () => {
     expect(downloader.dispose).toHaveBeenCalledTimes(1)
   })
 
-  it("seeds original subtitles into the scheduler before starting translation", async () => {
+  it("publishes source track without seeding untranslated cues into the scheduler", async () => {
     const subtitles = [
       { text: "I agree.", start: 0, end: 500 },
       { text: "It is true.", start: 500, end: 1000 },
@@ -267,17 +268,13 @@ describe("universalVideoAdapter", () => {
 
     await (adapter as any).processTranslatedSubtitles()
 
-    expect(subtitlesScheduler.supplementSubtitles).toHaveBeenCalled()
-    const seedCall = vi.mocked(subtitlesScheduler.supplementSubtitles).mock.calls[0]
-    const seeded = seedCall[0]
-    expect(seeded.length).toBeGreaterThan(0)
-    expect(seeded.every((fragment: { translation?: string }) => !fragment.translation)).toBe(true)
-    // Seed must upsert (not mergeOnly); translations later use mergeOnly.
-    expect(seedCall[1]?.mergeOnly).toBeFalsy()
+    const sourceTrack = subtitlesStore.get(sourceTrackAtom)
+    expect(sourceTrack.length).toBeGreaterThan(0)
+    expect(sourceTrack.every((f) => f.translation === undefined)).toBe(true)
 
-    const seedOrder = vi.mocked(subtitlesScheduler.supplementSubtitles).mock.invocationCallOrder[0]
-    const startOrder = startSpy.mock.invocationCallOrder[0]
-    expect(seedOrder).toBeLessThan(startOrder)
+    // Scheduler must not receive untranslated seeds; only coordinator will push translations later.
+    expect(subtitlesScheduler.supplementSubtitles).not.toHaveBeenCalled()
+    expect(startSpy).toHaveBeenCalled()
 
     startSpy.mockRestore()
   })

--- a/src/entrypoints/subtitles.content/atoms.ts
+++ b/src/entrypoints/subtitles.content/atoms.ts
@@ -33,12 +33,13 @@ export const displaySubtitleAtom = atom((get): SubtitlesFragment | null => {
     return null
   }
 
+  const timeMs = get(currentTimeMsAtom)
   const scheduled = get(currentSubtitleAtom)
-  if (scheduled) {
+  // Only prefer the scheduler cue when it still covers now (guards time/atom desync).
+  if (scheduled && scheduled.start <= timeMs && scheduled.end > timeMs) {
     return scheduled
   }
 
-  const timeMs = get(currentTimeMsAtom)
   return get(sourceTrackAtom).find((f) => f.start <= timeMs && f.end > timeMs) ?? null
 })
 

--- a/src/entrypoints/subtitles.content/atoms.ts
+++ b/src/entrypoints/subtitles.content/atoms.ts
@@ -11,7 +11,25 @@ export const subtitlesStore = createStore()
 
 export const currentTimeMsAtom = atom<number>(0)
 
+/** Scheduler’s current *translated* cue only (null when no translated cue covers now). */
 export const currentSubtitleAtom = atom<SubtitlesFragment | null>(null)
+
+/** Best original track (baseline or AI-segmented). Read-only for display/coordinator consumers. */
+export const sourceTrackAtom = atom<SubtitlesFragment[]>([])
+
+/**
+ * Display cue: prefer a translated scheduler cue; otherwise fall back to the source track
+ * at the current time (used for original / pending bilingual UI).
+ */
+export const displaySubtitleAtom = atom((get): SubtitlesFragment | null => {
+  const scheduled = get(currentSubtitleAtom)
+  if (scheduled) {
+    return scheduled
+  }
+
+  const timeMs = get(currentTimeMsAtom)
+  return get(sourceTrackAtom).find((f) => f.start <= timeMs && f.end > timeMs) ?? null
+})
 
 export const subtitlesStateAtom = atom<StateData | null>(null)
 
@@ -51,12 +69,21 @@ export interface SubtitlePosition {
 export const subtitlesPositionAtom = atom<SubtitlePosition>({ ...DEFAULT_SUBTITLE_POSITION })
 
 export const subtitlesDisplayAtom = atom((get) => {
-  const subtitle = get(currentSubtitleAtom)
+  const subtitle = get(displaySubtitleAtom)
+  const scheduled = get(currentSubtitleAtom)
   const stateData = get(subtitlesStateAtom)
   const isVisible = get(subtitlesVisibleAtom)
+  const { style } = get(configFieldsAtomMap.videoSubtitles)
+
+  // translationOnly must never fall back to source-only original for "content".
+  const contentSubtitle =
+    style.displayMode === "translationOnly" ? (scheduled?.translation ? scheduled : null) : subtitle
 
   return {
-    subtitle,
+    subtitle: contentSubtitle,
+    /** Raw display lookup including source fallback (for pending UI in bilingual). */
+    displaySubtitle: subtitle,
+    scheduled,
     stateData,
     isVisible,
   }

--- a/src/entrypoints/subtitles.content/atoms.ts
+++ b/src/entrypoints/subtitles.content/atoms.ts
@@ -11,6 +11,13 @@ export const subtitlesStore = createStore()
 
 export const currentTimeMsAtom = atom<number>(0)
 
+/**
+ * True while the host player is playing an ad (e.g. YouTube mid-roll).
+ * Suppresses overlay content so main-video captions are not shown over ads.
+ * Does not change user toggle intent (`subtitlesVisibleAtom`).
+ */
+export const adPlayingAtom = atom<boolean>(false)
+
 /** Scheduler’s current *translated* cue only (null when no translated cue covers now). */
 export const currentSubtitleAtom = atom<SubtitlesFragment | null>(null)
 
@@ -22,6 +29,10 @@ export const sourceTrackAtom = atom<SubtitlesFragment[]>([])
  * at the current time (used for original / pending bilingual UI).
  */
 export const displaySubtitleAtom = atom((get): SubtitlesFragment | null => {
+  if (get(adPlayingAtom)) {
+    return null
+  }
+
   const scheduled = get(currentSubtitleAtom)
   if (scheduled) {
     return scheduled
@@ -90,6 +101,8 @@ export const subtitlesDisplayAtom = atom((get) => {
 })
 
 export const subtitlesShowStateAtom = atom((get): Exclude<SubtitlesState, "idle"> | undefined => {
+  if (get(adPlayingAtom)) return undefined
+
   const { subtitle, stateData } = get(subtitlesDisplayAtom)
   const { style } = get(configFieldsAtomMap.videoSubtitles)
   const hasRenderable = hasRenderableSubtitleByMode(subtitle, style.displayMode)
@@ -101,6 +114,8 @@ export const subtitlesShowStateAtom = atom((get): Exclude<SubtitlesState, "idle"
 })
 
 export const subtitlesShowContentAtom = atom((get): boolean => {
+  if (get(adPlayingAtom)) return false
+
   const { subtitle, stateData, isVisible } = get(subtitlesDisplayAtom)
   const { style } = get(configFieldsAtomMap.videoSubtitles)
 

--- a/src/entrypoints/subtitles.content/atoms.ts
+++ b/src/entrypoints/subtitles.content/atoms.ts
@@ -82,20 +82,16 @@ export const subtitlesPositionAtom = atom<SubtitlePosition>({ ...DEFAULT_SUBTITL
 
 export const subtitlesDisplayAtom = atom((get) => {
   const subtitle = get(displaySubtitleAtom)
-  const scheduled = get(currentSubtitleAtom)
   const stateData = get(subtitlesStateAtom)
   const isVisible = get(subtitlesVisibleAtom)
   const { style } = get(configFieldsAtomMap.videoSubtitles)
 
   // translationOnly must never fall back to source-only original for "content".
   const contentSubtitle =
-    style.displayMode === "translationOnly" ? (scheduled?.translation ? scheduled : null) : subtitle
+    style.displayMode === "translationOnly" ? (subtitle?.translation ? subtitle : null) : subtitle
 
   return {
     subtitle: contentSubtitle,
-    /** Raw display lookup including source fallback (for pending UI in bilingual). */
-    displaySubtitle: subtitle,
-    scheduled,
     stateData,
     isVisible,
   }

--- a/src/entrypoints/subtitles.content/platforms/index.ts
+++ b/src/entrypoints/subtitles.content/platforms/index.ts
@@ -28,4 +28,10 @@ export interface PlatformConfig {
   getVideoId?: () => string | null
 
   createAiSubtitlesContext?: () => AiSubtitlesContext | null
+
+  /**
+   * When true, the host player is showing an ad. Overlay captions for the main
+   * video should be suppressed until the ad ends.
+   */
+  isAdPlaying?: (playerContainer: HTMLElement) => boolean
 }

--- a/src/entrypoints/subtitles.content/platforms/youtube/__tests__/ad-playing.test.ts
+++ b/src/entrypoints/subtitles.content/platforms/youtube/__tests__/ad-playing.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+import { getYoutubeConfig } from "../config"
+
+function fakePlayer(classes: string[] = []): HTMLElement {
+  const classSet = new Set(classes)
+  return {
+    classList: {
+      contains: (name: string) => classSet.has(name),
+      add: (name: string) => {
+        classSet.add(name)
+      },
+      remove: (name: string) => {
+        classSet.delete(name)
+      },
+    },
+  } as unknown as HTMLElement
+}
+
+describe("youtube isAdPlaying", () => {
+  it("detects ad-showing and ad-interrupting on the player", () => {
+    const { isAdPlaying } = getYoutubeConfig({ mode: "watch" })
+    expect(isAdPlaying).toBeTypeOf("function")
+
+    const player = fakePlayer()
+    expect(isAdPlaying!(player)).toBe(false)
+
+    player.classList.add("ad-showing")
+    expect(isAdPlaying!(player)).toBe(true)
+
+    player.classList.remove("ad-showing")
+    player.classList.add("ad-interrupting")
+    expect(isAdPlaying!(player)).toBe(true)
+  })
+})

--- a/src/entrypoints/subtitles.content/platforms/youtube/config.ts
+++ b/src/entrypoints/subtitles.content/platforms/youtube/config.ts
@@ -25,6 +25,14 @@ function createYoutubeAiSubtitlesContext() {
   return videoId ? { videoId, url: location.href } : null
 }
 
+/** YouTube marks mid-rolls / pre-rolls on the html5 player with these classes. */
+function isYoutubeAdPlaying(playerContainer: HTMLElement): boolean {
+  return (
+    playerContainer.classList.contains("ad-showing") ||
+    playerContainer.classList.contains("ad-interrupting")
+  )
+}
+
 const YOUTUBE_MODE_CONFIGS: Record<YoutubeMode, PlatformConfig> = {
   watch: {
     embedded: false,
@@ -49,6 +57,7 @@ const YOUTUBE_MODE_CONFIGS: Record<YoutubeMode, PlatformConfig> = {
     },
     getVideoId: getYoutubeVideoId,
     createAiSubtitlesContext: createYoutubeAiSubtitlesContext,
+    isAdPlaying: isYoutubeAdPlaying,
   },
 
   embed: {
@@ -73,6 +82,7 @@ const YOUTUBE_MODE_CONFIGS: Record<YoutubeMode, PlatformConfig> = {
     },
     getVideoId: getYoutubeVideoId,
     createAiSubtitlesContext: createYoutubeAiSubtitlesContext,
+    isAdPlaying: isYoutubeAdPlaying,
   },
 
   shorts: {
@@ -97,6 +107,7 @@ const YOUTUBE_MODE_CONFIGS: Record<YoutubeMode, PlatformConfig> = {
     },
     getVideoId: getYoutubeVideoId,
     createAiSubtitlesContext: createYoutubeAiSubtitlesContext,
+    isAdPlaying: isYoutubeAdPlaying,
   },
 }
 

--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -138,8 +138,10 @@ export class SegmentationPipeline {
     const chunkStart = chunk[0]!.start
     const chunkEnd = chunk.at(-1)!.end
 
+    // Drop any cue that overlaps the window (not just cues whose start falls inside it).
+    // Half-open: keep if end <= chunkStart || start >= chunkEnd.
     this.processedFragments = this.processedFragments.filter(
-      (fragment) => fragment.start < chunkStart || fragment.start > chunkEnd,
+      (fragment) => fragment.end <= chunkStart || fragment.start >= chunkEnd,
     )
     this.processedFragments.push(...nextFragments)
     this.processedFragments.sort((a, b) => a.start - b.start)

--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -108,16 +108,21 @@ export class SegmentationPipeline {
         chunk.forEach((f) => this.segmentedRawStarts.delete(f.start))
         return true
       }
-      if (config) {
-        const segmented = await aiSegmentBlock(chunk, config)
-        // Session may have been torn down while the AI call was in flight.
-        if (this.stopped) {
-          chunk.forEach((f) => this.segmentedRawStarts.delete(f.start))
-          return true
-        }
-        const optimized = optimizeSubtitles(segmented, this.getSourceLanguage())
+      if (!config) {
+        // Do not leave starts marked segmented with no replacement (would skip forever).
+        const optimized = optimizeSubtitles(chunk, this.getSourceLanguage())
         this.replaceProcessedChunk(chunk, optimized)
+        return true
       }
+
+      const segmented = await aiSegmentBlock(chunk, config)
+      // Session may have been torn down while the AI call was in flight.
+      if (this.stopped) {
+        chunk.forEach((f) => this.segmentedRawStarts.delete(f.start))
+        return true
+      }
+      const optimized = optimizeSubtitles(segmented, this.getSourceLanguage())
+      this.replaceProcessedChunk(chunk, optimized)
     } catch {
       if (this.stopped) {
         chunk.forEach((f) => this.segmentedRawStarts.delete(f.start))

--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -89,24 +89,32 @@ export class SegmentationPipeline {
   }
 
   private async processNextChunk(currentTimeMs: number): Promise<boolean> {
+    if (this.stopped) return false
+
     const chunk = this.findNextChunk(currentTimeMs)
     if (chunk.length === 0) return false
 
     chunk.forEach((f) => this.segmentedRawStarts.add(f.start))
 
     if (this.preSegmented) {
-      this.replaceProcessedChunk(chunk, chunk)
+      if (!this.stopped) {
+        this.replaceProcessedChunk(chunk, chunk)
+      }
       return true
     }
 
     try {
       const config = await getLocalConfig()
+      if (this.stopped) return true
       if (config) {
         const segmented = await aiSegmentBlock(chunk, config)
+        // Session may have been torn down while the AI call was in flight.
+        if (this.stopped) return true
         const optimized = optimizeSubtitles(segmented, this.getSourceLanguage())
         this.replaceProcessedChunk(chunk, optimized)
       }
     } catch {
+      if (this.stopped) return true
       chunk.forEach((f) => this.aiSegmentFailedRawStarts.add(f.start))
       const optimized = optimizeSubtitles(chunk, this.getSourceLanguage())
       this.replaceProcessedChunk(chunk, optimized)
@@ -116,6 +124,9 @@ export class SegmentationPipeline {
   }
 
   private replaceProcessedChunk(chunk: SubtitlesFragment[], nextFragments: SubtitlesFragment[]) {
+    // Do not mutate processed fragments or notify the adapter after stop().
+    if (this.stopped) return
+
     const chunkStart = chunk[0]!.start
     const chunkEnd = chunk.at(-1)!.end
 

--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -4,6 +4,11 @@ import { PROCESS_LOOK_AHEAD_MS } from "@/utils/constants/subtitles"
 import { aiSegmentBlock } from "@/utils/subtitles/processor/ai-segmentation"
 import { optimizeSubtitles } from "@/utils/subtitles/processor/optimizer"
 
+export type ChunkSegmentedHandler = (
+  chunk: SubtitlesFragment[],
+  nextFragments: SubtitlesFragment[],
+) => void
+
 export class SegmentationPipeline {
   // Segmented results, read by translation pipeline
   processedFragments: SubtitlesFragment[] = []
@@ -17,6 +22,7 @@ export class SegmentationPipeline {
   private getVideoElement: () => HTMLVideoElement | null
   private getSourceLanguage: () => string
   private preSegmented: boolean
+  private onChunkSegmented: ChunkSegmentedHandler | null
 
   constructor(options: {
     baselineFragments?: SubtitlesFragment[]
@@ -24,12 +30,14 @@ export class SegmentationPipeline {
     getVideoElement: () => HTMLVideoElement | null
     getSourceLanguage: () => string
     preSegmented?: boolean
+    onChunkSegmented?: ChunkSegmentedHandler
   }) {
     this.rawFragments = options.rawFragments
     this.processedFragments = [...(options.baselineFragments ?? [])]
     this.getVideoElement = options.getVideoElement
     this.getSourceLanguage = options.getSourceLanguage
     this.preSegmented = options.preSegmented ?? false
+    this.onChunkSegmented = options.onChunkSegmented ?? null
   }
 
   get isRunning(): boolean {
@@ -116,6 +124,8 @@ export class SegmentationPipeline {
     )
     this.processedFragments.push(...nextFragments)
     this.processedFragments.sort((a, b) => a.start - b.start)
+
+    this.onChunkSegmented?.(chunk, nextFragments)
   }
 
   private findNextChunk(currentTimeMs: number): SubtitlesFragment[] {

--- a/src/entrypoints/subtitles.content/segmentation-pipeline.ts
+++ b/src/entrypoints/subtitles.content/segmentation-pipeline.ts
@@ -97,24 +97,32 @@ export class SegmentationPipeline {
     chunk.forEach((f) => this.segmentedRawStarts.add(f.start))
 
     if (this.preSegmented) {
-      if (!this.stopped) {
-        this.replaceProcessedChunk(chunk, chunk)
-      }
+      this.replaceProcessedChunk(chunk, chunk)
       return true
     }
 
     try {
       const config = await getLocalConfig()
-      if (this.stopped) return true
+      if (this.stopped) {
+        // Re-queue: starts were marked segmented before await; allow retry after resume.
+        chunk.forEach((f) => this.segmentedRawStarts.delete(f.start))
+        return true
+      }
       if (config) {
         const segmented = await aiSegmentBlock(chunk, config)
         // Session may have been torn down while the AI call was in flight.
-        if (this.stopped) return true
+        if (this.stopped) {
+          chunk.forEach((f) => this.segmentedRawStarts.delete(f.start))
+          return true
+        }
         const optimized = optimizeSubtitles(segmented, this.getSourceLanguage())
         this.replaceProcessedChunk(chunk, optimized)
       }
     } catch {
-      if (this.stopped) return true
+      if (this.stopped) {
+        chunk.forEach((f) => this.segmentedRawStarts.delete(f.start))
+        return true
+      }
       chunk.forEach((f) => this.aiSegmentFailedRawStarts.add(f.start))
       const optimized = optimizeSubtitles(chunk, this.getSourceLanguage())
       this.replaceProcessedChunk(chunk, optimized)

--- a/src/entrypoints/subtitles.content/subtitles-scheduler.ts
+++ b/src/entrypoints/subtitles.content/subtitles-scheduler.ts
@@ -9,17 +9,13 @@ import {
 
 const ERROR_STATE_AUTO_HIDE_MS = 5_000
 
+/**
+ * Holds only *translated* cues. Originals live on sourceTrackAtom; the UI falls back there.
+ */
 export class SubtitlesScheduler {
   private videoElement: HTMLVideoElement
   private subtitles: SubtitlesFragment[] = []
   private currentIndex = -1
-  /** Stable identity for sticky active-cue selection across array rewrites. */
-  private currentStart: number | null = null
-  /**
-   * Recut fragments skipped while a same-start baseline cue was protected.
-   * Flushed once playback leaves the protected baseline so seek/replay sees segmented cues.
-   */
-  private deferredSameStartReplacements = new Map<number, SubtitlesFragment>()
   private active = false
   private currentState: StateData = {
     state: "idle",
@@ -38,49 +34,41 @@ export class SubtitlesScheduler {
   }
 
   /**
-   * @param mergeOnly - when true, only update translations on existing cues
-   *   (do not insert). Used for on-demand translation results so stale starts
-   *   from an in-flight batch cannot reappear after AI re-segmentation.
+   * Upsert translated cues by start. New cues are inserted; existing cues get translation updates.
    */
-  supplementSubtitles(subtitles: SubtitlesFragment[], options?: { mergeOnly?: boolean }) {
+  supplementSubtitles(subtitles: SubtitlesFragment[]) {
     if (subtitles.length === 0) {
       return
     }
 
-    const mergeOnly = options?.mergeOnly === true
     const existingMap = new Map(this.subtitles.map((s) => [s.start, s]))
     let currentSubtitleUpdated = false
+    const previousCurrentStart =
+      this.currentIndex >= 0 ? (this.subtitles[this.currentIndex]?.start ?? null) : null
 
     for (const newSub of subtitles) {
       const existing = existingMap.get(newSub.start)
 
       if (!existing) {
-        if (mergeOnly) {
-          continue
-        }
         this.subtitles.push(newSub)
         existingMap.set(newSub.start, newSub)
         continue
       }
 
-      // Apply empty-string translations too (error fallback for bilingual).
       if (newSub.translation !== undefined) {
-        // mergeOnly: only paint translations onto cues that still match the
-        // translated identity (start+end+text). Prevents a recut shorter line's
-        // translation from landing on a protected longer baseline cue that
-        // shares the same start time.
-        if (mergeOnly && (existing.end !== newSub.end || existing.text !== newSub.text)) {
-          continue
+        const updatedSub = {
+          ...existing,
+          text: newSub.text,
+          end: newSub.end,
+          translation: newSub.translation,
         }
-
-        const updatedSub = { ...existing, translation: newSub.translation }
         const idx = this.subtitles.findIndex((s) => s.start === existing.start)
         if (idx >= 0) {
           this.subtitles[idx] = updatedSub
           existingMap.set(existing.start, updatedSub)
         }
 
-        if (this.currentStart !== null && existing.start === this.currentStart) {
+        if (previousCurrentStart !== null && existing.start === previousCurrentStart) {
           currentSubtitleUpdated = true
         }
       }
@@ -89,51 +77,27 @@ export class SubtitlesScheduler {
     this.subtitles.sort((a, b) => a.start - b.start)
     this.updateSubtitles(this.videoElement.currentTime)
 
-    // Force update store if current subtitle's translation was modified
     if (currentSubtitleUpdated) {
-      this.syncCurrentIndexFromStart()
       this.updateCurrentSubtitle()
     }
   }
 
   /**
-   * Replace cues whose start falls in [windowStartMs, windowEndMs] with nextFragments.
-   * Protects the currently displayed cue so AI re-segmentation does not jump mid-line.
+   * Drop translated cues whose start falls in [windowStartMs, windowEndMs] (inclusive ends
+   * matching segmentation window semantics: start in range).
    */
-  replaceTimeWindow(
-    windowStartMs: number,
-    windowEndMs: number,
-    nextFragments: SubtitlesFragment[],
-  ) {
-    const timeMs = this.videoElement.currentTime * 1000
-    const protectedCue = this.getProtectedActiveCue(timeMs)
-
-    this.subtitles = this.subtitles.filter((fragment) => {
-      if (protectedCue && fragment.start === protectedCue.start) {
-        return true
-      }
-      return fragment.start < windowStartMs || fragment.start > windowEndMs
-    })
-
-    const existingStarts = new Set(this.subtitles.map((fragment) => fragment.start))
-
-    for (const next of nextFragments) {
-      if (protectedCue && next.start === protectedCue.start) {
-        // Keep the protected original text until its natural end, but remember
-        // the recut replacement so we can install it after the protected cue expires.
-        this.deferredSameStartReplacements.set(next.start, next)
-        continue
-      }
-      if (existingStarts.has(next.start)) {
-        continue
-      }
-      this.deferredSameStartReplacements.delete(next.start)
-      this.subtitles.push(next)
-      existingStarts.add(next.start)
+  removeCuesInTimeWindow(windowStartMs: number, windowEndMs: number) {
+    const previousLength = this.subtitles.length
+    this.subtitles = this.subtitles.filter(
+      (fragment) => fragment.start < windowStartMs || fragment.start > windowEndMs,
+    )
+    if (this.subtitles.length === previousLength) {
+      return
     }
-
-    this.subtitles.sort((a, b) => a.start - b.start)
+    // Force re-resolve: index alone may stay -1 while the atom still holds a removed cue.
+    this.currentIndex = -1
     this.updateSubtitles(this.videoElement.currentTime)
+    this.updateCurrentSubtitle()
   }
 
   getVideoElement(): HTMLVideoElement {
@@ -185,78 +149,7 @@ export class SubtitlesScheduler {
     this.setState("idle")
     this.subtitles = []
     this.currentIndex = -1
-    this.currentStart = null
-    this.deferredSameStartReplacements.clear()
     this.updateCurrentSubtitle()
-  }
-
-  /**
-   * When a protected baseline cue is no longer active, swap in the deferred recut
-   * fragment for the same start (if any).
-   */
-  private flushDeferredSameStartReplacements(timeMs: number) {
-    if (this.deferredSameStartReplacements.size === 0) {
-      return
-    }
-
-    let changed = false
-
-    for (const [start, deferred] of [...this.deferredSameStartReplacements]) {
-      const existingIndex = this.subtitles.findIndex((fragment) => fragment.start === start)
-      const existing = existingIndex >= 0 ? this.subtitles[existingIndex] : null
-
-      if (!existing) {
-        this.subtitles.push(deferred)
-        this.deferredSameStartReplacements.delete(start)
-        changed = true
-        continue
-      }
-
-      const stillInsideProtected = existing.start <= timeMs && existing.end > timeMs
-      // Still showing the longer/different protected baseline — wait.
-      if (
-        stillInsideProtected &&
-        (existing.end !== deferred.end || existing.text !== deferred.text)
-      ) {
-        continue
-      }
-
-      this.subtitles[existingIndex] = {
-        ...deferred,
-        // Preserve any translation already painted onto the protected cue only if identity matches.
-        translation:
-          existing.end === deferred.end && existing.text === deferred.text
-            ? existing.translation
-            : deferred.translation,
-      }
-      this.deferredSameStartReplacements.delete(start)
-      changed = true
-
-      if (this.currentStart === start) {
-        this.currentIndex = existingIndex
-      }
-    }
-
-    if (changed) {
-      this.subtitles.sort((a, b) => a.start - b.start)
-    }
-  }
-
-  private getProtectedActiveCue(timeMs: number): SubtitlesFragment | null {
-    if (this.currentStart === null) {
-      return null
-    }
-
-    const current = this.subtitles.find((fragment) => fragment.start === this.currentStart)
-    if (!current) {
-      return null
-    }
-
-    if (current.start <= timeMs && current.end > timeMs) {
-      return current
-    }
-
-    return null
   }
 
   private attachListeners() {
@@ -283,45 +176,15 @@ export class SubtitlesScheduler {
     this.updateSubtitles(currentTime)
   }
 
-  private syncCurrentIndexFromStart() {
-    if (this.currentStart === null) {
-      this.currentIndex = -1
-      return
-    }
-
-    this.currentIndex = this.subtitles.findIndex((fragment) => fragment.start === this.currentStart)
-    if (this.currentIndex < 0) {
-      this.currentStart = null
-    }
-  }
-
   private updateSubtitles(currentTime: number) {
     const timeMs = currentTime * 1000
     subtitlesStore.set(currentTimeMsAtom, timeMs)
 
-    this.flushDeferredSameStartReplacements(timeMs)
-
-    // Sticky: keep the active cue while playback remains inside its range,
-    // even if a re-segmented cue also covers this timestamp.
-    if (this.currentStart !== null) {
-      const sticky = this.subtitles.find((fragment) => fragment.start === this.currentStart)
-      if (sticky && sticky.start <= timeMs && sticky.end > timeMs) {
-        const stickyIndex = this.subtitles.indexOf(sticky)
-        if (stickyIndex !== this.currentIndex) {
-          this.currentIndex = stickyIndex
-          this.updateCurrentSubtitle()
-        }
-        return
-      }
-    }
-
     const subtitle = this.subtitles.find((sub) => sub.start <= timeMs && sub.end > timeMs)
     const newIndex = subtitle ? this.subtitles.indexOf(subtitle) : -1
-    const newStart = subtitle?.start ?? null
 
-    if (newIndex !== this.currentIndex || newStart !== this.currentStart) {
+    if (newIndex !== this.currentIndex) {
       this.currentIndex = newIndex
-      this.currentStart = newStart
       this.updateCurrentSubtitle()
     }
   }

--- a/src/entrypoints/subtitles.content/subtitles-scheduler.ts
+++ b/src/entrypoints/subtitles.content/subtitles-scheduler.ts
@@ -121,6 +121,7 @@ export class SubtitlesScheduler {
       next.length === this.subtitles.length &&
       next.every((fragment, index) => {
         const prev = this.subtitles[index]
+        if (!prev) return false
         return (
           prev.start === fragment.start &&
           prev.end === fragment.end &&

--- a/src/entrypoints/subtitles.content/subtitles-scheduler.ts
+++ b/src/entrypoints/subtitles.content/subtitles-scheduler.ts
@@ -60,6 +60,14 @@ export class SubtitlesScheduler {
 
       // Apply empty-string translations too (error fallback for bilingual).
       if (newSub.translation !== undefined) {
+        // mergeOnly: only paint translations onto cues that still match the
+        // translated identity (start+end+text). Prevents a recut shorter line's
+        // translation from landing on a protected longer baseline cue that
+        // shares the same start time.
+        if (mergeOnly && (existing.end !== newSub.end || existing.text !== newSub.text)) {
+          continue
+        }
+
         const updatedSub = { ...existing, translation: newSub.translation }
         const idx = this.subtitles.findIndex((s) => s.start === existing.start)
         if (idx >= 0) {

--- a/src/entrypoints/subtitles.content/subtitles-scheduler.ts
+++ b/src/entrypoints/subtitles.content/subtitles-scheduler.ts
@@ -13,6 +13,8 @@ export class SubtitlesScheduler {
   private videoElement: HTMLVideoElement
   private subtitles: SubtitlesFragment[] = []
   private currentIndex = -1
+  /** Stable identity for sticky active-cue selection across array rewrites. */
+  private currentStart: number | null = null
   private active = false
   private currentState: StateData = {
     state: "idle",
@@ -30,31 +32,42 @@ export class SubtitlesScheduler {
     this.updateVisibility()
   }
 
-  supplementSubtitles(subtitles: SubtitlesFragment[]) {
+  /**
+   * @param mergeOnly - when true, only update translations on existing cues
+   *   (do not insert). Used for on-demand translation results so stale starts
+   *   from an in-flight batch cannot reappear after AI re-segmentation.
+   */
+  supplementSubtitles(subtitles: SubtitlesFragment[], options?: { mergeOnly?: boolean }) {
     if (subtitles.length === 0) {
       return
     }
 
+    const mergeOnly = options?.mergeOnly === true
     const existingMap = new Map(this.subtitles.map((s) => [s.start, s]))
-    const currentSubtitle = this.currentIndex >= 0 ? this.subtitles[this.currentIndex] : null
     let currentSubtitleUpdated = false
 
     for (const newSub of subtitles) {
       const existing = existingMap.get(newSub.start)
 
       if (!existing) {
+        if (mergeOnly) {
+          continue
+        }
         this.subtitles.push(newSub)
+        existingMap.set(newSub.start, newSub)
         continue
       }
 
-      if (newSub.translation) {
+      // Apply empty-string translations too (error fallback for bilingual).
+      if (newSub.translation !== undefined) {
         const updatedSub = { ...existing, translation: newSub.translation }
         const idx = this.subtitles.findIndex((s) => s.start === existing.start)
         if (idx >= 0) {
           this.subtitles[idx] = updatedSub
+          existingMap.set(existing.start, updatedSub)
         }
 
-        if (currentSubtitle && existing.start === currentSubtitle.start) {
+        if (this.currentStart !== null && existing.start === this.currentStart) {
           currentSubtitleUpdated = true
         }
       }
@@ -65,8 +78,46 @@ export class SubtitlesScheduler {
 
     // Force update store if current subtitle's translation was modified
     if (currentSubtitleUpdated) {
+      this.syncCurrentIndexFromStart()
       this.updateCurrentSubtitle()
     }
+  }
+
+  /**
+   * Replace cues whose start falls in [windowStartMs, windowEndMs] with nextFragments.
+   * Protects the currently displayed cue so AI re-segmentation does not jump mid-line.
+   */
+  replaceTimeWindow(
+    windowStartMs: number,
+    windowEndMs: number,
+    nextFragments: SubtitlesFragment[],
+  ) {
+    const timeMs = this.videoElement.currentTime * 1000
+    const protectedCue = this.getProtectedActiveCue(timeMs)
+
+    this.subtitles = this.subtitles.filter((fragment) => {
+      if (protectedCue && fragment.start === protectedCue.start) {
+        return true
+      }
+      return fragment.start < windowStartMs || fragment.start > windowEndMs
+    })
+
+    const existingStarts = new Set(this.subtitles.map((fragment) => fragment.start))
+
+    for (const next of nextFragments) {
+      if (protectedCue && next.start === protectedCue.start) {
+        // Keep the protected original text until its natural end.
+        continue
+      }
+      if (existingStarts.has(next.start)) {
+        continue
+      }
+      this.subtitles.push(next)
+      existingStarts.add(next.start)
+    }
+
+    this.subtitles.sort((a, b) => a.start - b.start)
+    this.updateSubtitles(this.videoElement.currentTime)
   }
 
   getVideoElement(): HTMLVideoElement {
@@ -118,7 +169,25 @@ export class SubtitlesScheduler {
     this.setState("idle")
     this.subtitles = []
     this.currentIndex = -1
+    this.currentStart = null
     this.updateCurrentSubtitle()
+  }
+
+  private getProtectedActiveCue(timeMs: number): SubtitlesFragment | null {
+    if (this.currentStart === null) {
+      return null
+    }
+
+    const current = this.subtitles.find((fragment) => fragment.start === this.currentStart)
+    if (!current) {
+      return null
+    }
+
+    if (current.start <= timeMs && current.end > timeMs) {
+      return current
+    }
+
+    return null
   }
 
   private attachListeners() {
@@ -145,15 +214,43 @@ export class SubtitlesScheduler {
     this.updateSubtitles(currentTime)
   }
 
+  private syncCurrentIndexFromStart() {
+    if (this.currentStart === null) {
+      this.currentIndex = -1
+      return
+    }
+
+    this.currentIndex = this.subtitles.findIndex((fragment) => fragment.start === this.currentStart)
+    if (this.currentIndex < 0) {
+      this.currentStart = null
+    }
+  }
+
   private updateSubtitles(currentTime: number) {
     const timeMs = currentTime * 1000
     subtitlesStore.set(currentTimeMsAtom, timeMs)
 
+    // Sticky: keep the active cue while playback remains inside its range,
+    // even if a re-segmented cue also covers this timestamp.
+    if (this.currentStart !== null) {
+      const sticky = this.subtitles.find((fragment) => fragment.start === this.currentStart)
+      if (sticky && sticky.start <= timeMs && sticky.end > timeMs) {
+        const stickyIndex = this.subtitles.indexOf(sticky)
+        if (stickyIndex !== this.currentIndex) {
+          this.currentIndex = stickyIndex
+          this.updateCurrentSubtitle()
+        }
+        return
+      }
+    }
+
     const subtitle = this.subtitles.find((sub) => sub.start <= timeMs && sub.end > timeMs)
     const newIndex = subtitle ? this.subtitles.indexOf(subtitle) : -1
+    const newStart = subtitle?.start ?? null
 
-    if (newIndex !== this.currentIndex) {
+    if (newIndex !== this.currentIndex || newStart !== this.currentStart) {
       this.currentIndex = newIndex
+      this.currentStart = newStart
       this.updateCurrentSubtitle()
     }
   }

--- a/src/entrypoints/subtitles.content/subtitles-scheduler.ts
+++ b/src/entrypoints/subtitles.content/subtitles-scheduler.ts
@@ -89,14 +89,6 @@ export class SubtitlesScheduler {
   }
 
   /**
-   * Drop translated cues that overlap [windowStartMs, windowEndMs) — same half-open interval
-   * rule as replaceSourceTrackWindow, so spanning cues cannot outlive an AI recut.
-   */
-  removeCuesInTimeWindow(windowStartMs: number, windowEndMs: number) {
-    this.reconcileTranslatedCuesAfterRecut(windowStartMs, windowEndMs, [])
-  }
-
-  /**
    * After AI recut of a window: drop overlapping translated cues, but re-attach translations
    * whose start+end+text still match a next fragment. Unchanged cues must not be wiped then
    * skipped forever (coordinator still has them in translatedStarts).

--- a/src/entrypoints/subtitles.content/subtitles-scheduler.ts
+++ b/src/entrypoints/subtitles.content/subtitles-scheduler.ts
@@ -133,6 +133,12 @@ export class SubtitlesScheduler {
     this.updateVisibility()
   }
 
+  /** Force a cue resolve from the live video clock (e.g. after an ad ends). */
+  resyncFromVideo() {
+    if (!this.active) return
+    this.updateSubtitles(this.videoElement.currentTime)
+  }
+
   setState(state: SubtitlesState, data?: Partial<Omit<StateData, "state">>) {
     this.clearErrorAutoHide()
     this.currentState = {

--- a/src/entrypoints/subtitles.content/subtitles-scheduler.ts
+++ b/src/entrypoints/subtitles.content/subtitles-scheduler.ts
@@ -30,6 +30,8 @@ export class SubtitlesScheduler {
 
   start() {
     this.active = true
+    // Sync immediately: timeupdate may not fire while paused / mid-video.
+    this.updateSubtitles(this.videoElement.currentTime)
     this.updateVisibility()
   }
 
@@ -120,6 +122,8 @@ export class SubtitlesScheduler {
 
   show() {
     this.active = true
+    // Sync immediately: timeupdate may not fire while paused / mid-video.
+    this.updateSubtitles(this.videoElement.currentTime)
     this.updateVisibility()
   }
 

--- a/src/entrypoints/subtitles.content/subtitles-scheduler.ts
+++ b/src/entrypoints/subtitles.content/subtitles-scheduler.ts
@@ -15,6 +15,11 @@ export class SubtitlesScheduler {
   private currentIndex = -1
   /** Stable identity for sticky active-cue selection across array rewrites. */
   private currentStart: number | null = null
+  /**
+   * Recut fragments skipped while a same-start baseline cue was protected.
+   * Flushed once playback leaves the protected baseline so seek/replay sees segmented cues.
+   */
+  private deferredSameStartReplacements = new Map<number, SubtitlesFragment>()
   private active = false
   private currentState: StateData = {
     state: "idle",
@@ -114,12 +119,15 @@ export class SubtitlesScheduler {
 
     for (const next of nextFragments) {
       if (protectedCue && next.start === protectedCue.start) {
-        // Keep the protected original text until its natural end.
+        // Keep the protected original text until its natural end, but remember
+        // the recut replacement so we can install it after the protected cue expires.
+        this.deferredSameStartReplacements.set(next.start, next)
         continue
       }
       if (existingStarts.has(next.start)) {
         continue
       }
+      this.deferredSameStartReplacements.delete(next.start)
       this.subtitles.push(next)
       existingStarts.add(next.start)
     }
@@ -178,7 +186,60 @@ export class SubtitlesScheduler {
     this.subtitles = []
     this.currentIndex = -1
     this.currentStart = null
+    this.deferredSameStartReplacements.clear()
     this.updateCurrentSubtitle()
+  }
+
+  /**
+   * When a protected baseline cue is no longer active, swap in the deferred recut
+   * fragment for the same start (if any).
+   */
+  private flushDeferredSameStartReplacements(timeMs: number) {
+    if (this.deferredSameStartReplacements.size === 0) {
+      return
+    }
+
+    let changed = false
+
+    for (const [start, deferred] of [...this.deferredSameStartReplacements]) {
+      const existingIndex = this.subtitles.findIndex((fragment) => fragment.start === start)
+      const existing = existingIndex >= 0 ? this.subtitles[existingIndex] : null
+
+      if (!existing) {
+        this.subtitles.push(deferred)
+        this.deferredSameStartReplacements.delete(start)
+        changed = true
+        continue
+      }
+
+      const stillInsideProtected = existing.start <= timeMs && existing.end > timeMs
+      // Still showing the longer/different protected baseline — wait.
+      if (
+        stillInsideProtected &&
+        (existing.end !== deferred.end || existing.text !== deferred.text)
+      ) {
+        continue
+      }
+
+      this.subtitles[existingIndex] = {
+        ...deferred,
+        // Preserve any translation already painted onto the protected cue only if identity matches.
+        translation:
+          existing.end === deferred.end && existing.text === deferred.text
+            ? existing.translation
+            : deferred.translation,
+      }
+      this.deferredSameStartReplacements.delete(start)
+      changed = true
+
+      if (this.currentStart === start) {
+        this.currentIndex = existingIndex
+      }
+    }
+
+    if (changed) {
+      this.subtitles.sort((a, b) => a.start - b.start)
+    }
   }
 
   private getProtectedActiveCue(timeMs: number): SubtitlesFragment | null {
@@ -237,6 +298,8 @@ export class SubtitlesScheduler {
   private updateSubtitles(currentTime: number) {
     const timeMs = currentTime * 1000
     subtitlesStore.set(currentTimeMsAtom, timeMs)
+
+    this.flushDeferredSameStartReplacements(timeMs)
 
     // Sticky: keep the active cue while playback remains inside its range,
     // even if a re-segmented cue also covers this timestamp.

--- a/src/entrypoints/subtitles.content/subtitles-scheduler.ts
+++ b/src/entrypoints/subtitles.content/subtitles-scheduler.ts
@@ -9,6 +9,10 @@ import {
 
 const ERROR_STATE_AUTO_HIDE_MS = 5_000
 
+function cueIdentityKey(fragment: Pick<SubtitlesFragment, "start" | "end" | "text">): string {
+  return `${fragment.start}\0${fragment.end}\0${fragment.text}`
+}
+
 /**
  * Holds only *translated* cues. Originals live on sourceTrackAtom; the UI falls back there.
  */
@@ -89,15 +93,55 @@ export class SubtitlesScheduler {
    * rule as replaceSourceTrackWindow, so spanning cues cannot outlive an AI recut.
    */
   removeCuesInTimeWindow(windowStartMs: number, windowEndMs: number) {
-    const previousLength = this.subtitles.length
-    // Keep if no overlap: end <= windowStart || start >= windowEnd.
-    this.subtitles = this.subtitles.filter(
+    this.reconcileTranslatedCuesAfterRecut(windowStartMs, windowEndMs, [])
+  }
+
+  /**
+   * After AI recut of a window: drop overlapping translated cues, but re-attach translations
+   * whose start+end+text still match a next fragment. Unchanged cues must not be wiped then
+   * skipped forever (coordinator still has them in translatedStarts).
+   */
+  reconcileTranslatedCuesAfterRecut(
+    windowStartMs: number,
+    windowEndMs: number,
+    nextFragments: SubtitlesFragment[],
+  ) {
+    const outside = this.subtitles.filter(
       (fragment) => fragment.end <= windowStartMs || fragment.start >= windowEndMs,
     )
-    if (this.subtitles.length === previousLength) {
+    const overlapping = this.subtitles.filter(
+      (fragment) => fragment.end > windowStartMs && fragment.start < windowEndMs,
+    )
+
+    const byIdentity = new Map(
+      overlapping.map((fragment) => [cueIdentityKey(fragment), fragment] as const),
+    )
+    const preserved = nextFragments.flatMap((fragment) => {
+      const previous = byIdentity.get(cueIdentityKey(fragment))
+      if (previous?.translation === undefined) {
+        return []
+      }
+      return [{ ...fragment, translation: previous.translation }]
+    })
+
+    const next = [...outside, ...preserved].sort((a, b) => a.start - b.start)
+    const unchanged =
+      next.length === this.subtitles.length &&
+      next.every((fragment, index) => {
+        const prev = this.subtitles[index]
+        return (
+          prev.start === fragment.start &&
+          prev.end === fragment.end &&
+          prev.text === fragment.text &&
+          prev.translation === fragment.translation
+        )
+      })
+    if (unchanged) {
       return
     }
-    // Force re-resolve: index alone may stay -1 while the atom still holds a removed cue.
+
+    this.subtitles = next
+    // Force re-resolve: index alone may stay stale while the atom still holds a removed cue.
     this.currentIndex = -1
     this.updateSubtitles(this.videoElement.currentTime)
     this.updateCurrentSubtitle()

--- a/src/entrypoints/subtitles.content/subtitles-scheduler.ts
+++ b/src/entrypoints/subtitles.content/subtitles-scheduler.ts
@@ -85,13 +85,14 @@ export class SubtitlesScheduler {
   }
 
   /**
-   * Drop translated cues whose start falls in [windowStartMs, windowEndMs] (inclusive ends
-   * matching segmentation window semantics: start in range).
+   * Drop translated cues that overlap [windowStartMs, windowEndMs) — same half-open interval
+   * rule as replaceSourceTrackWindow, so spanning cues cannot outlive an AI recut.
    */
   removeCuesInTimeWindow(windowStartMs: number, windowEndMs: number) {
     const previousLength = this.subtitles.length
+    // Keep if no overlap: end <= windowStart || start >= windowEnd.
     this.subtitles = this.subtitles.filter(
-      (fragment) => fragment.start < windowStartMs || fragment.start > windowEndMs,
+      (fragment) => fragment.end <= windowStartMs || fragment.start >= windowEndMs,
     )
     if (this.subtitles.length === previousLength) {
       return

--- a/src/entrypoints/subtitles.content/translation-coordinator.ts
+++ b/src/entrypoints/subtitles.content/translation-coordinator.ts
@@ -209,17 +209,21 @@ export class TranslationCoordinator {
       const latestFragments = this.getFragments()
       this.updateLoadingStateAt(latestTimeMs, latestFragments)
     } catch (error) {
+      if (!this.active) {
+        batch.forEach((f) => this.translatingStarts.delete(f.start))
+        return
+      }
+
+      const byStart = new Map(this.getFragments().map((fragment) => [fragment.start, fragment]))
       batch.forEach((f) => {
         this.translatingStarts.delete(f.start)
-        if (this.active) {
+        const current = byStart.get(f.start)
+        // Only mark failed if the cue identity still matches (avoid poisoning a recut start).
+        if (current && current.end === f.end && current.text === f.text) {
           this.failedStarts.add(f.start)
           this.rememberIdentity(f)
         }
       })
-
-      if (!this.active) {
-        return
-      }
 
       const config = await getLocalConfig()
       const displayMode = config?.videoSubtitles?.style.displayMode

--- a/src/entrypoints/subtitles.content/translation-coordinator.ts
+++ b/src/entrypoints/subtitles.content/translation-coordinator.ts
@@ -25,6 +25,8 @@ export class TranslationCoordinator {
   /** Identity of the cue (end+text) associated with a booked start. */
   private knownIdentities = new Map<number, string>()
   private isTranslating = false
+  /** False after stop(); blocks chained ticks and in-flight result application. */
+  private active = false
   private lastEmittedState: SubtitlesState = "idle"
   private videoContext: SubtitlesVideoContext = { videoTitle: "", subtitlesTextContent: "" }
 
@@ -52,6 +54,8 @@ export class TranslationCoordinator {
     const video = this.getVideoElement()
     if (!video) return
 
+    this.active = true
+
     video.addEventListener("timeupdate", this.handleTranslationTick)
     video.addEventListener("seeked", this.handleTranslationTick)
 
@@ -64,6 +68,7 @@ export class TranslationCoordinator {
   }
 
   stop() {
+    this.active = false
     const video = this.getVideoElement()
     if (!video) return
     video.removeEventListener("timeupdate", this.handleTranslationTick)
@@ -73,6 +78,7 @@ export class TranslationCoordinator {
   }
 
   reset() {
+    this.active = false
     this.translatingStarts.clear()
     this.translatedStarts.clear()
     this.failedStarts.clear()
@@ -91,6 +97,8 @@ export class TranslationCoordinator {
    * (end+text) changed after AI re-segmentation — same start can be a recut line.
    */
   noteFragmentListChanged() {
+    if (!this.active) return
+
     const byStart = new Map(this.getFragments().map((fragment) => [fragment.start, fragment]))
 
     this.invalidateStaleStarts(this.translatedStarts, byStart)
@@ -122,6 +130,8 @@ export class TranslationCoordinator {
   }
 
   private handleTranslationTick = () => {
+    if (!this.active) return
+
     const video = this.getVideoElement()
     if (!video) return
 
@@ -145,6 +155,8 @@ export class TranslationCoordinator {
   }
 
   private async translateNearby(currentTimeMs: number) {
+    if (!this.active) return
+
     const fragments = this.getFragments()
 
     const batch = fragments
@@ -170,6 +182,11 @@ export class TranslationCoordinator {
 
     try {
       const translated = await translateSubtitles(batch, this.videoContext)
+      if (!this.active) {
+        batch.forEach((f) => this.translatingStarts.delete(f.start))
+        return
+      }
+
       // Only accept results whose cue identity still matches the current fragment list.
       const byStart = new Map(this.getFragments().map((fragment) => [fragment.start, fragment]))
       const stillValid = translated.filter((fragment) => {
@@ -194,9 +211,15 @@ export class TranslationCoordinator {
     } catch (error) {
       batch.forEach((f) => {
         this.translatingStarts.delete(f.start)
-        this.failedStarts.add(f.start)
-        this.rememberIdentity(f)
+        if (this.active) {
+          this.failedStarts.add(f.start)
+          this.rememberIdentity(f)
+        }
       })
+
+      if (!this.active) {
+        return
+      }
 
       const config = await getLocalConfig()
       const displayMode = config?.videoSubtitles?.style.displayMode
@@ -212,7 +235,10 @@ export class TranslationCoordinator {
     } finally {
       this.isTranslating = false
       // Kick the next nearby batch without waiting for the next timeupdate.
-      this.handleTranslationTick()
+      // Guarded: stop()/reset() must not chain more translation after teardown.
+      if (this.active) {
+        this.handleTranslationTick()
+      }
     }
   }
 

--- a/src/entrypoints/subtitles.content/translation-coordinator.ts
+++ b/src/entrypoints/subtitles.content/translation-coordinator.ts
@@ -4,6 +4,7 @@ import type { SubtitlesFragment, SubtitlesState } from "@/utils/subtitles/types"
 import { getLocalConfig } from "@/utils/config/storage"
 import { TRANSLATE_LOOK_AHEAD_MS, TRANSLATION_BATCH_SIZE } from "@/utils/constants/subtitles"
 import { translateSubtitles } from "@/utils/subtitles/processor/translator"
+import { adPlayingAtom, subtitlesStore } from "./atoms"
 
 export interface TranslationCoordinatorOptions {
   getFragments: () => SubtitlesFragment[]
@@ -131,6 +132,8 @@ export class TranslationCoordinator {
 
   private handleTranslationTick = () => {
     if (!this.active) return
+    // Ad timeline can freeze or jump; do not translate against main-video cues mid-ad.
+    if (subtitlesStore.get(adPlayingAtom)) return
 
     const video = this.getVideoElement()
     if (!video) return

--- a/src/entrypoints/subtitles.content/translation-coordinator.ts
+++ b/src/entrypoints/subtitles.content/translation-coordinator.ts
@@ -28,8 +28,11 @@ export class TranslationCoordinator {
   private isTranslating = false
   /** False after stop(); blocks chained ticks and in-flight result application. */
   private active = false
+  /** Bumped on stop() so in-flight batches cannot apply after stop/start. */
+  private runId = 0
   private lastEmittedState: SubtitlesState = "idle"
   private videoContext: SubtitlesVideoContext = { videoTitle: "", subtitlesTextContent: "" }
+  private listenersAttached = false
 
   private getFragments: () => SubtitlesFragment[]
   private getVideoElement: () => HTMLVideoElement | null
@@ -56,12 +59,9 @@ export class TranslationCoordinator {
     if (!video) return
 
     this.active = true
-
-    video.addEventListener("timeupdate", this.handleTranslationTick)
-    video.addEventListener("seeked", this.handleTranslationTick)
+    this.attachVideoListeners(video)
 
     if (this.segmentationPipeline) {
-      video.addEventListener("seeked", this.handleSeek)
       this.segmentationPipeline.start()
     }
 
@@ -70,16 +70,25 @@ export class TranslationCoordinator {
 
   stop() {
     this.active = false
-    const video = this.getVideoElement()
-    if (!video) return
-    video.removeEventListener("timeupdate", this.handleTranslationTick)
-    video.removeEventListener("seeked", this.handleTranslationTick)
-    video.removeEventListener("seeked", this.handleSeek)
+    this.runId += 1
+    // Allow a subsequent start() to translate immediately; the in-flight batch is
+    // invalidated by runId and must not leave locks stuck.
+    this.isTranslating = false
+    this.translatingStarts.clear()
+    this.detachVideoListeners()
     this.segmentationPipeline?.stop()
+  }
+
+  /** Kick a nearby pass without waiting for the next timeupdate (e.g. after an ad). */
+  requestTick() {
+    if (!this.active) return
+    this.handleTranslationTick()
   }
 
   reset() {
     this.active = false
+    this.runId += 1
+    this.detachVideoListeners()
     this.translatingStarts.clear()
     this.translatedStarts.clear()
     this.failedStarts.clear()
@@ -87,6 +96,27 @@ export class TranslationCoordinator {
     this.isTranslating = false
     this.lastEmittedState = "idle"
     this.videoContext = { videoTitle: "", subtitlesTextContent: "" }
+  }
+
+  private attachVideoListeners(video: HTMLVideoElement) {
+    if (this.listenersAttached) return
+    video.addEventListener("timeupdate", this.handleTranslationTick)
+    video.addEventListener("seeked", this.handleTranslationTick)
+    if (this.segmentationPipeline) {
+      video.addEventListener("seeked", this.handleSeek)
+    }
+    this.listenersAttached = true
+  }
+
+  private detachVideoListeners() {
+    if (!this.listenersAttached) return
+    const video = this.getVideoElement()
+    if (video) {
+      video.removeEventListener("timeupdate", this.handleTranslationTick)
+      video.removeEventListener("seeked", this.handleTranslationTick)
+      video.removeEventListener("seeked", this.handleSeek)
+    }
+    this.listenersAttached = false
   }
 
   clearFailed() {
@@ -177,6 +207,7 @@ export class TranslationCoordinator {
       return
     }
 
+    const runId = this.runId
     this.isTranslating = true
     batch.forEach((f) => {
       this.translatingStarts.add(f.start)
@@ -185,7 +216,7 @@ export class TranslationCoordinator {
 
     try {
       const translated = await translateSubtitles(batch, this.videoContext)
-      if (!this.active) {
+      if (!this.active || runId !== this.runId) {
         batch.forEach((f) => this.translatingStarts.delete(f.start))
         return
       }
@@ -208,7 +239,7 @@ export class TranslationCoordinator {
       const latestFragments = this.getFragments()
       this.updateLoadingStateAt(latestTimeMs, latestFragments)
     } catch (error) {
-      if (!this.active) {
+      if (!this.active || runId !== this.runId) {
         batch.forEach((f) => this.translatingStarts.delete(f.start))
         return
       }
@@ -226,7 +257,7 @@ export class TranslationCoordinator {
       })
 
       const config = await getLocalConfig()
-      if (!this.active) {
+      if (!this.active || runId !== this.runId) {
         return
       }
 
@@ -245,11 +276,12 @@ export class TranslationCoordinator {
       this.lastEmittedState = "error"
       this.onStateChange("error", { message: errorMessage })
     } finally {
-      this.isTranslating = false
-      // Kick the next nearby batch without waiting for the next timeupdate.
-      // Guarded: stop()/reset() must not chain more translation after teardown.
-      if (this.active) {
-        this.handleTranslationTick()
+      // Only the current generation may clear the lock / chain another tick.
+      if (runId === this.runId) {
+        this.isTranslating = false
+        if (this.active) {
+          this.handleTranslationTick()
+        }
       }
     }
   }

--- a/src/entrypoints/subtitles.content/translation-coordinator.ts
+++ b/src/entrypoints/subtitles.content/translation-coordinator.ts
@@ -188,11 +188,7 @@ export class TranslationCoordinator {
       }
 
       // Only accept results whose cue identity still matches the current fragment list.
-      const byStart = new Map(this.getFragments().map((fragment) => [fragment.start, fragment]))
-      const stillValid = translated.filter((fragment) => {
-        const current = byStart.get(fragment.start)
-        return !!current && current.end === fragment.end && current.text === fragment.text
-      })
+      const stillValid = this.filterIdentityValid(translated)
 
       stillValid.forEach((f) => {
         this.translatingStarts.delete(f.start)
@@ -214,24 +210,33 @@ export class TranslationCoordinator {
         return
       }
 
-      const byStart = new Map(this.getFragments().map((fragment) => [fragment.start, fragment]))
+      // Starts that disappeared or were recut mid-request should not stay "translating".
       batch.forEach((f) => {
         this.translatingStarts.delete(f.start)
-        const current = byStart.get(f.start)
-        // Only mark failed if the cue identity still matches (avoid poisoning a recut start).
-        if (current && current.end === f.end && current.text === f.text) {
-          this.failedStarts.add(f.start)
-          this.rememberIdentity(f)
-        }
+      })
+
+      // Same identity gate as the success path: never bookkeep or publish recut/stale cues.
+      const stillValid = this.filterIdentityValid(batch)
+      stillValid.forEach((f) => {
+        this.failedStarts.add(f.start)
+        this.rememberIdentity(f)
       })
 
       const config = await getLocalConfig()
+      if (!this.active) {
+        return
+      }
+
+      // Re-check after the await: AI recut may have landed while config was loading.
+      const validForFallback = this.filterIdentityValid(stillValid)
       const displayMode = config?.videoSubtitles?.style.displayMode
       const fallback =
         displayMode === "translationOnly"
-          ? batch.map((f) => ({ ...f, translation: f.text }))
-          : batch.map((f) => ({ ...f, translation: "" }))
-      this.onTranslated(fallback)
+          ? validForFallback.map((f) => ({ ...f, translation: f.text }))
+          : validForFallback.map((f) => ({ ...f, translation: "" }))
+      if (fallback.length > 0) {
+        this.onTranslated(fallback)
+      }
 
       const errorMessage = error instanceof Error ? error.message : String(error)
       this.lastEmittedState = "error"
@@ -252,6 +257,15 @@ export class TranslationCoordinator {
       return fallbackTimeMs
     }
     return video.currentTime * 1000
+  }
+
+  /** Keep only cues whose start+end+text still match the live fragment list. */
+  private filterIdentityValid(fragments: SubtitlesFragment[]): SubtitlesFragment[] {
+    const byStart = new Map(this.getFragments().map((fragment) => [fragment.start, fragment]))
+    return fragments.filter((fragment) => {
+      const current = byStart.get(fragment.start)
+      return !!current && current.end === fragment.end && current.text === fragment.text
+    })
   }
 
   private findActiveCue(timeMs: number, fragments: SubtitlesFragment[]): SubtitlesFragment | null {

--- a/src/entrypoints/subtitles.content/translation-coordinator.ts
+++ b/src/entrypoints/subtitles.content/translation-coordinator.ts
@@ -14,10 +14,16 @@ export interface TranslationCoordinatorOptions {
   onStateChange: (state: SubtitlesState, data?: Record<string, string>) => void
 }
 
+function fragmentIdentity(fragment: Pick<SubtitlesFragment, "end" | "text">): string {
+  return `${fragment.end}\0${fragment.text}`
+}
+
 export class TranslationCoordinator {
   private translatingStarts = new Set<number>()
   private translatedStarts = new Set<number>()
   private failedStarts = new Set<number>()
+  /** Identity of the cue (end+text) associated with a booked start. */
+  private knownIdentities = new Map<number, string>()
   private isTranslating = false
   private lastEmittedState: SubtitlesState = "idle"
   private videoContext: SubtitlesVideoContext = { videoTitle: "", subtitlesTextContent: "" }
@@ -70,6 +76,7 @@ export class TranslationCoordinator {
     this.translatingStarts.clear()
     this.translatedStarts.clear()
     this.failedStarts.clear()
+    this.knownIdentities.clear()
     this.isTranslating = false
     this.lastEmittedState = "idle"
     this.videoContext = { videoTitle: "", subtitlesTextContent: "" }
@@ -80,29 +87,38 @@ export class TranslationCoordinator {
   }
 
   /**
-   * Drop bookkeeping for starts that no longer exist after AI re-segmentation,
-   * then re-evaluate nearby translation.
+   * Drop bookkeeping for starts that no longer exist, or whose cue identity
+   * (end+text) changed after AI re-segmentation — same start can be a recut line.
    */
   noteFragmentListChanged() {
-    const validStarts = new Set(this.getFragments().map((fragment) => fragment.start))
+    const byStart = new Map(this.getFragments().map((fragment) => [fragment.start, fragment]))
 
-    for (const start of [...this.translatedStarts]) {
-      if (!validStarts.has(start)) {
-        this.translatedStarts.delete(start)
-      }
-    }
-    for (const start of [...this.translatingStarts]) {
-      if (!validStarts.has(start)) {
-        this.translatingStarts.delete(start)
-      }
-    }
-    for (const start of [...this.failedStarts]) {
-      if (!validStarts.has(start)) {
-        this.failedStarts.delete(start)
-      }
-    }
+    this.invalidateStaleStarts(this.translatedStarts, byStart)
+    this.invalidateStaleStarts(this.translatingStarts, byStart)
+    this.invalidateStaleStarts(this.failedStarts, byStart)
 
     this.handleTranslationTick()
+  }
+
+  private invalidateStaleStarts(starts: Set<number>, byStart: Map<number, SubtitlesFragment>) {
+    for (const start of [...starts]) {
+      const current = byStart.get(start)
+      if (!current) {
+        starts.delete(start)
+        this.knownIdentities.delete(start)
+        continue
+      }
+
+      const known = this.knownIdentities.get(start)
+      if (known !== undefined && known !== fragmentIdentity(current)) {
+        starts.delete(start)
+        this.knownIdentities.delete(start)
+      }
+    }
+  }
+
+  private rememberIdentity(fragment: SubtitlesFragment) {
+    this.knownIdentities.set(fragment.start, fragmentIdentity(fragment))
   }
 
   private handleTranslationTick = () => {
@@ -147,19 +163,26 @@ export class TranslationCoordinator {
     }
 
     this.isTranslating = true
-    batch.forEach((f) => this.translatingStarts.add(f.start))
+    batch.forEach((f) => {
+      this.translatingStarts.add(f.start)
+      this.rememberIdentity(f)
+    })
 
     try {
       const translated = await translateSubtitles(batch, this.videoContext)
-      // Drop results for starts removed by AI re-segmentation while the request was in flight.
-      const validStarts = new Set(this.getFragments().map((fragment) => fragment.start))
-      const stillValid = translated.filter((fragment) => validStarts.has(fragment.start))
+      // Only accept results whose cue identity still matches the current fragment list.
+      const byStart = new Map(this.getFragments().map((fragment) => [fragment.start, fragment]))
+      const stillValid = translated.filter((fragment) => {
+        const current = byStart.get(fragment.start)
+        return !!current && current.end === fragment.end && current.text === fragment.text
+      })
 
       stillValid.forEach((f) => {
         this.translatingStarts.delete(f.start)
         this.translatedStarts.add(f.start)
+        this.rememberIdentity(f)
       })
-      // Starts that disappeared mid-request should not stay "translating" forever.
+      // Starts that disappeared or were recut mid-request should not stay "translating".
       batch.forEach((f) => {
         this.translatingStarts.delete(f.start)
       })
@@ -172,6 +195,7 @@ export class TranslationCoordinator {
       batch.forEach((f) => {
         this.translatingStarts.delete(f.start)
         this.failedStarts.add(f.start)
+        this.rememberIdentity(f)
       })
 
       const config = await getLocalConfig()

--- a/src/entrypoints/subtitles.content/translation-coordinator.ts
+++ b/src/entrypoints/subtitles.content/translation-coordinator.ts
@@ -79,6 +79,32 @@ export class TranslationCoordinator {
     this.failedStarts.clear()
   }
 
+  /**
+   * Drop bookkeeping for starts that no longer exist after AI re-segmentation,
+   * then re-evaluate nearby translation.
+   */
+  noteFragmentListChanged() {
+    const validStarts = new Set(this.getFragments().map((fragment) => fragment.start))
+
+    for (const start of [...this.translatedStarts]) {
+      if (!validStarts.has(start)) {
+        this.translatedStarts.delete(start)
+      }
+    }
+    for (const start of [...this.translatingStarts]) {
+      if (!validStarts.has(start)) {
+        this.translatingStarts.delete(start)
+      }
+    }
+    for (const start of [...this.failedStarts]) {
+      if (!validStarts.has(start)) {
+        this.failedStarts.delete(start)
+      }
+    }
+
+    this.handleTranslationTick()
+  }
+
   private handleTranslationTick = () => {
     const video = this.getVideoElement()
     if (!video) return
@@ -125,11 +151,19 @@ export class TranslationCoordinator {
 
     try {
       const translated = await translateSubtitles(batch, this.videoContext)
-      translated.forEach((f) => {
+      // Drop results for starts removed by AI re-segmentation while the request was in flight.
+      const validStarts = new Set(this.getFragments().map((fragment) => fragment.start))
+      const stillValid = translated.filter((fragment) => validStarts.has(fragment.start))
+
+      stillValid.forEach((f) => {
         this.translatingStarts.delete(f.start)
         this.translatedStarts.add(f.start)
       })
-      this.onTranslated(translated)
+      // Starts that disappeared mid-request should not stay "translating" forever.
+      batch.forEach((f) => {
+        this.translatingStarts.delete(f.start)
+      })
+      this.onTranslated(stillValid)
 
       const latestTimeMs = this.getCurrentVideoTimeMs(currentTimeMs)
       const latestFragments = this.getFragments()
@@ -153,6 +187,8 @@ export class TranslationCoordinator {
       this.onStateChange("error", { message: errorMessage })
     } finally {
       this.isTranslating = false
+      // Kick the next nearby batch without waiting for the next timeupdate.
+      this.handleTranslationTick()
     }
   }
 
@@ -183,13 +219,14 @@ export class TranslationCoordinator {
       return
     }
 
-    // Gap: keep loading if next cue needs translation
-    const nextCue = fragments.find((f) => f.start > timeMs)
-    const nextState: SubtitlesState =
-      nextCue && !this.isCueResolved(nextCue.start) ? "loading" : "idle"
-    if (nextState === this.lastEmittedState) return
-    this.lastEmittedState = nextState
-    this.onStateChange(nextState)
+    // Gap / music intro / before first cue: never keep the corner loading badge up.
+    // Adapter may have set "loading" before fragments were ready; lastEmittedState can
+    // still be "idle" while the scheduler state remains "loading" — always clear it.
+    if (this.lastEmittedState === "idle" && this.getCurrentState() !== "loading") {
+      return
+    }
+    this.lastEmittedState = "idle"
+    this.onStateChange("idle")
   }
 
   private handleSeek = () => {

--- a/src/entrypoints/subtitles.content/ui/__tests__/subtitle-lines.test.tsx
+++ b/src/entrypoints/subtitles.content/ui/__tests__/subtitle-lines.test.tsx
@@ -1,11 +1,10 @@
 // @vitest-environment jsdom
 import type { LangCodeISO6393 } from "@read-frog/definitions"
-import { act, render, screen } from "@testing-library/react"
+import { render, screen } from "@testing-library/react"
 import { createStore, Provider } from "jotai"
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
-import { TRANSLATION_PENDING_INDICATOR_DELAY_MS } from "@/utils/constants/subtitles"
-import { currentSubtitleAtom } from "../../atoms"
+import { currentSubtitleAtom, currentTimeMsAtom, sourceTrackAtom } from "../../atoms"
 import { MainSubtitle, TranslationSubtitle } from "../subtitle-lines"
 
 const mockedAtoms = vi.hoisted(() => ({
@@ -46,10 +45,6 @@ function createStoreWithLanguage(targetCode: LangCodeISO6393) {
 }
 
 describe("subtitle lines", () => {
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
   it("applies rtl attributes to translation subtitle for Arabic target language", () => {
     const store = createStoreWithLanguage("arb")
 
@@ -92,14 +87,11 @@ describe("subtitle lines", () => {
     expect(line).not.toHaveAttribute("lang")
   })
 
-  it("delays pending translating label so fast translations do not flash", () => {
-    vi.useFakeTimers()
+  it("shows pending indicator when display cue has original but no translation", () => {
     const store = createStoreWithLanguage("eng")
-    store.set(currentSubtitleAtom, {
-      text: "Hello world",
-      start: 0,
-      end: 1000,
-    })
+    store.set(currentTimeMsAtom, 500)
+    store.set(currentSubtitleAtom, null)
+    store.set(sourceTrackAtom, [{ text: "Hello", start: 0, end: 1000 }])
 
     const { container } = render(
       <Provider store={store}>
@@ -107,35 +99,7 @@ describe("subtitle lines", () => {
       </Provider>,
     )
 
-    const pending = container.querySelector("[data-pending='true']")
-    expect(pending).not.toBeNull()
-    expect(pending?.querySelector("[data-subtitle-pending-indicator]")).toBeNull()
-
-    act(() => {
-      vi.advanceTimersByTime(TRANSLATION_PENDING_INDICATOR_DELAY_MS)
-    })
-
-    expect(pending?.querySelector("[data-subtitle-pending-indicator]")).not.toBeNull()
-    expect(pending?.querySelectorAll("[data-subtitle-pending-dots] span")).toHaveLength(3)
+    expect(container.querySelector("[data-pending='true']")).not.toBeNull()
     expect(screen.getByText("Translating")).toBeTruthy()
-    expect(pending).toHaveAttribute("aria-label", "Translating…")
-  })
-
-  it("does not show pending placeholder when translation is an empty string", () => {
-    const store = createStoreWithLanguage("eng")
-    store.set(currentSubtitleAtom, {
-      text: "Hello world",
-      start: 0,
-      end: 1000,
-      translation: "",
-    })
-
-    const { container } = render(
-      <Provider store={store}>
-        <TranslationSubtitle />
-      </Provider>,
-    )
-
-    expect(container.querySelector("[data-pending='true']")).toBeNull()
   })
 })

--- a/src/entrypoints/subtitles.content/ui/__tests__/subtitle-lines.test.tsx
+++ b/src/entrypoints/subtitles.content/ui/__tests__/subtitle-lines.test.tsx
@@ -1,14 +1,22 @@
 // @vitest-environment jsdom
 import type { LangCodeISO6393 } from "@read-frog/definitions"
-import { render, screen } from "@testing-library/react"
+import { act, render, screen } from "@testing-library/react"
 import { createStore, Provider } from "jotai"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { TRANSLATION_PENDING_INDICATOR_DELAY_MS } from "@/utils/constants/subtitles"
+import { currentSubtitleAtom } from "../../atoms"
 import { MainSubtitle, TranslationSubtitle } from "../subtitle-lines"
 
 const mockedAtoms = vi.hoisted(() => ({
   languageAtom: null as any,
   videoSubtitlesAtom: null as any,
+}))
+
+vi.mock("@/utils/i18n", () => ({
+  i18n: {
+    t: (key: string) => (key === "subtitles.state.translating" ? "Translating…" : key),
+  },
 }))
 
 vi.mock("@/utils/atoms/config", async () => {
@@ -38,6 +46,10 @@ function createStoreWithLanguage(targetCode: LangCodeISO6393) {
 }
 
 describe("subtitle lines", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it("applies rtl attributes to translation subtitle for Arabic target language", () => {
     const store = createStoreWithLanguage("arb")
 
@@ -78,5 +90,51 @@ describe("subtitle lines", () => {
     const line = screen.getByText("Hello world")
     expect(line).not.toHaveAttribute("dir")
     expect(line).not.toHaveAttribute("lang")
+  })
+
+  it("delays pending loading dots so fast translations do not flash", () => {
+    vi.useFakeTimers()
+    const store = createStoreWithLanguage("eng")
+    store.set(currentSubtitleAtom, {
+      text: "Hello world",
+      start: 0,
+      end: 1000,
+    })
+
+    const { container } = render(
+      <Provider store={store}>
+        <TranslationSubtitle />
+      </Provider>,
+    )
+
+    const pending = container.querySelector("[data-pending='true']")
+    expect(pending).not.toBeNull()
+    expect(pending?.querySelectorAll(".animate-bounce")).toHaveLength(0)
+
+    act(() => {
+      vi.advanceTimersByTime(TRANSLATION_PENDING_INDICATOR_DELAY_MS)
+    })
+
+    expect(pending?.querySelectorAll(".animate-bounce")).toHaveLength(3)
+    expect(screen.queryByText("Translating…")).toBeNull()
+    expect(pending).toHaveAttribute("aria-label", "Translating…")
+  })
+
+  it("does not show pending placeholder when translation is an empty string", () => {
+    const store = createStoreWithLanguage("eng")
+    store.set(currentSubtitleAtom, {
+      text: "Hello world",
+      start: 0,
+      end: 1000,
+      translation: "",
+    })
+
+    const { container } = render(
+      <Provider store={store}>
+        <TranslationSubtitle />
+      </Provider>,
+    )
+
+    expect(container.querySelector("[data-pending='true']")).toBeNull()
   })
 })

--- a/src/entrypoints/subtitles.content/ui/__tests__/subtitle-lines.test.tsx
+++ b/src/entrypoints/subtitles.content/ui/__tests__/subtitle-lines.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import type { LangCodeISO6393 } from "@read-frog/definitions"
-import { render, screen } from "@testing-library/react"
+import { act, render, screen } from "@testing-library/react"
 import { createStore, Provider } from "jotai"
 import { describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
@@ -101,5 +101,52 @@ describe("subtitle lines", () => {
 
     expect(container.querySelector("[data-pending='true']")).not.toBeNull()
     expect(screen.getByText("Translating")).toBeTruthy()
+  })
+
+  it("fades translation in when the pending cue resolves", () => {
+    const store = createStoreWithLanguage("eng")
+    store.set(currentTimeMsAtom, 500)
+    store.set(currentSubtitleAtom, null)
+    store.set(sourceTrackAtom, [{ text: "Hello", start: 0, end: 1000 }])
+
+    const { container } = render(
+      <Provider store={store}>
+        <TranslationSubtitle />
+      </Provider>,
+    )
+
+    expect(container.querySelector("[data-pending='true']")).not.toBeNull()
+
+    act(() => {
+      store.set(currentSubtitleAtom, {
+        text: "Hello",
+        start: 0,
+        end: 1000,
+        translation: "你好",
+      })
+    })
+
+    const line = screen.getByText("你好")
+    expect(line).toHaveClass("animate-subtitle-fade-in")
+  })
+
+  it("does not fade translation in for an already translated cue", () => {
+    const store = createStoreWithLanguage("eng")
+    store.set(currentTimeMsAtom, 500)
+    store.set(currentSubtitleAtom, {
+      text: "Hello",
+      start: 0,
+      end: 1000,
+      translation: "你好",
+    })
+
+    render(
+      <Provider store={store}>
+        <TranslationSubtitle />
+      </Provider>,
+    )
+
+    const line = screen.getByText("你好")
+    expect(line).not.toHaveClass("animate-subtitle-fade-in")
   })
 })

--- a/src/entrypoints/subtitles.content/ui/__tests__/subtitle-lines.test.tsx
+++ b/src/entrypoints/subtitles.content/ui/__tests__/subtitle-lines.test.tsx
@@ -92,7 +92,7 @@ describe("subtitle lines", () => {
     expect(line).not.toHaveAttribute("lang")
   })
 
-  it("delays pending loading dots so fast translations do not flash", () => {
+  it("delays pending translating label so fast translations do not flash", () => {
     vi.useFakeTimers()
     const store = createStoreWithLanguage("eng")
     store.set(currentSubtitleAtom, {
@@ -109,14 +109,15 @@ describe("subtitle lines", () => {
 
     const pending = container.querySelector("[data-pending='true']")
     expect(pending).not.toBeNull()
-    expect(pending?.querySelectorAll(".animate-bounce")).toHaveLength(0)
+    expect(pending?.querySelector("[data-subtitle-pending-indicator]")).toBeNull()
 
     act(() => {
       vi.advanceTimersByTime(TRANSLATION_PENDING_INDICATOR_DELAY_MS)
     })
 
-    expect(pending?.querySelectorAll(".animate-bounce")).toHaveLength(3)
-    expect(screen.queryByText("Translating…")).toBeNull()
+    expect(pending?.querySelector("[data-subtitle-pending-indicator]")).not.toBeNull()
+    expect(pending?.querySelectorAll("[data-subtitle-pending-dots] span")).toHaveLength(3)
+    expect(screen.getByText("Translating")).toBeTruthy()
     expect(pending).toHaveAttribute("aria-label", "Translating…")
   })
 

--- a/src/entrypoints/subtitles.content/ui/subtitle-lines.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitle-lines.tsx
@@ -1,7 +1,6 @@
 import type { SubtitleTextStyle } from "@/types/config/subtitles"
 import { useAtomValue } from "jotai"
 import { useEffect, useState } from "react"
-import LoadingDots from "@/components/loading-dots"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import {
   SUBTITLE_FONT_FAMILIES,
@@ -12,6 +11,7 @@ import { i18n } from "@/utils/i18n"
 import { cn } from "@/utils/styles/utils"
 import { isTranslationPending } from "@/utils/subtitles/display-rules"
 import { currentSubtitleAtom } from "../atoms"
+import { SubtitlePendingLabel } from "./subtitle-pending-label"
 
 interface SubtitleLineProps {
   content?: string
@@ -111,7 +111,7 @@ export function TranslationSubtitle({ content, className }: SubtitleLineProps) {
         aria-label={i18n.t("subtitles.state.translating")}
       >
         {showPendingDots ? (
-          <LoadingDots className="scale-75 opacity-70 [&>div]:bg-current" />
+          <SubtitlePendingLabel label={i18n.t("subtitles.state.translating")} />
         ) : null}
       </div>
     )

--- a/src/entrypoints/subtitles.content/ui/subtitle-lines.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitle-lines.tsx
@@ -1,9 +1,16 @@
 import type { SubtitleTextStyle } from "@/types/config/subtitles"
 import { useAtomValue } from "jotai"
+import { useEffect, useState } from "react"
+import LoadingDots from "@/components/loading-dots"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
-import { SUBTITLE_FONT_FAMILIES } from "@/utils/constants/subtitles"
+import {
+  SUBTITLE_FONT_FAMILIES,
+  TRANSLATION_PENDING_INDICATOR_DELAY_MS,
+} from "@/utils/constants/subtitles"
 import { getLanguageDirectionAndLang } from "@/utils/content/language-direction"
+import { i18n } from "@/utils/i18n"
 import { cn } from "@/utils/styles/utils"
+import { isTranslationPending } from "@/utils/subtitles/display-rules"
 import { currentSubtitleAtom } from "../atoms"
 
 interface SubtitleLineProps {
@@ -39,13 +46,85 @@ export function TranslationSubtitle({ content, className }: SubtitleLineProps) {
   const subtitle = useAtomValue(currentSubtitleAtom)
   const { style } = useAtomValue(configFieldsAtomMap.videoSubtitles)
   const language = useAtomValue(configFieldsAtomMap.language)
+  const pending = content === undefined && isTranslationPending(subtitle)
   const text = content ?? subtitle?.translation ?? ""
   const { dir, lang } = getLanguageDirectionAndLang(language.targetCode)
+  const textStyles = getTextStyles(style.translation)
+
+  const [showPendingDots, setShowPendingDots] = useState(false)
+  const [fadeIn, setFadeIn] = useState(!pending && !!text)
+
+  // Delay dots so fast translations never flash a pending state.
+  useEffect(() => {
+    if (!pending) {
+      setShowPendingDots(false)
+      return undefined
+    }
+
+    setShowPendingDots(false)
+    const timerId = window.setTimeout(() => {
+      setShowPendingDots(true)
+    }, TRANSLATION_PENDING_INDICATOR_DELAY_MS)
+
+    return () => {
+      window.clearTimeout(timerId)
+    }
+  }, [pending, subtitle?.start])
+
+  // Fade in when a real translation appears for the current cue.
+  // Double rAF so the browser commits opacity-0 before transitioning to 100.
+  useEffect(() => {
+    if (pending || !text) {
+      setFadeIn(false)
+      return undefined
+    }
+
+    setFadeIn(false)
+    let secondFrameId = 0
+    const firstFrameId = window.requestAnimationFrame(() => {
+      secondFrameId = window.requestAnimationFrame(() => {
+        setFadeIn(true)
+      })
+    })
+    return () => {
+      window.cancelAnimationFrame(firstFrameId)
+      window.cancelAnimationFrame(secondFrameId)
+    }
+  }, [pending, text, subtitle?.start])
+
+  if (pending) {
+    return (
+      <div
+        className={cn(
+          "subtitles-translation flex min-h-[1.25em] items-center justify-center leading-tight",
+          className,
+        )}
+        style={{
+          fontFamily: textStyles.fontFamily,
+          fontSize: textStyles.fontSize,
+          color: textStyles.color,
+        }}
+        dir={dir}
+        lang={lang}
+        data-pending="true"
+        aria-busy="true"
+        aria-label={i18n.t("subtitles.state.translating")}
+      >
+        {showPendingDots ? (
+          <LoadingDots className="scale-75 opacity-70 [&>div]:bg-current" />
+        ) : null}
+      </div>
+    )
+  }
 
   return (
     <div
-      className={cn("subtitles-translation text-xl leading-tight", className)}
-      style={getTextStyles(style.translation)}
+      className={cn(
+        "subtitles-translation text-xl leading-tight transition-opacity duration-200",
+        fadeIn ? "opacity-100" : "opacity-0",
+        className,
+      )}
+      style={textStyles}
       dir={dir}
       lang={lang}
     >

--- a/src/entrypoints/subtitles.content/ui/subtitle-lines.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitle-lines.tsx
@@ -1,5 +1,6 @@
 import type { SubtitleTextStyle } from "@/types/config/subtitles"
 import { useAtomValue } from "jotai"
+import { useEffect, useRef } from "react"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { SUBTITLE_FONT_FAMILIES } from "@/utils/constants/subtitles"
 import { getLanguageDirectionAndLang } from "@/utils/content/language-direction"
@@ -45,6 +46,19 @@ export function TranslationSubtitle({ content, className }: SubtitleLineProps) {
   const text = content ?? subtitle?.translation ?? ""
   const { dir, lang } = getLanguageDirectionAndLang(language.targetCode)
   const textStyles = getTextStyles(style.translation)
+  const lastFrameRef = useRef<{ start?: number; pending: boolean }>({
+    start: undefined,
+    pending: false,
+  })
+  const justResolved =
+    !pending &&
+    !!text &&
+    lastFrameRef.current.pending &&
+    lastFrameRef.current.start === subtitle?.start
+
+  useEffect(() => {
+    lastFrameRef.current = { start: subtitle?.start, pending }
+  })
 
   if (pending) {
     return (
@@ -70,9 +84,9 @@ export function TranslationSubtitle({ content, className }: SubtitleLineProps) {
 
   return (
     <div
-      key={subtitle?.start}
       className={cn(
-        "subtitles-translation animate-subtitle-fade-in text-xl leading-tight",
+        "subtitles-translation text-xl leading-tight",
+        justResolved && "animate-subtitle-fade-in",
         className,
       )}
       style={textStyles}

--- a/src/entrypoints/subtitles.content/ui/subtitle-lines.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitle-lines.tsx
@@ -1,16 +1,11 @@
 import type { SubtitleTextStyle } from "@/types/config/subtitles"
 import { useAtomValue } from "jotai"
-import { useEffect, useState } from "react"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
-import {
-  SUBTITLE_FONT_FAMILIES,
-  TRANSLATION_PENDING_INDICATOR_DELAY_MS,
-} from "@/utils/constants/subtitles"
+import { SUBTITLE_FONT_FAMILIES } from "@/utils/constants/subtitles"
 import { getLanguageDirectionAndLang } from "@/utils/content/language-direction"
-import { i18n } from "@/utils/i18n"
 import { cn } from "@/utils/styles/utils"
 import { isTranslationPending } from "@/utils/subtitles/display-rules"
-import { currentSubtitleAtom } from "../atoms"
+import { displaySubtitleAtom } from "../atoms"
 import { SubtitlePendingLabel } from "./subtitle-pending-label"
 
 interface SubtitleLineProps {
@@ -28,7 +23,7 @@ function getTextStyles(textStyle: SubtitleTextStyle) {
 }
 
 export function MainSubtitle({ content, className }: SubtitleLineProps) {
-  const subtitle = useAtomValue(currentSubtitleAtom)
+  const subtitle = useAtomValue(displaySubtitleAtom)
   const { style } = useAtomValue(configFieldsAtomMap.videoSubtitles)
   const text = content ?? subtitle?.text ?? ""
 
@@ -43,54 +38,13 @@ export function MainSubtitle({ content, className }: SubtitleLineProps) {
 }
 
 export function TranslationSubtitle({ content, className }: SubtitleLineProps) {
-  const subtitle = useAtomValue(currentSubtitleAtom)
+  const subtitle = useAtomValue(displaySubtitleAtom)
   const { style } = useAtomValue(configFieldsAtomMap.videoSubtitles)
   const language = useAtomValue(configFieldsAtomMap.language)
   const pending = content === undefined && isTranslationPending(subtitle)
   const text = content ?? subtitle?.translation ?? ""
   const { dir, lang } = getLanguageDirectionAndLang(language.targetCode)
   const textStyles = getTextStyles(style.translation)
-
-  const [showPendingDots, setShowPendingDots] = useState(false)
-  const [fadeIn, setFadeIn] = useState(!pending && !!text)
-
-  // Delay dots so fast translations never flash a pending state.
-  useEffect(() => {
-    if (!pending) {
-      setShowPendingDots(false)
-      return undefined
-    }
-
-    setShowPendingDots(false)
-    const timerId = window.setTimeout(() => {
-      setShowPendingDots(true)
-    }, TRANSLATION_PENDING_INDICATOR_DELAY_MS)
-
-    return () => {
-      window.clearTimeout(timerId)
-    }
-  }, [pending, subtitle?.start])
-
-  // Fade in when a real translation appears for the current cue.
-  // Double rAF so the browser commits opacity-0 before transitioning to 100.
-  useEffect(() => {
-    if (pending || !text) {
-      setFadeIn(false)
-      return undefined
-    }
-
-    setFadeIn(false)
-    let secondFrameId = 0
-    const firstFrameId = window.requestAnimationFrame(() => {
-      secondFrameId = window.requestAnimationFrame(() => {
-        setFadeIn(true)
-      })
-    })
-    return () => {
-      window.cancelAnimationFrame(firstFrameId)
-      window.cancelAnimationFrame(secondFrameId)
-    }
-  }, [pending, text, subtitle?.start])
 
   if (pending) {
     return (
@@ -108,20 +62,17 @@ export function TranslationSubtitle({ content, className }: SubtitleLineProps) {
         lang={lang}
         data-pending="true"
         aria-busy="true"
-        aria-label={i18n.t("subtitles.state.translating")}
       >
-        {showPendingDots ? (
-          <SubtitlePendingLabel label={i18n.t("subtitles.state.translating")} />
-        ) : null}
+        <SubtitlePendingLabel key={subtitle?.start} />
       </div>
     )
   }
 
   return (
     <div
+      key={subtitle?.start}
       className={cn(
-        "subtitles-translation text-xl leading-tight transition-opacity duration-200",
-        fadeIn ? "opacity-100" : "opacity-0",
+        "subtitles-translation animate-subtitle-fade-in text-xl leading-tight",
         className,
       )}
       style={textStyles}

--- a/src/entrypoints/subtitles.content/ui/subtitle-pending-label.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitle-pending-label.tsx
@@ -1,0 +1,64 @@
+import { cn } from "@/utils/styles/utils"
+
+const DOT_COUNT = 3
+/** Slow cycle keeps the motion peripheral during video watching. */
+const BREATH_MS = 2000
+const STAGGER_MS = 180
+
+interface SubtitlePendingLabelProps {
+  className?: string
+  label: string
+}
+
+/** Drop trailing ellipsis so we do not render "翻译中……". */
+function stripTrailingEllipsis(label: string): string {
+  return label.replace(/[\s.…⋯]+$/u, "").trimEnd()
+}
+
+/**
+ * Restrained pending indicator for bilingual subtitles:
+ * slightly smaller status text + soft opacity-only breathing dots.
+ * Dots are geometric circles flex-centered to the label's mid height.
+ */
+export function SubtitlePendingLabel({ className, label }: SubtitlePendingLabelProps) {
+  const text = stripTrailingEllipsis(label)
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center justify-center gap-[0.28em] leading-none font-normal tracking-wide",
+        className,
+      )}
+      data-subtitle-pending-indicator=""
+      aria-hidden
+    >
+      <style>{`
+        @keyframes rf-subtitle-pending-breath {
+          0%,
+          100% {
+            opacity: 0.22;
+          }
+          50% {
+            opacity: 0.58;
+          }
+        }
+      `}</style>
+      <span className="text-[0.74em] leading-none opacity-70">{text}</span>
+      <span className="inline-flex items-center gap-[0.18em]" data-subtitle-pending-dots="">
+        {Array.from({ length: DOT_COUNT }, (_, index) => (
+          <span
+            key={index}
+            className="inline-block size-[0.16em] max-h-[5px] min-h-[3px] max-w-[5px] min-w-[3px] rounded-full bg-current will-change-[opacity]"
+            style={{
+              animationName: "rf-subtitle-pending-breath",
+              animationDuration: `${BREATH_MS}ms`,
+              animationTimingFunction: "ease-in-out",
+              animationIterationCount: "infinite",
+              animationDelay: `${index * STAGGER_MS}ms`,
+            }}
+          />
+        ))}
+      </span>
+    </span>
+  )
+}

--- a/src/entrypoints/subtitles.content/ui/subtitle-pending-label.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitle-pending-label.tsx
@@ -1,61 +1,35 @@
+import { i18n } from "@/utils/i18n"
 import { cn } from "@/utils/styles/utils"
 
 const DOT_COUNT = 3
-/** Slow cycle keeps the motion peripheral during video watching. */
-const BREATH_MS = 2000
 const STAGGER_MS = 180
 
-interface SubtitlePendingLabelProps {
-  className?: string
-  label: string
-}
-
-/** Drop trailing ellipsis so we do not render "翻译中……". */
 function stripTrailingEllipsis(label: string): string {
   return label.replace(/[\s.…⋯]+$/u, "").trimEnd()
 }
 
 /**
- * Restrained pending indicator for bilingual subtitles:
- * slightly smaller status text + soft opacity-only breathing dots.
- * Dots are geometric circles flex-centered to the label's mid height.
+ * Restrained pending indicator for bilingual subtitles (CSS-driven appear + breath).
  */
-export function SubtitlePendingLabel({ className, label }: SubtitlePendingLabelProps) {
-  const text = stripTrailingEllipsis(label)
+export function SubtitlePendingLabel({ className }: { className?: string }) {
+  const text = stripTrailingEllipsis(i18n.t("subtitles.state.translating"))
 
   return (
     <span
       className={cn(
-        "inline-flex items-center justify-center gap-[0.28em] leading-none font-normal tracking-wide",
+        "inline-flex animate-subtitle-pending-appear items-center justify-center gap-[0.28em] leading-none font-normal tracking-wide",
         className,
       )}
       data-subtitle-pending-indicator=""
       aria-hidden
     >
-      <style>{`
-        @keyframes rf-subtitle-pending-breath {
-          0%,
-          100% {
-            opacity: 0.22;
-          }
-          50% {
-            opacity: 0.58;
-          }
-        }
-      `}</style>
       <span className="text-[0.74em] leading-none opacity-70">{text}</span>
       <span className="inline-flex items-center gap-[0.18em]" data-subtitle-pending-dots="">
         {Array.from({ length: DOT_COUNT }, (_, index) => (
           <span
             key={index}
-            className="inline-block size-[0.16em] max-h-[5px] min-h-[3px] max-w-[5px] min-w-[3px] rounded-full bg-current will-change-[opacity]"
-            style={{
-              animationName: "rf-subtitle-pending-breath",
-              animationDuration: `${BREATH_MS}ms`,
-              animationTimingFunction: "ease-in-out",
-              animationIterationCount: "infinite",
-              animationDelay: `${index * STAGGER_MS}ms`,
-            }}
+            className="inline-block size-[0.16em] max-h-[5px] min-h-[3px] max-w-[5px] min-w-[3px] animate-subtitle-pending-breath rounded-full bg-current will-change-[opacity]"
+            style={{ animationDelay: `${index * STAGGER_MS}ms` }}
           />
         ))}
       </span>

--- a/src/entrypoints/subtitles.content/ui/subtitles-view.tsx
+++ b/src/entrypoints/subtitles.content/ui/subtitles-view.tsx
@@ -4,7 +4,7 @@ import { Activity } from "react"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { SUBTITLES_VIEW_CLASS } from "@/utils/constants/subtitles"
 import { cn } from "@/utils/styles/utils"
-import { currentSubtitleAtom } from "../atoms"
+import { displaySubtitleAtom } from "../atoms"
 import { MainSubtitle, TranslationSubtitle } from "./subtitle-lines"
 import { useVerticalDrag } from "./use-vertical-drag"
 
@@ -13,13 +13,14 @@ interface SubtitlesViewProps {
 }
 
 function SubtitlesContent() {
-  const subtitle = useAtomValue(currentSubtitleAtom)
+  const subtitle = useAtomValue(displaySubtitleAtom)
   const { style } = useAtomValue(configFieldsAtomMap.videoSubtitles)
   const { displayMode, translationPosition, container } = style
 
   const translationAbove = translationPosition === "above"
   const showMain = displayMode !== "translationOnly"
   const isDuplicateTranslation = !!subtitle?.translation && subtitle.translation === subtitle.text
+  // Bilingual: keep translation row for pending indicator when original is shown without translation.
   const showTranslation =
     displayMode !== "originalOnly" && !(displayMode === "bilingual" && isDuplicateTranslation)
 

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -650,17 +650,25 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
       subtitlesTextContent: this.sessionSubtitles.map((f) => f.text).join(""),
     }
 
+    this.sessionProcessedFragments = [...this.sourceProcessedSubtitles]
+
+    // Seed originals immediately so bilingual/originalOnly can render before translations arrive.
+    scheduler.supplementSubtitles(this.sessionProcessedFragments)
+
     if (useAiSegmentation) {
-      this.sessionProcessedFragments = [...this.sourceProcessedSubtitles]
       this.segmentationPipeline = new SegmentationPipeline({
         baselineFragments: this.sourceProcessedSubtitles,
         rawFragments: this.sessionSubtitles,
         getVideoElement: () => this.subtitlesScheduler?.getVideoElement() ?? null,
         getSourceLanguage: () => this.fetcher.getSourceLanguage(),
         preSegmented: this.fetcher.isPreSegmented?.(),
+        onChunkSegmented: (chunk, nextFragments) => {
+          const chunkStart = chunk[0].start
+          const chunkEnd = chunk.at(-1)!.end
+          scheduler.replaceTimeWindow(chunkStart, chunkEnd, nextFragments)
+          this.translationCoordinator?.noteFragmentListChanged()
+        },
       })
-    } else {
-      this.sessionProcessedFragments = [...this.sourceProcessedSubtitles]
     }
 
     this.translationCoordinator = new TranslationCoordinator({
@@ -671,7 +679,7 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
       getVideoElement: () => scheduler.getVideoElement(),
       getCurrentState: () => scheduler.getState(),
       segmentationPipeline: this.segmentationPipeline,
-      onTranslated: (fragments) => scheduler.supplementSubtitles(fragments),
+      onTranslated: (fragments) => scheduler.supplementSubtitles(fragments, { mergeOnly: true }),
       onStateChange: (state, data) => scheduler.setState(state, data),
     })
     this.translationCoordinator.start(videoContext)

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -404,6 +404,7 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
     // Resync content time when the ad ends so the next cue is correct immediately.
     if (!playing) {
       this.subtitlesScheduler?.resyncFromVideo()
+      this.translationCoordinator?.requestTick()
     }
   }
 

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -28,6 +28,7 @@ import {
 } from "@/utils/subtitles/processor/translator"
 import { downloadSubtitlesAsSrt } from "@/utils/subtitles/srt"
 import {
+  currentTimeMsAtom,
   sourceTrackAtom,
   subtitlesPositionAtom,
   subtitlesSettingsPanelOpenAtom,
@@ -631,12 +632,17 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
       ...fragment,
       translation: fragment.text,
     }))
-    subtitlesStore.set(sourceTrackAtom, [...this.sourceProcessedSubtitles])
+    this.publishSourceTrack(this.sourceProcessedSubtitles)
     this.subtitlesScheduler?.supplementSubtitles(this.sessionProcessedFragments)
     this.subtitlesScheduler?.setState("idle")
   }
 
   private publishSourceTrack(fragments: SubtitlesFragment[]) {
+    // timeupdate may not have fired yet (paused / enable mid-video); keep display time fresh.
+    const video = this.subtitlesScheduler?.getVideoElement()
+    if (video) {
+      subtitlesStore.set(currentTimeMsAtom, video.currentTime * 1000)
+    }
     subtitlesStore.set(sourceTrackAtom, [...fragments])
   }
 
@@ -646,8 +652,10 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
     nextFragments: SubtitlesFragment[],
   ) {
     const previous = subtitlesStore.get(sourceTrackAtom)
+    // Drop any cue that overlaps the window (not just cues whose start falls inside it).
+    // Half-open: keep if end <= windowStart || start >= windowEnd.
     const kept = previous.filter(
-      (fragment) => fragment.start < windowStartMs || fragment.start > windowEndMs,
+      (fragment) => fragment.end <= windowStartMs || fragment.start >= windowEndMs,
     )
     const next = [...kept, ...nextFragments].sort((a, b) => a.start - b.start)
     this.publishSourceTrack(next)

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -28,6 +28,7 @@ import {
 } from "@/utils/subtitles/processor/translator"
 import { downloadSubtitlesAsSrt } from "@/utils/subtitles/srt"
 import {
+  sourceTrackAtom,
   subtitlesPositionAtom,
   subtitlesSettingsPanelOpenAtom,
   subtitlesSettingsPanelViewAtom,
@@ -265,6 +266,7 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
     this.sessionProcessedFragments = []
     this.sessionVideoId = null
     this.subtitlesSummaryContextHash = null
+    subtitlesStore.set(sourceTrackAtom, [])
   }
 
   private clearVisibleStateForNavigation() {
@@ -629,8 +631,26 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
       ...fragment,
       translation: fragment.text,
     }))
+    subtitlesStore.set(sourceTrackAtom, [...this.sourceProcessedSubtitles])
     this.subtitlesScheduler?.supplementSubtitles(this.sessionProcessedFragments)
     this.subtitlesScheduler?.setState("idle")
+  }
+
+  private publishSourceTrack(fragments: SubtitlesFragment[]) {
+    subtitlesStore.set(sourceTrackAtom, [...fragments])
+  }
+
+  private replaceSourceTrackWindow(
+    windowStartMs: number,
+    windowEndMs: number,
+    nextFragments: SubtitlesFragment[],
+  ) {
+    const previous = subtitlesStore.get(sourceTrackAtom)
+    const kept = previous.filter(
+      (fragment) => fragment.start < windowStartMs || fragment.start > windowEndMs,
+    )
+    const next = [...kept, ...nextFragments].sort((a, b) => a.start - b.start)
+    this.publishSourceTrack(next)
   }
 
   private async processTranslatedSubtitles() {
@@ -652,8 +672,8 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
 
     this.sessionProcessedFragments = [...this.sourceProcessedSubtitles]
 
-    // Seed originals immediately so bilingual/originalOnly can render before translations arrive.
-    scheduler.supplementSubtitles(this.sessionProcessedFragments)
+    // Source track for display fallback; scheduler only receives translated cues later.
+    this.publishSourceTrack(this.sessionProcessedFragments)
 
     if (useAiSegmentation) {
       this.segmentationPipeline = new SegmentationPipeline({
@@ -665,7 +685,9 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
         onChunkSegmented: (chunk, nextFragments) => {
           const chunkStart = chunk[0].start
           const chunkEnd = chunk.at(-1)!.end
-          scheduler.replaceTimeWindow(chunkStart, chunkEnd, nextFragments)
+          this.replaceSourceTrackWindow(chunkStart, chunkEnd, nextFragments)
+          // Drop translated cues in the window so display falls back to the new source cuts.
+          scheduler.removeCuesInTimeWindow(chunkStart, chunkEnd)
           this.translationCoordinator?.noteFragmentListChanged()
         },
       })
@@ -679,7 +701,7 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
       getVideoElement: () => scheduler.getVideoElement(),
       getCurrentState: () => scheduler.getState(),
       segmentationPipeline: this.segmentationPipeline,
-      onTranslated: (fragments) => scheduler.supplementSubtitles(fragments, { mergeOnly: true }),
+      onTranslated: (fragments) => scheduler.supplementSubtitles(fragments),
       onStateChange: (state, data) => scheduler.setState(state, data),
     })
     this.translationCoordinator.start(videoContext)

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -752,6 +752,7 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
         getSourceLanguage: () => this.fetcher.getSourceLanguage(),
         preSegmented: this.fetcher.isPreSegmented?.(),
         onChunkSegmented: (chunk, nextFragments) => {
+          if (chunk.length === 0 || !chunk[0]) return
           const chunkStart = chunk[0].start
           const chunkEnd = chunk.at(-1)!.end
           this.replaceSourceTrackWindow(chunkStart, chunkEnd, nextFragments)

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -756,8 +756,9 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
           const chunkStart = chunk[0].start
           const chunkEnd = chunk.at(-1)!.end
           this.replaceSourceTrackWindow(chunkStart, chunkEnd, nextFragments)
-          // Drop translated cues in the window so display falls back to the new source cuts.
-          scheduler.removeCuesInTimeWindow(chunkStart, chunkEnd)
+          // Drop identity-changed/spanning translations; keep translations for unchanged cues
+          // so preSegmented (and partial AI recuts) do not wipe work then skip re-translate.
+          scheduler.reconcileTranslatedCuesAfterRecut(chunkStart, chunkEnd, nextFragments)
           this.translationCoordinator?.noteFragmentListChanged()
         },
       })

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -359,9 +359,7 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
 
     this.teardownAdObserver()
 
-    const player = document.querySelector(
-      this.config.selectors.playerContainer,
-    ) as HTMLElement | null
+    const player = document.querySelector<HTMLElement>(this.config.selectors.playerContainer)
     if (!player) {
       subtitlesStore.set(adPlayingAtom, false)
       return
@@ -391,7 +389,7 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
 
     const player =
       this.observedAdPlayer ??
-      (document.querySelector(this.config.selectors.playerContainer) as HTMLElement | null)
+      document.querySelector<HTMLElement>(this.config.selectors.playerContainer)
 
     const playing = !!player && isAdPlaying(player)
     const wasPlaying = subtitlesStore.get(adPlayingAtom)

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -28,6 +28,7 @@ import {
 } from "@/utils/subtitles/processor/translator"
 import { downloadSubtitlesAsSrt } from "@/utils/subtitles/srt"
 import {
+  adPlayingAtom,
   currentTimeMsAtom,
   sourceTrackAtom,
   subtitlesPositionAtom,
@@ -90,6 +91,8 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
   private translationCoordinator: TranslationCoordinator | null = null
   private translatedSubtitlesDownloader: TranslatedSubtitlesDownloader | null = null
   private subtitlesSummaryContextHash: string | null = null
+  private adObserver: MutationObserver | null = null
+  private observedAdPlayer: HTMLElement | null = null
 
   get embedded() {
     return this.config.embedded
@@ -126,6 +129,7 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
     void this.renderTranslateButton()
 
     await this.initializeScheduler()
+    this.setupAdObserver()
     await this.tryAutoStartSubtitles()
     this.setupNavigationListeners()
   }
@@ -181,6 +185,7 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
   private resetForNavigation() {
     this.switchOperationId++
     this.clearNavigationReinitTimeout()
+    this.teardownAdObserver()
     this.destroyScheduler()
     this.clearRuntimeSession()
     this.clearSourceCache()
@@ -272,6 +277,7 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
 
   private clearVisibleStateForNavigation() {
     this.clearNavigationReinitTimeout()
+    this.teardownAdObserver()
     this.translatedSubtitlesDownloader?.dispose()
     this.destroyScheduler()
     this.translationCoordinator?.stop()
@@ -342,7 +348,63 @@ export class UniversalVideoAdapter implements SubtitlesProvidersAdapter {
     void this.renderTranslateButton()
 
     await this.initializeScheduler()
+    this.setupAdObserver()
     await this.tryAutoStartSubtitles()
+  }
+
+  private setupAdObserver() {
+    if (!this.config.isAdPlaying) {
+      return
+    }
+
+    this.teardownAdObserver()
+
+    const player = document.querySelector(
+      this.config.selectors.playerContainer,
+    ) as HTMLElement | null
+    if (!player) {
+      subtitlesStore.set(adPlayingAtom, false)
+      return
+    }
+
+    this.observedAdPlayer = player
+    this.syncAdPlayingState()
+
+    this.adObserver = new MutationObserver(() => {
+      this.syncAdPlayingState()
+    })
+    this.adObserver.observe(player, { attributes: true, attributeFilter: ["class"] })
+  }
+
+  private teardownAdObserver() {
+    this.adObserver?.disconnect()
+    this.adObserver = null
+    this.observedAdPlayer = null
+    subtitlesStore.set(adPlayingAtom, false)
+  }
+
+  private syncAdPlayingState() {
+    const isAdPlaying = this.config.isAdPlaying
+    if (!isAdPlaying) {
+      return
+    }
+
+    const player =
+      this.observedAdPlayer ??
+      (document.querySelector(this.config.selectors.playerContainer) as HTMLElement | null)
+
+    const playing = !!player && isAdPlaying(player)
+    const wasPlaying = subtitlesStore.get(adPlayingAtom)
+    if (playing === wasPlaying) {
+      return
+    }
+
+    subtitlesStore.set(adPlayingAtom, playing)
+
+    // Resync content time when the ad ends so the next cue is correct immediately.
+    if (!playing) {
+      this.subtitlesScheduler?.resyncFromVideo()
+    }
   }
 
   private async renderTranslateButton() {

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1171,6 +1171,7 @@ subtitles:
     downloadSource: Download source subtitles
   state:
     loading: Read Frog loading captions
+    translating: Translating…
     error: Error occurred
   errors:
     http429: 429 Too many requests to youtube subtitle API, please try again later

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -1171,6 +1171,7 @@ subtitles:
     downloadSource: Descargar subtítulos de origen
   state:
     loading: Read Frog está cargando subtítulos
+    translating: Traduciendo…
     error: Se produjo un error
   errors:
     http429: 429 Demasiadas solicitudes a la API de subtítulos de youtube; inténtalo de nuevo más tarde

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -1055,6 +1055,7 @@ subtitles:
     downloadSource: 元字幕をダウンロード
   state:
     loading: Read Frog 字幕読み込み中
+    translating: 翻訳中…
     error: エラーが発生しました
   errors:
     http429: 429 YouTube字幕APIへのリクエストが多すぎます。しばらくしてから再試行してください

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -1055,6 +1055,7 @@ subtitles:
     downloadSource: 원본 자막 다운로드
   state:
     loading: Read Frog 자막 로딩 중
+    translating: 번역 중…
     error: 오류 발생
   errors:
     http429: 429 유튜브 자막 인터페이스 요청이 너무 많습니다. 잠시 후 다시 시도해 주세요

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -1055,6 +1055,7 @@ subtitles:
     downloadSource: Скачать исходные субтитры
   state:
     loading: Read Frog загрузка субтитров
+    translating: Перевод…
     error: Произошла ошибка
   errors:
     http429: 429 Слишком много запросов к API YouTube субтитров, пожалуйста, попробуйте снова позже

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -1055,6 +1055,7 @@ subtitles:
     downloadSource: Kaynak altyazıları indir
   state:
     loading: Read Frog altyazılar yükleniyor
+    translating: Çevriliyor…
     error: Bir hata oluştu
   errors:
     http429: 429 YouTube altyazı API'sine çok fazla istek gönderildi. Lütfen biraz bekleyip tekrar deneyin.

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -1055,6 +1055,7 @@ subtitles:
     downloadSource: Tải phụ đề gốc
   state:
     loading: Read Frog đang tải phụ đề
+    translating: Đang dịch…
     error: Đã xảy ra lỗi
   errors:
     http429: 429 Đã gửi quá nhiều yêu cầu đến API phụ đề Youtube, vui lòng thử lại sau

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -1171,6 +1171,7 @@ subtitles:
     downloadSource: 下载原字幕
   state:
     loading: Read Frog 字幕加载中
+    translating: 翻译中…
     error: 发生错误
   errors:
     http429: 429 youtube 字幕接口请求次数过多，请稍后再试

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -1171,6 +1171,7 @@ subtitles:
     downloadSource: 下載原始字幕
   state:
     loading: 陪讀蛙字幕載入中
+    translating: 翻譯中…
     error: 發生錯誤
   errors:
     http429: 429 YouTube 字幕 API 請求次數過多，請稍後再試

--- a/src/utils/constants/subtitles.ts
+++ b/src/utils/constants/subtitles.ts
@@ -14,8 +14,6 @@ export const SENTENCE_END_PATTERN = /[,.。?？！!；;…؟۔\n]$/
 export const TRANSLATION_BATCH_SIZE = 5
 export const TRANSLATE_LOOK_AHEAD_MS = 30_000
 export const PROCESS_LOOK_AHEAD_MS = 60_000
-/** Delay before showing bilingual translation pending dots (avoids flash on fast responses). */
-export const TRANSLATION_PENDING_INDICATOR_DELAY_MS = 250
 
 // DOM IDs
 export const READ_FROG_SUBTITLES_UI_HOST_ID = "read-frog-subtitles-ui-host"

--- a/src/utils/constants/subtitles.ts
+++ b/src/utils/constants/subtitles.ts
@@ -14,6 +14,8 @@ export const SENTENCE_END_PATTERN = /[,.。?？！!；;…؟۔\n]$/
 export const TRANSLATION_BATCH_SIZE = 5
 export const TRANSLATE_LOOK_AHEAD_MS = 30_000
 export const PROCESS_LOOK_AHEAD_MS = 60_000
+/** Delay before showing bilingual translation pending dots (avoids flash on fast responses). */
+export const TRANSLATION_PENDING_INDICATOR_DELAY_MS = 250
 
 // DOM IDs
 export const READ_FROG_SUBTITLES_UI_HOST_ID = "read-frog-subtitles-ui-host"

--- a/src/utils/subtitles/__tests__/display-rules.test.ts
+++ b/src/utils/subtitles/__tests__/display-rules.test.ts
@@ -1,6 +1,10 @@
 import type { StateData, SubtitlesFragment } from "../types"
 import { describe, expect, it } from "vitest"
-import { hasRenderableSubtitleByMode, isAwaitingTranslation } from "../display-rules"
+import {
+  hasRenderableSubtitleByMode,
+  isAwaitingTranslation,
+  isTranslationPending,
+} from "../display-rules"
 
 function makeSubtitle(overrides?: Partial<SubtitlesFragment>): SubtitlesFragment {
   return {
@@ -63,5 +67,23 @@ describe("isAwaitingTranslation", () => {
     const idleState: StateData = { state: "idle" }
     // subtitle without translation → awaiting, regardless of stateData
     expect(isAwaitingTranslation(sub, idleState)).toBe(true)
+  })
+})
+
+describe("isTranslationPending", () => {
+  it("returns true when translation is missing", () => {
+    expect(isTranslationPending(makeSubtitle())).toBe(true)
+  })
+
+  it("returns false when translation is present", () => {
+    expect(isTranslationPending(makeSubtitle({ translation: "你好" }))).toBe(false)
+  })
+
+  it("returns false for empty-string translation (resolved but blank)", () => {
+    expect(isTranslationPending(makeSubtitle({ translation: "" }))).toBe(false)
+  })
+
+  it("returns false when subtitle is null", () => {
+    expect(isTranslationPending(null)).toBe(false)
   })
 })

--- a/src/utils/subtitles/display-rules.ts
+++ b/src/utils/subtitles/display-rules.ts
@@ -18,3 +18,8 @@ export function isAwaitingTranslation(
 ): boolean {
   return subtitle ? !subtitle.translation : stateData?.state === "loading"
 }
+
+/** True when a cue exists but translation has not been filled in yet (undefined/null). */
+export function isTranslationPending(subtitle: SubtitlesFragment | null): boolean {
+  return !!subtitle && (subtitle.translation === undefined || subtitle.translation === null)
+}


### PR DESCRIPTION
## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description


I hit a  UX issue when using a model endpoint.

After opening a YouTube video and enabling Read Frog subtitles with **bilingual (original + translation)** display, for a period of time the subtitle area only shows **"Read Frog loading captions"**. During that wait:

- Native YouTube captions are already hidden by the overlay flow
- The original track is not shown either
- Even though the user chose bilingual mode, they cannot read **any** original text until the translation model responds

When the model is slow, this wait is long enough to hurt comprehension and make bilingual mode feel broken—not “original first, translation when ready,” but “loading only.”

**Expected behavior:** while translation is still pending, users should still be able to read the **video’s original captions**. Translation can fill in later without blocking the original.


Display rules already allow bilingual mode to render when original text exists (translation is optional for “has renderable content”). The gap was upstream: source cues were not seeded into the overlay scheduler until translation results arrived, so `currentSubtitle` stayed empty and only the corner loading state was visible.

### What this PR changes

#### 1. Show original text while translation is pending

- Seed source (original) cues into the overlay as soon as they are fetched
- Bilingual / original-only can show original text immediately
- Translations merge onto existing cues incrementally (`mergeOnly`)
- On the translation line, after a short delay (250ms), show a pending indicator: smaller status text (e.g. 翻译中) - only breathing dots
- Fade in the translation when it arrives

#### 2. AI segmentation adaptation

Seeding originals early means AI re-segmentation may change cue boundaries after baseline text is already on screen. This PR adapts that path so re-segmentation stays safe:

- `onChunkSegmented` → scheduler `replaceTimeWindow`
- **Sticky active cue**: the currently displayed line does not jump mid-cue when AI returns
- Invalidate translation bookkeeping for removed starts; re-cut lines get translated again
- Translation results use `mergeOnly` and drop stale in-flight starts so old pre-segmentation cues cannot reappear

Compatible with the look-ahead bound from #1860 (does not eagerly segment the entire remaining video).

#### 3. Loading state correctness

- After source is ready, clear residual corner `loading` when there is **no active cue** (fixes state desync so the badge does not stick until the first caption appears, e.g. instrumental intros / gaps)
- Do not keep the corner badge on only because a *future* cue is untranslated; for the current bilingual cue, pending translation is shown on the translation line instead

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->
and someone else has the same issue.
https://github.com/mengxi-ream/read-frog/issues/1813

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [x] Added unit tests
- [x] Verified through manual testing

**Unit**

```bash
pnpm exec vitest run src/entrypoints/subtitles.content src/utils/subtitles/__tests__/display-rules.test.ts
```

## Screenshots

 
https://github.com/user-attachments/assets/7574354d-fee3-4bef-8fbd-c1945d40d538



<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->
