### PR TITLE
fix(custom-actions): add a link to open the connected notebase

### DIFF
--- a/.changeset/curvy-dodos-open.md
+++ b/.changeset/curvy-dodos-open.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(custom-actions): add a link to open the connected notebase

--- a/src/entrypoints/options/pages/custom-actions/action-config-form/notebase-connection-field.tsx
+++ b/src/entrypoints/options/pages/custom-actions/action-config-form/notebase-connection-field.tsx
@@ -6,7 +6,13 @@ import type {
   SelectionToolbarCustomActionNotebaseMapping,
   SelectionToolbarCustomActionOutputField,
 } from "@/types/config/selection-toolbar"
-import { IconChevronsRight, IconPlus, IconRefresh, IconTrash } from "@tabler/icons-react"
+import {
+  IconChevronsRight,
+  IconExternalLink,
+  IconPlus,
+  IconRefresh,
+  IconTrash,
+} from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
 import { useSelector } from "@tanstack/react-store"
 import { dequal } from "dequal"
@@ -447,21 +453,42 @@ export const NotebaseConnectionField = withForm({
                 <FieldLabel nativeLabel={false} render={<div />}>
                   {t("tableLabel")}
                 </FieldLabel>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={handleRefresh}
-                  disabled={
-                    !currentAccount ||
-                    !sanitizedConnection?.notebaseId ||
-                    !isOwnedConnection ||
-                    schemaQuery.isFetching
-                  }
-                >
-                  <IconRefresh className={schemaQuery.isFetching ? "animate-spin" : undefined} />
-                  {t("refreshAction")}
-                </Button>
+                <div className="flex items-center gap-2">
+                  {isOwnedConnection && !!sanitizedConnection?.notebaseId && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      render={
+                        <a
+                          href={new URL(
+                            `/notebase/${encodeURIComponent(sanitizedConnection.notebaseId)}`,
+                            env.WXT_WEBSITE_URL,
+                          ).toString()}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        />
+                      }
+                    >
+                      <IconExternalLink />
+                      {t("openNotebaseAction")}
+                    </Button>
+                  )}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={handleRefresh}
+                    disabled={
+                      !currentAccount ||
+                      !sanitizedConnection?.notebaseId ||
+                      !isOwnedConnection ||
+                      schemaQuery.isFetching
+                    }
+                  >
+                    <IconRefresh className={schemaQuery.isFetching ? "animate-spin" : undefined} />
+                    {t("refreshAction")}
+                  </Button>
+                </div>
               </div>
 
               <Select<string | null>


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

- Add an Open Notebase link immediately to the left of Refresh for the selected owned notebase.
- Open the selected notebase detail page in a new tab so users can add fields, then return and refresh the schema.
- Add a patch changeset for `@read-frog/extension`.

## Related Issue

None.

## How Has This Been Tested?

- [ ] Added unit tests
- [ ] Verified through manual testing
- `pnpm type-check`
- Pre-push checks: formatting, lint/type checking, and the full test suite (200 files, 1871 tests)

## Screenshots

Not included; this adds one outline link button beside the existing Refresh button.

## Checklist

- [x] I have tested these changes locally
- [x] Documentation changes are not required
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The dedicated regression test was intentionally removed before opening this PR.