### PR TITLE
fix(extension): isolate Sonner styles from host pages

### DIFF
--- a/.changeset/calm-toasts-stay.md
+++ b/.changeset/calm-toasts-stay.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(extension): isolate Sonner styles from host pages

--- a/src/entrypoints/subtitles.content/renderer/mount-subtitles-toast.tsx
+++ b/src/entrypoints/subtitles.content/renderer/mount-subtitles-toast.tsx
@@ -4,7 +4,7 @@ import themeCSS from "@/assets/styles/theme.css?inline"
 import { NOTRANSLATE_CLASS, REACT_SHADOW_HOST_CLASS } from "@/utils/constants/dom-labels"
 import { SUBTITLES_THEME } from "@/utils/constants/subtitles"
 import { ShadowHostBuilder } from "@/utils/react-shadow-host/shadow-host-builder"
-import { mirrorDynamicStyles } from "@/utils/styles"
+import { addStyleToShadow } from "@/utils/styles"
 import { applyTheme } from "@/utils/theme"
 
 const SUBTITLES_TOAST_HOST_ID = "read-frog-subtitles-toast-host"
@@ -28,7 +28,7 @@ export function mountSubtitlesToast(): () => void {
   })
   const reactContainer = hostBuilder.build()
   applyTheme(reactContainer, SUBTITLES_THEME)
-  const cleanupMirroredStyles = mirrorDynamicStyles("style", shadowRoot, "[data-sonner-toaster]")
+  addStyleToShadow(shadowRoot)
 
   const reactRoot = ReactDOM.createRoot(reactContainer)
   reactRoot.render(
@@ -40,7 +40,6 @@ export function mountSubtitlesToast(): () => void {
   target.appendChild(shadowHost)
 
   const cleanup = () => {
-    cleanupMirroredStyles()
     reactRoot.unmount()
     hostBuilder.cleanup()
     shadowHost.remove()

--- a/src/utils/__tests__/styles.test.ts
+++ b/src/utils/__tests__/styles.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest"
+
+const SONNER_STYLE_TEXT = "[data-sonner-toaster]{position:fixed}"
+
+vi.mock("sonner", () => {
+  const style = document.createElement("style")
+  style.dataset.readFrogTestSonner = ""
+  style.textContent = "[data-sonner-toaster]{position:fixed}"
+  document.head.append(style)
+
+  return {}
+})
+
+import { addStyleToShadow, protectInternalStyles } from "../styles"
+
+describe("Sonner style isolation", () => {
+  it("moves only the style injected by this bundle into the shadow root", () => {
+    const hostStyle = document.createElement("style")
+    hostStyle.dataset.hostSonner = ""
+    hostStyle.textContent = `${SONNER_STYLE_TEXT}[data-sonner-toast]{--offset:32px}`
+    document.head.prepend(hostStyle)
+
+    const shadowHost = document.createElement("div")
+    const shadowRoot = shadowHost.attachShadow({ mode: "open" })
+    const shadowHead = document.createElement("head")
+    shadowRoot.append(shadowHead)
+
+    const injectedStyle = document.head.querySelector("[data-read-frog-test-sonner]")
+    addStyleToShadow(shadowRoot)
+
+    expect(shadowHead.querySelector("[data-read-frog-test-sonner]")).toBe(injectedStyle)
+    expect(document.head.querySelector("[data-host-sonner]")).toBe(hostStyle)
+  })
+
+  it("does not treat a host Sonner stylesheet as an internal extension style", async () => {
+    const hostStyle = document.createElement("style")
+    hostStyle.textContent = SONNER_STYLE_TEXT
+    document.head.append(hostStyle)
+
+    const stopProtecting = protectInternalStyles()
+    hostStyle.remove()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(hostStyle.isConnected).toBe(false)
+    stopProtecting()
+  })
+})

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -1,17 +1,30 @@
-export function addStyleToShadow(shadow: ShadowRoot) {
-  document.head.querySelectorAll("style").forEach((styleEl) => {
-    if (styleEl.textContent?.includes("[data-sonner-toaster]")) {
-      const shadowHead = shadow.querySelector("head")
-      // Clone the style element instead of moving it to preserve the original
-      // Otherwise, append api will move the style element to the shadow root and cause the bug
-      const clonedStyle = styleEl.cloneNode(true)
-      if (shadowHead) {
-        shadowHead.append(clonedStyle)
-      } else {
-        shadow.append(clonedStyle)
-      }
+import "sonner"
+
+const SONNER_STYLE_SELECTOR = "[data-sonner-toaster]"
+
+function findInjectedSonnerStyle() {
+  const styles = document.head.querySelectorAll<HTMLStyleElement>("style")
+
+  for (let index = styles.length - 1; index >= 0; index -= 1) {
+    const style = styles[index]
+    if (style.textContent?.includes(SONNER_STYLE_SELECTOR)) {
+      return style
     }
-  })
+  }
+
+  return null
+}
+
+// Importing Sonner inserts its stylesheet synchronously. Retain the exact node
+// created for this content-script bundle so host-page Sonner styles stay untouched.
+const injectedSonnerStyle = typeof document === "undefined" ? null : findInjectedSonnerStyle()
+
+export function addStyleToShadow(shadow: ShadowRoot) {
+  if (!injectedSonnerStyle) return
+
+  const shadowHead = shadow.querySelector("head")
+  const styleTarget = shadowHead ?? shadow
+  styleTarget.append(injectedSonnerStyle)
 }
 
 function isInternalStyleElement(node: Node) {
@@ -25,10 +38,6 @@ function isInternalStyleElement(node: Node) {
   }
 
   if (node instanceof HTMLStyleElement && node.id === "_goober") {
-    return true
-  }
-
-  if (node instanceof HTMLStyleElement && node.textContent?.includes("[data-sonner-toaster]")) {
     return true
   }
 


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Sonner inserts its stylesheet synchronously when the module is evaluated. Each Read Frog content-script bundle now retains a direct reference to the style node it just created and moves that exact node into its Shadow Root.

This prevents Read Frog's global `[data-sonner-*]` rules from overriding host-page Sonner integrations while avoiding the inverse problem of cloning or moving a host site's own matching stylesheet.

The change also:

- stops treating every host `<style>` containing `[data-sonner-toaster]` as an internal protected style;
- migrates the subtitles toaster from broad dynamic style mirroring to the same owned-node isolation path;
- adds regression coverage for preserving host Sonner styles.

## Related Issue

Closes #1882

Related: #424

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

```bash
pnpm exec vitest run src/utils/__tests__/styles.test.ts
SKIP_FREE_API=true pnpm test
pnpm type-check
WXT_SKIP_ENV_VALIDATION=true pnpm build
```

Full test result: 200 test files passed, 1 skipped; 1869 tests passed, 4 skipped.

The production bundle was also inspected to confirm that `host`, `selection`, `side`, and `subtitles` evaluate Sonner before capturing their bundle-local injected style node.

## Screenshots

Not applicable; this change isolates stylesheet ownership and has no intended visual change to Read Frog UI.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Includes a patch changeset for `@read-frog/extension`.
