### PR TITLE
fix(translate): stop long-page freezes and drain cancelled translatio…

### DIFF
--- a/.changeset/olive-donkeys-refuse.md
+++ b/.changeset/olive-donkeys-refuse.md
@@ -1,0 +1,10 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): stop long-page freezes and drain cancelled translation queues (#1881)
+
+- Split giant observed paragraphs (e.g. a flat 185k-px article labeled as one paragraph) into their descendant paragraphs so viewport-lazy translation actually applies instead of enqueueing the whole page at once
+- Cap concurrent spinner animations and cancel them via stored handles — thousands of live WAAPI animations were driving continuous full-page style recalcs
+- Cancel a page-translation session's queued/in-flight background requests on toggle-off, tab close, or restart (scoped per tab + session, dedup-shared requests are refcounted)
+- Time-slice the initial DOM labeling walk and pace subtree translation so the main thread stays responsive on huge pages

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -25,6 +25,7 @@ import { onMessage } from "@/utils/message"
 import { getSubtitlesTranslatePrompt } from "@/utils/prompts/subtitles"
 import { getTranslatePrompt } from "@/utils/prompts/translate"
 import { BatchQueue } from "@/utils/request/batch-queue"
+import { CancelledScopeRegistry, TranslationCancelledError } from "@/utils/request/cancellation"
 import { RequestQueue } from "@/utils/request/request-queue"
 import { ensureInitializedConfig } from "./config"
 
@@ -282,6 +283,10 @@ export async function setUpWebPageTranslationQueue() {
     batchQueueConfig,
     promptResolver: getTranslatePrompt,
   })
+  // Scopes whose cancel already drained the queues. An enqueue handler that
+  // was suspended on the cache lookup when the cancel ran must not enqueue
+  // afterwards — nothing would ever drain that task again (#1881).
+  const cancelledScopes = new CancelledScopeRegistry()
 
   onMessage("enqueueTranslateRequest", async (message) => {
     const {
@@ -315,6 +320,14 @@ export async function setUpWebPageTranslationQueue() {
         validateHtmlAttributeMarkers,
       )
       if (cachedTranslation !== undefined) return cachedTranslation
+    }
+
+    // The cache lookup above yielded — the session's cancel may have drained
+    // the queues while this handler was suspended. Enqueueing now would park
+    // an undraininable task on a dead scope, so abort instead (the content
+    // side swallows this error).
+    if (scope && cancelledScopes.has(scope)) {
+      throw new TranslationCancelledError(scope)
     }
 
     let result: string
@@ -377,6 +390,9 @@ export async function setUpWebPageTranslationQueue() {
   onMessage("cancelPageTranslationRequests", (message) => {
     const scope = buildTranslationScopeKey(message.sender, message.data.sessionId)
     if (!scope) return
+    // Remember the scope so enqueue handlers suspended on the cache lookup
+    // refuse to enqueue after this drain.
+    cancelledScopes.markScope(scope)
     // Batch queue first so pending batches cannot flush new request-queue
     // tasks between the two drains.
     const cancelledBatch = batchQueue.cancelByScope(scope)
@@ -392,6 +408,7 @@ export async function setUpWebPageTranslationQueue() {
   // tab ever registered (#1881).
   browser.tabs.onRemoved.addListener((tabId) => {
     const prefix = `${tabId}:`
+    cancelledScopes.markPrefix(prefix)
     batchQueue.cancelWhere((scope) => scope.startsWith(prefix))
     requestQueue.cancelWhere((scope) => scope.startsWith(prefix))
   })

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -206,12 +206,14 @@ interface TranslationQueueSetupConfig<TContext = unknown> {
   requestQueueConfig: RequestQueueConfig
   batchQueueConfig: BatchQueueConfig
   promptResolver: PromptResolver<TContext>
+  // Present only for queues whose requests carry cancellation scopes.
+  isScopeCancelled?: (scopeKey: string) => boolean
 }
 
 async function createTranslationQueues<TContext>(config: TranslationQueueSetupConfig<TContext>) {
   const { rate, capacity } = config.requestQueueConfig
   const { maxCharactersPerBatch, maxItemsPerBatch } = config.batchQueueConfig
-  const { promptResolver } = config
+  const { promptResolver, isScopeCancelled } = config
 
   const requestQueue = new RequestQueue({
     rate,
@@ -236,6 +238,7 @@ async function createTranslationQueues<TContext>(config: TranslationQueueSetupCo
     getCharacters: (data) => data.text.length,
     getDedupKey: (data) => data.hash,
     getScope: (data) => data.scope,
+    isScopeCancelled,
     executeBatch: async (dataList, meta) => {
       const { providerConfig } = dataList[0]
       const hash = Sha256Hex(...dataList.map((d) => d.hash))
@@ -278,15 +281,19 @@ export async function setUpWebPageTranslationQueue() {
     translate: { requestQueueConfig, batchQueueConfig },
   } = config ?? DEFAULT_CONFIG
 
+  // Scopes whose cancel already drained the queues. Consulted by (a) the
+  // enqueue handler after its cache-lookup await and (b) the batch queue's
+  // retry/fallback path after its backoff sleep — both are windows where a
+  // request lives in NO cancellable structure, so a cancel arriving there
+  // would otherwise be lost (#1881).
+  const cancelledScopes = new CancelledScopeRegistry()
+
   const { requestQueue, batchQueue } = await createTranslationQueues({
     requestQueueConfig,
     batchQueueConfig,
     promptResolver: getTranslatePrompt,
+    isScopeCancelled: (scopeKey) => cancelledScopes.has(scopeKey),
   })
-  // Scopes whose cancel already drained the queues. An enqueue handler that
-  // was suspended on the cache lookup when the cancel ran must not enqueue
-  // afterwards — nothing would ever drain that task again (#1881).
-  const cancelledScopes = new CancelledScopeRegistry()
 
   onMessage("enqueueTranslateRequest", async (message) => {
     const {

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -3,6 +3,7 @@ import type { LLMProviderConfig, ProviderConfig } from "@/types/config/provider"
 import type { BatchQueueConfig, RequestQueueConfig } from "@/types/config/translate"
 import type { SubtitlePromptContext, WebPagePromptContext } from "@/types/content"
 import type { PromptResolver } from "@/utils/host/translate/api/ai"
+import { browser } from "#imports"
 import { isLLMProviderConfig } from "@/types/config/provider"
 import { putBatchRequestRecord } from "@/utils/batch-request-record"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
@@ -183,6 +184,21 @@ export interface TranslateBatchData<TContext = unknown> {
   hash: string
   scheduleAt: number
   context?: TContext
+  // Cancellation scope (`${tabId}:${sessionId}`); absent = uncancellable.
+  scope?: string
+}
+
+/**
+ * Compose the cancellation scope from the message sender and the content
+ * script's session id. Building it background-side from `sender.tab.id` makes
+ * cross-tab cancellation impossible by construction.
+ */
+export function buildTranslationScopeKey(
+  sender: { tab?: { id?: number } } | undefined,
+  sessionId: string | undefined,
+): string | undefined {
+  const tabId = sender?.tab?.id
+  return typeof tabId === "number" && sessionId ? `${tabId}:${sessionId}` : undefined
 }
 
 interface TranslationQueueSetupConfig<TContext = unknown> {
@@ -218,7 +234,8 @@ async function createTranslationQueues<TContext>(config: TranslationQueueSetupCo
     },
     getCharacters: (data) => data.text.length,
     getDedupKey: (data) => data.hash,
-    executeBatch: async (dataList) => {
+    getScope: (data) => data.scope,
+    executeBatch: async (dataList, meta) => {
       const { providerConfig } = dataList[0]
       const hash = Sha256Hex(...dataList.map((d) => d.hash))
       const earliestScheduleAt = Math.min(...dataList.map((d) => d.scheduleAt))
@@ -228,10 +245,10 @@ async function createTranslationQueues<TContext>(config: TranslationQueueSetupCo
         return await executeBatchTranslation(dataList, promptResolver, signal)
       }
 
-      return requestQueue.enqueue(batchThunk, earliestScheduleAt, hash)
+      return requestQueue.enqueue(batchThunk, earliestScheduleAt, hash, meta.scopes)
     },
     executeIndividual: async (data) => {
-      const { text, langConfig, providerConfig, hash, scheduleAt, context } = data
+      const { text, langConfig, providerConfig, hash, scheduleAt, context, scope } = data
       const thunk = async (signal?: AbortSignal) => {
         await putBatchRequestRecord({ originalRequestCount: 1, providerConfig })
         return executeTranslate(text, langConfig, providerConfig, promptResolver, {
@@ -239,7 +256,7 @@ async function createTranslationQueues<TContext>(config: TranslationQueueSetupCo
           signal,
         })
       }
-      return requestQueue.enqueue(thunk, scheduleAt, hash)
+      return requestQueue.enqueue(thunk, scheduleAt, hash, scope ? [scope] : undefined)
     },
     onError: (error, context) => {
       const errorType = context.isFallback ? "Individual request" : "Batch request"
@@ -279,8 +296,10 @@ export async function setUpWebPageTranslationQueue() {
         webDescription,
         webContent,
         webSummary,
+        sessionId,
       },
     } = message
+    const scope = buildTranslationScopeKey(message.sender, sessionId)
 
     const validateHtmlAttributeMarkers =
       textFormat === "html" && hasHtmlAttributeMarkerProtocol(text)
@@ -307,7 +326,7 @@ export async function setUpWebPageTranslationQueue() {
     }
 
     if (shouldUseBatchQueue(providerConfig)) {
-      const data = { text, langConfig, providerConfig, hash, scheduleAt, context }
+      const data = { text, langConfig, providerConfig, hash, scheduleAt, context, scope }
       result = await batchQueue.enqueue(data)
     } else {
       // Create thunk based on type and params
@@ -316,7 +335,7 @@ export async function setUpWebPageTranslationQueue() {
           textFormat,
           signal,
         })
-      result = await requestQueue.enqueue(thunk, scheduleAt, hash)
+      result = await requestQueue.enqueue(thunk, scheduleAt, hash, scope ? [scope] : undefined)
     }
 
     if (validateHtmlAttributeMarkers) {
@@ -353,6 +372,28 @@ export async function setUpWebPageTranslationQueue() {
   onMessage("setTranslateBatchQueueConfig", (message) => {
     const { data } = message
     batchQueue.setBatchConfig(data)
+  })
+
+  onMessage("cancelPageTranslationRequests", (message) => {
+    const scope = buildTranslationScopeKey(message.sender, message.data.sessionId)
+    if (!scope) return
+    // Batch queue first so pending batches cannot flush new request-queue
+    // tasks between the two drains.
+    const cancelledBatch = batchQueue.cancelByScope(scope)
+    const cancelledRequests = requestQueue.cancelByScope(scope)
+    if (cancelledBatch + cancelledRequests > 0) {
+      logger.info(
+        `Cancelled ${cancelledBatch + cancelledRequests} page-translation requests (scope: ${scope})`,
+      )
+    }
+  })
+
+  // A closed tab can never send its cancel message — sweep every scope the
+  // tab ever registered (#1881).
+  browser.tabs.onRemoved.addListener((tabId) => {
+    const prefix = `${tabId}:`
+    batchQueue.cancelWhere((scope) => scope.startsWith(prefix))
+    requestQueue.cancelWhere((scope) => scope.startsWith(prefix))
   })
 }
 

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -26,6 +26,7 @@ const {
   mockTranslateWalkedElement,
   mockValidateTranslationConfigAndToast,
   mockWalkAndLabelElement,
+  mockWalkAndLabelElementChunked,
 } = vi.hoisted(() => ({
   mockGetDetectedCodeFromStorage: vi.fn<(...args: any[]) => any>(),
   mockGetRandomUUID: vi.fn<(...args: any[]) => any>(),
@@ -36,6 +37,7 @@ const {
   mockIsDontWalkIntoAndDontTranslateAsChildElement: vi.fn<(...args: any[]) => any>(),
   mockIsDontWalkIntoButTranslateAsChildElement: vi.fn<(...args: any[]) => any>(),
   mockWalkAndLabelElement: vi.fn<(...args: any[]) => any>(),
+  mockWalkAndLabelElementChunked: vi.fn<(...args: any[]) => any>(),
   mockRemoveAllTranslatedWrapperNodes: vi.fn<(...args: any[]) => any>(),
   mockTranslateWalkedElement: vi.fn<(...args: any[]) => any>(),
   mockTranslateTextForPageTitle: vi.fn<(...args: any[]) => any>(),
@@ -60,6 +62,9 @@ vi.mock("@/utils/host/dom/filter", () => ({
   hasNoWalkAncestor: mockHasNoWalkAncestor,
   isDontWalkIntoAndDontTranslateAsChildElement: mockIsDontWalkIntoAndDontTranslateAsChildElement,
   isDontWalkIntoButTranslateAsChildElement: mockIsDontWalkIntoButTranslateAsChildElement,
+  isWalkBlockedElement: (element: HTMLElement, config: unknown) =>
+    mockIsDontWalkIntoButTranslateAsChildElement(element, config) ||
+    mockIsDontWalkIntoAndDontTranslateAsChildElement(element, config),
   isHTMLElement: (node: unknown) => node instanceof HTMLElement,
   isTranslatedWrapperNode: (node: unknown) =>
     node instanceof HTMLElement && node.classList.contains("read-frog-translated-content-wrapper"),
@@ -71,6 +76,7 @@ vi.mock("@/utils/host/dom/find", () => ({
 
 vi.mock("@/utils/host/dom/traversal", () => ({
   walkAndLabelElement: mockWalkAndLabelElement,
+  walkAndLabelElementChunked: mockWalkAndLabelElementChunked,
 }))
 
 vi.mock("@/utils/host/translate/node-manipulation", () => ({
@@ -181,8 +187,13 @@ function isBlockedForTraversal(element: HTMLElement): boolean {
   )
 }
 
-function walkAndLabelVisibleParagraphs(element: HTMLElement, walkId: string) {
+function walkAndLabelVisibleParagraphs(
+  element: HTMLElement,
+  walkId: string,
+  onBlockedElement?: (blocked: HTMLElement) => void,
+) {
   if (isBlockedForTraversal(element)) {
+    onBlockedElement?.(element)
     return {
       forceBlock: false,
       isInlineNode: false,
@@ -193,7 +204,7 @@ function walkAndLabelVisibleParagraphs(element: HTMLElement, walkId: string) {
 
   for (const child of element.children) {
     if (child instanceof HTMLElement) {
-      walkAndLabelVisibleParagraphs(child, walkId)
+      walkAndLabelVisibleParagraphs(child, walkId, onBlockedElement)
     }
   }
 
@@ -232,8 +243,21 @@ describe("pageTranslationManager mutation re-walk", () => {
       isBlockedForTraversal(element),
     )
     mockDeepQueryTopLevelSelector.mockImplementation(deepQueryTopLevelSelectorImpl)
-    mockWalkAndLabelElement.mockImplementation((element: HTMLElement, walkId: string) =>
-      walkAndLabelVisibleParagraphs(element, walkId),
+    mockWalkAndLabelElement.mockImplementation(
+      (
+        element: HTMLElement,
+        walkId: string,
+        _config: unknown,
+        callbacks?: { onBlockedElement?: (blocked: HTMLElement) => void },
+      ) => walkAndLabelVisibleParagraphs(element, walkId, callbacks?.onBlockedElement),
+    )
+    mockWalkAndLabelElementChunked.mockImplementation(
+      async (
+        element: HTMLElement,
+        walkId: string,
+        _config: unknown,
+        options?: { onBlockedElement?: (blocked: HTMLElement) => void },
+      ) => walkAndLabelVisibleParagraphs(element, walkId, options?.onBlockedElement),
     )
     mockTranslateTextForPageTitle.mockResolvedValue("")
     mockTranslateNodesBilingualMode.mockReset().mockResolvedValue(undefined)
@@ -266,7 +290,14 @@ describe("pageTranslationManager mutation re-walk", () => {
     await observer.triggerIntersect(panel)
     await flushDomUpdates()
 
-    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(panel, "walk-id", DEFAULT_CONFIG)
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(
+      panel,
+      "walk-id",
+      DEFAULT_CONFIG,
+      false,
+      expect.anything(),
+      expect.anything(),
+    )
 
     manager.stop()
   })
@@ -296,7 +327,14 @@ describe("pageTranslationManager mutation re-walk", () => {
     await observer.triggerIntersect(panel)
     await flushDomUpdates()
 
-    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(panel, "walk-id", DEFAULT_CONFIG)
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(
+      panel,
+      "walk-id",
+      DEFAULT_CONFIG,
+      false,
+      expect.anything(),
+      expect.anything(),
+    )
 
     manager.stop()
   })
@@ -326,7 +364,14 @@ describe("pageTranslationManager mutation re-walk", () => {
     await observer.triggerIntersect(panel)
     await flushDomUpdates()
 
-    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(panel, "walk-id", DEFAULT_CONFIG)
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(
+      panel,
+      "walk-id",
+      DEFAULT_CONFIG,
+      false,
+      expect.anything(),
+      expect.anything(),
+    )
 
     manager.stop()
   })
@@ -800,6 +845,48 @@ describe("pageTranslationManager mutation re-walk", () => {
     }
 
     expect((manager as any).mutationObservers.length).toBe(observerCountAfterStart)
+
+    manager.stop()
+  })
+
+  it("splits a giant paragraph into its descendant paragraphs for observation (#1881)", async () => {
+    // docs.docker.com regression shape: one flat container labeled as a
+    // paragraph spanning the whole document, with real paragraphs nested
+    // inside. Built via DOM APIs — the HTML parser refuses nested <p>.
+    const giant = document.createElement("p")
+    giant.id = "giant"
+    giant.append("direct inline text of the giant")
+    const inner1 = document.createElement("p")
+    inner1.id = "inner1"
+    inner1.textContent = "Nested paragraph one"
+    const inner2 = document.createElement("p")
+    inner2.id = "inner2"
+    inner2.textContent = "Nested paragraph two"
+    giant.append(inner1, inner2)
+
+    const unsplittable = document.createElement("p")
+    unsplittable.id = "unsplittable"
+    unsplittable.textContent = "One enormous paragraph without nested paragraphs"
+
+    document.body.append(giant, unsplittable)
+    // jsdom rects default to 0 — mark only the giants as taller than the
+    // split cap (3 viewports).
+    const tall = { height: 200_000 } as DOMRect
+    giant.getBoundingClientRect = () => tall
+    unsplittable.getBoundingClientRect = () => tall
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observer = intersectionObservers[0]
+    const observed = observer.observe.mock.calls.map((call) => call[0])
+    // The giant is split: its nested paragraphs are observed individually.
+    expect(observed).toContain(inner1)
+    expect(observed).toContain(inner2)
+    expect(observed).not.toContain(giant)
+    // A giant with no nested paragraphs cannot be split — observed whole.
+    expect(observed).toContain(unsplittable)
 
     manager.stop()
   })

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts
@@ -42,6 +42,7 @@ vi.mock("@/utils/host/dom/filter", () => ({
     .fn<(...args: any[]) => any>()
     .mockReturnValue(false),
   isDontWalkIntoButTranslateAsChildElement: vi.fn<(...args: any[]) => any>().mockReturnValue(false),
+  isWalkBlockedElement: vi.fn<(...args: any[]) => any>().mockReturnValue(false),
   isHTMLElement: (node: unknown) => node instanceof HTMLElement,
 }))
 
@@ -51,6 +52,9 @@ vi.mock("@/utils/host/dom/find", () => ({
 
 vi.mock("@/utils/host/dom/traversal", () => ({
   walkAndLabelElement: mockWalkAndLabelElement,
+  walkAndLabelElementChunked: vi
+    .fn<(...args: any[]) => any>()
+    .mockResolvedValue({ forceBlock: false, isInlineNode: false }),
 }))
 
 vi.mock("@/utils/host/translate/node-manipulation", () => ({

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -11,15 +11,19 @@ import {
   SPINNER_CLASS,
 } from "@/utils/constants/dom-labels"
 import { resolveProviderConfig } from "@/utils/constants/feature-providers"
+import {
+  GIANT_PARAGRAPH_MAX_SPLIT_DEPTH,
+  GIANT_PARAGRAPH_SPLIT_MIN_VIEWPORT_PX,
+  GIANT_PARAGRAPH_SPLIT_VIEWPORT_MULTIPLIER,
+} from "@/utils/constants/translate"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
 import {
   hasNoWalkAncestor,
-  isDontWalkIntoAndDontTranslateAsChildElement,
-  isDontWalkIntoButTranslateAsChildElement,
   isHTMLElement,
+  isWalkBlockedElement as isWalkBlockedElementFilter,
 } from "@/utils/host/dom/filter"
 import { deepQueryTopLevelSelector } from "@/utils/host/dom/find"
-import { walkAndLabelElement } from "@/utils/host/dom/traversal"
+import { walkAndLabelElement, walkAndLabelElementChunked } from "@/utils/host/dom/traversal"
 import {
   findStaleBilingualLayoutSource,
   findStaleTranslationOnlyAnchor,
@@ -34,11 +38,18 @@ import {
 } from "@/utils/host/translate/node-manipulation"
 import { validateTranslationConfigAndToast } from "@/utils/host/translate/translate-text"
 import { translateTextForPageTitle } from "@/utils/host/translate/translate-variants"
+import {
+  beginPageTranslationSession,
+  endPageTranslationSession,
+} from "@/utils/host/translate/translation-session"
+import { cancelSpinnerAnimation } from "@/utils/host/translate/ui/spinner"
 import { ensureSiteRuleCSS, removeSiteRuleCSS } from "@/utils/host/translate/ui/style-injector"
 import { getOrCreateWebPageContext } from "@/utils/host/translate/webpage-context"
 import { logger } from "@/utils/logger"
 import { sendMessage } from "@/utils/message"
 import { removeReactShadowHost } from "@/utils/react-shadow-host/create-shadow-host"
+import { isTranslationCancelledError } from "@/utils/request/cancellation"
+import { createWorkPacer } from "@/utils/scheduler"
 import { getEffectiveSiteRule } from "@/utils/site-rules/effective"
 
 type SimpleIntersectionOptions = Omit<IntersectionObserverInit, "threshold"> & {
@@ -112,6 +123,8 @@ export class PageTranslationManager implements IPageTranslationManager {
   // removed when a retry fires, so the set only holds armed timers.
   private pendingRetranslateRetries = new Set<DebouncedRetry>()
   private translationSessionVersion = 0
+  /** Pending initial chunked walk; mutation handling serializes behind it. */
+  private initialWalkDone: Promise<void> | null = null
   private titleObserver: MutationObserver | null = null
   private lastSourceTitle: string | null = null
   private lastAppliedTranslatedTitle: string | null = null
@@ -180,6 +193,7 @@ export class PageTranslationManager implements IPageTranslationManager {
 
       this.isPageTranslating = true
       this.translationSessionVersion += 1
+      beginPageTranslationSession()
 
       const siteRule = getEffectiveSiteRule(config, window.location.href)
       if (siteRule.injectedCss) {
@@ -194,30 +208,54 @@ export class PageTranslationManager implements IPageTranslationManager {
       // Listen to existing elements when they enter the viewport
       const walkId = getRandomUUID()
       this.walkId = walkId
-      this.intersectionObserver = new IntersectionObserver(async (entries, observer) => {
+      this.intersectionObserver = new IntersectionObserver((entries, observer) => {
+        const targets: HTMLElement[] = []
         for (const entry of entries) {
-          if (entry.isIntersecting) {
-            if (isHTMLElement(entry.target)) {
-              if (!entry.target.closest(`.${CONTENT_WRAPPER_CLASS}`)) {
-                const currentConfig = await getLocalConfig()
-                if (!currentConfig) {
-                  logger.error("Global config is not initialized")
-                  return
-                }
-                void translateWalkedElement(entry.target, walkId, currentConfig)
-              }
-            }
-            observer.unobserve(entry.target)
+          if (!entry.isIntersecting) continue
+          observer.unobserve(entry.target)
+          if (isHTMLElement(entry.target) && !entry.target.closest(`.${CONTENT_WRAPPER_CLASS}`)) {
+            targets.push(entry.target)
           }
         }
+        if (targets.length === 0) return
+        void (async () => {
+          // One config read per callback batch — a dense first intersection
+          // can deliver hundreds of entries at once (#1881).
+          const currentConfig = await getLocalConfig()
+          if (!currentConfig) {
+            logger.error("Global config is not initialized")
+            return
+          }
+          if (this.walkId !== walkId) return
+          // One shared pacer bounds the batch's synchronous expansion work;
+          // the liveness check stops paced expansion promptly if the user
+          // cancels mid-flight (#1881).
+          const pacer = createWorkPacer()
+          const isWalkCurrent = () => this.walkId === walkId
+          for (const target of targets) {
+            void translateWalkedElement(target, walkId, currentConfig, false, pacer, isWalkCurrent)
+          }
+        })()
       }, this.intersectionOptions)
 
-      // Initialize walkability state for existing elements
-      this.addWalkBlockedElements(document.body, config)
-      await this.observeTopLevelParagraphs(document.body, config)
-
-      // Start observing mutations from document.body and all shadow roots
+      // Observe mutations BEFORE the chunked walk: page JS runs between walk
+      // slices, and records emitted meanwhile must not be lost. The walk only
+      // writes data-read-frog-* attributes, which this observer's
+      // attributeFilter never reports, so this creates no feedback loop.
       this.observeMutations(document.body)
+
+      // Label existing elements in time-sliced chunks (walkability caching is
+      // handled by the walk's onBlockedElement callback).
+      const initialWalk = this.observeTopLevelParagraphs(document.body, config, { chunked: true })
+      this.initialWalkDone = initialWalk
+      try {
+        await initialWalk
+      } finally {
+        // restart() may already have installed a newer walk's promise.
+        if (this.initialWalkDone === initialWalk) {
+          this.initialWalkDone = null
+        }
+      }
 
       if (trackedContext) {
         void trackFeatureUsed({
@@ -261,6 +299,17 @@ export class PageTranslationManager implements IPageTranslationManager {
         enabled: false,
         url: window.location.href,
       })
+    }
+
+    // Drain this session's queued/in-flight requests in the background —
+    // without this, a long page keeps burning network/CPU/quota for minutes
+    // after the user cancels (#1881). Fire-and-forget: the synchronous DOM
+    // cleanup below finishes long before any rejection lands.
+    const endedSessionId = endPageTranslationSession()
+    if (endedSessionId) {
+      void sendMessage("cancelPageTranslationRequests", { sessionId: endedSessionId }).catch(
+        (error) => logger.warn("Failed to cancel pending translation requests", error),
+      )
     }
 
     this.isPageTranslating = false
@@ -462,6 +511,8 @@ export class PageTranslationManager implements IPageTranslationManager {
 
       document.title = nextTitle
     } catch (error) {
+      // A cancelled session's title request rejecting is expected, not noise.
+      if (isTranslationCancelledError(error)) return
       if (requestVersion === this.titleRequestVersion) {
         logger.warn("Failed to translate document title:", error)
       }
@@ -471,30 +522,47 @@ export class PageTranslationManager implements IPageTranslationManager {
   private async observeTopLevelParagraphs(
     container: HTMLElement,
     existingConfig?: Config,
+    options: { chunked?: boolean } = {},
   ): Promise<void> {
     const observer = this.intersectionObserver
-    if (!this.walkId || !observer) return
+    // Capture locals: this method awaits, and `this.walkId` may belong to a
+    // newer session by the time an await resumes.
+    const walkId = this.walkId
+    if (!walkId || !observer) return
 
     const config = existingConfig ?? (await getLocalConfig())
     if (!config) {
       logger.error("Global config is not initialized")
       return
     }
+    if (this.walkId !== walkId) return
 
     // Skip if container has an ancestor that should not be walked into
     if (hasNoWalkAncestor(container, config)) return
 
-    walkAndLabelElement(container, this.walkId, config)
+    const onBlockedElement = (element: HTMLElement) => {
+      this.walkBlockedElementsCache.add(element)
+    }
+    if (options.chunked) {
+      const result = await walkAndLabelElementChunked(container, walkId, config, {
+        onBlockedElement,
+        shouldContinue: () => this.isPageTranslating && this.walkId === walkId,
+      })
+      if (result === null || this.walkId !== walkId) return
+    } else {
+      walkAndLabelElement(container, walkId, config, { onBlockedElement })
+    }
+
     // if container itself has paragraph and the id
     if (
       container.hasAttribute("data-read-frog-paragraph") &&
-      container.getAttribute("data-read-frog-walked") === this.walkId
+      container.getAttribute("data-read-frog-walked") === walkId
     ) {
-      observer.observe(container)
+      this.observeParagraphUnit(container, walkId, 0)
       return
     }
 
-    const paragraphs = this.collectParagraphElementsDeep(container, this.walkId)
+    const paragraphs = this.collectParagraphElementsDeep(container, walkId)
     const topLevelParagraphs = paragraphs.filter((el) => {
       const ancestor = el.parentElement?.closest("[data-read-frog-paragraph]")
       // keep it if either:
@@ -502,7 +570,55 @@ export class PageTranslationManager implements IPageTranslationManager {
       //  • the ancestor is *not* inside container
       return !ancestor || !container.contains(ancestor)
     })
-    topLevelParagraphs.forEach((el) => observer.observe(el))
+    topLevelParagraphs.forEach((el) => this.observeParagraphUnit(el, walkId, 0))
+  }
+
+  /**
+   * Observe a paragraph as one lazy-translation unit — unless it is so tall
+   * that its first intersection would expand into (nearly) the whole page at
+   * once. docs.docker.com labels its entire flat 185k-px <article> as ONE
+   * paragraph (inline <em> dates are direct children), which defeated
+   * viewport gating and enqueued 5k+ paragraphs instantly (#1881). Giant
+   * paragraphs are split: their next-level descendant paragraphs are observed
+   * individually instead.
+   *
+   * Known tradeoff: direct inline children of a split giant (e.g. those date
+   * <em>s) are not covered by any observed unit and stay untranslated. Stray
+   * standalone inlines in a >3-viewport flat container are rare, and
+   * numeric-only text is skipped by the pipeline anyway.
+   */
+  private observeParagraphUnit(element: HTMLElement, walkId: string, depth: number): void {
+    const observer = this.intersectionObserver
+    if (!observer) return
+
+    const maxUnitHeight =
+      Math.max(window.innerHeight, GIANT_PARAGRAPH_SPLIT_MIN_VIEWPORT_PX) *
+      GIANT_PARAGRAPH_SPLIT_VIEWPORT_MULTIPLIER
+    if (
+      depth >= GIANT_PARAGRAPH_MAX_SPLIT_DEPTH ||
+      element.getBoundingClientRect().height <= maxUnitHeight
+    ) {
+      observer.observe(element)
+      return
+    }
+
+    const innerTopLevelParagraphs = this.collectParagraphElementsDeep(element, walkId).filter(
+      (paragraph) => {
+        if (paragraph === element) return false
+        const ancestor = paragraph.parentElement?.closest("[data-read-frog-paragraph]")
+        // Keep only paragraphs whose nearest paragraph ancestor is the giant
+        // itself (or that have none inside it, e.g. across shadow roots).
+        return !ancestor || ancestor === element || !element.contains(ancestor)
+      },
+    )
+    if (innerTopLevelParagraphs.length === 0) {
+      // Unsplittable giant (no nested paragraphs) — observe it whole.
+      observer.observe(element)
+      return
+    }
+    for (const paragraph of innerTopLevelParagraphs) {
+      this.observeParagraphUnit(paragraph, walkId, depth + 1)
+    }
   }
 
   /**
@@ -546,10 +662,7 @@ export class PageTranslationManager implements IPageTranslationManager {
    * panels can be re-walked when the site reveals an existing subtree.
    */
   private isWalkBlockedElement(element: HTMLElement, config: Config): boolean {
-    return (
-      isDontWalkIntoButTranslateAsChildElement(element, config) ||
-      isDontWalkIntoAndDontTranslateAsChildElement(element, config)
-    )
+    return isWalkBlockedElementFilter(element, config)
   }
 
   /**
@@ -665,7 +778,7 @@ export class PageTranslationManager implements IPageTranslationManager {
         .forEach((host) => removeReactShadowHost(host))
       node
         .querySelectorAll<HTMLElement>(`.${SPINNER_CLASS}`)
-        .forEach((spinner) => spinner.getAnimations?.().forEach((animation) => animation.cancel()))
+        .forEach((spinner) => cancelSpinnerAnimation(spinner))
     }
   }
 
@@ -679,6 +792,15 @@ export class PageTranslationManager implements IPageTranslationManager {
       if (!this.isSelfInflictedRecord(record)) hostRecords.push(record)
     }
     if (hostRecords.length === 0) return
+
+    // Serialize traversal-driven handling behind the initial chunked walk so
+    // a mutation-path sync walk never races the sliced startup walk over the
+    // same subtree. Records are static snapshots, so deferring is safe; the
+    // detached-artifact cleanup above already ran promptly.
+    if (this.initialWalkDone) {
+      await this.initialWalkDone
+      if (!this.isPageTranslating || this.translationSessionVersion !== sessionVersion) return
+    }
 
     const staleTranslatedSources = new Set<HTMLElement>()
     for (const record of hostRecords) {

--- a/src/utils/__tests__/scheduler.test.ts
+++ b/src/utils/__tests__/scheduler.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { createWorkPacer, pauseIfBudgetSpent, yieldToMain } from "../scheduler"
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("yieldToMain", () => {
+  it("prefers scheduler.yield when available", async () => {
+    const yieldFn = vi.fn<() => Promise<void>>(() => Promise.resolve())
+    vi.stubGlobal("scheduler", { yield: yieldFn })
+
+    await yieldToMain()
+    expect(yieldFn).toHaveBeenCalledTimes(1)
+  })
+
+  it("falls back to scheduler.postTask", async () => {
+    const postTask = vi.fn<
+      (callback: () => void, options?: { priority?: string }) => Promise<void>
+    >((callback) => {
+      callback()
+      return Promise.resolve()
+    })
+    vi.stubGlobal("scheduler", { postTask })
+
+    await yieldToMain()
+    expect(postTask).toHaveBeenCalledTimes(1)
+    expect(postTask.mock.calls[0][1]).toEqual({ priority: "user-visible" })
+  })
+
+  it("falls back to MessageChannel when no scheduler exists", async () => {
+    vi.stubGlobal("scheduler", undefined)
+    await expect(yieldToMain()).resolves.toBeUndefined()
+  })
+
+  it("falls back to setTimeout when MessageChannel is unavailable", async () => {
+    vi.stubGlobal("scheduler", undefined)
+    vi.stubGlobal("MessageChannel", undefined)
+    await expect(yieldToMain()).resolves.toBeUndefined()
+  })
+})
+
+describe("pauseIfBudgetSpent", () => {
+  it("does not yield while the slice budget remains", async () => {
+    const yieldFn = vi.fn<() => Promise<void>>(() => Promise.resolve())
+    vi.stubGlobal("scheduler", { yield: yieldFn })
+
+    const pacer = createWorkPacer(10_000)
+    await pauseIfBudgetSpent(pacer)
+    expect(yieldFn).not.toHaveBeenCalled()
+  })
+
+  it("yields and renews the deadline once the budget is spent", async () => {
+    const yieldFn = vi.fn<() => Promise<void>>(() => Promise.resolve())
+    vi.stubGlobal("scheduler", { yield: yieldFn })
+
+    const pacer = createWorkPacer(0)
+    const spentDeadline = pacer.deadline
+    await new Promise((resolve) => setTimeout(resolve, 1))
+
+    await pauseIfBudgetSpent(pacer)
+    expect(yieldFn).toHaveBeenCalledTimes(1)
+    expect(pacer.deadline).toBeGreaterThan(spentDeadline)
+  })
+})

--- a/src/utils/constants/translate.ts
+++ b/src/utils/constants/translate.ts
@@ -26,6 +26,17 @@ export const MIN_PRELOAD_THRESHOLD = 0
 export const MAX_PRELOAD_THRESHOLD = 1
 export const DEFAULT_PRELOAD_THRESHOLD = 0
 
+// A single observed paragraph taller than this many viewports is split into
+// its descendant paragraphs before observation, otherwise one flat giant
+// container (e.g. docs.docker.com's 185k-px <article>) defeats viewport-lazy
+// translation and enqueues the whole page at once (#1881).
+export const GIANT_PARAGRAPH_SPLIT_VIEWPORT_MULTIPLIER = 3
+// Floor for the viewport height used in the split cap, so tiny embedded
+// frames don't shred normal paragraphs into fragments.
+export const GIANT_PARAGRAPH_SPLIT_MIN_VIEWPORT_PX = 800
+// Defensive bound on split recursion.
+export const GIANT_PARAGRAPH_MAX_SPLIT_DEPTH = 10
+
 export const MIN_CHARACTERS_PER_NODE = 0
 export const MAX_CHARACTERS_PER_NODE = 1000
 export const DEFAULT_MIN_CHARACTERS_PER_NODE = 0

--- a/src/utils/host/__tests__/translate-text.test.tsx
+++ b/src/utils/host/__tests__/translate-text.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { NO_TRANSLATION_SENTINEL } from "@/utils/constants/prompt"
 import { detectLanguage } from "@/utils/content/language"
@@ -10,7 +10,12 @@ import {
   translateTextForPage,
   translateTextForPageTitle,
 } from "@/utils/host/translate/translate-variants"
+import {
+  beginPageTranslationSession,
+  endPageTranslationSession,
+} from "@/utils/host/translate/translation-session"
 import { getTranslatePrompt } from "@/utils/prompts/translate"
+import { isTranslationCancelledError } from "@/utils/request/cancellation"
 
 // Mock dependencies
 vi.mock("@/utils/config/storage", () => ({
@@ -220,6 +225,81 @@ describe("translate-text", () => {
         enableLLM: false,
       })
       expect(mockSendMessage).not.toHaveBeenCalled()
+    })
+
+    // #1881: the session id is captured at pipeline ENTRY, but requests race
+    // the awaits below (config, summary). If the user cancels mid-request the
+    // request must NOT be dispatched — otherwise it lands unscoped (or after
+    // the session's cancel drain) and becomes permanently uncancellable.
+    describe("session cancellation gate", () => {
+      afterEach(() => {
+        endPageTranslationSession()
+      })
+
+      it("sends with the captured sessionId while the session stays active", async () => {
+        mockSendMessage.mockResolvedValue("translated text")
+        const sessionId = beginPageTranslationSession()
+
+        await translateTextForPage("test text")
+
+        expect(mockSendMessage).toHaveBeenCalledWith(
+          "enqueueTranslateRequest",
+          expect.objectContaining({ sessionId }),
+        )
+      })
+
+      it("aborts without dispatching when the session ends mid-request", async () => {
+        mockSendMessage.mockResolvedValue("translated text")
+        beginPageTranslationSession()
+        // getLocalConfig is awaited after the session id is captured; ending the
+        // session here mimics a user cancel landing mid-request.
+        mockGetConfigFromStorage.mockImplementation(async () => {
+          endPageTranslationSession()
+          return DEFAULT_CONFIG
+        })
+
+        let caught: unknown
+        try {
+          await translateTextForPage("test text")
+        } catch (error) {
+          caught = error
+        }
+
+        expect(isTranslationCancelledError(caught)).toBe(true)
+        expect(mockSendMessage).not.toHaveBeenCalled()
+      })
+
+      it("aborts when a new session replaces the captured one mid-request", async () => {
+        mockSendMessage.mockResolvedValue("translated text")
+        beginPageTranslationSession()
+        mockGetConfigFromStorage.mockImplementation(async () => {
+          // restart(): old session ends, a new one begins.
+          endPageTranslationSession()
+          beginPageTranslationSession()
+          return DEFAULT_CONFIG
+        })
+
+        let caught: unknown
+        try {
+          await translateTextForPage("test text")
+        } catch (error) {
+          caught = error
+        }
+
+        expect(isTranslationCancelledError(caught)).toBe(true)
+        expect(mockSendMessage).not.toHaveBeenCalled()
+      })
+
+      it("does not gate input translation (no session id)", async () => {
+        mockSendMessage.mockResolvedValue("translated text")
+        beginPageTranslationSession()
+        endPageTranslationSession()
+
+        const result = await translateTextForInput("hello", "eng", "cmn")
+
+        expect(result).toBe("translated text")
+        expect(mockSendMessage).toHaveBeenCalled()
+      })
     })
   })
 

--- a/src/utils/host/dom/__tests__/traversal-chunked.test.ts
+++ b/src/utils/host/dom/__tests__/traversal-chunked.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+
+import type { Config } from "@/types/config/config"
+import { describe, expect, it } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { isWalkBlockedElement } from "../filter"
+import { deepQueryTopLevelSelector } from "../find"
+import { walkAndLabelElement, walkAndLabelElementChunked } from "../traversal"
+
+const WALK_ATTRIBUTES = [
+  "data-read-frog-walked",
+  "data-read-frog-paragraph",
+  "data-read-frog-block-node",
+  "data-read-frog-inline-node",
+] as const
+
+function config(): Config {
+  return structuredClone(DEFAULT_CONFIG)
+}
+
+/**
+ * The parity fixture mixes every labeling-relevant shape: block/inline
+ * elements, direct text, force-block tags, blocked subtrees (script, hidden,
+ * sr-only, notranslate), empty containers, and a shadow host. Built by a
+ * factory (not cloneNode) because clones don't carry shadow roots.
+ */
+function buildFixture(host: HTMLElement): void {
+  host.innerHTML = `
+    <div id="article">
+      Direct text of article
+      <em>2026-07-17</em>
+      <h2>Heading text</h2>
+      <p>Paragraph with <span>inline span</span> and <strong>bold</strong> text.</p>
+      <div>
+        <p>Nested paragraph one</p>
+        <ul><li>item one</li><li>item <b>two</b></li></ul>
+      </div>
+      <div class="empty-container"><div></div></div>
+      <script>ignored()</script>
+      <section hidden><p>hidden text</p></section>
+      <span class="sr-only">screen reader only</span>
+      <div class="notranslate">do not translate</div>
+      <p></p>
+    </div>
+  `
+  const article = host.firstElementChild as HTMLElement
+  const shadowHost = document.createElement("div")
+  article.append(shadowHost)
+  const shadowRoot = shadowHost.attachShadow({ mode: "open" })
+  const shadowParagraph = document.createElement("p")
+  shadowParagraph.textContent = "shadow paragraph"
+  const shadowHidden = document.createElement("div")
+  shadowHidden.hidden = true
+  shadowHidden.textContent = "hidden in shadow"
+  shadowRoot.append(shadowParagraph, shadowHidden)
+}
+
+/** DFS snapshot of every element's walk labels, shadow trees included. */
+function snapshotLabels(root: HTMLElement, walkId: string): string[] {
+  const lines: string[] = []
+  const visit = (element: Element, path: string) => {
+    const labels = WALK_ATTRIBUTES.map((attribute) => {
+      const value = element.getAttribute(attribute)
+      if (value === null) return `${attribute}=∅`
+      // Normalize walk ids so runs with different ids compare equal.
+      return attribute === "data-read-frog-walked"
+        ? `${attribute}=${value === walkId ? "SET" : "OTHER"}`
+        : `${attribute}=${value}`
+    }).join(" ")
+    lines.push(`${path}<${element.tagName.toLowerCase()}> ${labels}`)
+    if (element instanceof HTMLElement && element.shadowRoot) {
+      ;[...element.shadowRoot.children].forEach((child, index) =>
+        visit(child, `${path}#shadow/${index}/`),
+      )
+    }
+    ;[...element.children].forEach((child, index) => visit(child, `${path}${index}/`))
+  }
+  visit(root, "")
+  return lines
+}
+
+describe("walkAndLabelElementChunked parity", () => {
+  it("labels identically to the synchronous walk even when yielding at every element", async () => {
+    const syncHost = document.createElement("div")
+    const chunkedHost = document.createElement("div")
+    document.body.append(syncHost, chunkedHost)
+    buildFixture(syncHost)
+    buildFixture(chunkedHost)
+
+    const syncResult = walkAndLabelElement(syncHost, "sync-walk", config())
+    // budgetMs: 0 forces a yield at every single element — the worst case.
+    const chunkedResult = await walkAndLabelElementChunked(chunkedHost, "chunked-walk", config(), {
+      budgetMs: 0,
+    })
+
+    expect(chunkedResult).toEqual(syncResult)
+    expect(snapshotLabels(chunkedHost, "chunked-walk")).toEqual(
+      snapshotLabels(syncHost, "sync-walk"),
+    )
+
+    syncHost.remove()
+    chunkedHost.remove()
+  })
+
+  it("reports the same blocked elements as deepQueryTopLevelSelector", async () => {
+    const host = document.createElement("div")
+    document.body.append(host)
+    buildFixture(host)
+    const cfg = config()
+
+    const expected = deepQueryTopLevelSelector(host, (element) =>
+      isWalkBlockedElement(element, cfg),
+    )
+
+    const reported: HTMLElement[] = []
+    await walkAndLabelElementChunked(host, "walk", cfg, {
+      budgetMs: 0,
+      onBlockedElement: (element) => reported.push(element),
+    })
+
+    expect(new Set(reported)).toEqual(new Set(expected))
+    expect(reported.length).toBeGreaterThan(0)
+
+    host.remove()
+  })
+
+  it("aborts cleanly at a slice boundary when shouldContinue flips false", async () => {
+    const host = document.createElement("div")
+    document.body.append(host)
+    buildFixture(host)
+
+    let checks = 0
+    const result = await walkAndLabelElementChunked(host, "aborted-walk", config(), {
+      budgetMs: 0,
+      shouldContinue: () => {
+        checks += 1
+        return checks <= 3
+      },
+    })
+
+    expect(result).toBeNull()
+
+    const walked = host.querySelectorAll('[data-read-frog-walked="aborted-walk"]').length
+    const total = host.querySelectorAll("*").length
+    // A prefix was labeled, the rest was never touched, and no element got a
+    // paragraph/block/inline label without the walked marker.
+    expect(walked).toBeGreaterThan(0)
+    expect(walked).toBeLessThan(total)
+    for (const labeled of host.querySelectorAll(
+      "[data-read-frog-paragraph], [data-read-frog-block-node], [data-read-frog-inline-node]",
+    )) {
+      expect(labeled.getAttribute("data-read-frog-walked")).toBe("aborted-walk")
+    }
+
+    host.remove()
+  })
+
+  it("invokes onBlockedElement for a blocked root without walking it", async () => {
+    const host = document.createElement("div")
+    host.hidden = true
+    host.innerHTML = "<p>invisible</p>"
+    document.body.append(host)
+
+    const reported: HTMLElement[] = []
+    const result = await walkAndLabelElementChunked(host, "walk", config(), {
+      onBlockedElement: (element) => reported.push(element),
+    })
+
+    expect(result).toEqual({ forceBlock: false, isInlineNode: false })
+    expect(reported).toEqual([host])
+    expect(host.hasAttribute("data-read-frog-walked")).toBe(false)
+
+    host.remove()
+  })
+})

--- a/src/utils/host/dom/filter.ts
+++ b/src/utils/host/dom/filter.ts
@@ -36,8 +36,10 @@ export function isShallowInlineTransNode(node: Node): boolean {
 
 // treat large floating letter on some news websites as inline node
 // for example: https://www.economist.com/business/2025/08/21/china-is-quietly-upstaging-america-with-its-open-models
-function isLargeInitialFloatingLetter(element: HTMLElement): boolean {
-  const computedStyle = window.getComputedStyle(element)
+function isLargeInitialFloatingLetter(
+  element: HTMLElement,
+  computedStyle: CSSStyleDeclaration = window.getComputedStyle(element),
+): boolean {
   return (
     computedStyle.float === "left" &&
     !!element.nextSibling &&
@@ -61,7 +63,10 @@ function isInlineDisplay(display: string): boolean {
   )
 }
 
-export function isShallowInlineHTMLElement(element: HTMLElement): boolean {
+export function isShallowInlineHTMLElement(
+  element: HTMLElement,
+  computedStyle?: CSSStyleDeclaration,
+): boolean {
   // to prevent too many inline nodes that make <body> as a paragraph node
   if (!element.textContent?.trim()) {
     return false
@@ -71,13 +76,13 @@ export function isShallowInlineHTMLElement(element: HTMLElement): boolean {
     return false
   }
 
-  const computedStyle = window.getComputedStyle(element)
+  const style = computedStyle ?? window.getComputedStyle(element)
 
-  if (isLargeInitialFloatingLetter(element)) {
+  if (isLargeInitialFloatingLetter(element, style)) {
     return true
   }
 
-  return isInlineDisplay(computedStyle.display)
+  return isInlineDisplay(style.display)
 }
 
 // Note: !(inline node) != block node because of `notranslate` class and all cases not in the if else block
@@ -90,18 +95,21 @@ export function isShallowBlockTransNode(node: Node): boolean {
   return false
 }
 
-export function isShallowBlockHTMLElement(element: HTMLElement): boolean {
-  const computedStyle = window.getComputedStyle(element)
-
+export function isShallowBlockHTMLElement(
+  element: HTMLElement,
+  computedStyle?: CSSStyleDeclaration,
+): boolean {
   if (FORCE_BLOCK_TAGS.has(element.tagName)) {
     return true
   }
 
-  if (isLargeInitialFloatingLetter(element)) {
+  const style = computedStyle ?? window.getComputedStyle(element)
+
+  if (isLargeInitialFloatingLetter(element, style)) {
     return false
   }
 
-  return !isInlineDisplay(computedStyle.display)
+  return !isInlineDisplay(style.display)
 }
 
 export function isSiteRuleExcludedElement(element: HTMLElement, config: Config): boolean {
@@ -185,34 +193,44 @@ export function isDontWalkIntoAndDontTranslateAsChildElement(
   element: HTMLElement,
   config: Config,
 ): boolean {
-  const dontWalkCustomElement =
-    !isDontWalkIntoButTranslateAsChildElement(element, config) &&
-    isSiteRuleExcludedElement(element, config)
+  // Cheap structural predicates first; the getComputedStyle check runs last
+  // because it can force a style recalculation, and the full-page walk
+  // evaluates this predicate for every element (#1881).
+  const dontWalkInvalidTag = DONT_WALK_AND_TRANSLATE_TAGS.has(element.tagName)
+  if (dontWalkInvalidTag) return true
+
+  const dontWalkHidden = element.hidden
+  if (dontWalkHidden) return true
+
+  const dontWalkVisuallyHidden = ["sr-only", "visually-hidden"].some((cls) =>
+    element.classList.contains(cls),
+  )
+  if (dontWalkVisuallyHidden) return true
+
   const dontWalkContent =
     config.translate.page.range !== "all" &&
     MAIN_CONTENT_IGNORE_TAGS.has(element.tagName) &&
     !isInsideContentContainer(element)
-  const dontWalkInvalidTag = DONT_WALK_AND_TRANSLATE_TAGS.has(element.tagName)
-  const dontWalkCSS =
-    window.getComputedStyle(element).display === "none" ||
-    window.getComputedStyle(element).visibility === "hidden"
-  const dontWalkHidden = element.hidden
-  const dontWalkVisuallyHidden = ["sr-only", "visually-hidden"].some((cls) =>
-    element.classList.contains(cls),
+  if (dontWalkContent) return true
+
+  const dontWalkCustomElement =
+    !isDontWalkIntoButTranslateAsChildElement(element, config) &&
+    isSiteRuleExcludedElement(element, config)
+  if (dontWalkCustomElement) return true
+
+  const computedStyle = window.getComputedStyle(element)
+  return computedStyle.display === "none" || computedStyle.visibility === "hidden"
+}
+
+/**
+ * The walk-blocking predicate shared by the traversal (which stops descent at
+ * such elements) and the mutation pipeline's walkability cache.
+ */
+export function isWalkBlockedElement(element: HTMLElement, config: Config): boolean {
+  return (
+    isDontWalkIntoButTranslateAsChildElement(element, config) ||
+    isDontWalkIntoAndDontTranslateAsChildElement(element, config)
   )
-
-  if (
-    dontWalkCustomElement ||
-    dontWalkContent ||
-    dontWalkInvalidTag ||
-    dontWalkCSS ||
-    dontWalkHidden ||
-    dontWalkVisuallyHidden
-  ) {
-    return true
-  }
-
-  return false
 }
 
 export function isInlineTransNode(node: TransNode): boolean {
@@ -287,10 +305,7 @@ export function isTranslatedContentNode(node: Node): boolean {
 export function hasNoWalkAncestor(element: HTMLElement, config: Config): boolean {
   let current: HTMLElement | null = element.parentElement
   while (current) {
-    if (
-      isDontWalkIntoButTranslateAsChildElement(current, config) ||
-      isDontWalkIntoAndDontTranslateAsChildElement(current, config)
-    ) {
+    if (isWalkBlockedElement(current, config)) {
       return true
     }
     current = current.parentElement

--- a/src/utils/host/dom/traversal.ts
+++ b/src/utils/host/dom/traversal.ts
@@ -7,15 +7,16 @@ import {
   WALKED_ATTRIBUTE,
 } from "@/utils/constants/dom-labels"
 import { FORCE_BLOCK_TAGS } from "@/utils/constants/dom-rules"
+import { DEFAULT_WALK_BUDGET_MS, yieldToMain } from "@/utils/scheduler"
 import {
   isDontWalkIntoAndDontTranslateAsChildElement,
-  isDontWalkIntoButTranslateAsChildElement,
   isHTMLElement,
   isShallowBlockHTMLElement,
   isShallowInlineHTMLElement,
   isSiteRuleForceBlockElement,
   isTextNode,
   isTranslatedWrapperNode,
+  isWalkBlockedElement,
   isWithinIncludeScope,
 } from "./filter"
 
@@ -67,46 +68,62 @@ export function extractTextContent(node: TransNode, config: Config): string {
   }, "")
 }
 
-export function walkAndLabelElement(
+export interface WalkResult {
+  forceBlock: boolean
+  isInlineNode: boolean
+}
+
+export interface WalkCallbacks {
+  /** Invoked for each element the walk refuses to descend into. */
+  onBlockedElement?: (element: HTMLElement) => void
+}
+
+export interface ChunkedWalkOptions extends WalkCallbacks {
+  budgetMs?: number
+  /** Checked at every slice boundary; returning false aborts the walk. */
+  shouldContinue?: () => boolean
+}
+
+const SKIPPED_WALK_RESULT: WalkResult = { forceBlock: false, isInlineNode: false }
+
+/**
+ * Recursive generator holding the single copy of the labeling logic. Each
+ * `yield` (one per element, BEFORE any attribute write) is a potential pause
+ * point for the chunked driver; `yield*` delegation preserves the post-order
+ * dataflow (a parent's paragraph label depends on every child's isInlineNode,
+ * and forceBlock propagates child → parent).
+ *
+ * Precondition: `element` already passed the blocked check.
+ */
+function* walkNode(
   element: HTMLElement,
   walkId: string,
   config: Config,
-): { forceBlock: boolean; isInlineNode: boolean } {
-  if (
-    isDontWalkIntoButTranslateAsChildElement(element, config) ||
-    isDontWalkIntoAndDontTranslateAsChildElement(element, config)
-  ) {
-    return {
-      forceBlock: false,
-      isInlineNode: false,
-    }
-  }
+  callbacks: WalkCallbacks,
+): Generator<void, WalkResult> {
+  yield
 
   element.setAttribute(WALKED_ATTRIBUTE, walkId)
 
   if (element.shadowRoot) {
-    for (const child of element.shadowRoot.children) {
-      if (isHTMLElement(child)) {
-        walkAndLabelElement(child, walkId, config)
+    // Snapshot the live HTMLCollection: the chunked driver yields between
+    // elements, and a page mutation during a pause could otherwise shift the
+    // collection and skip an unvisited sibling (which no mutation record would
+    // repair, since observers do not pierce the shadow boundary).
+    for (const child of [...element.shadowRoot.children]) {
+      if (!isHTMLElement(child)) continue
+      if (isWalkBlockedElement(child, config)) {
+        callbacks.onBlockedElement?.(child)
+        continue
       }
+      yield* walkNode(child, walkId, config, callbacks)
     }
   }
 
   let hasInlineNodeChild = false
   let forceBlock = false
 
-  const validChildNodes = [...element.childNodes].filter((child: ChildNode) => {
-    if (child.nodeType === Node.TEXT_NODE) return true
-    if (isHTMLElement(child)) {
-      return !(
-        isDontWalkIntoButTranslateAsChildElement(child, config) ||
-        isDontWalkIntoAndDontTranslateAsChildElement(child, config)
-      )
-    }
-    return false
-  })
-
-  for (const child of validChildNodes) {
+  for (const child of [...element.childNodes]) {
     if (child.nodeType === Node.TEXT_NODE) {
       if (child.textContent?.trim()) {
         hasInlineNodeChild = true
@@ -115,7 +132,14 @@ export function walkAndLabelElement(
     }
 
     if (isHTMLElement(child)) {
-      const result = walkAndLabelElement(child, walkId, config)
+      // Evaluate the blocked predicate once per child, here — the recursive
+      // call's precondition replaces the old duplicate entry re-check.
+      if (isWalkBlockedElement(child, config)) {
+        callbacks.onBlockedElement?.(child)
+        continue
+      }
+
+      const result = yield* walkNode(child, walkId, config, callbacks)
 
       forceBlock = forceBlock || result.forceBlock
 
@@ -139,11 +163,14 @@ export function walkAndLabelElement(
     }
   }
 
-  const isInlineNode = isShallowInlineHTMLElement(element)
+  // One computed-style resolution feeds both shallow-shape checks (was up to
+  // four separate getComputedStyle calls per element, #1881).
+  const computedStyle = window.getComputedStyle(element)
+  const isInlineNode = isShallowInlineHTMLElement(element, computedStyle)
 
   if (
-    isShallowBlockHTMLElement(element) ||
     forceBlock ||
+    isShallowBlockHTMLElement(element, computedStyle) ||
     isSiteRuleForceBlockElement(element, config)
   ) {
     element.setAttribute(BLOCK_ATTRIBUTE, "")
@@ -155,4 +182,59 @@ export function walkAndLabelElement(
     forceBlock,
     isInlineNode,
   }
+}
+
+export function walkAndLabelElement(
+  element: HTMLElement,
+  walkId: string,
+  config: Config,
+  callbacks: WalkCallbacks = {},
+): WalkResult {
+  if (isWalkBlockedElement(element, config)) {
+    callbacks.onBlockedElement?.(element)
+    return SKIPPED_WALK_RESULT
+  }
+
+  const iterator = walkNode(element, walkId, config, callbacks)
+  let step = iterator.next()
+  while (!step.done) {
+    step = iterator.next()
+  }
+  return step.value
+}
+
+/**
+ * Time-sliced variant of walkAndLabelElement: labels identically, but yields
+ * to the main thread whenever a slice's budget is spent so input and
+ * rendering stay responsive on huge pages (#1881). Returns `null` when
+ * aborted via `shouldContinue`. The generator suspends at element ENTRY
+ * (before any attribute write), so an abort never leaves a half-labeled
+ * element — the frontier element is simply unwalked.
+ */
+export async function walkAndLabelElementChunked(
+  element: HTMLElement,
+  walkId: string,
+  config: Config,
+  options: ChunkedWalkOptions = {},
+): Promise<WalkResult | null> {
+  const { budgetMs = DEFAULT_WALK_BUDGET_MS, shouldContinue = () => true, ...callbacks } = options
+
+  if (!shouldContinue()) return null
+  if (isWalkBlockedElement(element, config)) {
+    callbacks.onBlockedElement?.(element)
+    return SKIPPED_WALK_RESULT
+  }
+
+  const iterator = walkNode(element, walkId, config, callbacks)
+  let deadline = performance.now() + budgetMs
+  let step = iterator.next()
+  while (!step.done) {
+    if (performance.now() >= deadline) {
+      await yieldToMain()
+      if (!shouldContinue()) return null
+      deadline = performance.now() + budgetMs
+    }
+    step = iterator.next()
+  }
+  return step.value
 }

--- a/src/utils/host/translate/core/__tests__/translation-walker-liveness.test.ts
+++ b/src/utils/host/translate/core/__tests__/translation-walker-liveness.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { WALKED_ATTRIBUTE } from "@/utils/constants/dom-labels"
+import { createWorkPacer } from "@/utils/scheduler"
+import { translateWalkedElement } from "../translation-walker"
+
+const { mockTranslateNodes } = vi.hoisted(() => ({
+  mockTranslateNodes: vi.fn<(...args: any[]) => any>(),
+}))
+
+vi.mock("../translation-modes", () => ({
+  translateNodes: mockTranslateNodes,
+}))
+
+vi.mock("../translation-state", () => ({
+  getTranslationOnlyAnchorState: vi.fn<(...args: any[]) => any>().mockReturnValue(undefined),
+}))
+
+// Label a container as a paragraph tree: the container plus each child <p> is a
+// paragraph, so translateWalkedElement recurses and calls translateNodes per unit.
+function buildParagraphTree(childCount: number): HTMLElement {
+  const container = document.createElement("div")
+  container.setAttribute(WALKED_ATTRIBUTE, "walk-1")
+  container.setAttribute("data-read-frog-paragraph", "")
+  container.setAttribute("data-read-frog-block-node", "")
+  for (let i = 0; i < childCount; i++) {
+    const p = document.createElement("p")
+    p.setAttribute(WALKED_ATTRIBUTE, "walk-1")
+    p.setAttribute("data-read-frog-paragraph", "")
+    p.setAttribute("data-read-frog-block-node", "")
+    p.textContent = `paragraph ${i}`
+    container.append(p)
+  }
+  document.body.append(container)
+  return container
+}
+
+// The container has block children, so its loop emits empty translateNodes([])
+// calls between block children (structural, not real work). Count only the
+// real leaf-paragraph translations.
+function realTranslationTexts(): string[] {
+  return mockTranslateNodes.mock.calls
+    .map((call) => call[0] as ChildNode[])
+    .filter((nodes) => nodes.length > 0)
+    .map((nodes) => nodes.map((n) => n.textContent).join(""))
+    .filter((text) => text.startsWith("paragraph"))
+}
+
+describe("translateWalkedElement liveness", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    document.body.innerHTML = ""
+    mockTranslateNodes.mockResolvedValue(undefined)
+  })
+
+  it("translates nothing when the session is already cancelled", async () => {
+    const container = buildParagraphTree(6)
+    const pacer = createWorkPacer(0)
+
+    await translateWalkedElement(container, "walk-1", DEFAULT_CONFIG, false, pacer, () => false)
+
+    expect(realTranslationTexts()).toHaveLength(0)
+  })
+
+  it("stops paced expansion once shouldContinue turns false mid-flight", async () => {
+    const container = buildParagraphTree(6)
+    // budgetMs 0 forces a yield (and a liveness check) at every recursive entry;
+    // the checks fire in spawn order as each chain resumes from its yield.
+    const pacer = createWorkPacer(0)
+
+    // Simulate a cancel landing after the third liveness check.
+    let checks = 0
+    const shouldContinue = () => {
+      checks += 1
+      return checks <= 3
+    }
+
+    await translateWalkedElement(container, "walk-1", DEFAULT_CONFIG, false, pacer, shouldContinue)
+
+    const translated = realTranslationTexts()
+    // Without the gate all 6 children translate; with it, expansion halts as
+    // soon as a resumed chain sees the cancel.
+    expect(translated.length).toBeGreaterThan(0)
+    expect(translated.length).toBeLessThan(6)
+  })
+
+  it("translates the whole tree when the session stays alive", async () => {
+    const container = buildParagraphTree(4)
+    const pacer = createWorkPacer(0)
+
+    await translateWalkedElement(container, "walk-1", DEFAULT_CONFIG, false, pacer, () => true)
+
+    expect(new Set(realTranslationTexts()).size).toBe(4)
+  })
+})

--- a/src/utils/host/translate/core/translation-walker.ts
+++ b/src/utils/host/translate/core/translation-walker.ts
@@ -1,4 +1,6 @@
 import type { Config } from "@/types/config/config"
+import type { WorkPacer } from "@/utils/scheduler"
+import { createWorkPacer, pauseIfBudgetSpent } from "@/utils/scheduler"
 import {
   BLOCK_ATTRIBUTE,
   CONTENT_WRAPPER_CLASS,
@@ -33,7 +35,21 @@ export async function translateWalkedElement(
   walkId: string,
   config: Config,
   toggle: boolean = false,
+  pacer: WorkPacer = createWorkPacer(),
+  // Liveness gate re-checked after every yield. Because pacing spreads a giant
+  // subtree's expansion across seconds, a session cancelled mid-expansion must
+  // stop here — the WALKED attribute alone does not (stop() never strips it),
+  // so without this the walk keeps inserting wrappers/spinners into the page
+  // the user just cleared (#1881).
+  shouldContinue: () => boolean = () => true,
 ): Promise<void> {
+  // Self-pacing: a giant observed subtree (a flat article can label as ONE
+  // huge paragraph unit, #1881) must not expand into thousands of wrapper
+  // insertions in a single task. Intersection-callback batches share one
+  // pacer so a burst of entries is throttled globally.
+  await pauseIfBudgetSpent(pacer)
+  if (!shouldContinue()) return
+
   // Translated regions are skipped on non-toggle walks. In-place-swapped
   // paragraphs leave no wrapper, so also check the anchor marker attribute.
   if (
@@ -74,7 +90,9 @@ export async function translateWalkedElement(
             translateNodes(consecutiveInlineNodes, walkId, toggle, config, !isFlexParent),
           )
           consecutiveInlineNodes = []
-          promises.push(translateWalkedElement(child, walkId, config, toggle))
+          promises.push(
+            translateWalkedElement(child, walkId, config, toggle, pacer, shouldContinue),
+          )
         } else {
           consecutiveInlineNodes.push(child)
         }
@@ -87,13 +105,15 @@ export async function translateWalkedElement(
   } else {
     for (const child of element.childNodes) {
       if (isHTMLElement(child)) {
-        promises.push(translateWalkedElement(child, walkId, config, toggle))
+        promises.push(translateWalkedElement(child, walkId, config, toggle, pacer, shouldContinue))
       }
     }
     if (element.shadowRoot) {
       for (const child of element.shadowRoot.children) {
         if (isHTMLElement(child)) {
-          promises.push(translateWalkedElement(child, walkId, config, toggle))
+          promises.push(
+            translateWalkedElement(child, walkId, config, toggle, pacer, shouldContinue),
+          )
         }
       }
     }

--- a/src/utils/host/translate/dom/translation-cleanup.ts
+++ b/src/utils/host/translate/dom/translation-cleanup.ts
@@ -34,6 +34,7 @@ import {
   unregisterVirtualParagraphGroup,
   unregisterVirtualParagraphWrapper,
 } from "../core/translation-state"
+import { cancelSpinnerAnimation } from "../ui/spinner"
 
 export function removeShadowHostInTranslatedWrapper(wrapper: HTMLElement): void {
   // Remove React shadow hosts (for error components)
@@ -46,7 +47,7 @@ export function removeShadowHostInTranslatedWrapper(wrapper: HTMLElement): void 
   // detached node is not rooted by the renderer (#1831).
   const spinner = wrapper.querySelector(`.${SPINNER_CLASS}`)
   if (spinner && isHTMLElement(spinner)) {
-    spinner.getAnimations?.().forEach((animation) => animation.cancel())
+    cancelSpinnerAnimation(spinner)
     spinner.remove()
   }
 }

--- a/src/utils/host/translate/translate-text.ts
+++ b/src/utils/host/translate/translate-text.ts
@@ -12,9 +12,11 @@ import { detectLanguage } from "@/utils/content/language"
 import { i18n } from "@/utils/i18n"
 import { logger } from "@/utils/logger"
 import { getTranslatePrompt } from "@/utils/prompts/translate"
+import { TranslationCancelledError } from "@/utils/request/cancellation"
 import { Sha256Hex } from "../../hash"
 import { sendMessage } from "../../message"
 import { prepareTranslationText } from "./text-preparation"
+import { getPageTranslationSessionId } from "./translation-session"
 
 // Minimum text length for skip language detection (shorter than general detection
 // to catch short phrases like "Bonjour!" or "こんにちは")
@@ -135,6 +137,9 @@ export interface TranslateTextOptions {
   extraHashTags?: string[]
   webPageContext?: WebPagePromptContext
   textFormat?: TranslationTextFormat
+  // Page-translation session id used for cancellation scoping. Deliberately
+  // NOT part of the cache hash — cache identity must not vary per session.
+  sessionId?: string
 }
 
 /**
@@ -150,6 +155,7 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     extraHashTags = [],
     webPageContext,
     textFormat = "plain",
+    sessionId,
   } = options
 
   const preparedText = prepareTranslationText(text)
@@ -171,6 +177,17 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
   // Add extra hash tags for cache differentiation
   hashComponents.push(...extraHashTags)
 
+  // Final gate before dispatch: if the page-translation session that owned
+  // this request has ended (or been replaced) while we were preparing it,
+  // abort instead of enqueueing. Sending now would either be unscoped (if the
+  // id had gone null) or re-populate the queue AFTER the session's cancel
+  // message already drained it — both defeat cancellation (#1881). Callers on
+  // the page path swallow this error; input/selection requests carry no
+  // sessionId and skip the gate entirely.
+  if (sessionId !== undefined && getPageTranslationSessionId() !== sessionId) {
+    throw new TranslationCancelledError(sessionId)
+  }
+
   const result = await sendMessage("enqueueTranslateRequest", {
     text: preparedText,
     langConfig,
@@ -182,6 +199,7 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     webDescription: normalizedWebPageContext?.webDescription,
     webContent: normalizedWebPageContext?.webContent,
     webSummary: normalizedWebPageContext?.webSummary,
+    sessionId,
   })
   // The sentinel must be mapped here and only here: every batch-pipeline
   // consumer (page paragraphs, document title, input translation, selection

--- a/src/utils/host/translate/translate-variants.ts
+++ b/src/utils/host/translate/translate-variants.ts
@@ -13,6 +13,7 @@ import {
   shouldSkipByLanguage,
   translateTextCore,
 } from "./translate-text"
+import { getPageTranslationSessionId } from "./translation-session"
 import { getOrCreateWebPageContext } from "./webpage-context"
 import { getOrGenerateWebPageSummary } from "./webpage-summary"
 
@@ -64,6 +65,8 @@ async function translateTextUsingPageConfig(
       webSummary?: string | null
     }
     textFormat?: TranslationTextFormat
+    // Session captured at pipeline entry by the caller; see translateTextForPage.
+    sessionId?: string
   } = {},
 ): Promise<string> {
   const preparedText = prepareTranslationText(text)
@@ -106,6 +109,7 @@ async function translateTextUsingPageConfig(
     extraHashTags: options.extraHashTags,
     webPageContext: options.webPageContext,
     textFormat: options.textFormat,
+    sessionId: options.sessionId,
   })
 }
 
@@ -117,6 +121,11 @@ export async function translateTextForPage(
   text: string,
   textFormat: TranslationTextFormat = "plain",
 ): Promise<string> {
+  // Capture the session id synchronously at pipeline entry. Reading it later
+  // (after the awaits below, e.g. the network-backed page summary) could see
+  // null if the user cancelled mid-request — the request would then be sent
+  // unscoped and stay permanently uncancellable, re-creating #1881.
+  const sessionId = getPageTranslationSessionId() ?? undefined
   const config = await getConfigOrThrow()
   const providerConfig = resolveProviderConfig(config, "translate")
   const webPageContext = await getWebPagePromptContext(
@@ -128,6 +137,7 @@ export async function translateTextForPage(
   return translateTextUsingPageConfig(config, text, {
     webPageContext,
     textFormat,
+    sessionId,
   })
 }
 
@@ -136,6 +146,7 @@ export async function translateTextForPage(
  * current source title as the webpage title context.
  */
 export async function translateTextForPageTitle(text: string): Promise<string> {
+  const sessionId = getPageTranslationSessionId() ?? undefined
   const config = await getConfigOrThrow()
   const providerConfig = resolveProviderConfig(config, "translate")
   const webPageContext = config.translate.enableAIContentAware
@@ -150,6 +161,7 @@ export async function translateTextForPageTitle(text: string): Promise<string> {
       webContent: webPageContext?.webContent,
       webSummary: webPageContext?.webSummary,
     },
+    sessionId,
   })
 }
 

--- a/src/utils/host/translate/translation-session.ts
+++ b/src/utils/host/translate/translation-session.ts
@@ -1,0 +1,34 @@
+/**
+ * Identity of the current page-translation session in this frame. Module
+ * scope is correct: exactly one PageTranslationManager exists per frame.
+ *
+ * Every page-translation request carries this id so the background can drain
+ * the session's queued/in-flight requests when the user cancels (#1881). A
+ * fresh id per session means cancelling an old wave can never affect a
+ * restarted session's requests.
+ *
+ * The id is a correlation key, not cryptographic material — it deliberately
+ * avoids getRandomUUID so sessions never consume from the same source as walk
+ * ids. The random component keeps ids unique across frames of the same tab
+ * (the background scopes by tab id + session id only).
+ */
+let currentPageTranslationSessionId: string | null = null
+let sessionCounter = 0
+
+export function beginPageTranslationSession(): string {
+  sessionCounter += 1
+  currentPageTranslationSessionId = `${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 10)}-${sessionCounter}`
+  return currentPageTranslationSessionId
+}
+
+export function endPageTranslationSession(): string | null {
+  const endedSessionId = currentPageTranslationSessionId
+  currentPageTranslationSessionId = null
+  return endedSessionId
+}
+
+export function getPageTranslationSessionId(): string | null {
+  return currentPageTranslationSessionId
+}

--- a/src/utils/host/translate/ui/__tests__/spinner.test.ts
+++ b/src/utils/host/translate/ui/__tests__/spinner.test.ts
@@ -1,7 +1,15 @@
 // @vitest-environment jsdom
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { createLightweightSpinner, createSpinnerInside } from "../spinner"
+import { TRANSLATION_ERROR_CONTAINER_CLASS } from "@/utils/constants/dom-labels"
+import { TranslationCancelledError } from "@/utils/request/cancellation"
+import {
+  cancelSpinnerAnimation,
+  createLightweightSpinner,
+  createSpinnerInside,
+  getTranslatedTextAndRemoveSpinner,
+  MAX_ANIMATED_SPINNERS,
+} from "../spinner"
 
 const { ensurePresetStylesMock } = vi.hoisted(() => ({
   ensurePresetStylesMock: vi.fn<(...args: any[]) => any>(),
@@ -100,5 +108,103 @@ describe("spinner", () => {
 
     expect(animateMock).not.toHaveBeenCalled()
     expect(spinner.style.borderTopColor).toBe("var(--read-frog-muted-foreground)")
+  })
+})
+
+describe("spinner animation registry (#1881)", () => {
+  // jsdom has no WAAPI: install a fake Element.animate returning a
+  // cancellable handle so the registry/cap logic is observable.
+  const createdAnimations: { cancel: ReturnType<typeof vi.fn> }[] = []
+  const animateMock = vi.fn<() => Animation>(() => {
+    const animation = { cancel: vi.fn<() => void>() }
+    createdAnimations.push(animation)
+    return animation as unknown as Animation
+  })
+
+  // Spinners created per test, cancelled afterwards so the module-level
+  // active-animation counter never leaks between tests.
+  let createdSpinners: HTMLElement[] = []
+
+  function makeSpinner(): HTMLElement {
+    const spinner = createLightweightSpinner(document)
+    createdSpinners.push(spinner)
+    return spinner
+  }
+
+  beforeEach(() => {
+    createdSpinners.forEach((spinner) => cancelSpinnerAnimation(spinner))
+    createdSpinners = []
+    createdAnimations.length = 0
+    animateMock.mockClear()
+    Object.defineProperty(HTMLElement.prototype, "animate", {
+      value: animateMock,
+      configurable: true,
+      writable: true,
+    })
+    // The reduced-motion test above redefines window.matchMedia persistently;
+    // force motion back on for this block.
+    Object.defineProperty(window, "matchMedia", {
+      value: vi.fn<(...args: any[]) => any>().mockReturnValue({ matches: false }),
+      configurable: true,
+      writable: true,
+    })
+  })
+
+  it("cancels the stored animation directly instead of calling getAnimations", () => {
+    const spinner = makeSpinner()
+    expect(animateMock).toHaveBeenCalledTimes(1)
+
+    const getAnimations = vi.fn<() => Animation[]>(() => [])
+    spinner.getAnimations = getAnimations
+
+    cancelSpinnerAnimation(spinner)
+    expect(createdAnimations[0].cancel).toHaveBeenCalledTimes(1)
+    expect(getAnimations).not.toHaveBeenCalled()
+
+    // Second cancel: registry entry is gone — falls back to getAnimations.
+    cancelSpinnerAnimation(spinner)
+    expect(getAnimations).toHaveBeenCalledTimes(1)
+    expect(createdAnimations[0].cancel).toHaveBeenCalledTimes(1)
+  })
+
+  it("caps concurrent animations and reopens slots after cancellation", () => {
+    for (let i = 0; i < MAX_ANIMATED_SPINNERS; i++) {
+      makeSpinner()
+    }
+    expect(animateMock).toHaveBeenCalledTimes(MAX_ANIMATED_SPINNERS)
+
+    // Above the cap: static muted ring, no new animation.
+    const overCap = makeSpinner()
+    expect(animateMock).toHaveBeenCalledTimes(MAX_ANIMATED_SPINNERS)
+    expect(overCap.style.borderTopColor).toBe("var(--read-frog-muted-foreground)")
+
+    // Cancelling one frees a slot for the next spinner.
+    cancelSpinnerAnimation(createdSpinners[0])
+    makeSpinner()
+    expect(animateMock).toHaveBeenCalledTimes(MAX_ANIMATED_SPINNERS + 1)
+  })
+
+  it("swallows TranslationCancelledError silently even when isCurrent stays true", async () => {
+    const wrapper = document.createElement("span")
+    document.body.append(wrapper)
+    const spinner = makeSpinner()
+    wrapper.append(spinner)
+
+    const result = await getTranslatedTextAndRemoveSpinner(
+      [],
+      "source text",
+      spinner,
+      wrapper,
+      () => true,
+      "plain",
+      () => Promise.reject(new TranslationCancelledError("7:session")),
+    )
+
+    expect(result).toBeUndefined()
+    expect(wrapper.querySelector(`.${TRANSLATION_ERROR_CONTAINER_CLASS}`)).toBeNull()
+    expect(spinner.isConnected).toBe(false)
+    expect(createdAnimations[0].cancel).toHaveBeenCalled()
+
+    wrapper.remove()
   })
 })

--- a/src/utils/host/translate/ui/spinner.ts
+++ b/src/utils/host/translate/ui/spinner.ts
@@ -5,10 +5,46 @@ import textSmallCSS from "@/assets/styles/text-small.css?inline"
 import themeCSS from "@/assets/styles/theme.css?inline"
 import { TranslationError } from "@/components/translation/error"
 import { createReactShadowHost } from "@/utils/react-shadow-host/create-shadow-host"
+import { isTranslationCancelledError } from "@/utils/request/cancellation"
 import { SPINNER_CLASS, TRANSLATION_ERROR_CONTAINER_CLASS } from "../../../constants/dom-labels"
 import { getContainingShadowRoot, getOwnerDocument } from "../../dom/node"
 import { translateTextForPage } from "../translate-variants"
 import { ensurePresetStyles } from "./style-injector"
+
+/**
+ * Concurrent spin-animation ceiling. Thousands of live WAAPI animations tick
+ * a full-page style recalc every frame and saturate the main thread on long
+ * pages (#1881: 2400+ concurrent spinners measured). Beyond the cap, pending
+ * paragraphs get the static muted ring instead.
+ */
+export const MAX_ANIMATED_SPINNERS = 60
+
+/**
+ * Animation created for each spinner, kept so teardown can cancel it directly.
+ * Element.getAnimations() gets expensive when the document holds thousands of
+ * live animations (10% of CPU samples in the #1881 trace); the stored handle
+ * makes cancellation O(1).
+ */
+const spinnerAnimations = new WeakMap<HTMLElement, Animation>()
+let activeSpinnerAnimationCount = 0
+
+/**
+ * Cancel the spinner's spin animation. A running animation roots its detached
+ * target in the renderer, leaking one node per translated paragraph (#1831),
+ * so every teardown path must call this before dropping the spinner.
+ */
+export function cancelSpinnerAnimation(spinner: HTMLElement): void {
+  const animation = spinnerAnimations.get(spinner)
+  if (animation) {
+    spinnerAnimations.delete(spinner)
+    activeSpinnerAnimationCount = Math.max(0, activeSpinnerAnimationCount - 1)
+    animation.cancel()
+    return
+  }
+  // Fallback for spinners created before this registry existed (or if the
+  // WeakMap entry was lost). jsdom lacks getAnimations, hence the `?.`.
+  spinner.getAnimations?.().forEach((liveAnimation) => liveAnimation.cancel())
+}
 
 /**
  * Create a lightweight spinner element without React/Shadow DOM overhead
@@ -47,12 +83,21 @@ export function createLightweightSpinner(ownerDoc: Document): HTMLElement {
   const prefersReducedMotion = ownerDoc.defaultView?.matchMedia
     ? ownerDoc.defaultView.matchMedia("(prefers-reduced-motion: reduce)").matches
     : false
-  if (!prefersReducedMotion && spinner.animate) {
-    spinner.animate([{ transform: "rotate(0deg)" }, { transform: "rotate(360deg)" }], {
-      duration: 600,
-      iterations: Infinity,
-      easing: "linear",
-    })
+  if (
+    !prefersReducedMotion &&
+    spinner.animate &&
+    activeSpinnerAnimationCount < MAX_ANIMATED_SPINNERS
+  ) {
+    const animation = spinner.animate(
+      [{ transform: "rotate(0deg)" }, { transform: "rotate(360deg)" }],
+      {
+        duration: 600,
+        iterations: Infinity,
+        easing: "linear",
+      },
+    )
+    spinnerAnimations.set(spinner, animation)
+    activeSpinnerAnimationCount++
   } else {
     // For reduced motion or when Web Animations API isn't available,
     // keep a static muted segment so the loading state stays visible
@@ -88,6 +133,11 @@ export async function getTranslatedTextAndRemoveSpinner(
     translatedText = await translateRequest()
     if (!isCurrent()) return undefined
   } catch (error) {
+    // User-cancelled sessions must fail silently: the wrapper is already
+    // detached by stop(), and translationOnly mode passes isCurrent=()=>true,
+    // so rendering an error here would mount a React root on a detached
+    // wrapper (the #1831 leak class).
+    if (isTranslationCancelledError(error)) return undefined
     if (!isCurrent()) return undefined
 
     const errorComponent = React.createElement(TranslationError, {
@@ -107,10 +157,7 @@ export async function getTranslatedTextAndRemoveSpinner(
 
     translatedWrapperNode.appendChild(container)
   } finally {
-    // The spin animation runs with iterations: Infinity; a running animation
-    // roots its detached target in the renderer, leaking one node per
-    // translated paragraph (#1831). jsdom lacks getAnimations, hence the `?.`.
-    spinner.getAnimations?.().forEach((animation) => animation.cancel())
+    cancelSpinnerAnimation(spinner)
     spinner.remove()
   }
 

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -100,7 +100,15 @@ interface ProtocolMap {
     webDescription?: string | null
     webContent?: string | null
     webSummary?: string | null
+    // Page-translation session this request belongs to; scopes the request
+    // for cancelPageTranslationRequests. Absent for non-page requests
+    // (input/selection translation), which are never cancellable.
+    sessionId?: string
   }) => Promise<string>
+  // Drain queued/in-flight page-translation requests of one session (#1881).
+  // The background composes the scope as `${sender.tab.id}:${sessionId}`, so a
+  // tab can only ever cancel its own requests.
+  cancelPageTranslationRequests: (data: { sessionId: string }) => void
   getOrGenerateWebPageSummary: (data: {
     webTitle: string
     webContent: string

--- a/src/utils/request/__tests__/cancellation.test.ts
+++ b/src/utils/request/__tests__/cancellation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import {
+  isTranslationCancelledError,
+  TRANSLATION_CANCELLED_ERROR_NAME,
+  TranslationCancelledError,
+} from "../cancellation"
+
+describe("isTranslationCancelledError", () => {
+  it("recognizes a same-realm instance", () => {
+    expect(isTranslationCancelledError(new TranslationCancelledError("7:sess"))).toBe(true)
+  })
+
+  it("recognizes the messaging-boundary shape (plain Error carrying only the name)", () => {
+    // @webext-core/messaging re-creates background rejections on the content
+    // side via @aklinker1/zero-serialize-error as `Error(msg)` with `.name`
+    // copied — the prototype (and thus instanceof) is lost. Detection MUST be
+    // name-based; this pins that so a refactor to `instanceof` can't slip
+    // through green (#1881).
+    const crossBoundary = Object.assign(new Error("Translation request cancelled"), {
+      name: TRANSLATION_CANCELLED_ERROR_NAME,
+    })
+    expect(crossBoundary).not.toBeInstanceOf(TranslationCancelledError)
+    expect(isTranslationCancelledError(crossBoundary)).toBe(true)
+  })
+
+  it("rejects unrelated errors and non-errors", () => {
+    expect(isTranslationCancelledError(new Error("boom"))).toBe(false)
+    expect(isTranslationCancelledError({ name: TRANSLATION_CANCELLED_ERROR_NAME })).toBe(false)
+    expect(isTranslationCancelledError(undefined)).toBe(false)
+    expect(isTranslationCancelledError("cancelled")).toBe(false)
+  })
+})

--- a/src/utils/request/__tests__/cancellation.test.ts
+++ b/src/utils/request/__tests__/cancellation.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import {
+  CancelledScopeRegistry,
   isTranslationCancelledError,
   TRANSLATION_CANCELLED_ERROR_NAME,
   TranslationCancelledError,
@@ -28,5 +29,53 @@ describe("isTranslationCancelledError", () => {
     expect(isTranslationCancelledError({ name: TRANSLATION_CANCELLED_ERROR_NAME })).toBe(false)
     expect(isTranslationCancelledError(undefined)).toBe(false)
     expect(isTranslationCancelledError("cancelled")).toBe(false)
+  })
+})
+
+describe("cancelledScopeRegistry", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("remembers exact cancelled scopes", () => {
+    const registry = new CancelledScopeRegistry()
+    registry.markScope("7:session-a")
+
+    expect(registry.has("7:session-a")).toBe(true)
+    expect(registry.has("7:session-b")).toBe(false)
+    expect(registry.has("8:session-a")).toBe(false)
+  })
+
+  it("matches tab-close prefixes against every session of that tab", () => {
+    const registry = new CancelledScopeRegistry()
+    registry.markPrefix("7:")
+
+    expect(registry.has("7:session-a")).toBe(true)
+    expect(registry.has("7:session-b")).toBe(true)
+    expect(registry.has("8:session-a")).toBe(false)
+  })
+
+  it("expires entries after the TTL", () => {
+    vi.useFakeTimers()
+    const registry = new CancelledScopeRegistry(1_000)
+    registry.markScope("7:old")
+
+    vi.advanceTimersByTime(2_000)
+    // Pruning happens on write; a new mark evicts the expired entry.
+    registry.markScope("7:new")
+
+    expect(registry.has("7:old")).toBe(false)
+    expect(registry.has("7:new")).toBe(true)
+  })
+
+  it("evicts the oldest entries beyond the size cap", () => {
+    const registry = new CancelledScopeRegistry(60_000, 2)
+    registry.markScope("7:a")
+    registry.markScope("7:b")
+    registry.markScope("7:c")
+
+    expect(registry.has("7:a")).toBe(false)
+    expect(registry.has("7:b")).toBe(true)
+    expect(registry.has("7:c")).toBe(true)
   })
 })

--- a/src/utils/request/__tests__/queue-cancellation.test.ts
+++ b/src/utils/request/__tests__/queue-cancellation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { BatchQueue } from "../batch-queue"
+import { BatchCountMismatchError, BatchQueue } from "../batch-queue"
 import { isTranslationCancelledError, TranslationCancelledError } from "../cancellation"
 import { RequestQueue } from "../request-queue"
 
@@ -258,17 +258,20 @@ function createBatchQueue(options: {
   executeIndividual?: (data: FakeBatchData) => Promise<string>
   batchDelay?: number
   maxItemsPerBatch?: number
+  maxRetries?: number
+  isScopeCancelled?: (scopeKey: string) => boolean
 }) {
   return new BatchQueue<FakeBatchData, string>({
     maxCharactersPerBatch: 1_000,
     maxItemsPerBatch: options.maxItemsPerBatch ?? 10,
     batchDelay: options.batchDelay ?? 100,
-    maxRetries: 0,
+    maxRetries: options.maxRetries ?? 0,
     enableFallbackToIndividual: Boolean(options.executeIndividual),
     getBatchKey: () => "batch",
     getCharacters: (data) => data.text.length,
     getDedupKey: (data) => data.key,
     getScope: (data) => data.scope,
+    isScopeCancelled: options.isScopeCancelled,
     executeBatch: options.executeBatch,
     executeIndividual: options.executeIndividual,
   })
@@ -462,5 +465,77 @@ describe("batchQueue – cancelByScope", () => {
     gate.resolve()
     await expect(fromB).resolves.toBe("t:shared")
     expect(signals.B?.aborted).toBe(false)
+  })
+
+  it("aborts the retry backoff when every scope was cancelled during the sleep (#1881)", async () => {
+    vi.useFakeTimers()
+    const cancelled = new Set<string>()
+    // First attempt: LLM returns the wrong number of results → retry path.
+    const executeBatch = vi.fn<
+      (
+        dataList: FakeBatchData[],
+        meta: { scopes: readonly string[] | undefined },
+      ) => Promise<string[]>
+    >(async () => {
+      throw new BatchCountMismatchError(2, 1, ["only-one"])
+    })
+    const executeIndividual = vi.fn<(data: FakeBatchData) => Promise<string>>(
+      async (item) => `solo:${item.text}`,
+    )
+    const q = createBatchQueue({
+      batchDelay: 10,
+      maxRetries: 3,
+      executeBatch,
+      executeIndividual,
+      isScopeCancelled: (scope) => cancelled.has(scope),
+    })
+
+    const a1 = q.enqueue({ text: "alpha", key: "a1", scope: "A" })
+    const a2 = q.enqueue({ text: "beta", key: "a2", scope: "A" })
+    const settled = Promise.all([expectCancelled(a1), expectCancelled(a2)])
+
+    // Flush → first attempt fails → batch enters its backoff sleep, where it
+    // lives in no cancellable structure.
+    await vi.advanceTimersByTimeAsync(20)
+    expect(executeBatch).toHaveBeenCalledTimes(1)
+
+    // The session cancels during the backoff (registry marks the scope).
+    cancelled.add("A")
+
+    // Past every backoff window: no second attempt, no per-item fallback.
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(executeBatch).toHaveBeenCalledTimes(1)
+    expect(executeIndividual).not.toHaveBeenCalled()
+    await settled
+  })
+
+  it("keeps retrying when the scopes stay live (control)", async () => {
+    vi.useFakeTimers()
+    const executeBatch = vi.fn<
+      (
+        dataList: FakeBatchData[],
+        meta: { scopes: readonly string[] | undefined },
+      ) => Promise<string[]>
+    >(async (dataList) => {
+      if (executeBatch.mock.calls.length === 1) {
+        throw new BatchCountMismatchError(1, 0, [])
+      }
+      return dataList.map((d) => `t:${d.text}`)
+    })
+    const q = createBatchQueue({
+      batchDelay: 10,
+      maxRetries: 3,
+      executeBatch,
+      isScopeCancelled: () => false,
+    })
+
+    const a1 = q.enqueue({ text: "alpha", key: "a1", scope: "A" })
+
+    await vi.advanceTimersByTimeAsync(20)
+    expect(executeBatch).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(executeBatch).toHaveBeenCalledTimes(2)
+    await expect(a1).resolves.toBe("t:alpha")
   })
 })

--- a/src/utils/request/__tests__/queue-cancellation.test.ts
+++ b/src/utils/request/__tests__/queue-cancellation.test.ts
@@ -1,0 +1,414 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { BatchQueue } from "../batch-queue"
+import { isTranslationCancelledError, TranslationCancelledError } from "../cancellation"
+import { RequestQueue } from "../request-queue"
+
+const baseConfig = {
+  rate: 1, // 1 token / sec
+  capacity: 1, // bucket size 1
+  timeoutMs: 10_000,
+  maxRetries: 0,
+  baseRetryDelayMs: 100,
+} as const
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+async function expectCancelled(promise: Promise<unknown>): Promise<void> {
+  let caught: unknown
+  try {
+    await promise
+  } catch (error) {
+    caught = error
+  }
+  expect(caught).toBeInstanceOf(Error)
+  expect((caught as Error).name).toBe("TranslationCancelledError")
+  expect(isTranslationCancelledError(caught)).toBe(true)
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("requestQueue – cancelByScope", () => {
+  it("rejects waiting tasks without running their thunks and aborts the executing one", async () => {
+    vi.useFakeTimers()
+    const q = new RequestQueue(baseConfig)
+
+    const executing = createDeferred<string>()
+    let executingSignal: AbortSignal | undefined
+    const p1 = q.enqueue(
+      (signal) => {
+        executingSignal = signal
+        return executing.promise
+      },
+      Date.now(),
+      "h1",
+      ["A"],
+    )
+
+    const thunk2 = vi.fn<() => Promise<string>>(async () => "two")
+    const thunk3 = vi.fn<() => Promise<string>>(async () => "three")
+    const p2 = q.enqueue(thunk2, Date.now(), "h2", ["A"])
+    const p3 = q.enqueue(thunk3, Date.now(), "h3", ["A"])
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(executingSignal).toBeDefined()
+
+    const cancelled = q.cancelByScope("A")
+    expect(cancelled).toBe(3)
+
+    await expectCancelled(p1)
+    await expectCancelled(p2)
+    await expectCancelled(p3)
+    expect(thunk2).not.toHaveBeenCalled()
+    expect(thunk3).not.toHaveBeenCalled()
+    expect(executingSignal!.aborted).toBe(true)
+  })
+
+  it("does not retry a cancelled executing task", async () => {
+    vi.useFakeTimers()
+    const q = new RequestQueue({ ...baseConfig, maxRetries: 2 })
+
+    let attempts = 0
+    const promise = q.enqueue(
+      (signal) =>
+        new Promise((_, reject) => {
+          attempts += 1
+          signal?.addEventListener("abort", () => reject(signal.reason))
+        }),
+      Date.now(),
+      "hang",
+      ["A"],
+    )
+    const settled = expectCancelled(promise)
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(attempts).toBe(1)
+
+    q.cancelByScope("A")
+    await settled
+
+    // Advance past every retry window — no further attempts may start.
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(attempts).toBe(1)
+  })
+
+  it("keeps a dedup-shared task alive while another scope still needs it", async () => {
+    const q = new RequestQueue({ ...baseConfig, rate: 100, capacity: 100 })
+
+    const gate = createDeferred<string>()
+    const thunk = vi.fn<() => Promise<string>>(() => gate.promise)
+    const scheduledAt = Date.now() + 5_000
+
+    vi.useFakeTimers()
+    const fromA = q.enqueue(thunk, scheduledAt, "shared", ["A"])
+    const fromB = q.enqueue(thunk, scheduledAt, "shared", ["B"])
+    expect(fromB).toBe(fromA)
+
+    expect(q.cancelByScope("A")).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(6_000)
+    gate.resolve("value")
+    await expect(fromA).resolves.toBe("value")
+    expect(thunk).toHaveBeenCalledTimes(1)
+  })
+
+  it("cancels a dedup-shared task when every scope is cancelled", async () => {
+    vi.useFakeTimers()
+    const q = new RequestQueue(baseConfig)
+
+    const thunk = vi.fn<() => Promise<string>>(async () => "value")
+    const scheduledAt = Date.now() + 5_000
+    const fromA = q.enqueue(thunk, scheduledAt, "shared", ["A"])
+    void q.enqueue(thunk, scheduledAt, "shared", ["B"])
+
+    q.cancelByScope("A")
+    expect(q.cancelByScope("B")).toBe(1)
+
+    await expectCancelled(fromA)
+    await vi.advanceTimersByTimeAsync(10_000)
+    expect(thunk).not.toHaveBeenCalled()
+  })
+
+  it("is pinned by an unscoped duplicate subscriber", async () => {
+    vi.useFakeTimers()
+    const q = new RequestQueue(baseConfig)
+
+    const thunk = vi.fn<() => Promise<string>>(async () => "value")
+    const scheduledAt = Date.now() + 1_000
+    const fromA = q.enqueue(thunk, scheduledAt, "shared", ["A"])
+    const unscoped = q.enqueue(thunk, scheduledAt, "shared")
+
+    expect(q.cancelByScope("A")).toBe(0)
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    await expect(fromA).resolves.toBe("value")
+    await expect(unscoped).resolves.toBe("value")
+  })
+
+  it("keeps the heap dispatching surviving tasks in schedule order after selective removal", async () => {
+    vi.useFakeTimers()
+    const q = new RequestQueue({ ...baseConfig, rate: 1000, capacity: 1000 })
+    const started: string[] = []
+    const now = Date.now()
+
+    const enqueueTracked = (name: string, delayMs: number, scope: string) =>
+      q.enqueue(
+        async () => {
+          started.push(name)
+          return name
+        },
+        now + delayMs,
+        name,
+        [scope],
+      )
+
+    const survivors = [
+      enqueueTracked("b1", 300, "B"),
+      enqueueTracked("b2", 100, "B"),
+      enqueueTracked("b3", 500, "B"),
+    ]
+    const doomed = [
+      enqueueTracked("a1", 50, "A"),
+      enqueueTracked("a2", 200, "A"),
+      enqueueTracked("a3", 400, "A"),
+    ]
+    doomed.forEach((p) => p.catch(() => {}))
+
+    q.cancelByScope("A")
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await Promise.all(survivors)
+    expect(started).toEqual(["b2", "b1", "b3"])
+  })
+
+  it("allows re-enqueueing the same hash after cancellation", async () => {
+    vi.useFakeTimers()
+    const q = new RequestQueue(baseConfig)
+
+    const first = q.enqueue(async () => "first", Date.now() + 5_000, "same", ["A"])
+    q.cancelByScope("A")
+    await expectCancelled(first)
+
+    const second = q.enqueue(async () => "second", Date.now(), "same", ["A"])
+    await vi.advanceTimersByTimeAsync(0)
+    await expect(second).resolves.toBe("second")
+  })
+
+  it("cancels a task waiting in its retry backoff window", async () => {
+    vi.useFakeTimers()
+    const q = new RequestQueue({ ...baseConfig, maxRetries: 3, baseRetryDelayMs: 1_000 })
+
+    let attempts = 0
+    const promise = q.enqueue(
+      async () => {
+        attempts += 1
+        throw new Error("transient")
+      },
+      Date.now(),
+      "retrying",
+      ["A"],
+    )
+    const settled = expectCancelled(promise)
+
+    // First attempt fails and schedules a retry.
+    await vi.advanceTimersByTimeAsync(10)
+    expect(attempts).toBe(1)
+
+    q.cancelByScope("A")
+    await settled
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(attempts).toBe(1)
+  })
+
+  it("cancelWhere matches scope prefixes (tab close sweep)", async () => {
+    vi.useFakeTimers()
+    const q = new RequestQueue(baseConfig)
+
+    const fromTab7 = q.enqueue(async () => "seven", Date.now() + 5_000, "h7", ["7:sess-a"])
+    const fromTab8 = q.enqueue(async () => "eight", Date.now() + 5_000, "h8", ["8:sess-b"])
+
+    expect(q.cancelWhere((scope) => scope.startsWith("7:"))).toBe(1)
+    await expectCancelled(fromTab7)
+
+    await vi.advanceTimersByTimeAsync(10_000)
+    await expect(fromTab8).resolves.toBe("eight")
+  })
+})
+
+interface FakeBatchData {
+  text: string
+  key: string
+  scope?: string
+}
+
+function createBatchQueue(options: {
+  executeBatch: (
+    dataList: FakeBatchData[],
+    meta: { scopes: readonly string[] | undefined },
+  ) => Promise<string[]>
+  executeIndividual?: (data: FakeBatchData) => Promise<string>
+  batchDelay?: number
+  maxItemsPerBatch?: number
+}) {
+  return new BatchQueue<FakeBatchData, string>({
+    maxCharactersPerBatch: 1_000,
+    maxItemsPerBatch: options.maxItemsPerBatch ?? 10,
+    batchDelay: options.batchDelay ?? 100,
+    maxRetries: 0,
+    enableFallbackToIndividual: Boolean(options.executeIndividual),
+    getBatchKey: () => "batch",
+    getCharacters: (data) => data.text.length,
+    getDedupKey: (data) => data.key,
+    getScope: (data) => data.scope,
+    executeBatch: options.executeBatch,
+    executeIndividual: options.executeIndividual,
+  })
+}
+
+describe("batchQueue – cancelByScope", () => {
+  it("drops cancelled members from a pending batch and flushes only survivors", async () => {
+    vi.useFakeTimers()
+    const executeBatch = vi.fn<(dataList: FakeBatchData[]) => Promise<string[]>>(async (dataList) =>
+      dataList.map((d) => `t:${d.text}`),
+    )
+    const q = createBatchQueue({ executeBatch })
+
+    const a1 = q.enqueue({ text: "alpha", key: "a1", scope: "A" })
+    const a2 = q.enqueue({ text: "beta", key: "a2", scope: "A" })
+    const b1 = q.enqueue({ text: "gamma", key: "b1", scope: "B" })
+
+    expect(q.cancelByScope("A")).toBe(2)
+    await expectCancelled(a1)
+    await expectCancelled(a2)
+
+    await vi.advanceTimersByTimeAsync(200)
+    expect(executeBatch).toHaveBeenCalledTimes(1)
+    expect(executeBatch.mock.calls[0][0].map((d: FakeBatchData) => d.text)).toEqual(["gamma"])
+    await expect(b1).resolves.toBe("t:gamma")
+  })
+
+  it("cancelling every member drops the batch entirely and stops the timer", async () => {
+    vi.useFakeTimers()
+    const executeBatch = vi.fn<(dataList: FakeBatchData[]) => Promise<string[]>>(async (dataList) =>
+      dataList.map((d) => `t:${d.text}`),
+    )
+    const q = createBatchQueue({ executeBatch })
+
+    const a1 = q.enqueue({ text: "alpha", key: "a1", scope: "A" })
+    const a2 = q.enqueue({ text: "beta", key: "a2", scope: "A" })
+
+    q.cancelByScope("A")
+    await expectCancelled(a1)
+    await expectCancelled(a2)
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(executeBatch).not.toHaveBeenCalled()
+  })
+
+  it("refcounts dedup subscribers across scopes", async () => {
+    vi.useFakeTimers()
+    const executeBatch = vi.fn<(dataList: FakeBatchData[]) => Promise<string[]>>(async (dataList) =>
+      dataList.map((d) => `t:${d.text}`),
+    )
+    const q = createBatchQueue({ executeBatch })
+
+    const fromA = q.enqueue({ text: "shared", key: "same", scope: "A" })
+    const fromB = q.enqueue({ text: "shared", key: "same", scope: "B" })
+    expect(fromB).toBe(fromA)
+
+    // A alone is not enough to cancel the shared member.
+    expect(q.cancelByScope("A")).toBe(0)
+    await vi.advanceTimersByTimeAsync(200)
+    await expect(fromA).resolves.toBe("t:shared")
+
+    // A fresh enqueue with the same dedup key creates a new task (released).
+    const again = q.enqueue({ text: "shared", key: "same", scope: "B" })
+    expect(again).not.toBe(fromA)
+    q.cancelByScope("B")
+    await expectCancelled(again)
+  })
+
+  it("aborts an in-flight all-cancelled batch through the request queue without individual fallback", async () => {
+    vi.useFakeTimers()
+    const requestQueue = new RequestQueue({ ...baseConfig, rate: 100, capacity: 100 })
+    let batchSignal: AbortSignal | undefined
+    const executeIndividual = vi.fn<(data: FakeBatchData) => Promise<string>>(
+      async (item) => `solo:${item.text}`,
+    )
+
+    const q = createBatchQueue({
+      batchDelay: 10,
+      executeBatch: (dataList, meta) =>
+        requestQueue.enqueue(
+          (signal) =>
+            new Promise<string[]>((_, reject) => {
+              batchSignal = signal
+              signal?.addEventListener("abort", () => reject(signal.reason))
+            }),
+          Date.now(),
+          `batch:${dataList.map((d) => d.key).join(",")}`,
+          meta.scopes,
+        ),
+      executeIndividual,
+    })
+
+    const a1 = q.enqueue({ text: "alpha", key: "a1", scope: "A" })
+    const a2 = q.enqueue({ text: "beta", key: "a2", scope: "A" })
+    const settled = Promise.all([expectCancelled(a1), expectCancelled(a2)])
+
+    // Flush the pending batch into the request queue and start executing.
+    await vi.advanceTimersByTimeAsync(50)
+    expect(batchSignal).toBeDefined()
+
+    // Pending members are gone; the flushed batch task carries the scope.
+    q.cancelByScope("A")
+    requestQueue.cancelByScope("A")
+
+    await settled
+    expect(batchSignal!.aborted).toBe(true)
+    expect(batchSignal!.reason).toBeInstanceOf(TranslationCancelledError)
+    expect(executeIndividual).not.toHaveBeenCalled()
+  })
+
+  it("lets an in-flight mixed batch complete for every member", async () => {
+    vi.useFakeTimers()
+    const requestQueue = new RequestQueue({ ...baseConfig, rate: 100, capacity: 100 })
+    const gate = createDeferred<void>()
+
+    const q = createBatchQueue({
+      batchDelay: 10,
+      executeBatch: (dataList, meta) =>
+        requestQueue.enqueue(
+          async () => {
+            await gate.promise
+            return dataList.map((d) => `t:${d.text}`)
+          },
+          Date.now(),
+          `batch:${dataList.map((d) => d.key).join(",")}`,
+          meta.scopes,
+        ),
+    })
+
+    const fromA = q.enqueue({ text: "alpha", key: "a1", scope: "A" })
+    const fromB = q.enqueue({ text: "beta", key: "b1", scope: "B" })
+
+    await vi.advanceTimersByTimeAsync(50)
+
+    // Only scope A cancels — the mixed batch must keep running to completion.
+    q.cancelByScope("A")
+    requestQueue.cancelByScope("A")
+
+    gate.resolve()
+    await expect(fromA).resolves.toBe("t:alpha")
+    await expect(fromB).resolves.toBe("t:beta")
+  })
+})

--- a/src/utils/request/__tests__/queue-cancellation.test.ts
+++ b/src/utils/request/__tests__/queue-cancellation.test.ts
@@ -411,4 +411,56 @@ describe("batchQueue – cancelByScope", () => {
     await expect(fromA).resolves.toBe("t:alpha")
     await expect(fromB).resolves.toBe("t:beta")
   })
+
+  it("does not drop a later session's paragraph that dedups a same-hash request after flush (#1881)", async () => {
+    vi.useFakeTimers()
+    const requestQueue = new RequestQueue({ ...baseConfig, rate: 100, capacity: 100 })
+    const gate = createDeferred<void>()
+    const signals: Record<string, AbortSignal | undefined> = {}
+    let rqSeq = 0
+
+    const q = createBatchQueue({
+      batchDelay: 10,
+      // Unique downstream hash per flush so the two sessions land on distinct
+      // RequestQueue tasks — this isolates the BatchQueue-level fix (the
+      // request queue's own dedup would otherwise mask it).
+      executeBatch: (dataList, meta) => {
+        const scopeKey = meta.scopes?.[0]
+        return requestQueue.enqueue(
+          (signal) =>
+            new Promise<string[]>((resolve, reject) => {
+              if (scopeKey) signals[scopeKey] = signal
+              signal?.addEventListener("abort", () => reject(signal.reason))
+              void gate.promise.then(() => resolve(dataList.map((d) => `t:${d.text}`)))
+            }),
+          Date.now(),
+          `rq-${rqSeq++}`,
+          meta.scopes,
+        )
+      },
+    })
+
+    // Session A: same text, flushed into the request queue and now in flight.
+    const fromA = q.enqueue({ text: "shared", key: "same", scope: "A" })
+    const settledA = expectCancelled(fromA)
+    await vi.advanceTimersByTimeAsync(20)
+
+    // Session B: identical dedup key, but arriving AFTER A's batch flushed.
+    const fromB = q.enqueue({ text: "shared", key: "same", scope: "B" })
+    await vi.advanceTimersByTimeAsync(20)
+
+    // The fix: B must not share A's frozen downstream task.
+    expect(fromB).not.toBe(fromA)
+
+    // A cancels; B stays active.
+    q.cancelByScope("A")
+    requestQueue.cancelByScope("A")
+    await settledA
+    expect(signals.A?.aborted).toBe(true)
+
+    // B's paragraph completes instead of being silently dropped.
+    gate.resolve()
+    await expect(fromB).resolves.toBe("t:shared")
+    expect(signals.B?.aborted).toBe(false)
+  })
 })

--- a/src/utils/request/batch-queue.ts
+++ b/src/utils/request/batch-queue.ts
@@ -1,5 +1,6 @@
 import { batchQueueConfigSchema } from "@/types/config/translate"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
+import { TranslationCancelledError } from "./cancellation"
 
 export class BatchCountMismatchError extends Error {
   constructor(expected: number, got: number, results: unknown[]) {
@@ -17,6 +18,10 @@ interface BatchTask<T, R> {
   data: T
   resolve: (value: R) => void
   reject: (error: Error) => void
+  // Same refcounting contract as QueuedRequestTask.cancelScopes: `null` pins
+  // the task (an unscoped subscriber exists); otherwise the task is cancelled
+  // only when its last scope is cancelled.
+  cancelScopes: Set<string> | null
 }
 
 interface PendingBatch<T, R> {
@@ -24,6 +29,15 @@ interface PendingBatch<T, R> {
   tasks: BatchTask<T, R>[]
   totalCharacters: number
   createdAt: number
+}
+
+export interface BatchExecutionMeta {
+  /**
+   * Union of the live members' cancellation scopes at flush time, or
+   * `undefined` when any member is uncancellable. Thread this into the
+   * downstream RequestQueue so cancelling the scopes aborts the whole batch.
+   */
+  scopes: readonly string[] | undefined
 }
 
 export interface BatchOptions<T, R> {
@@ -35,7 +49,8 @@ export interface BatchOptions<T, R> {
   getBatchKey: (data: T) => string
   getCharacters: (data: T) => number
   getDedupKey?: (data: T) => string | undefined
-  executeBatch: (dataList: T[]) => Promise<R[]>
+  getScope?: (data: T) => string | undefined
+  executeBatch: (dataList: T[], meta: BatchExecutionMeta) => Promise<R[]>
   executeIndividual?: (data: T) => Promise<R>
   onError?: (
     error: Error,
@@ -45,7 +60,7 @@ export interface BatchOptions<T, R> {
 
 export class BatchQueue<T, R> {
   private pendingBatchMap = new Map<string, PendingBatch<T, R>>()
-  private inFlightTasks = new Map<string, Promise<R>>()
+  private inFlightTasks = new Map<string, { promise: Promise<R>; task: BatchTask<T, R> }>()
   private nextScheduleTimer: NodeJS.Timeout | null = null
   private maxCharactersPerBatch: number
   private maxItemsPerBatch: number
@@ -55,7 +70,8 @@ export class BatchQueue<T, R> {
   private getBatchKey: (data: T) => string
   private getCharacters: (data: T) => number
   private getDedupKey?: (data: T) => string | undefined
-  private executeBatch: (dataList: T[]) => Promise<R[]>
+  private getScope?: (data: T) => string | undefined
+  private executeBatch: (dataList: T[], meta: BatchExecutionMeta) => Promise<R[]>
   private executeIndividual?: (data: T) => Promise<R>
   private onError?: (
     error: Error,
@@ -71,17 +87,30 @@ export class BatchQueue<T, R> {
     this.getBatchKey = config.getBatchKey
     this.getCharacters = config.getCharacters
     this.getDedupKey = config.getDedupKey
+    this.getScope = config.getScope
     this.executeBatch = config.executeBatch
     this.executeIndividual = config.executeIndividual
     this.onError = config.onError
   }
 
   enqueue(data: T): Promise<R> {
+    const scope = this.getScope?.(data)
     const dedupKey = this.getDedupKey?.(data)
     if (dedupKey) {
-      const inFlightPromise = this.inFlightTasks.get(dedupKey)
-      if (inFlightPromise) {
-        return inFlightPromise
+      const inFlight = this.inFlightTasks.get(dedupKey)
+      if (inFlight) {
+        // Refcount the duplicate subscriber's scope. Limitation (accepted):
+        // once the batch has flushed into the RequestQueue, the downstream
+        // task's scope set is frozen — a late subscriber from another scope
+        // shares the original scopes' cancellation. Window is one batchDelay
+        // with identical text from two sessions; the retranslation pipeline
+        // heals the dropped paragraph.
+        if (!scope) {
+          inFlight.task.cancelScopes = null
+        } else if (inFlight.task.cancelScopes !== null) {
+          inFlight.task.cancelScopes.add(scope)
+        }
+        return inFlight.promise
       }
     }
 
@@ -93,12 +122,17 @@ export class BatchQueue<T, R> {
     })
 
     const batchKey = this.getBatchKey(data)
-    const task: BatchTask<T, R> = { data, resolve, reject }
+    const task: BatchTask<T, R> = {
+      data,
+      resolve,
+      reject,
+      cancelScopes: scope ? new Set([scope]) : null,
+    }
 
     if (dedupKey) {
-      this.inFlightTasks.set(dedupKey, promise)
+      this.inFlightTasks.set(dedupKey, { promise, task })
       const release = () => {
-        if (this.inFlightTasks.get(dedupKey) === promise) {
+        if (this.inFlightTasks.get(dedupKey)?.promise === promise) {
           this.inFlightTasks.delete(dedupKey)
         }
       }
@@ -109,6 +143,56 @@ export class BatchQueue<T, R> {
     this.schedule()
 
     return promise
+  }
+
+  /**
+   * Cancel every not-yet-flushed member subscribed to the given scope (see
+   * RequestQueue.cancelByScope for the refcounting contract). Batches already
+   * flushed live as a single RequestQueue task carrying the scope union —
+   * cancel them there.
+   */
+  cancelByScope(scopeKey: string): number {
+    return this.cancelWhere((scope) => scope === scopeKey)
+  }
+
+  cancelWhere(scopeMatches: (scopeKey: string) => boolean): number {
+    let cancelled = 0
+    for (const [batchKey, batch] of [...this.pendingBatchMap]) {
+      const kept: BatchTask<T, R>[] = []
+      for (const task of batch.tasks) {
+        const scopes = task.cancelScopes
+        if (scopes === null) {
+          kept.push(task)
+          continue
+        }
+        let matchedScope: string | undefined
+        for (const scope of scopes) {
+          if (scopeMatches(scope)) {
+            matchedScope = scope
+            scopes.delete(scope)
+          }
+        }
+        if (matchedScope === undefined || scopes.size > 0) {
+          kept.push(task)
+          continue
+        }
+        // inFlightTasks self-releases via the promise.then(release, release)
+        // handler attached at enqueue time.
+        task.reject(new TranslationCancelledError(matchedScope))
+        cancelled++
+      }
+      if (kept.length === 0) {
+        this.pendingBatchMap.delete(batchKey)
+      } else if (kept.length !== batch.tasks.length) {
+        batch.tasks = kept
+        batch.totalCharacters = kept.reduce((sum, task) => sum + this.getCharacters(task.data), 0)
+      }
+    }
+    if (this.pendingBatchMap.size === 0 && this.nextScheduleTimer) {
+      clearTimeout(this.nextScheduleTimer)
+      this.nextScheduleTimer = null
+    }
+    return cancelled
   }
 
   private schedule() {
@@ -186,16 +270,33 @@ export class BatchQueue<T, R> {
 
     const { tasks } = pendingBatch
 
-    void this.executeBatchWithRetry(tasks, batchKey, 0)
+    // Scope union frozen at flush time: if every member is scoped, cancelling
+    // all those scopes downstream aborts the whole batch; one unscoped member
+    // pins it (scopes: undefined).
+    let scopes: string[] | undefined = []
+    for (const task of tasks) {
+      if (task.cancelScopes === null) {
+        scopes = undefined
+        break
+      }
+      scopes.push(...task.cancelScopes)
+    }
+    const meta: BatchExecutionMeta = { scopes: scopes ? [...new Set(scopes)] : undefined }
+
+    void this.executeBatchWithRetry(tasks, batchKey, meta, 0)
   }
 
   private async executeBatchWithRetry(
     tasks: BatchTask<T, R>[],
     batchKey: string,
+    meta: BatchExecutionMeta,
     retryCount: number,
   ): Promise<void> {
     try {
-      const results = await this.executeBatch(tasks.map((task) => task.data))
+      const results = await this.executeBatch(
+        tasks.map((task) => task.data),
+        meta,
+      )
 
       if (!results) {
         throw new Error("Batch execution results are undefined")
@@ -215,7 +316,7 @@ export class BatchQueue<T, R> {
       if (retryCount < this.maxRetries && err instanceof BatchCountMismatchError) {
         const delay = this.calculateBackoffDelay(retryCount)
         await this.sleep(delay)
-        return this.executeBatchWithRetry(tasks, batchKey, retryCount + 1)
+        return this.executeBatchWithRetry(tasks, batchKey, meta, retryCount + 1)
       }
 
       if (

--- a/src/utils/request/batch-queue.ts
+++ b/src/utils/request/batch-queue.ts
@@ -53,6 +53,9 @@ export interface BatchOptions<T, R> {
   getCharacters: (data: T) => number
   getDedupKey?: (data: T) => string | undefined
   getScope?: (data: T) => string | undefined
+  // Liveness check for a scope whose cancel may have run while a flushed
+  // batch was outside every cancellable structure (retry backoff sleep).
+  isScopeCancelled?: (scopeKey: string) => boolean
   executeBatch: (dataList: T[], meta: BatchExecutionMeta) => Promise<R[]>
   executeIndividual?: (data: T) => Promise<R>
   onError?: (
@@ -74,6 +77,7 @@ export class BatchQueue<T, R> {
   private getCharacters: (data: T) => number
   private getDedupKey?: (data: T) => string | undefined
   private getScope?: (data: T) => string | undefined
+  private isScopeCancelled?: (scopeKey: string) => boolean
   private executeBatch: (dataList: T[], meta: BatchExecutionMeta) => Promise<R[]>
   private executeIndividual?: (data: T) => Promise<R>
   private onError?: (
@@ -91,6 +95,7 @@ export class BatchQueue<T, R> {
     this.getCharacters = config.getCharacters
     this.getDedupKey = config.getDedupKey
     this.getScope = config.getScope
+    this.isScopeCancelled = config.isScopeCancelled
     this.executeBatch = config.executeBatch
     this.executeIndividual = config.executeIndividual
     this.onError = config.onError
@@ -326,6 +331,11 @@ export class BatchQueue<T, R> {
       if (retryCount < this.maxRetries && err instanceof BatchCountMismatchError) {
         const delay = this.calculateBackoffDelay(retryCount)
         await this.sleep(delay)
+        // During the backoff this batch lived in NO cancellable structure
+        // (its RequestQueue task already completed, it left pendingBatchMap at
+        // flush) — a cancel that arrived meanwhile drained nothing, so re-check
+        // scope liveness before burning another provider round trip (#1881).
+        if (this.rejectIfAllScopesCancelled(tasks, meta)) return
         return this.executeBatchWithRetry(tasks, batchKey, meta, retryCount + 1)
       }
 
@@ -334,11 +344,28 @@ export class BatchQueue<T, R> {
         this.executeIndividual &&
         err instanceof BatchCountMismatchError
       ) {
+        // Same gate before the per-item fallback: the failed attempt's provider
+        // call may have straddled the cancel.
+        if (this.rejectIfAllScopesCancelled(tasks, meta)) return
         return this.executeFallbackIndividual(tasks, batchKey)
       }
 
       tasks.forEach((task) => task.reject(err))
     }
+  }
+
+  /**
+   * When every scope this batch was flushed with has since been cancelled,
+   * reject all members with the cancellation error and report true. A batch
+   * with an unscoped member (scopes: undefined) or any surviving scope keeps
+   * running — same mixed-batch semantics as cancelByScope.
+   */
+  private rejectIfAllScopesCancelled(tasks: BatchTask<T, R>[], meta: BatchExecutionMeta): boolean {
+    if (!this.isScopeCancelled || !meta.scopes || meta.scopes.length === 0) return false
+    if (!meta.scopes.every((scope) => this.isScopeCancelled!(scope))) return false
+    const error = new TranslationCancelledError(meta.scopes.join(","))
+    tasks.forEach((task) => task.reject(error))
+    return true
   }
 
   private async executeFallbackIndividual(tasks: BatchTask<T, R>[], batchKey: string) {

--- a/src/utils/request/batch-queue.ts
+++ b/src/utils/request/batch-queue.ts
@@ -22,6 +22,9 @@ interface BatchTask<T, R> {
   // the task (an unscoped subscriber exists); otherwise the task is cancelled
   // only when its last scope is cancelled.
   cancelScopes: Set<string> | null
+  // Set once the batch has been handed to executeBatch: its scope snapshot is
+  // now frozen downstream, so late dedup subscribers must NOT join it (#1881).
+  flushed: boolean
 }
 
 interface PendingBatch<T, R> {
@@ -98,13 +101,16 @@ export class BatchQueue<T, R> {
     const dedupKey = this.getDedupKey?.(data)
     if (dedupKey) {
       const inFlight = this.inFlightTasks.get(dedupKey)
-      if (inFlight) {
-        // Refcount the duplicate subscriber's scope. Limitation (accepted):
-        // once the batch has flushed into the RequestQueue, the downstream
-        // task's scope set is frozen — a late subscriber from another scope
-        // shares the original scopes' cancellation. Window is one batchDelay
-        // with identical text from two sessions; the retranslation pipeline
-        // heals the dropped paragraph.
+      // Only join a still-pending batch: its cancelScopes set is mutable and
+      // its flush-time union will include this scope. A flushed batch has
+      // already handed a FROZEN scope snapshot to the RequestQueue, so a late
+      // cross-scope subscriber joining it would be cancelled when the original
+      // scope cancels — silently dropping this (still-active) session's
+      // paragraph. Fall through to a fresh task instead; the RequestQueue's own
+      // hash dedup re-coalesces identical batches, so the common case (two tabs
+      // on the same page) stays deduped, and at worst one duplicate request is
+      // issued for a genuinely different batch (#1881).
+      if (inFlight && !inFlight.task.flushed) {
         if (!scope) {
           inFlight.task.cancelScopes = null
         } else if (inFlight.task.cancelScopes !== null) {
@@ -127,6 +133,7 @@ export class BatchQueue<T, R> {
       resolve,
       reject,
       cancelScopes: scope ? new Set([scope]) : null,
+      flushed: false,
     }
 
     if (dedupKey) {
@@ -269,6 +276,9 @@ export class BatchQueue<T, R> {
     this.pendingBatchMap.delete(batchKey)
 
     const { tasks } = pendingBatch
+    // Freeze the batch: from here its downstream scope snapshot is fixed, so
+    // enqueue() must stop letting late subscribers dedup into these tasks.
+    for (const task of tasks) task.flushed = true
 
     // Scope union frozen at flush time: if every member is scoped, cancelling
     // all those scopes downstream aborts the whole batch; one unscoped member

--- a/src/utils/request/cancellation.ts
+++ b/src/utils/request/cancellation.ts
@@ -1,0 +1,19 @@
+export const TRANSLATION_CANCELLED_ERROR_NAME = "TranslationCancelledError"
+
+/**
+ * Rejection used when the user cancels a page-translation session and its
+ * queued/in-flight requests are drained (#1881). Detection is name-based so it
+ * survives the content↔background messaging boundary: background rejections
+ * are re-created on the sender side by zero-serialize-error, which preserves
+ * `name` but not the prototype chain.
+ */
+export class TranslationCancelledError extends Error {
+  constructor(scope?: string) {
+    super(`Translation request cancelled${scope ? ` (scope: ${scope})` : ""}`)
+    this.name = TRANSLATION_CANCELLED_ERROR_NAME
+  }
+}
+
+export function isTranslationCancelledError(error: unknown): boolean {
+  return error instanceof Error && error.name === TRANSLATION_CANCELLED_ERROR_NAME
+}

--- a/src/utils/request/cancellation.ts
+++ b/src/utils/request/cancellation.ts
@@ -17,3 +17,54 @@ export class TranslationCancelledError extends Error {
 export function isTranslationCancelledError(error: unknown): boolean {
   return error instanceof Error && error.name === TRANSLATION_CANCELLED_ERROR_NAME
 }
+
+/**
+ * Remembers cancelled scopes so an enqueue handler that was suspended on an
+ * await (e.g. the IndexedDB cache lookup) when the cancel drained the queues
+ * can refuse to enqueue afterwards — otherwise the request enters the queue
+ * with a dead scope that no future cancel will ever drain (#1881).
+ *
+ * Session ids are never reused, so remembering a scope can never wrongly
+ * reject a live request; the TTL and size cap exist purely to bound memory.
+ */
+export class CancelledScopeRegistry {
+  private readonly scopes = new Map<string, number>()
+  private readonly prefixes = new Map<string, number>()
+
+  constructor(
+    private readonly ttlMs: number = 10 * 60_000,
+    private readonly maxEntries: number = 256,
+  ) {}
+
+  markScope(scopeKey: string): void {
+    this.scopes.set(scopeKey, Date.now())
+    this.prune()
+  }
+
+  /** Mark every scope of a tab (tab close sweep), e.g. `${tabId}:`. */
+  markPrefix(scopePrefix: string): void {
+    this.prefixes.set(scopePrefix, Date.now())
+    this.prune()
+  }
+
+  has(scopeKey: string): boolean {
+    if (this.scopes.has(scopeKey)) return true
+    for (const prefix of this.prefixes.keys()) {
+      if (scopeKey.startsWith(prefix)) return true
+    }
+    return false
+  }
+
+  private prune(): void {
+    const cutoff = Date.now() - this.ttlMs
+    for (const map of [this.scopes, this.prefixes]) {
+      for (const [key, markedAt] of map) {
+        if (markedAt < cutoff) map.delete(key)
+      }
+      // Maps iterate in insertion order, so overflow evicts the oldest first.
+      while (map.size > this.maxEntries) {
+        map.delete(map.keys().next().value!)
+      }
+    }
+  }
+}

--- a/src/utils/request/priority-queue.ts
+++ b/src/utils/request/priority-queue.ts
@@ -5,6 +5,7 @@ interface PriorityQueue<T> {
   size: () => number
   isEmpty: () => boolean
   clear: () => void
+  removeWhere: (predicate: (value: T) => boolean) => void
 }
 
 export class BinaryHeapPQ<T> implements PriorityQueue<T> {
@@ -45,6 +46,21 @@ export class BinaryHeapPQ<T> implements PriorityQueue<T> {
 
   clear() {
     this.heap = []
+  }
+
+  /**
+   * Remove every entry matching the predicate. Removal (rather than
+   * mark-and-skip-on-pop) matters: schedule() derives its next timer delay
+   * from peek(), so a cancelled head with a far-future priority would stall
+   * dispatch of the live tasks behind it.
+   */
+  removeWhere(predicate: (value: T) => boolean) {
+    const kept = this.heap.filter((entry) => !predicate(entry.value))
+    if (kept.length === this.heap.length) return
+    this.heap = kept
+    for (let i = Math.floor(this.heap.length / 2) - 1; i >= 0; i--) {
+      this.heapifyDown(i)
+    }
   }
 
   private heapifyUp(index: number) {

--- a/src/utils/request/request-queue.ts
+++ b/src/utils/request/request-queue.ts
@@ -2,6 +2,7 @@ import type { RequestRetryPolicy } from "./retry-policy"
 import { deepmerge } from "deepmerge-ts"
 import { requestQueueConfigSchema } from "@/types/config/translate"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
+import { TranslationCancelledError } from "./cancellation"
 import { BinaryHeapPQ } from "./priority-queue"
 import { defaultRequestRetryPolicy } from "./retry-policy"
 
@@ -17,7 +18,15 @@ export interface RequestTask {
   drained: boolean
 }
 
-type QueuedRequestTask = RequestTask & { hash: string; abortController?: AbortController }
+type QueuedRequestTask = RequestTask & {
+  hash: string
+  abortController?: AbortController
+  // Cancellation scopes subscribed to this task. Dedup can attach several
+  // (same hash from multiple tabs/sessions); the task is only cancelled when
+  // its LAST scope is cancelled. `null` means an unscoped subscriber exists,
+  // which pins the task as uncancellable.
+  cancelScopes: Set<string> | null
+}
 
 export interface QueueOptions {
   rate: number // tokens/sec
@@ -50,10 +59,16 @@ export class RequestQueue {
     thunk: (signal?: AbortSignal) => Promise<T>,
     scheduleAt: number,
     hash: string,
+    scopes?: readonly string[],
   ): Promise<T> {
     const duplicateTask = this.duplicateTask(hash)
     if (duplicateTask) {
       // console.info(`🔄 Found duplicate task for hash: ${hash}, returning existing promise`)
+      if (!scopes?.length) {
+        duplicateTask.cancelScopes = null
+      } else if (duplicateTask.cancelScopes !== null) {
+        scopes.forEach((scope) => duplicateTask.cancelScopes!.add(scope))
+      }
       return duplicateTask.promise
     }
 
@@ -75,6 +90,7 @@ export class RequestQueue {
       createdAt: Date.now(),
       retryCount: 0,
       drained: false,
+      cancelScopes: scopes?.length ? new Set(scopes) : null,
     }
 
     this.waitingTasks.set(hash, task)
@@ -102,6 +118,55 @@ export class RequestQueue {
     }
   }
 
+  /**
+   * Cancel every task subscribed to the given scope. Refcounted: a task shared
+   * with another scope (dedup) or with an unscoped subscriber survives; only
+   * tasks whose LAST scope this is are rejected/aborted (#1881).
+   */
+  cancelByScope(scopeKey: string): number {
+    return this.cancelWhere((scope) => scope === scopeKey)
+  }
+
+  /**
+   * Cancel every task all of whose scopes match the predicate. Unscoped tasks
+   * (`cancelScopes === null`) never match.
+   */
+  cancelWhere(scopeMatches: (scopeKey: string) => boolean): number {
+    let cancelled = 0
+
+    const cancelMatchingScopes = (task: QueuedRequestTask): boolean => {
+      if (task.cancelScopes === null) return false
+      let matchedScope: string | undefined
+      for (const scope of task.cancelScopes) {
+        if (scopeMatches(scope)) {
+          matchedScope = scope
+          task.cancelScopes.delete(scope)
+        }
+      }
+      if (matchedScope === undefined || task.cancelScopes.size > 0) return false
+      this.rejectDrainedTask(task, new TranslationCancelledError(matchedScope))
+      return true
+    }
+
+    for (const [hash, task] of [...this.waitingTasks]) {
+      if (!cancelMatchingScopes(task)) continue
+      this.waitingTasks.delete(hash)
+      cancelled++
+    }
+    this.waitingQueue.removeWhere((task) => task.drained)
+
+    for (const [hash, task] of [...this.executingTasks]) {
+      if (!cancelMatchingScopes(task)) continue
+      this.executingTasks.delete(hash)
+      cancelled++
+    }
+
+    if (cancelled > 0) {
+      this.schedule()
+    }
+    return cancelled
+  }
+
   private schedule() {
     this.refillTokens()
 
@@ -109,6 +174,13 @@ export class RequestQueue {
       const now = Date.now()
 
       const task = this.waitingQueue.peek()
+      if (task?.drained) {
+        // Safety net: a drained task should have been removed from the heap,
+        // but never dispatch or let one stall the timer computation below.
+        this.waitingQueue.pop()
+        this.waitingTasks.delete(task.hash)
+        continue
+      }
       if (task && task.scheduleAt <= now) {
         this.waitingQueue.pop()
         this.waitingTasks.delete(task.hash)

--- a/src/utils/scheduler.ts
+++ b/src/utils/scheduler.ts
@@ -1,0 +1,52 @@
+/** Time budget for one synchronous slice of chunked DOM work (#1881). */
+export const DEFAULT_WALK_BUDGET_MS = 12
+
+interface SchedulerLike {
+  yield?: () => Promise<void>
+  postTask?: (callback: () => void, options?: { priority?: string }) => Promise<void>
+}
+
+/**
+ * Yield to the event loop so input and rendering can run between work slices.
+ * MV3 content scripts share the page's main thread, so long synchronous DOM
+ * work freezes the page (#1881). Preference order: scheduler.yield (Chrome
+ * 129+) → scheduler.postTask (Chrome 94+ / Firefox 101+) → MessageChannel
+ * (everywhere; unlike setTimeout it dodges the nested-timer 4ms clamp) →
+ * setTimeout(0).
+ */
+export function yieldToMain(): Promise<void> {
+  const scheduler = (globalThis as { scheduler?: SchedulerLike }).scheduler
+  if (typeof scheduler?.yield === "function") {
+    return scheduler.yield()
+  }
+  if (typeof scheduler?.postTask === "function") {
+    return scheduler.postTask(() => {}, { priority: "user-visible" })
+  }
+  if (typeof MessageChannel !== "undefined") {
+    return new Promise((resolve) => {
+      const { port1, port2 } = new MessageChannel()
+      port1.onmessage = () => {
+        port1.close()
+        resolve()
+      }
+      port2.postMessage(null)
+    })
+  }
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+export interface WorkPacer {
+  deadline: number
+  budgetMs: number
+}
+
+export function createWorkPacer(budgetMs: number = DEFAULT_WALK_BUDGET_MS): WorkPacer {
+  return { deadline: performance.now() + budgetMs, budgetMs }
+}
+
+/** Yield to the main thread when the pacer's current slice budget is spent. */
+export async function pauseIfBudgetSpent(pacer: WorkPacer): Promise<void> {
+  if (performance.now() < pacer.deadline) return
+  await yieldToMain()
+  pacer.deadline = performance.now() + pacer.budgetMs
+}


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)
- [x] ⚡ Performance improvement (perf)

## Description

Translating a very long, deeply nested page (e.g. the [Docker Desktop release notes](https://docs.docker.com/desktop/release-notes/)) froze the tab hard — the mouse locked up, the page couldn't scroll, and Chrome eventually showed its "Page unresponsive" dialog. Cancelling the translation didn't stop the damage: the background kept firing translation requests for minutes afterward.

I reproduced the freeze on the real page with a headless-Chrome harness (CDP metrics + a V8 CPU trace) and attributed three concrete root causes:

1. **Viewport translation silently failed.** The page's entire flat `<article>` (185,137 px tall, 1,683 direct children) was labeled as a *single* paragraph — because inline `<em>` date elements are its direct children — so it became one giant observed unit that enqueued all ~5,345 paragraphs the instant it intersected the viewport.
2. **A spinner animation storm burned the CPU.** Every pending paragraph mounted an infinite Web-Animations spinner; ~2,400 ran concurrently, driving a full-page style recalculation every frame. The initial DOM walk itself was only a single ~768 ms task — the animations were the sustained fire.
3. **Cancelling didn't cancel.** The background request/batch queues (global singletons shared across tabs) had no cancellation channel, so toggling translation off left them draining to the provider for minutes.

### What this PR changes

- **Giant-paragraph split** — a paragraph taller than ~3 viewports is split into its descendant paragraphs for observation, so viewport-lazy translation actually applies instead of translating the whole document at once.
- **Spinner cost** — animation handles are stored in a `WeakMap` (O(1) cancel, no more expensive `getAnimations()` sweeps) and concurrent animated spinners are capped, falling back to a static ring beyond the cap.
- **Request cancellation** — translation requests are scoped per `tabId:sessionId`; toggling off (or restart, or tab close) drains that session's queued and in-flight requests. Dedup-shared requests are refcounted so one tab's cancel never affects another, and the cancellation error is detected by name so it survives the content↔background messaging boundary.
- **Responsiveness** — the initial DOM-labeling walk is a time-sliced generator that yields to the main thread, and subtree translation is self-paced. The session id is captured at pipeline entry (not at send time) and re-checked before dispatch, so a request racing past `stop()` is aborted rather than leaking out unscoped and uncancellable.

## Related Issue

Closes #1881
Closes #996

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

**Unit tests** (full suite: 1,905 passing): new suites for queue cancellation (`queue-cancellation.test.ts`, `cancellation.test.ts`), the chunked/generator walk equivalence and abort (`traversal-chunked.test.ts`), the scheduler fallbacks (`scheduler.test.ts`), the walker liveness gate (`translation-walker-liveness.test.ts`), spinner animation-registry + cap + cancelled-error swallow, the giant-paragraph split, and the session-capture send gate.

**End-to-end** (built extension in real Chrome on the Docker release-notes page, compared against the recorded broken build):

| Metric | Broken | Fixed |
|---|---|---|
| Wrappers ~3 s after toggle | 3,205 | 72 |
| Peak concurrent animations | 2,405 | 1 |
| Background fetch growth 40 s after cancel | +16/s, never stops | 0 (flat) |
| Longest new long task | 768 ms | none above page baseline |
| Scroll → progressive translation | — | grows 72→114→164→213, translates near viewport |

## Additional Information

The queue-cancellation design was hardened after an adversarial review that surfaced two ways requests could still race past `stop()` and leak unscoped (uncancellable) — both are addressed by capturing the session id at pipeline entry and adding a liveness gate to the paced walker, each covered by a regression test.