### PR TITLE
fix(i18n): use zh-TW for Traditional Chinese website links

### DIFF
--- a/.changeset/bright-frogs-tw-locale.md
+++ b/.changeset/bright-frogs-tw-locale.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(i18n): open Traditional Chinese website links under the zh-TW locale

--- a/src/utils/__tests__/blog.test.ts
+++ b/src/utils/__tests__/blog.test.ts
@@ -184,11 +184,11 @@ describe("resolveBlogLocale", () => {
     expect(resolveBlogLocale("zh_Hans")).toBe("zh")
   })
 
-  it("maps traditional Chinese locales to zh-Hant", () => {
-    expect(resolveBlogLocale("zh-TW")).toBe("zh-Hant")
-    expect(resolveBlogLocale("zh_Hant")).toBe("zh-Hant")
-    expect(resolveBlogLocale("zh-HK")).toBe("zh-Hant")
-    expect(resolveBlogLocale("zh-MO")).toBe("zh-Hant")
+  it("maps traditional Chinese locales to zh-TW", () => {
+    expect(resolveBlogLocale("zh-TW")).toBe("zh-TW")
+    expect(resolveBlogLocale("zh_Hant")).toBe("zh-TW")
+    expect(resolveBlogLocale("zh-HK")).toBe("zh-TW")
+    expect(resolveBlogLocale("zh-MO")).toBe("zh-TW")
   })
 
   it("keeps English as en", () => {

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -11,7 +11,7 @@ const BILIBILI_HOSTNAME_PATTERN = /(?:^|\.)bilibili\.com$/i
 const BILIBILI_VIDEO_ID_PATTERN = /^BV[0-9A-Z]+$/i
 const DEFAULT_BLOG_LOCALE = "en"
 
-export type BlogLocale = "en" | "zh" | "zh-Hant" | "ko" | "vi" | "ru" | "tr" | "ja" | "es"
+export type BlogLocale = "en" | "zh" | "zh-TW" | "ko" | "vi" | "ru" | "tr" | "ja" | "es"
 
 const BLOG_LOCALE_BY_PRIMARY_LANGUAGE: Partial<Record<string, BlogLocale>> = {
   en: "en",
@@ -128,7 +128,7 @@ export function resolveBlogLocale(uiLocale?: string | null): BlogLocale {
       normalizedLocale === "zh-tw" ||
       normalizedLocale === "zh-hk" ||
       normalizedLocale === "zh-mo"
-      ? "zh-Hant"
+      ? "zh-TW"
       : "zh"
   }
 

--- a/src/utils/guide/__tests__/dictionary-notebase.test.ts
+++ b/src/utils/guide/__tests__/dictionary-notebase.test.ts
@@ -43,9 +43,7 @@ describe("Dictionary Notebase guide tracking", () => {
     expect(isGuideDictionaryNotebaseGuideUrl(GUIDE_URL)).toBe(true)
     expect(isGuideDictionaryNotebaseGuideUrl("https://readfrog.app/guide/step-3/")).toBe(true)
     expect(isGuideDictionaryNotebaseGuideUrl("https://readfrog.app/en/guide/step-3")).toBe(true)
-    expect(isGuideDictionaryNotebaseGuideUrl("https://readfrog.app/zh-Hant/guide/step-3")).toBe(
-      true,
-    )
+    expect(isGuideDictionaryNotebaseGuideUrl("https://readfrog.app/zh-TW/guide/step-3")).toBe(true)
     expect(
       isGuideDictionaryNotebaseGuideUrl(
         "https://readfrog.app/fr-CA/guide/step-3/?from=guide#dictionary",


### PR DESCRIPTION
## Type of Changes

- [x] 🌐 Internationalization (i18n)

## Description

- emit zh-TW instead of zh-Hant for Traditional Chinese website blog requests and links
- update the guide URL fixture to the canonical `/zh-TW` website route
- keep browser/provider language inputs such as zh_Hant supported while leaving website language independent from the extension UI setting
- add a patch changeset for `@read-frog/extension`

## Related Issue

No linked issue.

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing
- 37 targeted blog and guide tests passed
- type-aware lint passed
- full formatting and lint checks passed
- full suite reached 199 passed files and 1870 passed tests; one unrelated TTS offscreen test timed out under full parallel load and passed 5/5 when rerun in isolation

## Screenshots

Not applicable.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

General website links remain unprefixed, so manually selecting zh-TW in the extension does not control the website or Stripe locale.