### PR TITLE
fix(selection): prevent shadow overlays from covering pages

### DIFF
--- a/.changeset/fix-aliyun-shadow-overlay.md
+++ b/.changeset/fix-aliyun-shadow-overlay.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection): prevent shadow overlays from covering pages after refresh

--- a/src/entrypoints/selection.content/index.tsx
+++ b/src/entrypoints/selection.content/index.tsx
@@ -16,7 +16,7 @@ import { initI18n } from "@/utils/i18n"
 import { LocaleBoundary } from "@/utils/i18n/locale-boundary"
 import { ensureIconifyBackgroundFetch } from "@/utils/iconify/setup-background-fetch"
 import { protectSelectAllShadowRoot } from "@/utils/select-all"
-import { insertShadowRootUIWrapperInto } from "@/utils/shadow-root"
+import { insertShadowRootUIWrapperInto, OVERLAY_SHADOW_ROOT_CSS } from "@/utils/shadow-root"
 import {
   clearEffectiveSiteControlUrl,
   getEffectiveSiteControlUrl,
@@ -57,8 +57,9 @@ async function mountSelectionUI(ctx: ContentScriptContext) {
     name: `${kebabCase(APP_NAME)}-selection`,
     position: "overlay",
     anchor: "body",
+    css: OVERLAY_SHADOW_ROOT_CSS,
     onMount: (container, shadow, shadowHost) => {
-      const wrapper = insertShadowRootUIWrapperInto(container)
+      const wrapper = insertShadowRootUIWrapperInto(container, shadowHost)
       shadowWrapper = wrapper
       addStyleToShadow(shadow)
       protectSelectAllShadowRoot(shadowHost, wrapper)

--- a/src/entrypoints/side.content/index.tsx
+++ b/src/entrypoints/side.content/index.tsx
@@ -18,7 +18,7 @@ import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { initI18n } from "@/utils/i18n"
 import { LocaleBoundary } from "@/utils/i18n/locale-boundary"
 import { protectSelectAllShadowRoot } from "@/utils/select-all"
-import { insertShadowRootUIWrapperInto } from "@/utils/shadow-root"
+import { insertShadowRootUIWrapperInto, OVERLAY_SHADOW_ROOT_CSS } from "@/utils/shadow-root"
 import { isSiteEnabled } from "@/utils/site-control"
 import { queryClient } from "@/utils/tanstack-query"
 import { getLocalThemeMode } from "@/utils/theme"
@@ -68,9 +68,10 @@ export default defineContentScript({
       position: "overlay",
       anchor: "body",
       append: "last",
+      css: OVERLAY_SHADOW_ROOT_CSS,
       onMount: (container, shadow, shadowHost) => {
         // Store shadow root reference
-        const wrapper = insertShadowRootUIWrapperInto(container)
+        const wrapper = insertShadowRootUIWrapperInto(container, shadowHost)
         shadowWrapper = wrapper
 
         addStyleToShadow(shadow)

--- a/src/utils/__tests__/shadow-root.test.ts
+++ b/src/utils/__tests__/shadow-root.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import {
+  BLOCK_ATTRIBUTE,
+  NOTRANSLATE_CLASS,
+  PARAGRAPH_ATTRIBUTE,
+  WALKED_ATTRIBUTE,
+} from "@/utils/constants/dom-labels"
+import { walkAndLabelElement } from "@/utils/host/dom/traversal"
+import { insertShadowRootUIWrapperInto, OVERLAY_SHADOW_ROOT_CSS } from "../shadow-root"
+
+function createOverlayShadowRoot() {
+  const shadowHost = document.createElement("read-frog-selection")
+  const shadow = shadowHost.attachShadow({ mode: "open" })
+  const shadowHtml = document.createElement("html")
+  const container = document.createElement("body")
+  shadowHtml.append(container)
+  shadow.append(shadowHtml)
+  document.body.append(shadowHost)
+
+  return { container, shadowHost, shadowHtml }
+}
+
+describe("insertShadowRootUIWrapperInto", () => {
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("defines overlay geometry inside the Shadow DOM cascade", () => {
+    for (const declaration of [
+      "display: block !important",
+      "height: 0 !important",
+      "overflow: visible !important",
+      "position: relative !important",
+      "width: 0 !important",
+      "background-color: transparent !important",
+    ]) {
+      expect(OVERLAY_SHADOW_ROOT_CSS).toContain(declaration)
+    }
+  })
+
+  it("marks the shadow host and wrapper as non-translatable", () => {
+    const { container, shadowHost } = createOverlayShadowRoot()
+
+    const wrapper = insertShadowRootUIWrapperInto(container, shadowHost)
+
+    expect(shadowHost.classList).toContain(NOTRANSLATE_CLASS)
+    expect(wrapper.parentElement).toBe(container)
+    expect(wrapper.classList).toContain(NOTRANSLATE_CLASS)
+    expect(wrapper.classList).toContain("z-[2147483647]")
+  })
+
+  it("prevents page translation from walking the extension shadow tree", () => {
+    const { container, shadowHost, shadowHtml } = createOverlayShadowRoot()
+    const extensionText = document.createElement("p")
+    extensionText.textContent = "Translate action"
+    container.append(extensionText)
+    insertShadowRootUIWrapperInto(container, shadowHost)
+
+    walkAndLabelElement(document.body, "walk-id", DEFAULT_CONFIG)
+
+    for (const element of [shadowHost, shadowHtml, container, extensionText]) {
+      expect(element).not.toHaveAttribute(WALKED_ATTRIBUTE)
+      expect(element).not.toHaveAttribute(PARAGRAPH_ATTRIBUTE)
+      expect(element).not.toHaveAttribute(BLOCK_ATTRIBUTE)
+    }
+  })
+})

--- a/src/utils/__tests__/styles.test.ts
+++ b/src/utils/__tests__/styles.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { addStyleToShadow } from "../styles"
+
+vi.mock("sonner/dist/styles.css?inline", () => ({
+  default: "[data-sonner-toaster] { position: fixed; }",
+}))
+
+function createShadowDocument() {
+  const host = document.createElement("div")
+  const shadow = host.attachShadow({ mode: "open" })
+  const html = document.createElement("html")
+  const head = document.createElement("head")
+  const body = document.createElement("body")
+  html.append(head, body)
+  shadow.append(html)
+  document.body.append(host)
+
+  return { head, shadow }
+}
+
+describe("addStyleToShadow", () => {
+  afterEach(() => {
+    document.head.querySelectorAll("style").forEach((style) => style.remove())
+    document.body.innerHTML = ""
+  })
+
+  it("injects only Sonner's stylesheet instead of cloning a matching page bundle", () => {
+    const pageStyle = document.createElement("style")
+    pageStyle.textContent = `
+      html, body { height: 100%; background: white; }
+      [data-sonner-toaster] { position: fixed; }
+    `
+    document.head.append(pageStyle)
+    const { head, shadow } = createShadowDocument()
+
+    addStyleToShadow(shadow)
+    addStyleToShadow(shadow)
+
+    const injectedStyles = head.querySelectorAll("style[data-read-frog-sonner-styles]")
+    expect(injectedStyles).toHaveLength(1)
+    expect(injectedStyles[0].textContent).toContain("[data-sonner-toaster]")
+    expect(injectedStyles[0].textContent).not.toContain("background: white")
+    expect(injectedStyles[0].textContent).not.toBe(pageStyle.textContent)
+  })
+})

--- a/src/utils/shadow-root.ts
+++ b/src/utils/shadow-root.ts
@@ -1,6 +1,25 @@
 import { NOTRANSLATE_CLASS } from "@/utils/constants/dom-labels"
 
-export function insertShadowRootUIWrapperInto(container: HTMLElement) {
+// WXT prepends `:host { all: initial !important }` inside each isolated UI.
+// These declarations must live in the same Shadow DOM cascade (and after that
+// reset) to restore WXT's intended zero-sized overlay geometry.
+export const OVERLAY_SHADOW_ROOT_CSS = `
+:host {
+  display: block !important;
+  height: 0 !important;
+  overflow: visible !important;
+  position: relative !important;
+  width: 0 !important;
+}
+
+body {
+  background-color: transparent !important;
+}
+`
+
+export function insertShadowRootUIWrapperInto(container: HTMLElement, shadowHost: HTMLElement) {
+  shadowHost.classList.add(NOTRANSLATE_CLASS)
+
   const wrapper = document.createElement("div")
   wrapper.className = `text-base antialiased font-sans text-foreground z-[2147483647] ${NOTRANSLATE_CLASS}`
   container.append(wrapper)

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -1,17 +1,24 @@
+import sonnerCSS from "sonner/dist/styles.css?inline"
+
+const SONNER_SHADOW_STYLE_ATTRIBUTE = "data-read-frog-sonner-styles"
+
 export function addStyleToShadow(shadow: ShadowRoot) {
-  document.head.querySelectorAll("style").forEach((styleEl) => {
-    if (styleEl.textContent?.includes("[data-sonner-toaster]")) {
-      const shadowHead = shadow.querySelector("head")
-      // Clone the style element instead of moving it to preserve the original
-      // Otherwise, append api will move the style element to the shadow root and cause the bug
-      const clonedStyle = styleEl.cloneNode(true)
-      if (shadowHead) {
-        shadowHead.append(clonedStyle)
-      } else {
-        shadow.append(clonedStyle)
-      }
-    }
-  })
+  if (shadow.querySelector(`style[${SONNER_SHADOW_STYLE_ATTRIBUTE}]`)) return
+
+  // Sonner injects its stylesheet into the page's document head. Copying any
+  // page style that merely mentions Sonner can pull an entire host-site bundle
+  // into the ShadowRoot, including global `html` and `body` rules. Inject the
+  // package's own stylesheet instead so host-page CSS cannot leak in.
+  const style = document.createElement("style")
+  style.setAttribute(SONNER_SHADOW_STYLE_ATTRIBUTE, "")
+  style.textContent = sonnerCSS
+
+  const shadowHead = shadow.querySelector("head")
+  if (shadowHead) {
+    shadowHead.append(style)
+  } else {
+    shadow.append(style)
+  }
 }
 
 function isInternalStyleElement(node: Node) {


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fixes a blank-page overlay on the Alibaba Cloud Digital Certificate console after enabling page translation, disabling it, and refreshing the page.

The selection content script previously copied every document stylesheet containing a Sonner selector into its Shadow Root. Alibaba Cloud includes that selector inside a large bundled stylesheet with global `html` and `body` rules, which made the selection Shadow DOM expand to the viewport and cover the console.

This change:

- injects Sonner's own stylesheet directly instead of cloning matching host-page styles;
- restores zero-sized, transparent WXT overlay geometry inside the Shadow DOM cascade;
- marks the overlay host as non-translatable so page translation does not traverse extension UI;
- adds regression coverage for host-style isolation, overlay geometry, and translation traversal.

## Related Issue

Closes #1886

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Automated validation:

- `pnpm exec vitest run src/utils/__tests__/shadow-root.test.ts src/utils/__tests__/styles.test.ts` — 4 tests passed
- `SKIP_FREE_API=true pnpm test` — 206 test files passed, 1 intentionally skipped; 1,916 tests passed
- `pnpm lint`
- `pnpm build`
- pre-push checks — formatting, lint, and 1,920 tests passed

Manual regression validation used the production Chrome MV3 build in a real authenticated Alibaba Cloud console session:

1. Opened Digital Certificate Management → Overview.
2. Enabled bilingual page translation and observed 55 translated wrappers.
3. Disabled translation and observed the wrapper count return to 0.
4. Refreshed the page and confirmed the console remained visible.
5. Confirmed the selection host, Shadow `html`, and Shadow `body` remained `0 × 0` and transparent.
6. Confirmed center-page hit testing contained only Alibaba Cloud elements and no `read-frog-selection` overlay.

## Screenshots

The original blank-page screenshots are available in #1886. Post-fix manual testing confirmed the full certificate overview remained visible after the translate → disable → refresh sequence.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The overlay CSS is passed through WXT's `createShadowRootUi` `css` option. WXT still owns Shadow Root creation and lifecycle; the shared helper only creates the React mount wrapper inside WXT's container.
