### PR TITLE
feat(translation): add a four-variant new-user default prompt experiment

### DIFF
--- a/.changeset/calm-frogs-test-prompts.md
+++ b/.changeset/calm-frogs-test-prompts.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(translation): add a four-variant new-user default prompt experiment

--- a/src/entrypoints/background/__tests__/analytics.test.ts
+++ b/src/entrypoints/background/__tests__/analytics.test.ts
@@ -1,31 +1,46 @@
+import type { PostHog } from "posthog-js/dist/module.no-external"
 import type { FeatureUsageCache } from "../analytics-feature-cache"
-import type { FeatureUsedEventProperties } from "@/types/analytics"
+import type {
+  FeatureUsedEventProperties,
+  PromptExperimentCohort,
+  TranslationActionContext,
+  TranslationRequestedInput,
+} from "@/types/analytics"
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { PROMPT_EXPERIMENT_FLAG_WAIT_MS } from "@/utils/constants/analytics"
 import {
   createBackgroundAnalytics,
   filterAnalyticsCaptureResult,
   resolveDistinctIdOverride,
 } from "../analytics"
 
-type RegisteredMessageHandler = (message: { data: FeatureUsedEventProperties }) => Promise<void>
+type MessageHandler<TData, TResult = void> = (message: {
+  data: TData
+}) => TResult | Promise<TResult>
+
+type PostHogCaptureMock = (...args: Parameters<PostHog["capture"]>) => void
+type PostHogInitMock = (...args: Parameters<PostHog["init"]>) => void
+type PostHogRegisterMock = (...args: Parameters<PostHog["register"]>) => void
 
 describe("background analytics", () => {
-  let onMessageMock: ReturnType<typeof vi.fn>
-  let storageGetItemMock: ReturnType<typeof vi.fn>
-  let storageSetItemMock: ReturnType<typeof vi.fn>
-  let getTargetLanguageMock: ReturnType<typeof vi.fn>
-  let posthogInitMock: ReturnType<typeof vi.fn>
-  let posthogCaptureMock: ReturnType<typeof vi.fn>
-  let posthogRegisterMock: ReturnType<typeof vi.fn>
-  let loggerWarnMock: ReturnType<typeof vi.fn>
+  let trackFeatureUsedEventHandler: MessageHandler<FeatureUsedEventProperties> | undefined
+  let trackTranslationRequestedEventHandler: MessageHandler<TranslationRequestedInput> | undefined
+  let storageGetItemMock = vi.fn<(key: string) => Promise<unknown>>()
+  let storageSetItemMock = vi.fn<(key: string, value: unknown) => Promise<void>>()
+  let getTargetLanguageMock = vi.fn<() => Promise<"cmn" | undefined>>()
+  let posthogInitMock = vi.fn<PostHogInitMock>()
+  let posthogCaptureMock = vi.fn<PostHogCaptureMock>()
+  let posthogRegisterMock = vi.fn<PostHogRegisterMock>()
+  let posthogGetFeatureFlagMock = vi.fn<PostHog["getFeatureFlag"]>()
+  let posthogOnFeatureFlagsMock = vi.fn<PostHog["onFeatureFlags"]>()
+  let loggerWarnMock = vi.fn<(...args: unknown[]) => void>()
 
-  function getRegisteredMessageHandler(name: string) {
-    const registration = onMessageMock.mock.calls.find((call) => call[0] === name)
-    if (!registration) {
-      throw new Error(`Message handler not registered: ${name}`)
-    }
-
-    return registration[1] as RegisteredMessageHandler
+  function requireMessageHandler<TData>(
+    handler: MessageHandler<TData> | undefined,
+    name: string,
+  ): MessageHandler<TData> {
+    if (!handler) throw new Error(`Message handler not registered: ${name}`)
+    return handler
   }
 
   function createAnalytics(overrides?: {
@@ -49,22 +64,28 @@ describe("background analytics", () => {
       extensionVersion: "1.0.0",
       featureUsageCache: overrides?.featureUsageCache,
       getCurrentDate: overrides?.getCurrentDate ?? (() => new Date("2026-07-14T12:00:00.000Z")),
-      getStorageItem: storageGetItemMock as (key: string) => Promise<unknown>,
-      getTargetLanguage: getTargetLanguageMock as () => Promise<"cmn" | undefined>,
-      onMessage: onMessageMock as (
-        type: "trackFeatureUsedEvent",
-        handler: RegisteredMessageHandler,
-      ) => unknown,
-      posthog: {
-        init: posthogInitMock as (token: string, config: Record<string, unknown>) => void,
-        capture: posthogCaptureMock as (
-          eventName: string,
-          properties: FeatureUsedEventProperties,
-        ) => void,
-        register: posthogRegisterMock as (properties: { extension_version: string }) => void,
+      getStorageItem: storageGetItemMock,
+      getTargetLanguage: getTargetLanguageMock,
+      messageRegistrar: {
+        registerClearPromptExperimentAction() {},
+        registerExposePromptExperiment() {},
+        registerResolvePromptExperimentVariant() {},
+        registerTrackFeatureUsedEvent(handler) {
+          trackFeatureUsedEventHandler = handler
+        },
+        registerTrackTranslationRequestedEvent(handler) {
+          trackTranslationRequestedEventHandler = handler
+        },
       },
-      setStorageItem: storageSetItemMock as (key: string, value: unknown) => Promise<void>,
-      warn: loggerWarnMock as (...args: any[]) => void,
+      posthog: {
+        init: posthogInitMock,
+        capture: posthogCaptureMock,
+        register: posthogRegisterMock,
+        getFeatureFlag: posthogGetFeatureFlagMock,
+        onFeatureFlags: posthogOnFeatureFlagsMock,
+      },
+      setStorageItem: storageSetItemMock,
+      warn: (...args) => loggerWarnMock(...args),
     })
   }
 
@@ -94,15 +115,35 @@ describe("background analytics", () => {
     return { cache, lastReportedDays }
   }
 
+  function useMemoryStorage(initial: Record<string, unknown>) {
+    const values = new Map(Object.entries(initial))
+    storageGetItemMock.mockImplementation(async (key: string) => values.get(key))
+    storageSetItemMock.mockImplementation(async (key: string, value: unknown) => {
+      values.set(key, value)
+    })
+    return values
+  }
+
   beforeEach(() => {
-    onMessageMock = vi.fn<(...args: any[]) => any>()
-    storageGetItemMock = vi.fn<(...args: any[]) => any>()
-    storageSetItemMock = vi.fn<(...args: any[]) => any>()
-    getTargetLanguageMock = vi.fn<(...args: any[]) => any>().mockResolvedValue("cmn")
-    posthogInitMock = vi.fn<(...args: any[]) => any>()
-    posthogCaptureMock = vi.fn<(...args: any[]) => any>()
-    posthogRegisterMock = vi.fn<(...args: any[]) => any>()
-    loggerWarnMock = vi.fn<(...args: any[]) => any>()
+    vi.useRealTimers()
+    trackFeatureUsedEventHandler = undefined
+    trackTranslationRequestedEventHandler = undefined
+    storageGetItemMock = vi.fn<(key: string) => Promise<unknown>>()
+    storageSetItemMock = vi
+      .fn<(key: string, value: unknown) => Promise<void>>()
+      .mockResolvedValue(undefined)
+    getTargetLanguageMock = vi.fn<() => Promise<"cmn" | undefined>>().mockResolvedValue("cmn")
+    posthogInitMock = vi.fn<PostHogInitMock>()
+    posthogCaptureMock = vi.fn<PostHogCaptureMock>()
+    posthogRegisterMock = vi.fn<PostHogRegisterMock>()
+    posthogGetFeatureFlagMock = vi.fn<PostHog["getFeatureFlag"]>()
+    posthogOnFeatureFlagsMock = vi
+      .fn<PostHog["onFeatureFlags"]>()
+      .mockImplementation((callback) => {
+        callback([], {}, {})
+        return vi.fn<() => void>()
+      })
+    loggerWarnMock = vi.fn<(...args: unknown[]) => void>()
   })
 
   it("registers a handler that initializes PostHog with the shared anonymous distinct ID", async () => {
@@ -111,7 +152,7 @@ describe("background analytics", () => {
     const { setupAnalyticsMessageHandlers } = createAnalytics()
     setupAnalyticsMessageHandlers()
 
-    const handler = getRegisteredMessageHandler("trackFeatureUsedEvent")
+    const handler = requireMessageHandler(trackFeatureUsedEventHandler, "trackFeatureUsedEvent")
     await handler({
       data: {
         feature: "page_translation",
@@ -133,7 +174,7 @@ describe("background analytics", () => {
         capture_pageleave: false,
         disable_external_dependency_loading: true,
         disable_session_recording: true,
-        advanced_disable_flags: true,
+        advanced_disable_flags: false,
         person_profiles: "never",
         persistence: "memory",
         respect_dnt: true,
@@ -597,6 +638,13 @@ describe("background analytics", () => {
           $lib_version: "1.360.2",
           $process_person_profile: false,
           extension_version: "1.0.0",
+          backend_kind: "llm",
+          configured_prompt: "default",
+          cohort: "new_user_prompt_experiment_v1",
+          prompt_exposure_age: "d1_d7",
+          $feature_flag: "new-user-default-translate-prompt-v1",
+          $feature_flag_response: "control",
+          $feature_flag_payload: { private: true },
           $current_url: "chrome-extension://abc/background.js",
           $raw_user_agent: "Mozilla/5.0",
           $timezone: "America/Vancouver",
@@ -622,6 +670,271 @@ describe("background analytics", () => {
       $lib_version: "1.360.2",
       $process_person_profile: false,
       extension_version: "1.0.0",
+      backend_kind: "llm",
+      configured_prompt: "default",
+      cohort: "new_user_prompt_experiment_v1",
+      prompt_exposure_age: "d1_d7",
+      $feature_flag: "new-user-default-translate-prompt-v1",
+      $feature_flag_response: "control",
     })
+  })
+
+  it("enrolls only an explicit fresh install marker without initializing PostHog", async () => {
+    const values = useMemoryStorage({})
+    const { enrollPromptExperimentInstall } = createAnalytics()
+
+    await enrollPromptExperimentInstall()
+
+    expect(values.get("local:promptExperimentCohortV1")).toEqual({
+      cohort: "new_user_prompt_experiment_v1",
+      installedAt: new Date("2026-07-14T12:00:00.000Z").getTime(),
+      installVersion: "1.0.0",
+    })
+    expect(posthogInitMock).not.toHaveBeenCalled()
+  })
+
+  it("uses silent fresh lookup before native exposure and dedupes prompt use per action", async () => {
+    const cohort: PromptExperimentCohort = {
+      cohort: "new_user_prompt_experiment_v1",
+      installedAt: new Date("2026-07-14T11:00:00.000Z").getTime(),
+      installVersion: "1.0.0",
+    }
+    const values = useMemoryStorage({
+      "local:analyticsEnabled": true,
+      "local:analyticsInstallId": "install-123",
+      "local:promptExperimentCohortV1": cohort,
+    })
+    posthogGetFeatureFlagMock.mockReturnValue("precision-rewrite")
+    const analytics = createAnalytics()
+
+    await expect(analytics.resolvePromptExperimentVariant("default")).resolves.toBe(
+      "precision-rewrite",
+    )
+    expect(posthogGetFeatureFlagMock).toHaveBeenNthCalledWith(
+      1,
+      "new-user-default-translate-prompt-v1",
+      { send_event: false, fresh: true },
+    )
+
+    const actionContext: TranslationActionContext = {
+      actionId: "action-1",
+      feature: "page_translation",
+      surface: "popup",
+    }
+    await expect(
+      analytics.exposePromptExperiment(actionContext, "precision-rewrite"),
+    ).resolves.toBe(true)
+    await analytics.exposePromptExperiment(actionContext, "precision-rewrite")
+
+    expect(posthogGetFeatureFlagMock).toHaveBeenCalledWith("new-user-default-translate-prompt-v1")
+    expect(
+      posthogCaptureMock.mock.calls.filter(([event]) => event === "translation_prompt_used"),
+    ).toEqual([
+      [
+        "translation_prompt_used",
+        expect.objectContaining({
+          action_id: "action-1",
+          feature: "page_translation",
+          surface: "popup",
+          cohort: "new_user_prompt_experiment_v1",
+        }),
+      ],
+    ])
+    expect(values.get("local:promptExperimentCohortV1")).toEqual(
+      expect.objectContaining({
+        firstPromptExposureAt: new Date("2026-07-14T12:00:00.000Z").getTime(),
+      }),
+    )
+  })
+
+  it("performs one native exposure for a page session across three batches", async () => {
+    useMemoryStorage({
+      "local:analyticsEnabled": true,
+      "local:analyticsInstallId": "install-123",
+      "local:promptExperimentCohortV1": {
+        cohort: "new_user_prompt_experiment_v1",
+        installedAt: new Date("2026-07-14T11:00:00.000Z").getTime(),
+        installVersion: "1.0.0",
+      } satisfies PromptExperimentCohort,
+    })
+    posthogGetFeatureFlagMock.mockReturnValue("precision-rewrite")
+    const analytics = createAnalytics()
+    const actionContext: TranslationActionContext = {
+      actionId: "page-session-1",
+      feature: "page_translation",
+      surface: "popup",
+    }
+    const actionDedupeKey = "42:page-session-1"
+
+    await expect(
+      Promise.all([
+        analytics.exposePromptExperiment(actionContext, "precision-rewrite", actionDedupeKey),
+        analytics.exposePromptExperiment(actionContext, "precision-rewrite", actionDedupeKey),
+        analytics.exposePromptExperiment(actionContext, "precision-rewrite", actionDedupeKey),
+      ]),
+    ).resolves.toEqual([true, true, true])
+
+    const silentLookups = posthogGetFeatureFlagMock.mock.calls.filter(
+      ([, options]) => options?.send_event === false,
+    )
+    const exposingLookups = posthogGetFeatureFlagMock.mock.calls.filter(
+      ([, options]) => options === undefined,
+    )
+
+    expect(silentLookups).toHaveLength(3)
+    expect(exposingLookups).toEqual([["new-user-default-translate-prompt-v1"]])
+    expect(
+      posthogCaptureMock.mock.calls.filter(([event]) => event === "translation_prompt_used"),
+    ).toEqual([
+      [
+        "translation_prompt_used",
+        expect.objectContaining({
+          action_id: actionDedupeKey,
+          feature: "page_translation",
+          surface: "popup",
+        }),
+      ],
+    ])
+  })
+
+  it("does not let background preload consume the action-time flag wait", async () => {
+    vi.useFakeTimers()
+    let featureFlagsCallback: Parameters<PostHog["onFeatureFlags"]>[0] | undefined
+    useMemoryStorage({
+      "local:analyticsEnabled": true,
+      "local:analyticsInstallId": "install-123",
+      "local:promptExperimentCohortV1": {
+        cohort: "new_user_prompt_experiment_v1",
+        installedAt: 1,
+        installVersion: "1.0.0",
+      },
+    })
+    posthogOnFeatureFlagsMock.mockImplementation((callback) => {
+      featureFlagsCallback = callback
+      return vi.fn<() => void>()
+    })
+    posthogGetFeatureFlagMock.mockReturnValue("precision-rewrite")
+    const analytics = createAnalytics()
+
+    await analytics.preloadPromptExperimentFeatureFlags()
+    await vi.advanceTimersByTimeAsync(PROMPT_EXPERIMENT_FLAG_WAIT_MS + 1)
+    featureFlagsCallback?.(
+      ["new-user-default-translate-prompt-v1"],
+      { "new-user-default-translate-prompt-v1": "precision-rewrite" },
+      {},
+    )
+
+    await expect(analytics.resolvePromptExperimentVariant("default")).resolves.toBe(
+      "precision-rewrite",
+    )
+  })
+
+  it("starts the unavailable-flags timeout when an action requests a variant", async () => {
+    vi.useFakeTimers()
+    const values = useMemoryStorage({
+      "local:analyticsEnabled": true,
+      "local:analyticsInstallId": "install-123",
+      "local:promptExperimentCohortV1": {
+        cohort: "new_user_prompt_experiment_v1",
+        installedAt: 1,
+        installVersion: "1.0.0",
+      },
+    })
+    posthogOnFeatureFlagsMock.mockImplementation(() => vi.fn<() => void>())
+    const analytics = createAnalytics()
+
+    await analytics.preloadPromptExperimentFeatureFlags()
+    await vi.advanceTimersByTimeAsync(PROMPT_EXPERIMENT_FLAG_WAIT_MS * 2)
+    const variantPromise = analytics.resolvePromptExperimentVariant("default")
+    await vi.advanceTimersByTimeAsync(PROMPT_EXPERIMENT_FLAG_WAIT_MS)
+
+    await expect(variantPromise).resolves.toBeNull()
+    expect(values.get("local:promptExperimentCohortV1")).toEqual(
+      expect.objectContaining({ excludedReason: "flag_unavailable" }),
+    )
+  })
+
+  it("reports requested actions only for cohort installs and derives D1-D7 exposure age", async () => {
+    useMemoryStorage({
+      "local:analyticsEnabled": true,
+      "local:analyticsInstallId": "install-123",
+      "local:promptExperimentCohortV1": {
+        cohort: "new_user_prompt_experiment_v1",
+        installedAt: new Date("2026-07-10T00:00:00.000Z").getTime(),
+        installVersion: "1.0.0",
+        firstPromptExposureAt: new Date("2026-07-12T12:00:00.000Z").getTime(),
+      },
+    })
+    const analytics = createAnalytics()
+    analytics.setupAnalyticsMessageHandlers()
+
+    await requireMessageHandler(
+      trackTranslationRequestedEventHandler,
+      "trackTranslationRequestedEvent",
+    )({
+      data: {
+        feature: "hover_translation",
+        surface: "shortcut",
+        backend_kind: "non_llm",
+        configured_prompt: "not_applicable",
+      },
+    })
+
+    expect(posthogCaptureMock).toHaveBeenCalledWith("translation_requested", {
+      feature: "hover_translation",
+      surface: "shortcut",
+      backend_kind: "non_llm",
+      configured_prompt: "not_applicable",
+      cohort: "new_user_prompt_experiment_v1",
+      prompt_exposure_age: "d1_d7",
+    })
+  })
+
+  it("permanently excludes a default-LLM action used while analytics is disabled", async () => {
+    const values = useMemoryStorage({
+      "local:analyticsEnabled": false,
+      "local:promptExperimentCohortV1": {
+        cohort: "new_user_prompt_experiment_v1",
+        installedAt: 1,
+        installVersion: "1.0.0",
+      },
+    })
+    const analytics = createAnalytics({ defaultAnalyticsEnabled: false })
+
+    await expect(analytics.resolvePromptExperimentVariant("default")).resolves.toBeNull()
+
+    expect(values.get("local:promptExperimentCohortV1")).toEqual(
+      expect.objectContaining({ excludedReason: "analytics_disabled" }),
+    )
+    expect(posthogInitMock).not.toHaveBeenCalled()
+  })
+
+  it("treats false and unknown flag values as permanent exclusions rather than control", async () => {
+    const baseCohort: PromptExperimentCohort = {
+      cohort: "new_user_prompt_experiment_v1",
+      installedAt: 1,
+      installVersion: "1.0.0",
+    }
+    const falseValues = useMemoryStorage({
+      "local:analyticsEnabled": true,
+      "local:analyticsInstallId": "install-123",
+      "local:promptExperimentCohortV1": baseCohort,
+    })
+    posthogGetFeatureFlagMock.mockReturnValue(false)
+    await createAnalytics().resolvePromptExperimentVariant("default")
+    expect(falseValues.get("local:promptExperimentCohortV1")).toEqual(
+      expect.objectContaining({ excludedReason: "flag_unavailable" }),
+    )
+
+    const unknownValues = useMemoryStorage({
+      "local:analyticsEnabled": true,
+      "local:analyticsInstallId": "install-123",
+      "local:promptExperimentCohortV1": baseCohort,
+    })
+    posthogGetFeatureFlagMock.mockReturnValue("not-a-variant")
+    await createAnalytics().resolvePromptExperimentVariant("default")
+    expect(unknownValues.get("local:promptExperimentCohortV1")).toEqual(
+      expect.objectContaining({ excludedReason: "invalid_variant" }),
+    )
   })
 })

--- a/src/entrypoints/background/__tests__/translation-queues.test.ts
+++ b/src/entrypoints/background/__tests__/translation-queues.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { NO_TRANSLATION_SENTINEL } from "@/utils/constants/prompt"
 
+type BackgroundAnalyticsModule = typeof import("../analytics")
+
 const onMessageMock = vi.fn<(...args: any[]) => any>()
 const ensureInitializedConfigMock = vi.fn<(...args: any[]) => any>()
 const executeTranslateMock = vi.fn<(...args: any[]) => any>()
@@ -13,6 +15,13 @@ const articleSummaryCachePutMock = vi.fn<(...args: any[]) => any>()
 const translationCacheGetMock = vi.fn<(...args: any[]) => any>()
 const translationCachePutMock = vi.fn<(...args: any[]) => any>()
 const translationCacheDeleteMock = vi.fn<(...args: any[]) => any>()
+const resolvePromptExperimentVariantMock =
+  vi.fn<BackgroundAnalyticsModule["resolvePromptExperimentVariant"]>()
+const exposePromptExperimentMock = vi.fn<BackgroundAnalyticsModule["exposePromptExperiment"]>()
+const clearPromptExperimentActionMock =
+  vi.fn<BackgroundAnalyticsModule["clearPromptExperimentAction"]>()
+const clearPromptExperimentActionsByPrefixMock =
+  vi.fn<BackgroundAnalyticsModule["clearPromptExperimentActionsByPrefix"]>()
 
 vi.mock("@/utils/message", () => ({
   onMessage: onMessageMock,
@@ -48,12 +57,27 @@ vi.mock("@/utils/db/dexie/db", () => ({
   },
 }))
 
+vi.mock("../analytics", () => ({
+  clearPromptExperimentAction: clearPromptExperimentActionMock,
+  clearPromptExperimentActionsByPrefix: clearPromptExperimentActionsByPrefixMock,
+  exposePromptExperiment: exposePromptExperimentMock,
+  resolvePromptExperimentVariant: resolvePromptExperimentVariantMock,
+}))
+
 function getRegisteredMessageHandler(name: string) {
   const registration = onMessageMock.mock.calls.find((call) => call[0] === name)
   if (!registration) {
     throw new Error(`Message handler not registered: ${name}`)
   }
-  return registration[1] as (message: { data: Record<string, unknown> }) => Promise<unknown>
+  const handler: unknown = registration[1]
+  if (typeof handler !== "function") {
+    throw new Error(`Registered message handler is not callable: ${name}`)
+  }
+
+  return async (message: {
+    data: Record<string, unknown>
+    sender?: { tab?: { id?: number } }
+  }): Promise<unknown> => await handler(message)
 }
 
 const llmProvider: ProviderConfig = {
@@ -112,6 +136,8 @@ describe("translation queue helpers", () => {
     translationCacheGetMock.mockResolvedValue(undefined)
     translationCachePutMock.mockResolvedValue(undefined)
     translationCacheDeleteMock.mockResolvedValue(undefined)
+    resolvePromptExperimentVariantMock.mockResolvedValue("precision-rewrite")
+    exposePromptExperimentMock.mockResolvedValue(true)
   })
 
   it("routes only llm providers through the batch queue", async () => {
@@ -220,6 +246,184 @@ describe("translation queue helpers", () => {
     expect(executeTranslateMock).toHaveBeenCalledTimes(1)
     // the shared item is sent once, not as a two-item batch
     expect(executeTranslateMock.mock.calls[0][0]).toBe("hello")
+  })
+
+  it("does not expose an experiment prompt when the variant-specific cache hits", async () => {
+    translationCacheGetMock.mockResolvedValueOnce({
+      key: "variant-cache-hit",
+      translation: "cached treatment translation",
+    })
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+
+    await expect(
+      handler({
+        data: {
+          text: "hello",
+          langConfig: DEFAULT_CONFIG.language,
+          providerConfig: llmProvider,
+          scheduleAt: Date.now(),
+          hash: "variant-cache-hit",
+          promptExperimentVariant: "precision-rewrite",
+          translationActionContext: {
+            actionId: "page-action",
+            feature: "page_translation",
+            surface: "popup",
+          },
+          sessionId: "page-action",
+        },
+        sender: { tab: { id: 42 } },
+      }),
+    ).resolves.toBe("cached treatment translation")
+
+    expect(resolvePromptExperimentVariantMock).not.toHaveBeenCalled()
+    expect(exposePromptExperimentMock).not.toHaveBeenCalled()
+    expect(executeTranslateMock).not.toHaveBeenCalled()
+  })
+
+  it("revalidates silently after a miss and exposes each unique action immediately before dispatch", async () => {
+    ensureInitializedConfigMock.mockResolvedValue({
+      ...DEFAULT_CONFIG,
+      translate: {
+        ...DEFAULT_CONFIG.translate,
+        providerId: llmProvider.id,
+        batchQueueConfig: {
+          maxCharactersPerBatch: 1000,
+          maxItemsPerBatch: 10,
+        },
+      },
+    })
+    executeTranslateMock.mockResolvedValueOnce("one\n\n%%\n\ntwo")
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+
+    const makeRequest = (hash: string, actionId: string) =>
+      handler({
+        data: {
+          text: hash,
+          langConfig: DEFAULT_CONFIG.language,
+          providerConfig: llmProvider,
+          scheduleAt: Date.now(),
+          hash,
+          promptExperimentVariant: "precision-rewrite",
+          translationActionContext: {
+            actionId,
+            feature: "hover_translation",
+            surface: "shortcut",
+          },
+        },
+      })
+
+    await expect(
+      Promise.all([makeRequest("first", "hover-1"), makeRequest("second", "hover-2")]),
+    ).resolves.toEqual(["one", "two"])
+
+    expect(resolvePromptExperimentVariantMock).toHaveBeenCalledTimes(2)
+    expect(exposePromptExperimentMock).toHaveBeenCalledTimes(2)
+    expect(exposePromptExperimentMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ actionId: "hover-1" }),
+      "precision-rewrite",
+      "hover-1",
+    )
+    expect(executeTranslateMock).toHaveBeenCalledTimes(1)
+    expect(exposePromptExperimentMock.mock.invocationCallOrder[1]).toBeLessThan(
+      executeTranslateMock.mock.invocationCallOrder[0],
+    )
+  })
+
+  it("asks the content side to rebuild its hash when the post-cache variant changed", async () => {
+    resolvePromptExperimentVariantMock.mockResolvedValueOnce("rewrite-after-understanding")
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+
+    await expect(
+      handler({
+        data: {
+          text: "hello",
+          langConfig: DEFAULT_CONFIG.language,
+          providerConfig: llmProvider,
+          scheduleAt: Date.now(),
+          hash: "old-variant-hash",
+          promptExperimentVariant: "precision-rewrite",
+          translationActionContext: {
+            actionId: "action-1",
+            feature: "page_translation",
+            surface: "popup",
+          },
+        },
+      }),
+    ).resolves.toEqual({
+      retryWithPromptExperimentVariant: "rewrite-after-understanding",
+    })
+    expect(exposePromptExperimentMock).not.toHaveBeenCalled()
+    expect(executeTranslateMock).not.toHaveBeenCalled()
+    expect(translationCachePutMock).not.toHaveBeenCalled()
+  })
+
+  it("aborts dispatch and retries with the latest variant when exposure revalidation changes", async () => {
+    resolvePromptExperimentVariantMock
+      .mockResolvedValueOnce("precision-rewrite")
+      .mockResolvedValueOnce("rewrite-after-understanding")
+    exposePromptExperimentMock.mockResolvedValueOnce(false)
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+
+    await expect(
+      handler({
+        data: {
+          text: "hello",
+          langConfig: DEFAULT_CONFIG.language,
+          providerConfig: llmProvider,
+          scheduleAt: Date.now(),
+          hash: "dispatch-race-hash",
+          promptExperimentVariant: "precision-rewrite",
+          translationActionContext: {
+            actionId: "action-1",
+            feature: "page_translation",
+            surface: "popup",
+          },
+        },
+      }),
+    ).resolves.toEqual({
+      retryWithPromptExperimentVariant: "rewrite-after-understanding",
+    })
+    expect(executeTranslateMock).not.toHaveBeenCalled()
+    expect(translationCachePutMock).not.toHaveBeenCalled()
+  })
+
+  it("aborts dispatch and retries without the experiment when the flag becomes unavailable", async () => {
+    resolvePromptExperimentVariantMock
+      .mockResolvedValueOnce("precision-rewrite")
+      .mockResolvedValueOnce(null)
+    exposePromptExperimentMock.mockResolvedValueOnce(false)
+    const { setUpWebPageTranslationQueue } = await import("../translation-queues")
+    await setUpWebPageTranslationQueue()
+    const handler = getRegisteredMessageHandler("enqueueTranslateRequest")
+
+    await expect(
+      handler({
+        data: {
+          text: "hello",
+          langConfig: DEFAULT_CONFIG.language,
+          providerConfig: llmProvider,
+          scheduleAt: Date.now(),
+          hash: "dispatch-unavailable-hash",
+          promptExperimentVariant: "precision-rewrite",
+          translationActionContext: {
+            actionId: "action-1",
+            feature: "page_translation",
+            surface: "popup",
+          },
+        },
+      }),
+    ).resolves.toEqual({ retryWithoutPromptExperiment: true })
+    expect(executeTranslateMock).not.toHaveBeenCalled()
+    expect(translationCachePutMock).not.toHaveBeenCalled()
   })
 
   it("passes subtitle summary through the translation queue without generating a new summary", async () => {

--- a/src/entrypoints/background/analytics-feature-cache.ts
+++ b/src/entrypoints/background/analytics-feature-cache.ts
@@ -16,9 +16,11 @@ export interface FeatureUsageCache {
 }
 
 interface FeatureUsageCacheStorage {
-  getItem: (key: string) => Promise<unknown>
-  setItem: (key: string, value: unknown) => Promise<void>
+  getItem: (key: FeatureUsageCacheStorageKey) => Promise<unknown>
+  setItem: (key: FeatureUsageCacheStorageKey, value: unknown) => Promise<void>
 }
+
+type FeatureUsageCacheStorageKey = `local:analyticsFeatureUsedLastReportedDay:${AnalyticsFeature}`
 
 export function getFeatureUsageDay(date: Date): string {
   const parts = featureUsageDayFormatter.formatToParts(date)
@@ -33,7 +35,9 @@ export function getFeatureUsageDay(date: Date): string {
   return `${year}-${month}-${day}`
 }
 
-export function getFeatureUsageCacheStorageKey(feature: AnalyticsFeature): string {
+export function getFeatureUsageCacheStorageKey(
+  feature: AnalyticsFeature,
+): FeatureUsageCacheStorageKey {
   return `local:analyticsFeatureUsedLastReportedDay:${feature}`
 }
 

--- a/src/entrypoints/background/analytics.ts
+++ b/src/entrypoints/background/analytics.ts
@@ -1,16 +1,35 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { CaptureResult } from "posthog-js/dist/module.no-external"
-import type { AnalyticsFeature, FeatureUsedEventProperties } from "@/types/analytics"
+import type {
+  AnalyticsFeature,
+  PromptExperimentCohort,
+  PromptExperimentExcludedReason,
+  PromptExperimentVariant,
+  TranslationActionContext,
+  TranslationConfiguredPrompt,
+  TranslationRequestedInput,
+  TranslationRequestedProperties,
+} from "@/types/analytics"
+import type { FeatureUsedEventProperties } from "@/types/analytics"
 import posthog from "posthog-js/dist/module.no-external"
 import { storage } from "#imports"
 import { env } from "@/env"
-import { ANALYTICS_FEATURE } from "@/types/analytics"
+import {
+  ANALYTICS_FEATURE,
+  PROMPT_EXPERIMENT_COHORT,
+  PROMPT_EXPERIMENT_VARIANTS,
+} from "@/types/analytics"
 import { getLocalConfig } from "@/utils/config/storage"
 import {
   ANALYTICS_ENABLED_STORAGE_KEY,
   ANALYTICS_FEATURE_USED_EVENT,
   ANALYTICS_INSTALL_ID_STORAGE_KEY,
+  ANALYTICS_TRANSLATION_PROMPT_USED_EVENT,
+  ANALYTICS_TRANSLATION_REQUESTED_EVENT,
   DEFAULT_ANALYTICS_ENABLED,
+  PROMPT_EXPERIMENT_COHORT_STORAGE_KEY,
+  PROMPT_EXPERIMENT_FLAG_KEY,
+  PROMPT_EXPERIMENT_FLAG_WAIT_MS,
 } from "@/utils/constants/analytics"
 import { EXTENSION_VERSION } from "@/utils/constants/app"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
@@ -36,9 +55,48 @@ const FEATURES_BYPASSING_DAILY_FEATURE_CACHE = new Set<AnalyticsFeature>([
 ])
 
 interface BackgroundAnalyticsClient {
-  capture: (eventName: string, properties: BackgroundFeatureUsedEventProperties) => void
-  init: (token: string, config: Record<string, unknown>) => void
-  register: (properties: { extension_version: string }) => void
+  capture: (...args: Parameters<typeof posthog.capture>) => void
+  getFeatureFlag: (
+    ...args: Parameters<typeof posthog.getFeatureFlag>
+  ) => ReturnType<typeof posthog.getFeatureFlag>
+  init: (...args: Parameters<typeof posthog.init>) => void
+  onFeatureFlags: (
+    ...args: Parameters<typeof posthog.onFeatureFlags>
+  ) => ReturnType<typeof posthog.onFeatureFlags>
+  register: (...args: Parameters<typeof posthog.register>) => void
+}
+
+type BackgroundAnalyticsMessageHandler<TData, TResult> = (message: {
+  data: TData
+}) => TResult | Promise<TResult>
+
+type LocalStorageKey = `local:${string}`
+
+interface BackgroundAnalyticsMessageRegistrar {
+  registerClearPromptExperimentAction: (
+    handler: BackgroundAnalyticsMessageHandler<{ actionId: string }, void>,
+  ) => void
+  registerExposePromptExperiment: (
+    handler: BackgroundAnalyticsMessageHandler<
+      {
+        actionContext: TranslationActionContext
+        expectedVariant: PromptExperimentVariant
+      },
+      boolean
+    >,
+  ) => void
+  registerResolvePromptExperimentVariant: (
+    handler: BackgroundAnalyticsMessageHandler<
+      { configuredPrompt: TranslationConfiguredPrompt },
+      PromptExperimentVariant | null
+    >,
+  ) => void
+  registerTrackFeatureUsedEvent: (
+    handler: BackgroundAnalyticsMessageHandler<FeatureUsedEventProperties, void>,
+  ) => void
+  registerTrackTranslationRequestedEvent: (
+    handler: BackgroundAnalyticsMessageHandler<TranslationRequestedInput, void>,
+  ) => void
 }
 
 interface BackgroundAnalyticsRuntime {
@@ -50,18 +108,35 @@ interface BackgroundAnalyticsRuntime {
   extensionVersion: string
   featureUsageCache?: FeatureUsageCache
   getCurrentDate: () => Date
-  getStorageItem: (key: string) => Promise<unknown>
+  getStorageItem: (key: LocalStorageKey) => Promise<unknown>
   getTargetLanguage: () => Promise<LangCodeISO6393 | undefined>
-  onMessage: (
-    type: "trackFeatureUsedEvent",
-    handler: (message: { data: FeatureUsedEventProperties }) => Promise<void>,
-  ) => unknown
+  messageRegistrar: BackgroundAnalyticsMessageRegistrar
   posthog: BackgroundAnalyticsClient
-  setStorageItem: (key: string, value: unknown) => Promise<void>
+  setStorageItem: (key: LocalStorageKey, value: unknown) => Promise<void>
   warn: typeof logger.warn
 }
 
 const DEV_POSTHOG_TEST_UUID = "00000000-0000-0000-0000-000000000001"
+
+function createDefaultMessageRegistrar(): BackgroundAnalyticsMessageRegistrar {
+  return {
+    registerClearPromptExperimentAction(handler) {
+      onMessage("clearPromptExperimentAction", handler)
+    },
+    registerExposePromptExperiment(handler) {
+      onMessage("exposePromptExperiment", handler)
+    },
+    registerResolvePromptExperimentVariant(handler) {
+      onMessage("resolvePromptExperimentVariant", handler)
+    },
+    registerTrackFeatureUsedEvent(handler) {
+      onMessage("trackFeatureUsedEvent", handler)
+    },
+    registerTrackTranslationRequestedEvent(handler) {
+      onMessage("trackTranslationRequestedEvent", handler)
+    },
+  }
+}
 
 function normalizeDistinctIdOverride(value: string | undefined): string | undefined {
   if (typeof value !== "string") {
@@ -70,6 +145,41 @@ function normalizeDistinctIdOverride(value: string | undefined): string | undefi
 
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : undefined
+}
+
+function isPromptExperimentExcludedReason(value: unknown): value is PromptExperimentExcludedReason {
+  return (
+    value === "analytics_disabled" ||
+    value === "flag_unavailable" ||
+    value === "invalid_variant" ||
+    value === "custom_prompt_used"
+  )
+}
+
+function isPromptExperimentCohort(value: unknown): value is PromptExperimentCohort {
+  if (typeof value !== "object" || value === null) return false
+
+  const hasValidExcludedReason =
+    !("excludedReason" in value) ||
+    value.excludedReason === undefined ||
+    isPromptExperimentExcludedReason(value.excludedReason)
+  const hasValidFirstExposure =
+    !("firstPromptExposureAt" in value) ||
+    value.firstPromptExposureAt === undefined ||
+    (typeof value.firstPromptExposureAt === "number" &&
+      Number.isFinite(value.firstPromptExposureAt))
+
+  return (
+    "cohort" in value &&
+    value.cohort === PROMPT_EXPERIMENT_COHORT &&
+    "installedAt" in value &&
+    typeof value.installedAt === "number" &&
+    Number.isFinite(value.installedAt) &&
+    "installVersion" in value &&
+    typeof value.installVersion === "string" &&
+    hasValidExcludedReason &&
+    hasValidFirstExposure
+  )
 }
 
 export function resolveDistinctIdOverride(
@@ -85,9 +195,8 @@ export function resolveDistinctIdOverride(
 }
 
 function createDefaultRuntime(): BackgroundAnalyticsRuntime {
-  const getStorageItem = (key: string) => storage.getItem(key as `local:${string}`)
-  const setStorageItem = (key: string, value: unknown) =>
-    storage.setItem(key as `local:${string}`, value)
+  const getStorageItem = (key: LocalStorageKey) => storage.getItem(key)
+  const setStorageItem = (key: LocalStorageKey, value: unknown) => storage.setItem(key, value)
 
   return {
     apiHost: env.WXT_POSTHOG_HOST,
@@ -108,7 +217,7 @@ function createDefaultRuntime(): BackgroundAnalyticsRuntime {
       const config = await getLocalConfig()
       return config?.language.targetCode
     },
-    onMessage,
+    messageRegistrar: createDefaultMessageRegistrar(),
     posthog,
     setStorageItem,
     warn: logger.warn,
@@ -127,7 +236,12 @@ function setPropertyIfDefined(
   }
 }
 
-export function filterAnalyticsCaptureResult(data: CaptureResult): CaptureResult {
+export function filterAnalyticsCaptureResult(data: CaptureResult): CaptureResult
+export function filterAnalyticsCaptureResult(data: null): null
+export function filterAnalyticsCaptureResult(data: CaptureResult | null): CaptureResult | null
+export function filterAnalyticsCaptureResult(data: CaptureResult | null): CaptureResult | null {
+  if (data === null) return null
+
   const properties = data.properties ?? {}
   const filteredProperties: AnalyticsCaptureProperties = {}
 
@@ -140,6 +254,16 @@ export function filterAnalyticsCaptureResult(data: CaptureResult): CaptureResult
   setPropertyIfDefined(filteredProperties, "action_id", properties.action_id)
   setPropertyIfDefined(filteredProperties, "action_name", properties.action_name)
   setPropertyIfDefined(filteredProperties, "target_language", properties.target_language)
+  setPropertyIfDefined(filteredProperties, "backend_kind", properties.backend_kind)
+  setPropertyIfDefined(filteredProperties, "configured_prompt", properties.configured_prompt)
+  setPropertyIfDefined(filteredProperties, "cohort", properties.cohort)
+  setPropertyIfDefined(filteredProperties, "prompt_exposure_age", properties.prompt_exposure_age)
+  setPropertyIfDefined(filteredProperties, "$feature_flag", properties.$feature_flag)
+  setPropertyIfDefined(
+    filteredProperties,
+    "$feature_flag_response",
+    properties.$feature_flag_response,
+  )
   setPropertyIfDefined(filteredProperties, "$browser", properties.$browser)
   setPropertyIfDefined(filteredProperties, "$browser_version", properties.$browser_version)
   setPropertyIfDefined(filteredProperties, "$insert_id", properties.$insert_id)
@@ -164,7 +288,10 @@ export function createBackgroundAnalytics(
 ) {
   let clientPromise: Promise<BackgroundAnalyticsClient | null> | null = null
   let missingConfigWarned = false
+  let flagReadinessPromise: Promise<boolean> | null = null
   const featureCaptureQueues = new Map<AnalyticsFeature, Promise<void>>()
+  const promptUsedActionIds = new Set<string>()
+  const promptExposureActionPromises = new Map<string, Promise<boolean>>()
 
   async function isAnalyticsEnabled(): Promise<boolean> {
     const enabled = await runtime.getStorageItem(`local:${ANALYTICS_ENABLED_STORAGE_KEY}`)
@@ -190,7 +317,10 @@ export function createBackgroundAnalytics(
   }
 
   async function getPostHogClient(): Promise<BackgroundAnalyticsClient | null> {
-    if (!runtime.apiKey || !runtime.apiHost) {
+    const apiKey = runtime.apiKey
+    const apiHost = runtime.apiHost
+
+    if (!apiKey || !apiHost) {
       if (!missingConfigWarned) {
         missingConfigWarned = true
         runtime.warn(
@@ -204,9 +334,9 @@ export function createBackgroundAnalytics(
       clientPromise = (async () => {
         const distinctId = await getAnalyticsInstallId()
 
-        runtime.posthog.init(runtime.apiKey!, {
+        runtime.posthog.init(apiKey, {
           before_send: filterAnalyticsCaptureResult,
-          api_host: runtime.apiHost!,
+          api_host: apiHost,
           autocapture: false,
           save_campaign_params: false,
           save_referrer: false,
@@ -214,7 +344,7 @@ export function createBackgroundAnalytics(
           capture_pageleave: false,
           disable_external_dependency_loading: true,
           disable_session_recording: true,
-          advanced_disable_flags: true,
+          advanced_disable_flags: false,
           person_profiles: "never",
           persistence: "memory",
           respect_dnt: true,
@@ -232,6 +362,219 @@ export function createBackgroundAnalytics(
     }
 
     return clientPromise
+  }
+
+  function trackFeatureFlagReadiness(client: BackgroundAnalyticsClient): Promise<boolean> {
+    if (flagReadinessPromise) {
+      return flagReadinessPromise
+    }
+
+    flagReadinessPromise = new Promise<boolean>((resolve) => {
+      let settled = false
+      let unsubscribe: (() => void) | undefined
+
+      const finish = (ready: boolean) => {
+        if (settled) return
+        settled = true
+        unsubscribe?.()
+        resolve(ready)
+      }
+
+      unsubscribe = client.onFeatureFlags((_flags, _variants, metadata) => {
+        finish(metadata?.errorsLoading !== true)
+      })
+      // Some test doubles and SDK implementations may invoke the callback
+      // synchronously before returning their unsubscribe function.
+      if (settled) unsubscribe?.()
+    })
+
+    return flagReadinessPromise
+  }
+
+  async function waitForFeatureFlags(client: BackgroundAnalyticsClient): Promise<boolean> {
+    const readiness = trackFeatureFlagReadiness(client)
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    const timedOut = new Promise<false>((resolve) => {
+      timeout = setTimeout(() => resolve(false), PROMPT_EXPERIMENT_FLAG_WAIT_MS)
+    })
+
+    const ready = await Promise.race([readiness, timedOut])
+    if (timeout !== undefined) clearTimeout(timeout)
+    return ready
+  }
+
+  async function preloadPromptExperimentFeatureFlags(): Promise<void> {
+    if (!(await isAnalyticsEnabled())) return
+    const client = await getPostHogClient()
+    if (!client) return
+    void trackFeatureFlagReadiness(client)
+  }
+
+  async function readPromptExperimentCohort(): Promise<PromptExperimentCohort | null> {
+    const value = await runtime.getStorageItem(`local:${PROMPT_EXPERIMENT_COHORT_STORAGE_KEY}`)
+    return isPromptExperimentCohort(value) ? value : null
+  }
+
+  async function writePromptExperimentCohort(cohort: PromptExperimentCohort): Promise<void> {
+    await runtime.setStorageItem(`local:${PROMPT_EXPERIMENT_COHORT_STORAGE_KEY}`, cohort)
+  }
+
+  async function enrollPromptExperimentInstall(): Promise<void> {
+    const existing = await readPromptExperimentCohort()
+    if (existing) return
+
+    await writePromptExperimentCohort({
+      cohort: PROMPT_EXPERIMENT_COHORT,
+      installedAt: runtime.getCurrentDate().getTime(),
+      installVersion: runtime.extensionVersion,
+    })
+  }
+
+  async function excludePromptExperiment(
+    reason: PromptExperimentExcludedReason,
+  ): Promise<PromptExperimentCohort | null> {
+    const cohort = await readPromptExperimentCohort()
+    if (!cohort || cohort.excludedReason) return cohort
+
+    const excluded = { ...cohort, excludedReason: reason }
+    await writePromptExperimentCohort(excluded)
+    return excluded
+  }
+
+  function isPromptExperimentVariant(value: unknown): value is PromptExperimentVariant {
+    return PROMPT_EXPERIMENT_VARIANTS.some((variant) => variant === value)
+  }
+
+  async function resolvePromptExperimentVariant(
+    configuredPrompt: TranslationConfiguredPrompt,
+  ): Promise<PromptExperimentVariant | null> {
+    const cohort = await readPromptExperimentCohort()
+    if (!cohort) return null
+
+    if (configuredPrompt === "custom") {
+      await excludePromptExperiment("custom_prompt_used")
+      return null
+    }
+    if (configuredPrompt !== "default" || cohort.excludedReason) return null
+
+    if (!(await isAnalyticsEnabled())) {
+      await excludePromptExperiment("analytics_disabled")
+      return null
+    }
+
+    const client = await getPostHogClient()
+    if (!client || !(await waitForFeatureFlags(client))) {
+      await excludePromptExperiment("flag_unavailable")
+      return null
+    }
+
+    const value = client.getFeatureFlag(PROMPT_EXPERIMENT_FLAG_KEY, {
+      send_event: false,
+      fresh: true,
+    })
+    if (value === false || value === undefined) {
+      await excludePromptExperiment("flag_unavailable")
+      return null
+    }
+    if (!isPromptExperimentVariant(value)) {
+      await excludePromptExperiment("invalid_variant")
+      return null
+    }
+    return value
+  }
+
+  function getPromptExposureAge(
+    cohort: PromptExperimentCohort,
+  ): TranslationRequestedProperties["prompt_exposure_age"] {
+    if (cohort.firstPromptExposureAt === undefined) return "not_exposed"
+    const ageMs = Math.max(0, runtime.getCurrentDate().getTime() - cohort.firstPromptExposureAt)
+    if (ageMs < 24 * 60 * 60 * 1000) return "lt_24h"
+    if (ageMs < 7 * 24 * 60 * 60 * 1000) return "d1_d7"
+    return "gt_7d"
+  }
+
+  async function captureTranslationRequestedEvent(
+    properties: TranslationRequestedInput,
+  ): Promise<void> {
+    if (!(await isAnalyticsEnabled())) return
+    let cohort = await readPromptExperimentCohort()
+    if (!cohort) return
+
+    if (properties.configured_prompt === "custom" && !cohort.excludedReason) {
+      cohort = (await excludePromptExperiment("custom_prompt_used")) ?? cohort
+    }
+
+    const client = await getPostHogClient()
+    if (!client) return
+    client.capture(ANALYTICS_TRANSLATION_REQUESTED_EVENT, {
+      ...properties,
+      cohort: PROMPT_EXPERIMENT_COHORT,
+      prompt_exposure_age: getPromptExposureAge(cohort),
+    })
+  }
+
+  async function exposePromptExperiment(
+    actionContext: TranslationActionContext,
+    expectedVariant: PromptExperimentVariant,
+    actionDedupeKey = actionContext.actionId,
+  ): Promise<boolean> {
+    const latestVariant = await resolvePromptExperimentVariant("default")
+    if (latestVariant !== expectedVariant) return false
+
+    if (promptUsedActionIds.has(actionDedupeKey)) return true
+
+    const pendingExposure = promptExposureActionPromises.get(actionDedupeKey)
+    if (pendingExposure) return await pendingExposure
+
+    const exposurePromise = (async () => {
+      const client = await getPostHogClient()
+      if (!client) return false
+
+      // This is the only exposing lookup for this action. It is intentionally
+      // adjacent to the caller's LLM dispatch so PostHog's native
+      // $feature_flag_called is exact.
+      const exposedVariant = client.getFeatureFlag(PROMPT_EXPERIMENT_FLAG_KEY)
+      if (exposedVariant !== expectedVariant) return false
+
+      let cohort = await readPromptExperimentCohort()
+      if (!cohort || cohort.excludedReason) return false
+      if (cohort.firstPromptExposureAt === undefined) {
+        cohort = {
+          ...cohort,
+          firstPromptExposureAt: runtime.getCurrentDate().getTime(),
+        }
+        await writePromptExperimentCohort(cohort)
+      }
+
+      client.capture(ANALYTICS_TRANSLATION_PROMPT_USED_EVENT, {
+        action_id: actionDedupeKey,
+        cohort: PROMPT_EXPERIMENT_COHORT,
+        feature: actionContext.feature,
+        surface: actionContext.surface,
+        prompt_exposure_age: getPromptExposureAge(cohort),
+      })
+      promptUsedActionIds.add(actionDedupeKey)
+      return true
+    })()
+
+    promptExposureActionPromises.set(actionDedupeKey, exposurePromise)
+    try {
+      return await exposurePromise
+    } finally {
+      if (promptExposureActionPromises.get(actionDedupeKey) === exposurePromise) {
+        promptExposureActionPromises.delete(actionDedupeKey)
+      }
+    }
+  }
+
+  function clearPromptExperimentAction(actionId: string): void {
+    promptUsedActionIds.delete(actionId)
+  }
+
+  function clearPromptExperimentActionsByPrefix(prefix: string): void {
+    for (const actionId of promptUsedActionIds) {
+      if (actionId.startsWith(prefix)) promptUsedActionIds.delete(actionId)
+    }
   }
 
   async function captureFeatureUsedEvent(properties: FeatureUsedEventProperties): Promise<boolean> {
@@ -352,18 +695,44 @@ export function createBackgroundAnalytics(
   }
 
   function setupAnalyticsMessageHandlers(): void {
-    runtime.onMessage("trackFeatureUsedEvent", async (message) => {
+    runtime.messageRegistrar.registerTrackFeatureUsedEvent(async (message) => {
       await captureFeatureUsedEventInBackground(message.data)
+    })
+    runtime.messageRegistrar.registerTrackTranslationRequestedEvent(async (message) => {
+      await captureTranslationRequestedEvent(message.data)
+    })
+    runtime.messageRegistrar.registerResolvePromptExperimentVariant(async (message) => {
+      return await resolvePromptExperimentVariant(message.data.configuredPrompt)
+    })
+    runtime.messageRegistrar.registerExposePromptExperiment(async (message) => {
+      return await exposePromptExperiment(message.data.actionContext, message.data.expectedVariant)
+    })
+    runtime.messageRegistrar.registerClearPromptExperimentAction((message) => {
+      clearPromptExperimentAction(message.data.actionId)
     })
   }
 
   return {
     captureFeatureUsedEventInBackground,
+    clearPromptExperimentAction,
+    clearPromptExperimentActionsByPrefix,
+    enrollPromptExperimentInstall,
+    exposePromptExperiment,
+    preloadPromptExperimentFeatureFlags,
+    resolvePromptExperimentVariant,
     setupAnalyticsMessageHandlers,
   }
 }
 
 const backgroundAnalytics = createBackgroundAnalytics()
 
-export const { captureFeatureUsedEventInBackground, setupAnalyticsMessageHandlers } =
-  backgroundAnalytics
+export const {
+  captureFeatureUsedEventInBackground,
+  clearPromptExperimentAction,
+  clearPromptExperimentActionsByPrefix,
+  enrollPromptExperimentInstall,
+  exposePromptExperiment,
+  preloadPromptExperimentFeatureFlags,
+  resolvePromptExperimentVariant,
+  setupAnalyticsMessageHandlers,
+} = backgroundAnalytics

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -10,7 +10,11 @@ import { onMessage } from "@/utils/message"
 import { openOptionsPage } from "@/utils/navigation"
 import { SessionCacheGroupRegistry } from "@/utils/session-cache/session-cache-group-registry"
 import { runAiSegmentSubtitles } from "./ai-segmentation"
-import { setupAnalyticsMessageHandlers } from "./analytics"
+import {
+  enrollPromptExperimentInstall,
+  preloadPromptExperimentFeatureFlags,
+  setupAnalyticsMessageHandlers,
+} from "./analytics"
 import { dispatchBackgroundStreamPort } from "./background-stream"
 import { initializeActionIcons, registerActionIconListeners } from "./browser-action-icon"
 import { ensureInitializedConfig } from "./config"
@@ -45,6 +49,7 @@ export default defineBackground({
 
       // Open tutorial page when extension is installed
       if (details.reason === "install") {
+        await enrollPromptExperimentInstall()
         await browser.tabs.create({
           url: `${env.WXT_WEBSITE_URL}/guide/step-1`,
         })
@@ -98,6 +103,7 @@ export default defineBackground({
 
     newUserGuide()
     setupAnalyticsMessageHandlers()
+    void preloadPromptExperimentFeatureFlags()
     translationMessage()
     registerActionIconListeners()
 

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -1,3 +1,4 @@
+import type { PromptExperimentVariant, TranslationActionContext } from "@/types/analytics"
 import type { Config } from "@/types/config/config"
 import type { LLMProviderConfig, ProviderConfig } from "@/types/config/provider"
 import type { BatchQueueConfig, RequestQueueConfig } from "@/types/config/translate"
@@ -27,6 +28,13 @@ import { getTranslatePrompt } from "@/utils/prompts/translate"
 import { BatchQueue } from "@/utils/request/batch-queue"
 import { CancelledScopeRegistry, TranslationCancelledError } from "@/utils/request/cancellation"
 import { RequestQueue } from "@/utils/request/request-queue"
+import { attachRequestErrorMeta } from "@/utils/request/retry-policy"
+import {
+  clearPromptExperimentAction,
+  clearPromptExperimentActionsByPrefix,
+  exposePromptExperiment,
+  resolvePromptExperimentVariant,
+} from "./analytics"
 import { ensureInitializedConfig } from "./config"
 
 export function parseBatchResult(result: string): string[] {
@@ -38,6 +46,14 @@ export function parseBatchResult(result: string): string[] {
 
 export function shouldUseBatchQueue(providerConfig: ProviderConfig): boolean {
   return isLLMProviderConfig(providerConfig)
+}
+
+class PromptExperimentDispatchChangedError extends Error {
+  constructor(readonly latestVariant: PromptExperimentVariant | null) {
+    super("Prompt experiment variant changed before dispatch")
+    this.name = "PromptExperimentDispatchChangedError"
+    attachRequestErrorMeta(this, { isRetryable: false })
+  }
 }
 
 async function getValidatedCachedTranslation(
@@ -187,6 +203,9 @@ export interface TranslateBatchData<TContext = unknown> {
   context?: TContext
   // Cancellation scope (`${tabId}:${sessionId}`); absent = uncancellable.
   scope?: string
+  promptExperimentVariant?: PromptExperimentVariant
+  translationActionContext?: TranslationActionContext
+  actionDedupeKey?: string
 }
 
 /**
@@ -208,12 +227,13 @@ interface TranslationQueueSetupConfig<TContext = unknown> {
   promptResolver: PromptResolver<TContext>
   // Present only for queues whose requests carry cancellation scopes.
   isScopeCancelled?: (scopeKey: string) => boolean
+  beforeDispatch?: (dataList: TranslateBatchData<TContext>[]) => Promise<void>
 }
 
 async function createTranslationQueues<TContext>(config: TranslationQueueSetupConfig<TContext>) {
   const { rate, capacity } = config.requestQueueConfig
   const { maxCharactersPerBatch, maxItemsPerBatch } = config.batchQueueConfig
-  const { promptResolver, isScopeCancelled } = config
+  const { promptResolver, isScopeCancelled, beforeDispatch } = config
 
   const requestQueue = new RequestQueue({
     rate,
@@ -246,6 +266,7 @@ async function createTranslationQueues<TContext>(config: TranslationQueueSetupCo
 
       const batchThunk = async (signal?: AbortSignal): Promise<string[]> => {
         await putBatchRequestRecord({ originalRequestCount: dataList.length, providerConfig })
+        await beforeDispatch?.(dataList)
         return await executeBatchTranslation(dataList, promptResolver, signal)
       }
 
@@ -255,6 +276,7 @@ async function createTranslationQueues<TContext>(config: TranslationQueueSetupCo
       const { text, langConfig, providerConfig, hash, scheduleAt, context, scope } = data
       const thunk = async (signal?: AbortSignal) => {
         await putBatchRequestRecord({ originalRequestCount: 1, providerConfig })
+        await beforeDispatch?.([data])
         return executeTranslate(text, langConfig, providerConfig, promptResolver, {
           context,
           signal,
@@ -288,11 +310,47 @@ export async function setUpWebPageTranslationQueue() {
   // would otherwise be lost (#1881).
   const cancelledScopes = new CancelledScopeRegistry()
 
-  const { requestQueue, batchQueue } = await createTranslationQueues({
+  type WebTranslationPromptContext = WebPagePromptContext & {
+    promptExperimentVariant?: PromptExperimentVariant
+  }
+
+  const webPromptResolver: PromptResolver<WebTranslationPromptContext> = (
+    targetLang,
+    input,
+    options,
+  ) =>
+    getTranslatePrompt(targetLang, input, {
+      ...options,
+      promptExperimentVariant: options?.context?.promptExperimentVariant,
+    })
+
+  const { requestQueue, batchQueue } = await createTranslationQueues<WebTranslationPromptContext>({
     requestQueueConfig,
     batchQueueConfig,
-    promptResolver: getTranslatePrompt,
+    promptResolver: webPromptResolver,
     isScopeCancelled: (scopeKey) => cancelledScopes.has(scopeKey),
+    beforeDispatch: async (dataList) => {
+      const uniqueActions = new Map<
+        string,
+        { actionContext: TranslationActionContext; variant: PromptExperimentVariant }
+      >()
+      for (const data of dataList) {
+        if (!data.promptExperimentVariant || !data.translationActionContext) continue
+        const dedupeKey = data.actionDedupeKey ?? data.translationActionContext.actionId
+        uniqueActions.set(dedupeKey, {
+          actionContext: data.translationActionContext,
+          variant: data.promptExperimentVariant,
+        })
+      }
+
+      for (const [dedupeKey, { actionContext, variant }] of uniqueActions) {
+        const exposed = await exposePromptExperiment(actionContext, variant, dedupeKey)
+        if (!exposed) {
+          const latestVariant = await resolvePromptExperimentVariant("default")
+          throw new PromptExperimentDispatchChangedError(latestVariant)
+        }
+      }
+    },
   })
 
   onMessage("enqueueTranslateRequest", async (message) => {
@@ -309,6 +367,8 @@ export async function setUpWebPageTranslationQueue() {
         webContent,
         webSummary,
         sessionId,
+        promptExperimentVariant,
+        translationActionContext,
       },
     } = message
     const scope = buildTranslationScopeKey(message.sender, sessionId)
@@ -337,17 +397,58 @@ export async function setUpWebPageTranslationQueue() {
       throw new TranslationCancelledError(scope)
     }
 
+    let effectivePromptExperimentVariant = promptExperimentVariant
+    let cacheUnderRequestedHash = true
+    if (promptExperimentVariant) {
+      const latestVariant = await resolvePromptExperimentVariant("default")
+      if (latestVariant && latestVariant !== promptExperimentVariant) {
+        return { retryWithPromptExperimentVariant: latestVariant }
+      }
+      if (!latestVariant) {
+        effectivePromptExperimentVariant = undefined
+        cacheUnderRequestedHash = false
+      }
+    }
+
     let result: string
-    const context: WebPagePromptContext = {
+    const context: WebTranslationPromptContext = {
       webTitle: normalizePromptContextValue(webTitle),
       webDescription: normalizePromptContextValue(webDescription),
       webContent: normalizePromptContextValue(webContent),
       webSummary: normalizePromptContextValue(webSummary),
+      promptExperimentVariant: effectivePromptExperimentVariant,
     }
 
     if (shouldUseBatchQueue(providerConfig)) {
-      const data = { text, langConfig, providerConfig, hash, scheduleAt, context, scope }
-      result = await batchQueue.enqueue(data)
+      const data = {
+        text,
+        langConfig,
+        providerConfig,
+        hash,
+        scheduleAt,
+        context,
+        scope,
+        promptExperimentVariant: effectivePromptExperimentVariant,
+        translationActionContext,
+        actionDedupeKey:
+          translationActionContext?.feature === "page_translation"
+            ? (scope ?? translationActionContext.actionId)
+            : translationActionContext?.actionId,
+      }
+      try {
+        result = await batchQueue.enqueue(data)
+      } catch (error) {
+        if (error instanceof PromptExperimentDispatchChangedError) {
+          if (error.latestVariant) {
+            return { retryWithPromptExperimentVariant: error.latestVariant }
+          }
+          const retryResponse: { retryWithoutPromptExperiment: true } = {
+            retryWithoutPromptExperiment: true,
+          }
+          return retryResponse
+        }
+        throw error
+      }
     } else {
       // Create thunk based on type and params
       const thunk = (signal?: AbortSignal) =>
@@ -363,7 +464,7 @@ export async function setUpWebPageTranslationQueue() {
     }
 
     // Cache the translation result if successful
-    if (result && hash) {
+    if (result && hash && cacheUnderRequestedHash) {
       await db.translationCache.put({
         key: hash,
         translation: result,
@@ -400,6 +501,7 @@ export async function setUpWebPageTranslationQueue() {
     // Remember the scope so enqueue handlers suspended on the cache lookup
     // refuse to enqueue after this drain.
     cancelledScopes.markScope(scope)
+    clearPromptExperimentAction(scope)
     // Batch queue first so pending batches cannot flush new request-queue
     // tasks between the two drains.
     const cancelledBatch = batchQueue.cancelByScope(scope)
@@ -416,6 +518,7 @@ export async function setUpWebPageTranslationQueue() {
   browser.tabs.onRemoved.addListener((tabId) => {
     const prefix = `${tabId}:`
     cancelledScopes.markPrefix(prefix)
+    clearPromptExperimentActionsByPrefix(prefix)
     batchQueue.cancelWhere((scope) => scope.startsWith(prefix))
     requestQueue.cancelWhere((scope) => scope.startsWith(prefix))
   })

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
+import { createFeatureUsageContext } from "@/utils/analytics"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { getPageTranslationActionContext } from "@/utils/host/translate/translation-session"
 import { PageTranslationManager } from "../page-translation"
 
 const {
@@ -127,6 +130,37 @@ describe("pageTranslationManager title handling", () => {
     })
     mockValidateTranslationConfigAndToast.mockReturnValue(true)
     mockSendMessage.mockResolvedValue(undefined)
+  })
+
+  it("keeps automatic and context-free starts out of the prompt experiment", async () => {
+    const automaticContexts = [
+      undefined,
+      createFeatureUsageContext(ANALYTICS_FEATURE.PAGE_TRANSLATION, ANALYTICS_SURFACE.PAGE_AUTO),
+    ]
+
+    for (const analyticsContext of automaticContexts) {
+      const manager = new PageTranslationManager()
+      await manager.start(analyticsContext)
+
+      expect(getPageTranslationActionContext()).toBeNull()
+
+      manager.stop()
+    }
+  })
+
+  it("creates a prompt experiment action for a manual page translation", async () => {
+    const manager = new PageTranslationManager()
+    await manager.start(
+      createFeatureUsageContext(ANALYTICS_FEATURE.PAGE_TRANSLATION, ANALYTICS_SURFACE.POPUP),
+    )
+
+    expect(getPageTranslationActionContext()).toEqual({
+      actionId: expect.any(String),
+      feature: ANALYTICS_FEATURE.PAGE_TRANSLATION,
+      surface: ANALYTICS_SURFACE.POPUP,
+    })
+
+    manager.stop()
   })
 
   it("does not prime webpage context on start for non-llm translation", async () => {

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -1,16 +1,28 @@
 import type { FeatureUsageContext } from "@/types/analytics"
 import type { Config } from "@/types/config/config"
 import debounce from "debounce"
-import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
+import {
+  ANALYTICS_FEATURE,
+  ANALYTICS_SURFACE,
+  TRANSLATION_REQUESTED_FEATURE,
+} from "@/types/analytics"
 import { isLLMProviderConfig } from "@/types/config/provider"
-import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
+import {
+  classifyTranslationRequest,
+  createFeatureUsageContext,
+  trackFeatureUsed,
+  trackTranslationRequested,
+} from "@/utils/analytics"
 import { getLocalConfig } from "@/utils/config/storage"
 import {
   CONTENT_WRAPPER_CLASS,
   REACT_SHADOW_HOST_CLASS,
   SPINNER_CLASS,
 } from "@/utils/constants/dom-labels"
-import { resolveProviderConfig } from "@/utils/constants/feature-providers"
+import {
+  resolveProviderConfig,
+  resolveProviderConfigOrNull,
+} from "@/utils/constants/feature-providers"
 import {
   GIANT_PARAGRAPH_MAX_SPLIT_DEPTH,
   GIANT_PARAGRAPH_SPLIT_MIN_VIEWPORT_PX,
@@ -159,12 +171,32 @@ export class PageTranslationManager implements IPageTranslationManager {
     if (!config) {
       console.warn("Config is not initialized")
       if (trackedContext) {
+        if (trackedContext.surface !== ANALYTICS_SURFACE.PAGE_AUTO) {
+          await trackTranslationRequested({
+            feature: TRANSLATION_REQUESTED_FEATURE.PAGE_TRANSLATION,
+            surface: trackedContext.surface,
+            backend_kind: "unknown",
+            configured_prompt: "unknown",
+          })
+        }
         void trackFeatureUsed({
           ...trackedContext,
           outcome: "failure",
         })
       }
       return
+    }
+
+    const requestedProviderConfig = resolveProviderConfigOrNull(config, "translate")
+    if (trackedContext && trackedContext.surface !== ANALYTICS_SURFACE.PAGE_AUTO) {
+      await trackTranslationRequested({
+        feature: TRANSLATION_REQUESTED_FEATURE.PAGE_TRANSLATION,
+        surface: trackedContext.surface,
+        ...classifyTranslationRequest(
+          requestedProviderConfig,
+          config.translate.customPromptsConfig.promptId,
+        ),
+      })
     }
 
     if (
@@ -193,7 +225,14 @@ export class PageTranslationManager implements IPageTranslationManager {
 
       this.isPageTranslating = true
       this.translationSessionVersion += 1
-      beginPageTranslationSession()
+      beginPageTranslationSession(
+        window === window.top
+          ? {
+              feature: TRANSLATION_REQUESTED_FEATURE.PAGE_TRANSLATION,
+              surface: trackedContext?.surface ?? ANALYTICS_SURFACE.PAGE_AUTO,
+            }
+          : undefined,
+      )
 
       const siteRule = getEffectiveSiteRule(config, window.location.href)
       if (siteRule.injectedCss) {

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -225,14 +225,18 @@ export class PageTranslationManager implements IPageTranslationManager {
 
       this.isPageTranslating = true
       this.translationSessionVersion += 1
-      beginPageTranslationSession(
-        window === window.top
+
+      const promptExperimentAction =
+        window === window.top &&
+        trackedContext &&
+        trackedContext.surface !== ANALYTICS_SURFACE.PAGE_AUTO
           ? {
               feature: TRANSLATION_REQUESTED_FEATURE.PAGE_TRANSLATION,
-              surface: trackedContext?.surface ?? ANALYTICS_SURFACE.PAGE_AUTO,
+              surface: trackedContext.surface,
             }
-          : undefined,
-      )
+          : undefined
+
+      beginPageTranslationSession(promptExperimentAction)
 
       const siteRule = getEffectiveSiteRule(config, window.location.href)
       if (siteRule.injectedCss) {

--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx
@@ -2,6 +2,7 @@ import type { Hotkey } from "@tanstack/hotkeys"
 import type { ReactNode } from "react"
 import type { SelectionSession, SelectionToolbarTranslateRequestSlice } from "../atoms"
 import type { SelectionToolbarInlineError } from "../inline-error"
+import type { TranslationActionContext } from "@/types/analytics"
 import type { BackgroundTextStreamSnapshot, ThinkingSnapshot } from "@/types/background-stream"
 import type { LLMProviderConfig, ProviderConfig } from "@/types/config/provider"
 import { LANG_CODE_TO_EN_NAME } from "@read-frog/definitions"
@@ -19,9 +20,18 @@ import {
 } from "react"
 import { toastManager } from "@/components/ui/base-ui/toast"
 import { SelectionPopover } from "@/components/ui/selection-popover"
-import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
+import {
+  ANALYTICS_FEATURE,
+  ANALYTICS_SURFACE,
+  TRANSLATION_REQUESTED_FEATURE,
+} from "@/types/analytics"
 import { isLLMProviderConfig, isTranslateProviderConfig } from "@/types/config/provider"
-import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
+import {
+  classifyTranslationRequest,
+  createFeatureUsageContext,
+  trackFeatureUsed,
+  trackTranslationRequested,
+} from "@/utils/analytics"
 import { configFieldsAtomMap, writeConfigAtom } from "@/utils/atoms/config"
 import { buildFeatureProviderPatch } from "@/utils/constants/feature-providers"
 import { streamBackgroundText } from "@/utils/content-script/background-stream-client"
@@ -29,7 +39,7 @@ import { prepareTranslationText } from "@/utils/host/translate/text-preparation"
 import { translateTextCore } from "@/utils/host/translate/translate-text"
 import { getOrCreateWebPageContext } from "@/utils/host/translate/webpage-context"
 import { getOrGenerateWebPageSummary } from "@/utils/host/translate/webpage-summary"
-import { onMessage } from "@/utils/message"
+import { onMessage, sendMessage } from "@/utils/message"
 import {
   isPageTranslationShortcutEmpty,
   isValidConfiguredPageTranslationShortcut,
@@ -98,6 +108,7 @@ async function translateWithTextStream({
   translateRequest,
   onChunk,
   registerAbortController,
+  actionContext,
 }: {
   preparedText: string
   providerId: string
@@ -105,6 +116,7 @@ async function translateWithTextStream({
   translateRequest: SelectionToolbarTranslateRequestSlice
   onChunk: (data: BackgroundTextStreamSnapshot) => void
   registerAbortController: (abortController: AbortController) => void
+  actionContext: TranslationActionContext
 }) {
   const targetLangName = LANG_CODE_TO_EN_NAME[translateRequest.language.targetCode]
   const modelName = resolveModelId(providerConfig.model)
@@ -130,21 +142,55 @@ async function translateWithTextStream({
     translateRequest.enableAIContentAware,
   )
   throwIfAborted()
-  const { systemPrompt, prompt } = getTranslatePromptFromConfig(
+  const configuredPrompt =
+    translateRequest.customPromptsConfig.promptId === null ? "default" : "custom"
+  const promptExperimentVariant =
+    (await sendMessage("resolvePromptExperimentVariant", { configuredPrompt })) ?? undefined
+  throwIfAborted()
+
+  let { systemPrompt, prompt } = getTranslatePromptFromConfig(
     { customPromptsConfig: translateRequest.customPromptsConfig },
     targetLangName,
     preparedText,
-    webPageContext
-      ? {
-          context: {
-            webTitle: webPageContext.webTitle,
-            webDescription: webPageContext.webDescription,
-            webContent: webPageContext.webContent,
-            webSummary: webPageContext.webSummary,
-          },
-        }
-      : undefined,
+    {
+      promptExperimentVariant,
+      ...(webPageContext
+        ? {
+            context: {
+              webTitle: webPageContext.webTitle,
+              webDescription: webPageContext.webDescription,
+              webContent: webPageContext.webContent,
+              webSummary: webPageContext.webSummary,
+            },
+          }
+        : {}),
+    },
   )
+
+  if (promptExperimentVariant) {
+    const exposed = await sendMessage("exposePromptExperiment", {
+      actionContext,
+      expectedVariant: promptExperimentVariant,
+    })
+    throwIfAborted()
+    if (!exposed) {
+      ;({ systemPrompt, prompt } = getTranslatePromptFromConfig(
+        { customPromptsConfig: translateRequest.customPromptsConfig },
+        targetLangName,
+        preparedText,
+        webPageContext
+          ? {
+              context: {
+                webTitle: webPageContext.webTitle,
+                webDescription: webPageContext.webDescription,
+                webContent: webPageContext.webContent,
+                webSummary: webPageContext.webSummary,
+              },
+            }
+          : undefined,
+      ))
+    }
+  }
 
   const translatedText = await streamBackgroundText(
     {
@@ -333,6 +379,22 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
         ANALYTICS_FEATURE.SELECTION_TRANSLATION,
         sourceSurface,
       )
+      const actionContext: TranslationActionContext = {
+        actionId: `selection-${activeSession?.id ?? "unknown"}-${runId}`,
+        feature: TRANSLATION_REQUESTED_FEATURE.SELECTION_TRANSLATION,
+        surface: sourceSurface,
+      }
+
+      const requestedProvider =
+        translateRequest.provider?.kind === "local" ? translateRequest.provider.config : null
+      const translationRequestedPromise = trackTranslationRequested({
+        feature: TRANSLATION_REQUESTED_FEATURE.SELECTION_TRANSLATION,
+        surface: sourceSurface,
+        ...classifyTranslationRequest(
+          requestedProvider,
+          translateRequest.customPromptsConfig.promptId,
+        ),
+      })
 
       setIsTranslating(true)
       setTranslatedText(undefined)
@@ -392,6 +454,7 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
 
         let nextTranslatedText = ""
         if (isLLMProviderConfig(providerConfig)) {
+          await translationRequestedPromise
           setThinking({
             status: "thinking",
             text: "",
@@ -411,6 +474,7 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
             registerAbortController: (abortController) => {
               abortControllerRef.current = abortController
             },
+            actionContext,
           })
 
           nextTranslatedText = nextSnapshot.output
@@ -447,13 +511,18 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
           })
         }
       } finally {
+        void Promise.resolve(
+          sendMessage("clearPromptExperimentAction", {
+            actionId: actionContext.actionId,
+          }),
+        ).catch(() => undefined)
         if (runIdRef.current === runId) {
           abortControllerRef.current = null
           setIsTranslating(false)
         }
       }
     },
-    [resetTranslationState, selectionText, sourceSurface, translateRequest],
+    [activeSession?.id, resetTranslationState, selectionText, sourceSurface, translateRequest],
   )
 
   const startTranslation = useEffectEvent((runId: number) => {

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -48,3 +48,69 @@ export interface FeatureUsedEventProperties {
   action_id?: string
   action_name?: string
 }
+
+export const TRANSLATION_REQUESTED_FEATURE = {
+  PAGE_TRANSLATION: "page_translation",
+  HOVER_TRANSLATION: "hover_translation",
+  SELECTION_TRANSLATION: "selection_translation",
+} as const
+
+export type TranslationRequestedFeature =
+  (typeof TRANSLATION_REQUESTED_FEATURE)[keyof typeof TRANSLATION_REQUESTED_FEATURE]
+
+export type TranslationBackendKind = "llm" | "non_llm" | "unknown"
+export type TranslationConfiguredPrompt = "default" | "custom" | "not_applicable" | "unknown"
+export type PromptExposureAge = "not_exposed" | "lt_24h" | "d1_d7" | "gt_7d"
+
+export const PROMPT_EXPERIMENT_COHORT = "new_user_prompt_experiment_v1"
+
+export const PROMPT_EXPERIMENT_VARIANTS = [
+  "control",
+  "rewrite-after-understanding",
+  "precision-rewrite",
+  "expressive-translation-master",
+] as const
+
+export type PromptExperimentVariant = (typeof PROMPT_EXPERIMENT_VARIANTS)[number]
+
+export type PromptExperimentExcludedReason =
+  | "analytics_disabled"
+  | "flag_unavailable"
+  | "invalid_variant"
+  | "custom_prompt_used"
+
+export interface PromptExperimentCohort {
+  cohort: typeof PROMPT_EXPERIMENT_COHORT
+  installedAt: number
+  installVersion: string
+  excludedReason?: PromptExperimentExcludedReason
+  firstPromptExposureAt?: number
+}
+
+export interface TranslationActionContext {
+  actionId: string
+  feature: TranslationRequestedFeature
+  surface: AnalyticsSurface
+}
+
+export interface TranslationRequestedProperties {
+  feature: TranslationRequestedFeature
+  surface: AnalyticsSurface
+  backend_kind: TranslationBackendKind
+  configured_prompt: TranslationConfiguredPrompt
+  cohort: typeof PROMPT_EXPERIMENT_COHORT
+  prompt_exposure_age: PromptExposureAge
+}
+
+export type TranslationRequestedInput = Pick<
+  TranslationRequestedProperties,
+  "feature" | "surface" | "backend_kind" | "configured_prompt"
+>
+
+export interface TranslationPromptUsedProperties {
+  feature: TranslationRequestedFeature
+  surface: AnalyticsSurface
+  action_id: string
+  cohort: typeof PROMPT_EXPERIMENT_COHORT
+  prompt_exposure_age: PromptExposureAge
+}

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -3,7 +3,13 @@ import type {
   AnalyticsSurface,
   FeatureUsageContext,
   FeatureUsedEventProperties,
+  TranslationBackendKind,
+  TranslationConfiguredPrompt,
+  TranslationRequestedFeature,
+  TranslationRequestedInput,
 } from "@/types/analytics"
+import type { ProviderConfig } from "@/types/config/provider"
+import { isLLMProviderConfig } from "@/types/config/provider"
 import { ANALYTICS_FEATURE_USED_EVENT } from "@/utils/constants/analytics"
 import { logger } from "@/utils/logger"
 import { sendMessage } from "@/utils/message"
@@ -56,6 +62,45 @@ export async function trackFeatureUsed(input: FeatureUsedEventInput): Promise<vo
   } catch (error) {
     if (typeof logger.warn === "function") {
       logger.warn(`[Analytics] Failed to track ${ANALYTICS_FEATURE_USED_EVENT}`, error)
+    }
+  }
+}
+
+export function classifyTranslationRequest(
+  providerConfig: ProviderConfig | null | undefined,
+  promptId: string | null | undefined,
+): Pick<TranslationRequestedInput, "backend_kind" | "configured_prompt"> {
+  if (!providerConfig) {
+    return {
+      backend_kind: "unknown",
+      configured_prompt: "unknown",
+    }
+  }
+
+  if (!isLLMProviderConfig(providerConfig)) {
+    return {
+      backend_kind: "non_llm",
+      configured_prompt: "not_applicable",
+    }
+  }
+
+  return {
+    backend_kind: "llm",
+    configured_prompt: promptId === null ? "default" : "custom",
+  }
+}
+
+export async function trackTranslationRequested(input: {
+  feature: TranslationRequestedFeature
+  surface: AnalyticsSurface
+  backend_kind: TranslationBackendKind
+  configured_prompt: TranslationConfiguredPrompt
+}): Promise<void> {
+  try {
+    await sendMessage("trackTranslationRequestedEvent", input)
+  } catch (error) {
+    if (typeof logger.warn === "function") {
+      logger.warn("[Analytics] Failed to track translation_requested", error)
     }
   }
 }

--- a/src/utils/constants/analytics.ts
+++ b/src/utils/constants/analytics.ts
@@ -1,6 +1,11 @@
 export const ANALYTICS_ENABLED_STORAGE_KEY = "analyticsEnabled"
 export const ANALYTICS_INSTALL_ID_STORAGE_KEY = "analyticsInstallId"
 export const ANALYTICS_FEATURE_USED_EVENT = "feature_used"
+export const ANALYTICS_TRANSLATION_REQUESTED_EVENT = "translation_requested"
+export const ANALYTICS_TRANSLATION_PROMPT_USED_EVENT = "translation_prompt_used"
+export const PROMPT_EXPERIMENT_COHORT_STORAGE_KEY = "promptExperimentCohortV1"
+export const PROMPT_EXPERIMENT_FLAG_KEY = "new-user-default-translate-prompt-v1"
+export const PROMPT_EXPERIMENT_FLAG_WAIT_MS = 500
 
 export function getDefaultAnalyticsEnabled(browser = import.meta.env.BROWSER): boolean {
   return browser !== "firefox"

--- a/src/utils/host/__tests__/translate-text.test.tsx
+++ b/src/utils/host/__tests__/translate-text.test.tsx
@@ -5,6 +5,7 @@ import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { NO_TRANSLATION_SENTINEL } from "@/utils/constants/prompt"
 import { detectLanguage } from "@/utils/content/language"
 import { executeTranslate } from "@/utils/host/translate/execute-translate"
+import { translateTextCore } from "@/utils/host/translate/translate-text"
 import {
   translateTextForInput,
   translateTextForPage,
@@ -16,6 +17,8 @@ import {
 } from "@/utils/host/translate/translation-session"
 import { getTranslatePrompt } from "@/utils/prompts/translate"
 import { isTranslationCancelledError } from "@/utils/request/cancellation"
+
+type TranslatePromptOptions = NonNullable<Parameters<typeof getTranslatePrompt>[2]>
 
 // Mock dependencies
 vi.mock("@/utils/config/storage", () => ({
@@ -120,6 +123,98 @@ describe("translate-text", () => {
   })
 
   describe("translateTextForPage", () => {
+    it("rebuilds the variant-specific prompt hash when background flags changed", async () => {
+      const llmProvider = DEFAULT_CONFIG.providersConfig.find(
+        (provider) => provider.provider === "openai",
+      )!
+      mockGetTranslatePrompt.mockImplementation(
+        async (_target: string, _input: string, options: TranslatePromptOptions) => ({
+          systemPrompt: `system:${options.promptExperimentVariant ?? "control"}`,
+          prompt: `prompt:${options.promptExperimentVariant ?? "control"}`,
+        }),
+      )
+      let enqueueCount = 0
+      mockSendMessage.mockImplementation(async (type: string) => {
+        if (type === "resolvePromptExperimentVariant") return "precision-rewrite"
+        enqueueCount += 1
+        return enqueueCount === 1
+          ? { retryWithPromptExperimentVariant: "rewrite-after-understanding" }
+          : "translated text"
+      })
+
+      await expect(
+        translateTextCore({
+          text: "hello",
+          langConfig: DEFAULT_CONFIG.language,
+          providerConfig: llmProvider,
+          configuredPrompt: "default",
+          translationActionContext: {
+            actionId: "action-1",
+            feature: "page_translation",
+            surface: "popup",
+          },
+        }),
+      ).resolves.toBe("translated text")
+
+      expect(
+        mockSendMessage.mock.calls.filter(
+          ([type]: [string]) => type === "resolvePromptExperimentVariant",
+        ),
+      ).toHaveLength(1)
+      const enqueueCalls = mockSendMessage.mock.calls.filter(
+        ([type]: [string]) => type === "enqueueTranslateRequest",
+      )
+      expect(enqueueCalls).toHaveLength(2)
+      expect(enqueueCalls[0][1].promptExperimentVariant).toBe("precision-rewrite")
+      expect(enqueueCalls[1][1].promptExperimentVariant).toBe("rewrite-after-understanding")
+      expect(enqueueCalls[0][1].hash).not.toBe(enqueueCalls[1][1].hash)
+    })
+
+    it("rebuilds the current default prompt hash when the experiment becomes unavailable", async () => {
+      const llmProvider = DEFAULT_CONFIG.providersConfig.find(
+        (provider) => provider.provider === "openai",
+      )!
+      mockGetTranslatePrompt.mockImplementation(
+        async (_target: string, _input: string, options: TranslatePromptOptions) => ({
+          systemPrompt: `system:${options.promptExperimentVariant ?? "control"}`,
+          prompt: `prompt:${options.promptExperimentVariant ?? "control"}`,
+        }),
+      )
+      let enqueueCount = 0
+      mockSendMessage.mockImplementation(async (type: string) => {
+        if (type === "resolvePromptExperimentVariant") return "precision-rewrite"
+        enqueueCount += 1
+        return enqueueCount === 1 ? { retryWithoutPromptExperiment: true } : "translated text"
+      })
+
+      await expect(
+        translateTextCore({
+          text: "hello",
+          langConfig: DEFAULT_CONFIG.language,
+          providerConfig: llmProvider,
+          configuredPrompt: "default",
+          translationActionContext: {
+            actionId: "action-1",
+            feature: "page_translation",
+            surface: "popup",
+          },
+        }),
+      ).resolves.toBe("translated text")
+
+      expect(
+        mockSendMessage.mock.calls.filter(
+          ([type]: [string]) => type === "resolvePromptExperimentVariant",
+        ),
+      ).toHaveLength(1)
+      const enqueueCalls = mockSendMessage.mock.calls.filter(
+        ([type]: [string]) => type === "enqueueTranslateRequest",
+      )
+      expect(enqueueCalls).toHaveLength(2)
+      expect(enqueueCalls[0][1].promptExperimentVariant).toBe("precision-rewrite")
+      expect(enqueueCalls[1][1].promptExperimentVariant).toBeUndefined()
+      expect(enqueueCalls[0][1].hash).not.toBe(enqueueCalls[1][1].hash)
+    })
+
     it("should send message with correct parameters", async () => {
       mockSendMessage.mockResolvedValue("translated text")
 

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -1,3 +1,4 @@
+import type { TranslationActionContext } from "@/types/analytics"
 import type { Config } from "@/types/config/config"
 import type { TranslationMode } from "@/types/config/translate"
 import type { TransNode } from "@/types/dom"
@@ -78,6 +79,16 @@ interface DeepLXHtmlAttributeProbe {
   resolve: (result: DeepLXHtmlAttributeProbeResult) => void
 }
 const deepLXHtmlAttributeProbes = new Map<string, DeepLXHtmlAttributeProbe>()
+
+function translateTextForAction(
+  text: string,
+  textFormat: "plain" | "html",
+  actionContext?: TranslationActionContext,
+): Promise<string> {
+  return actionContext
+    ? translateTextForPage(text, textFormat, actionContext)
+    : translateTextForPage(text, textFormat)
+}
 
 function createDeepLXHtmlAttributeProbe(): DeepLXHtmlAttributeProbe {
   let resolve!: (result: DeepLXHtmlAttributeProbeResult) => void
@@ -183,6 +194,7 @@ async function translateVirtualParagraph(
   nodes: ChildNode[],
   config: Config,
   forceBlockTranslation: boolean,
+  actionContext?: TranslationActionContext,
 ): Promise<void> {
   const { flowSource, unit, wrapper } = entry
   const isCurrent = () => isVirtualParagraphGroupCurrent(group, wrapper)
@@ -194,6 +206,8 @@ async function translateVirtualParagraph(
     spinner,
     wrapper,
     isCurrent,
+    "plain",
+    actionContext ? () => translateTextForPage(unit.text, "plain", actionContext) : undefined,
   )
   if (!isCurrent()) {
     disposeVirtualParagraphGroup(group)
@@ -231,6 +245,7 @@ async function translateVirtualParagraphs(
   walkId: string,
   config: Config,
   forceBlockTranslation: boolean,
+  actionContext?: TranslationActionContext,
 ): Promise<void> {
   const group: VirtualParagraphGroup = {
     id: `${walkId}:${virtualParagraphGroupSequence++}`,
@@ -303,6 +318,7 @@ async function translateVirtualParagraphs(
         nodes,
         config,
         forceBlockTranslation,
+        actionContext,
       ),
     ),
   )
@@ -314,12 +330,20 @@ export async function translateNodes(
   toggle: boolean = false,
   config: Config,
   forceBlockTranslation: boolean = false,
+  actionContext?: TranslationActionContext,
 ): Promise<void> {
   const translationMode = config.translate.mode
   if (translationMode === "translationOnly") {
-    await translateNodeTranslationOnlyMode(nodes, walkId, config, toggle)
+    await translateNodeTranslationOnlyMode(nodes, walkId, config, toggle, actionContext)
   } else if (translationMode === "bilingual") {
-    await translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
+    await translateNodesBilingualMode(
+      nodes,
+      walkId,
+      config,
+      toggle,
+      forceBlockTranslation,
+      actionContext,
+    )
   }
 }
 
@@ -329,6 +353,7 @@ export async function translateNodesBilingualMode(
   config: Config,
   toggle: boolean = false,
   forceBlockTranslation: boolean = false,
+  actionContext?: TranslationActionContext,
 ): Promise<void> {
   const transNodes = nodes.filter((node) => isTransNode(node))
   if (transNodes.length === 0) {
@@ -397,6 +422,7 @@ export async function translateNodesBilingualMode(
           walkId,
           config,
           true,
+          actionContext,
         )
         return
       }
@@ -414,7 +440,14 @@ export async function translateNodesBilingualMode(
         return
       }
       nodes.forEach((node) => translatingNodes.delete(node))
-      return translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
+      return translateNodesBilingualMode(
+        nodes,
+        walkId,
+        config,
+        toggle,
+        forceBlockTranslation,
+        actionContext,
+      )
     }
 
     // After a translationOnly session, an in-place-swapped paragraph has no
@@ -471,7 +504,14 @@ export async function translateNodesBilingualMode(
       unregisterBilingualTranslationState(bilingualState)
       if (shouldRetry) {
         nodes.forEach((node) => translatingNodes.delete(node))
-        return translateNodesBilingualMode(nodes, walkId, config, toggle, forceBlockTranslation)
+        return translateNodesBilingualMode(
+          nodes,
+          walkId,
+          config,
+          toggle,
+          forceBlockTranslation,
+          actionContext,
+        )
       }
       return
     }
@@ -529,6 +569,8 @@ export async function translateNodesBilingualMode(
       spinner,
       translatedWrapperNode,
       isCurrent,
+      "plain",
+      actionContext ? () => translateTextForPage(textContent, "plain", actionContext) : undefined,
     )
 
     if (!isCurrent()) {
@@ -595,6 +637,7 @@ export async function translateNodeTranslationOnlyMode(
   walkId: string,
   config: Config,
   toggle: boolean = false,
+  actionContext?: TranslationActionContext,
 ): Promise<void> {
   const isTransNodeAndNotTranslatedWrapper = (node: Node): node is TransNode => {
     if (isHTMLElement(node) && node.classList.contains(CONTENT_WRAPPER_CLASS)) return false
@@ -637,7 +680,7 @@ export async function translateNodeTranslationOnlyMode(
     if (!toggle) {
       const retryNodes = restored.filter((node) => node.isConnected)
       if (retryNodes.length > 0) {
-        void translateNodeTranslationOnlyMode(retryNodes, walkId, config, toggle)
+        void translateNodeTranslationOnlyMode(retryNodes, walkId, config, toggle, actionContext)
       }
     }
     return
@@ -698,7 +741,7 @@ export async function translateNodeTranslationOnlyMode(
         ? nodes
         : restoredNodes.filter((node) => node.isConnected)
       if (retryNodes.length > 0) {
-        void translateNodeTranslationOnlyMode(retryNodes, walkId, config, toggle)
+        void translateNodeTranslationOnlyMode(retryNodes, walkId, config, toggle, actionContext)
       }
       return
     }
@@ -752,7 +795,11 @@ export async function translateNodeTranslationOnlyMode(
     // its tags intact.
     const deepLXProviderKey = getDeepLXHtmlAttributeProviderKey(config)
     const translateLegacyHtml = async () => {
-      const translatedHtml = await translateTextForPage(protectedHtml.legacyRequestHtml, "html")
+      const translatedHtml = await translateTextForAction(
+        protectedHtml.legacyRequestHtml,
+        "html",
+        actionContext,
+      )
       return translatedHtml ? protectedHtml.restoreLegacy(translatedHtml) : translatedHtml
     }
     const translateRequest = async () => {
@@ -766,7 +813,11 @@ export async function translateNodeTranslationOnlyMode(
       }
 
       try {
-        const translatedHtml = await translateTextForPage(protectedHtml.requestHtml, "html")
+        const translatedHtml = await translateTextForAction(
+          protectedHtml.requestHtml,
+          "html",
+          actionContext,
+        )
         if (!translatedHtml) {
           if (deepLXProviderKey) {
             finishDeepLXHtmlAttributeProbe(deepLXProviderKey, ownedDeepLXProbe, "unknown")

--- a/src/utils/host/translate/core/translation-walker.ts
+++ b/src/utils/host/translate/core/translation-walker.ts
@@ -1,3 +1,4 @@
+import type { TranslationActionContext } from "@/types/analytics"
 import type { Config } from "@/types/config/config"
 import type { WorkPacer } from "@/utils/scheduler"
 import { createWorkPacer, pauseIfBudgetSpent } from "@/utils/scheduler"
@@ -42,6 +43,7 @@ export async function translateWalkedElement(
   // so without this the walk keeps inserting wrappers/spinners into the page
   // the user just cleared (#1881).
   shouldContinue: () => boolean = () => true,
+  actionContext?: TranslationActionContext,
 ): Promise<void> {
   // Self-pacing: a giant observed subtree (a flat article can label as ONE
   // huge paragraph unit, #1881) must not expand into thousands of wrapper
@@ -78,7 +80,7 @@ export async function translateWalkedElement(
     const isFlexParent = computedStyle.display.includes("flex")
 
     if (!hasBlockNodeChild) {
-      promises.push(translateNodes([element], walkId, toggle, config))
+      promises.push(translateNodes([element], walkId, toggle, config, false, actionContext))
     } else {
       // prevent children change during iteration
       const children = [...element.childNodes]
@@ -87,11 +89,26 @@ export async function translateWalkedElement(
         if (isTransNode(child) && isBlockTransNode(child) && !isTextNode(child)) {
           // force the children to be block translation style unless the parent is a flex parent
           promises.push(
-            translateNodes(consecutiveInlineNodes, walkId, toggle, config, !isFlexParent),
+            translateNodes(
+              consecutiveInlineNodes,
+              walkId,
+              toggle,
+              config,
+              !isFlexParent,
+              actionContext,
+            ),
           )
           consecutiveInlineNodes = []
           promises.push(
-            translateWalkedElement(child, walkId, config, toggle, pacer, shouldContinue),
+            translateWalkedElement(
+              child,
+              walkId,
+              config,
+              toggle,
+              pacer,
+              shouldContinue,
+              actionContext,
+            ),
           )
         } else {
           consecutiveInlineNodes.push(child)
@@ -99,20 +116,47 @@ export async function translateWalkedElement(
       }
 
       if (consecutiveInlineNodes.length) {
-        promises.push(translateNodes(consecutiveInlineNodes, walkId, toggle, config, !isFlexParent))
+        promises.push(
+          translateNodes(
+            consecutiveInlineNodes,
+            walkId,
+            toggle,
+            config,
+            !isFlexParent,
+            actionContext,
+          ),
+        )
       }
     }
   } else {
     for (const child of element.childNodes) {
       if (isHTMLElement(child)) {
-        promises.push(translateWalkedElement(child, walkId, config, toggle, pacer, shouldContinue))
+        promises.push(
+          translateWalkedElement(
+            child,
+            walkId,
+            config,
+            toggle,
+            pacer,
+            shouldContinue,
+            actionContext,
+          ),
+        )
       }
     }
     if (element.shadowRoot) {
       for (const child of element.shadowRoot.children) {
         if (isHTMLElement(child)) {
           promises.push(
-            translateWalkedElement(child, walkId, config, toggle, pacer, shouldContinue),
+            translateWalkedElement(
+              child,
+              walkId,
+              config,
+              toggle,
+              pacer,
+              shouldContinue,
+              actionContext,
+            ),
           )
         }
       }

--- a/src/utils/host/translate/node-manipulation.ts
+++ b/src/utils/host/translate/node-manipulation.ts
@@ -1,6 +1,11 @@
+import type { AnalyticsSurface, TranslationActionContext } from "@/types/analytics"
 import type { Config } from "@/types/config/config"
 import type { Point } from "@/types/dom"
+import { ANALYTICS_SURFACE, TRANSLATION_REQUESTED_FEATURE } from "@/types/analytics"
+import { classifyTranslationRequest, trackTranslationRequested } from "@/utils/analytics"
+import { resolveProviderConfigOrNull } from "@/utils/constants/feature-providers"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
+import { sendMessage } from "@/utils/message"
 import { isHTMLElement } from "../dom/filter"
 import { findNearestAncestorBlockNodeAt } from "../dom/find"
 import { walkAndLabelElement } from "../dom/traversal"
@@ -17,10 +22,35 @@ export { translateWalkedElement } from "./core/translation-walker"
 export { removeAllTranslatedWrapperNodes } from "./dom/translation-cleanup"
 
 // High-level orchestration function
-export async function removeOrShowNodeTranslation(point: Point, config: Config): Promise<boolean> {
+export async function removeOrShowNodeTranslation(
+  point: Point,
+  config: Config,
+  surface?: AnalyticsSurface,
+): Promise<boolean> {
   const node = findNearestAncestorBlockNodeAt(point)
 
   if (!node || !isHTMLElement(node)) return false
+
+  const id = getRandomUUID()
+  const analyticsSurface =
+    surface ??
+    (config.translate.node.hotkey === "clickAndHold"
+      ? ANALYTICS_SURFACE.TOUCH_GESTURE
+      : ANALYTICS_SURFACE.SHORTCUT)
+  const actionContext: TranslationActionContext = {
+    actionId: id,
+    feature: TRANSLATION_REQUESTED_FEATURE.HOVER_TRANSLATION,
+    surface: analyticsSurface,
+  }
+
+  await trackTranslationRequested({
+    feature: TRANSLATION_REQUESTED_FEATURE.HOVER_TRANSLATION,
+    surface: analyticsSurface,
+    ...classifyTranslationRequest(
+      resolveProviderConfigOrNull(config, "translate"),
+      config.translate.customPromptsConfig.promptId,
+    ),
+  })
 
   if (
     !validateTranslationConfigAndToast({
@@ -32,8 +62,13 @@ export async function removeOrShowNodeTranslation(point: Point, config: Config):
     return false
   }
 
-  const id = getRandomUUID()
   walkAndLabelElement(node, id, config)
-  await translateWalkedElement(node, id, config, true)
+  try {
+    await translateWalkedElement(node, id, config, true, undefined, undefined, actionContext)
+  } finally {
+    void Promise.resolve(sendMessage("clearPromptExperimentAction", { actionId: id })).catch(
+      () => undefined,
+    )
+  }
   return true
 }

--- a/src/utils/host/translate/translate-text.ts
+++ b/src/utils/host/translate/translate-text.ts
@@ -1,4 +1,9 @@
 import type { LangCodeISO6393, LangLevel } from "@read-frog/definitions"
+import type {
+  PromptExperimentVariant,
+  TranslationActionContext,
+  TranslationConfiguredPrompt,
+} from "@/types/analytics"
 import type { Config } from "@/types/config/config"
 import type { ProviderConfig } from "@/types/config/provider"
 import type { TranslationTextFormat } from "@/types/config/translate"
@@ -16,7 +21,7 @@ import { TranslationCancelledError } from "@/utils/request/cancellation"
 import { Sha256Hex } from "../../hash"
 import { sendMessage } from "../../message"
 import { prepareTranslationText } from "./text-preparation"
-import { getPageTranslationSessionId } from "./translation-session"
+import { getPageTranslationActionContext, getPageTranslationSessionId } from "./translation-session"
 
 // Minimum text length for skip language detection (shorter than general detection
 // to catch short phrases like "Bonjour!" or "こんにちは")
@@ -78,6 +83,7 @@ async function buildWebPageHashComponents(
   enableAIContentAware: boolean,
   textFormat: TranslationTextFormat,
   webPageContext?: WebPagePromptContext,
+  promptExperimentVariant?: PromptExperimentVariant,
 ): Promise<string[]> {
   const preparedText = prepareTranslationText(text)
   const normalizedWebPageContext = normalizeWebPagePromptContext(webPageContext)
@@ -100,6 +106,7 @@ async function buildWebPageHashComponents(
   const { systemPrompt, prompt } = await getTranslatePrompt(targetLangName, preparedText, {
     isBatch: true,
     context: normalizedWebPageContext,
+    promptExperimentVariant,
   })
   hashComponents.push(systemPrompt, prompt)
   hashComponents.push(
@@ -140,6 +147,12 @@ export interface TranslateTextOptions {
   // Page-translation session id used for cancellation scoping. Deliberately
   // NOT part of the cache hash — cache identity must not vary per session.
   sessionId?: string
+  configuredPrompt?: TranslationConfiguredPrompt
+  translationActionContext?: TranslationActionContext
+  /** Internal retry state after the background observes a newer flag value. */
+  promptExperimentVariant?: PromptExperimentVariant
+  promptExperimentRetryCount?: number
+  skipPromptExperimentResolution?: boolean
 }
 
 /**
@@ -156,6 +169,11 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     webPageContext,
     textFormat = "plain",
     sessionId,
+    configuredPrompt,
+    translationActionContext = getPageTranslationActionContext() ?? undefined,
+    promptExperimentVariant: forcedPromptExperimentVariant,
+    promptExperimentRetryCount = 0,
+    skipPromptExperimentResolution = false,
   } = options
 
   const preparedText = prepareTranslationText(text)
@@ -165,6 +183,20 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
 
   const normalizedWebPageContext = normalizeWebPagePromptContext(webPageContext)
 
+  let promptExperimentVariant = forcedPromptExperimentVariant
+  if (
+    isLLMProviderConfig(providerConfig) &&
+    translationActionContext &&
+    configuredPrompt &&
+    !skipPromptExperimentResolution &&
+    promptExperimentVariant === undefined
+  ) {
+    promptExperimentVariant =
+      (await sendMessage("resolvePromptExperimentVariant", {
+        configuredPrompt,
+      })) ?? undefined
+  }
+
   const hashComponents = await buildWebPageHashComponents(
     preparedText,
     providerConfig,
@@ -172,6 +204,7 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     enableAIContentAware,
     textFormat,
     normalizedWebPageContext,
+    promptExperimentVariant,
   )
 
   // Add extra hash tags for cache differentiation
@@ -200,7 +233,27 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     webContent: normalizedWebPageContext?.webContent,
     webSummary: normalizedWebPageContext?.webSummary,
     sessionId,
+    promptExperimentVariant,
+    translationActionContext,
   })
+  if (typeof result !== "string") {
+    if (promptExperimentRetryCount >= 2) {
+      throw new Error("Prompt experiment variant changed repeatedly during one request")
+    }
+    if ("retryWithoutPromptExperiment" in result) {
+      return translateTextCore({
+        ...options,
+        promptExperimentVariant: undefined,
+        promptExperimentRetryCount: promptExperimentRetryCount + 1,
+        skipPromptExperimentResolution: true,
+      })
+    }
+    return translateTextCore({
+      ...options,
+      promptExperimentVariant: result.retryWithPromptExperimentVariant,
+      promptExperimentRetryCount: promptExperimentRetryCount + 1,
+    })
+  }
   // The sentinel must be mapped here and only here: every batch-pipeline
   // consumer (page paragraphs, document title, input translation, selection
   // toolbar standard path) routes through this function and already handles

--- a/src/utils/host/translate/translate-variants.ts
+++ b/src/utils/host/translate/translate-variants.ts
@@ -1,4 +1,5 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
+import type { TranslationActionContext } from "@/types/analytics"
 import type { Config, InputTranslationLang } from "@/types/config/config"
 import type { TranslationTextFormat } from "@/types/config/translate"
 import { isLLMProviderConfig } from "@/types/config/provider"
@@ -67,6 +68,8 @@ async function translateTextUsingPageConfig(
     textFormat?: TranslationTextFormat
     // Session captured at pipeline entry by the caller; see translateTextForPage.
     sessionId?: string
+    configuredPrompt?: "default" | "custom"
+    translationActionContext?: TranslationActionContext
   } = {},
 ): Promise<string> {
   const preparedText = prepareTranslationText(text)
@@ -110,6 +113,8 @@ async function translateTextUsingPageConfig(
     webPageContext: options.webPageContext,
     textFormat: options.textFormat,
     sessionId: options.sessionId,
+    configuredPrompt: options.configuredPrompt,
+    translationActionContext: options.translationActionContext,
   })
 }
 
@@ -120,6 +125,7 @@ async function translateTextUsingPageConfig(
 export async function translateTextForPage(
   text: string,
   textFormat: TranslationTextFormat = "plain",
+  translationActionContext?: TranslationActionContext,
 ): Promise<string> {
   // Capture the session id synchronously at pipeline entry. Reading it later
   // (after the awaits below, e.g. the network-backed page summary) could see
@@ -138,6 +144,8 @@ export async function translateTextForPage(
     webPageContext,
     textFormat,
     sessionId,
+    configuredPrompt: config.translate.customPromptsConfig.promptId === null ? "default" : "custom",
+    translationActionContext,
   })
 }
 
@@ -162,6 +170,7 @@ export async function translateTextForPageTitle(text: string): Promise<string> {
       webSummary: webPageContext?.webSummary,
     },
     sessionId,
+    configuredPrompt: config.translate.customPromptsConfig.promptId === null ? "default" : "custom",
   })
 }
 

--- a/src/utils/host/translate/translation-session.ts
+++ b/src/utils/host/translate/translation-session.ts
@@ -1,3 +1,5 @@
+import type { TranslationActionContext } from "@/types/analytics"
+
 /**
  * Identity of the current page-translation session in this frame. Module
  * scope is correct: exactly one PageTranslationManager exists per frame.
@@ -13,22 +15,33 @@
  * (the background scopes by tab id + session id only).
  */
 let currentPageTranslationSessionId: string | null = null
+let currentPageTranslationActionContext: TranslationActionContext | null = null
 let sessionCounter = 0
 
-export function beginPageTranslationSession(): string {
+export function beginPageTranslationSession(
+  action?: Omit<TranslationActionContext, "actionId">,
+): string {
   sessionCounter += 1
   currentPageTranslationSessionId = `${Date.now().toString(36)}-${Math.random()
     .toString(36)
     .slice(2, 10)}-${sessionCounter}`
+  currentPageTranslationActionContext = action
+    ? { ...action, actionId: currentPageTranslationSessionId }
+    : null
   return currentPageTranslationSessionId
 }
 
 export function endPageTranslationSession(): string | null {
   const endedSessionId = currentPageTranslationSessionId
   currentPageTranslationSessionId = null
+  currentPageTranslationActionContext = null
   return endedSessionId
 }
 
 export function getPageTranslationSessionId(): string | null {
   return currentPageTranslationSessionId
+}
+
+export function getPageTranslationActionContext(): TranslationActionContext | null {
+  return currentPageTranslationActionContext
 }

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -1,6 +1,13 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { GuideDictionaryNotebaseCompletionInput } from "./guide/dictionary-notebase"
-import type { FeatureUsageContext, FeatureUsedEventProperties } from "@/types/analytics"
+import type {
+  FeatureUsageContext,
+  FeatureUsedEventProperties,
+  PromptExperimentVariant,
+  TranslationActionContext,
+  TranslationConfiguredPrompt,
+  TranslationRequestedInput,
+} from "@/types/analytics"
 import type {
   BackgroundGenerateTextPayload,
   BackgroundGenerateTextResponse,
@@ -82,6 +89,15 @@ interface ProtocolMap {
   readAloudSelectionFromContextMenu: (data: { selectionText: string }) => void
   // analytics
   trackFeatureUsedEvent: (data: FeatureUsedEventProperties) => void
+  trackTranslationRequestedEvent: (data: TranslationRequestedInput) => void
+  resolvePromptExperimentVariant: (data: {
+    configuredPrompt: TranslationConfiguredPrompt
+  }) => PromptExperimentVariant | null
+  exposePromptExperiment: (data: {
+    actionContext: TranslationActionContext
+    expectedVariant: PromptExperimentVariant
+  }) => boolean
+  clearPromptExperimentAction: (data: { actionId: string }) => void
   // user guide
   pinStateChanged: (data: { isPinned: boolean }) => void
   getPinState: () => boolean
@@ -104,7 +120,17 @@ interface ProtocolMap {
     // for cancelPageTranslationRequests. Absent for non-page requests
     // (input/selection translation), which are never cancellable.
     sessionId?: string
-  }) => Promise<string>
+    promptExperimentVariant?: PromptExperimentVariant
+    translationActionContext?: TranslationActionContext
+  }) => Promise<
+    | string
+    | {
+        retryWithPromptExperimentVariant: PromptExperimentVariant
+      }
+    | {
+        retryWithoutPromptExperiment: true
+      }
+  >
   // Drain queued/in-flight page-translation requests of one session (#1881).
   // The background composes the scope as `${sender.tab.id}:${sessionId}`, so a
   // tab can only ever cancel its own requests.

--- a/src/utils/prompts/__tests__/translate.test.ts
+++ b/src/utils/prompts/__tests__/translate.test.ts
@@ -86,6 +86,71 @@ describe("translate prompt tokens", () => {
     expect(result.prompt).toBe("Translate Hola to {{targetLang}}")
   })
 
+  it.each([
+    ["control", "You are a professional Japanese native translator"],
+    ["rewrite-after-understanding", "Cross-Cultural Content Reconstruction Specialist"],
+    ["precision-rewrite", "Elite Translator and Rewriting Expert"],
+    ["expressive-translation-master", "Master of Expressive Translation"],
+  ] as const)("uses the immutable %s default-prompt snapshot", (variant, marker) => {
+    const result = getTranslatePromptFromConfig(defaultTranslatePromptConfig, "Japanese", "Hello", {
+      promptExperimentVariant: variant,
+      context: {
+        webTitle: "Prompt test title",
+        webSummary: "Prompt test summary",
+      },
+    })
+
+    expect(result.systemPrompt).toContain(marker)
+    expect(result.systemPrompt).not.toContain("{{targetLang}}")
+    expect(result.systemPrompt).not.toContain("{{title}}")
+    expect(result.systemPrompt).not.toContain("{{summary}}")
+    expect(result.prompt).toContain("Hello")
+  })
+
+  it.each([
+    "control",
+    "rewrite-after-understanding",
+    "precision-rewrite",
+    "expressive-translation-master",
+  ] as const)("keeps the %s experiment prompt instructions in English", (variant) => {
+    const result = getTranslatePromptFromConfig(defaultTranslatePromptConfig, "French", "Hello", {
+      promptExperimentVariant: variant,
+      context: {
+        webTitle: "English-only prompt test",
+        webSummary: "English-only prompt summary",
+      },
+    })
+
+    expect(result.systemPrompt).not.toMatch(/\p{Script=Han}/u)
+    expect(result.prompt).not.toMatch(/\p{Script=Han}/u)
+  })
+
+  it("never applies an experiment snapshot to a selected custom prompt", () => {
+    const result = getTranslatePromptFromConfig(
+      {
+        customPromptsConfig: {
+          promptId: "mine",
+          patterns: [
+            {
+              id: "mine",
+              name: "Mine",
+              systemPrompt: "My custom system prompt",
+              prompt: "My custom prompt: {{input}}",
+            },
+          ],
+        },
+      },
+      "English",
+      "Hola",
+      { promptExperimentVariant: "expressive-translation-master" },
+    )
+
+    expect(result).toEqual({
+      systemPrompt: "My custom system prompt",
+      prompt: "My custom prompt: Hola",
+    })
+  })
+
   it("appends mandatory marker rules to the default system prompt", () => {
     const input = `<span ${HTML_ATTRIBUTE_MARKER}="0">Hello</span>`
 

--- a/src/utils/prompts/translate-experiment.ts
+++ b/src/utils/prompts/translate-experiment.ts
@@ -1,0 +1,143 @@
+import type { TranslatePromptResult } from "./translate"
+import type { PromptExperimentVariant } from "@/types/analytics"
+import { DEFAULT_TRANSLATE_PROMPT, DEFAULT_TRANSLATE_SYSTEM_PROMPT } from "@/utils/constants/prompt"
+
+/**
+ * English-localized experiment snapshots from GitHub Discussion #820 (captured 2026-07-18).
+ * Runtime prompt selection must never depend on GitHub or mutable community content.
+ * Community instructions were translated to English, and legacy variables were
+ * normalized to Read Frog's current prompt token names.
+ */
+const REWRITE_AFTER_UNDERSTANDING: TranslatePromptResult = {
+  systemPrompt: `# Role: Cross-Cultural Content Reconstruction Specialist
+You are a native-level expression specialist in {{targetLanguage}}. Your task is not merely to "translate," but to reconstruct the underlying logic.
+Regardless of the source language's grammatical structure—whether it uses inversion, long sentences, or a specialized honorific system—fully deconstruct it, extract the core intent, and re-express it in the way that feels most natural to a native {{targetLanguage}} speaker.
+
+## Core Directive: Prioritize Meaning over Form
+1.  Break Free from Source-Language Word Order:
+    *   Do not let source-language word order, such as Japanese SOV structure or English inversion, shape the translation.
+    *   Directly identify who did what and what consequence followed, then rearrange those elements according to the natural logic of {{targetLanguage}}.
+2.  Write Like a Human:
+    *   Eliminate translationese. Never produce rigid word-for-word translations. For example, do not mechanically reproduce constructions such as the Japanese "... no koto" ("the matter of ..."), and do not preserve unnecessarily complex clause structures from European languages.
+    *   Favor Verbs: Use concrete verbs instead of piling up abstract nouns.
+    *   Prefer Active Voice: Use active voice unless the passive is genuinely necessary. For example, rewrite "The error was detected by the system" as "The system detected the error."
+3.  Align Emotion and Context:
+    *   For forums or chats: Keep the tone natural, direct, and emotionally expressive—whether the speaker is complaining, joking, or delighted. Conversational phrasing is welcome.
+    *   For news or informational content: Be concise, objective, and information-dense.
+    *   For technical documentation: Maintain rigorous logic, precise terminology, and no ambiguity.
+
+## Prohibited Style Patterns
+*   Do not use stiff, mechanically translated connectors such as "at the time when...," "under...," or "as far as ... is concerned."
+*   Do not preserve redundant source-language modifiers, such as excessive Japanese honorifics or weak-verb constructions from English.
+*   Do not use generic AI filler such as "let us delve deeper" or "this marks a significant milestone." Replace it with concrete information.
+
+## Extension-Specific Technical Requirements
+1.  No Explanation: Output only the final translation. Do not add prefixes or suffixes such as "Translation:" or "The meaning is as follows:"
+2.  Preserve Format Anchors:
+    *   HTML Tags: Preserve every HTML tag from the source, such as <br>, <b>, or <span class="...">. Position each tag where it fits the translated sentence's logic; never misplace or delete it.
+    *   Symbols and Placeholders: Preserve variables such as %s and {name}, along with special brackets, numbering, and other structural symbols.
+3.  Do Not Translate:
+    *   Code blocks, command-line text, URLs, proper nouns without an established translation, and technical term IDs.
+
+## Internal Workflow
+1.  Read: Ignore the source language's surface grammar and identify the essential information.
+2.  Reconstruct: Imagine how a native {{targetLanguage}} speaker would express the same meaning in the same situation.
+3.  Output: Write the most idiomatic and concise version possible, leaving no trace of translationese.
+
+## Context
+Title: {{webTitle}}
+Summary: {{webSummary}}`,
+  prompt: `Translate to {{targetLanguage}}:
+
+{{input}}`,
+}
+
+const PRECISION_REWRITE: TranslatePromptResult = {
+  systemPrompt: `# Role: Elite Translator and Rewriting Expert
+You are a {{targetLanguage}} native expert who masters the philosophy of "Translation as Rewriting." Your task is not merely to translate words, but to recreate the text in an idiomatic, fluent, and publishable form that aligns with the thought patterns and conventions of the target language.
+## Core Strategies
+1.  **Meaning over Form, Hypotaxis to Parataxis**: Deeply understand the original logic. Break free from the source language's syntactic constraints. Reconstruct the content using short sentences and word order that feel natural in {{targetLanguage}}.
+2.  **Eradicate Translationese**: Proactively avoid Europeanized expressions such as overuse of passive voice, redundant conjunctions, and stacked abstract nouns. Strive for a style that reads as naturally as a native composition.
+3.  **Handle Terminology Precisely**: Use established, authoritative translations for academic terms. If none exist, retain the original term and provide a brief clarification. Process proper nouns according to standard, authoritative translations.
+4.  **Preserve Format & Untranslatables**: Fully retain the original formatting—paragraph structure, headings, lists, etc.—as well as elements like code, proper nouns, and other content that should not be translated.
+## Output Rules
+1.  **Output Translation Only**: Provide **only** the final translation/rewritten result. Do not include any explanatory text (e.g., "Here is the translation:").
+2.  **Strict Format Correspondence**: The translation must match the original exactly in terms of paragraph count, list items, and other formatting. Handle the placement of elements like HTML tags appropriately.
+3.  **Utilize Context**: Use the provided document metadata (Title, Summary) to ensure terminological consistency and contextual accuracy.
+## Execution Workflow (Three-Step Method)
+For each translation task, please follow this internal thought and execution process:
+1.  **Deep Comprehension & First Rewrite Draft**: Apply the strategies above to produce a fluent first draft liberated from the original structure.
+2.  **Self-Critique & Diagnosis**: Review the draft from a native speaker's perspective. List all issues identified, such as traces of "translationese," illogical flow, or inaccurate terminology.
+3.  **Polishing & Final Version**: Comprehensively optimize the text based on the diagnosis to produce the final, publication-ready version.
+## Document Metadata (For Context Awareness)
+Title: {{webTitle}}
+Summary: {{webSummary}}`,
+  prompt: `Translate to {{targetLanguage}}:
+{{input}}`,
+}
+
+const EXPRESSIVE_TRANSLATION_MASTER: TranslatePromptResult = {
+  systemPrompt: `## ROLE: Master of Expressive Translation & Cultural Adaptation
+
+### 1. Your Core Identity
+You are not a machine translator; you are a **Linguistic Artist** and a **Cultural Bridge**. Your purpose is to resurrect the soul, rhythm, and intent of the source text in fluent, natural, and elegant **{{targetLanguage}}**. You operate at the intersection of language, culture, and art, ensuring the final text feels as if it were originally crafted by a native master of **{{targetLanguage}}**.
+
+### 2. The Guiding Philosophy: The Triad of Faithfulness, Expressiveness, and Elegance
+This philosophy is your compass. It must guide every decision you make.
+- **Faithfulness to INTENT:** Your loyalty is to the original author's _intent_, not their literal words. Grasp the core message, the subtext, and the emotional undercurrent. If a literal translation is awkward or misses the point, you must abandon it in favor of a translation that faithfully conveys the intended meaning and feeling.
+- **Expressiveness & FLOW:** The translation must be exceptionally smooth and clear. It must flow beautifully in **{{targetLanguage}}**, free of any awkward phrasing or "translation-ese." The reader should never feel they are reading a translation.
+- **Elegance & CULTURAL ADAPTATION:** Elevate the text. Adapt its style, tone, and cultural references to resonate deeply with a **{{targetLanguage}}** audience.
+  - **Idioms & Slang:** Replace source-language idioms with their closest cultural equivalents in **{{targetLanguage}}**. Do not translate them literally.
+  - **Tone:** Masterfully replicate the original tone, whether it's humorous, formal, technical, or poetic.
+
+### 3. Context for Awareness & Nuance
+Use the following metadata to deeply understand the context, tone, and specific terminology required. This is not text to be translated, but information to guide your artistic choices.
+
+- **Title:** {{webTitle}}
+- **Summary:** {{webSummary}}
+
+### 4. CRUCIAL Execution Directives
+
+**1. Architectural Integrity:**
+- Preserve the exact paragraph breaks and formatting of the original text. The skeleton of the document is sacred.
+- When handling HTML tags, intelligently reposition them to ensure grammatical correctness and natural flow in **{{targetLanguage}}**, without breaking the layout.
+
+**2. Respect for Identity (Non-Translatables):**
+- The following items **MUST** remain in their original form. Do not translate them:
+- **Proper Nouns:** Brand names (e.g., "Apple," "Microsoft"), specific person/place names unless a widely accepted **{{targetLanguage}}** equivalent exists.
+- **Code & Technical Terms:** \`code_snippets\`, \`variableNames\`, specific technical jargon with no established translation.
+- **Arabic Numerals:** Digits like \`1, 2, 3, 100\` must be preserved.
+
+**3. Absolute Purity of Output:**
+- Your final delivery is the masterpiece itself. Provide **only** the translated text.
+- **DO NOT** include any introductory phrases, notes, or explanations like "Here is the translation:". Your response must begin with the first word of the translation and end with the last.
+
+Now, embody this persona and adapt the following text into **{{targetLanguage}}**:`,
+  prompt: `Now, fully embodying your role as a Master of Expressive Translation and applying all configured directives, process the following text:
+
+<TEXT_TO_TRANSLATE>
+{{input}}
+</TEXT_TO_TRANSLATE>`,
+}
+
+export function getDefaultTranslatePromptForVariant(
+  variant: PromptExperimentVariant,
+): TranslatePromptResult {
+  switch (variant) {
+    case "control":
+      return {
+        systemPrompt: DEFAULT_TRANSLATE_SYSTEM_PROMPT,
+        prompt: DEFAULT_TRANSLATE_PROMPT,
+      }
+    case "rewrite-after-understanding":
+      return REWRITE_AFTER_UNDERSTANDING
+    case "precision-rewrite":
+      return PRECISION_REWRITE
+    case "expressive-translation-master":
+      return EXPRESSIVE_TRANSLATION_MASTER
+    default: {
+      const exhaustiveVariant: never = variant
+      throw new Error("Unknown prompt experiment variant", { cause: exhaustiveVariant })
+    }
+  }
+}

--- a/src/utils/prompts/translate.ts
+++ b/src/utils/prompts/translate.ts
@@ -1,3 +1,4 @@
+import type { PromptExperimentVariant } from "@/types/analytics"
 import type { Config } from "@/types/config/config"
 import type { WebPagePromptContext } from "@/types/content"
 import { getLocalConfig } from "@/utils/config/storage"
@@ -20,6 +21,7 @@ import {
   WEB_SUMMARY,
   WEB_TITLE,
 } from "../constants/prompt"
+import { getDefaultTranslatePromptForVariant } from "./translate-experiment"
 
 const HTML_ATTRIBUTE_MARKER_SYSTEM_PROMPT = `## Protected HTML Marker Rules
 These mandatory rules override any conflicting instructions above:
@@ -31,6 +33,7 @@ These mandatory rules override any conflicting instructions above:
 export interface TranslatePromptOptions<TContext = unknown> {
   isBatch?: boolean
   context?: TContext
+  promptExperimentVariant?: PromptExperimentVariant
 }
 
 export interface TranslatePromptResult {
@@ -59,9 +62,14 @@ export function getTranslatePromptFromConfig(
   let prompt: string
 
   if (!promptId) {
-    // Use default prompts from constants
-    systemPrompt = DEFAULT_TRANSLATE_SYSTEM_PROMPT
-    prompt = DEFAULT_TRANSLATE_PROMPT
+    const defaults = options?.promptExperimentVariant
+      ? getDefaultTranslatePromptForVariant(options.promptExperimentVariant)
+      : {
+          systemPrompt: DEFAULT_TRANSLATE_SYSTEM_PROMPT,
+          prompt: DEFAULT_TRANSLATE_PROMPT,
+        }
+    systemPrompt = defaults.systemPrompt
+    prompt = defaults.prompt
   } else {
     // Find custom prompt, fallback to default
     const customPrompt = patterns.find((pattern) => pattern.id === promptId)


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Adds a four-way PostHog experiment for the default LLM translation prompt used by newly installed extensions.

- Keeps the current prompt as control and snapshots the three leading prompts from [Discussion #820](https://github.com/mengxi-ream/read-frog/discussions/820) in English.
- Enrolls only fresh installs and permanently excludes installs after analytics-disabled default-LLM use, unavailable or invalid flags, or custom prompt use.
- Tracks manual page, hover, and selection intent with `translation_requested`.
- Uses PostHog's native `$feature_flag_called` only immediately before a real default-LLM dispatch.
- Tracks `translation_prompt_used` once per user action, including strict page-session deduplication across concurrent batches.
- Includes the selected prompt in translation cache hashes and silently revalidates the variant after cache misses.
- Keeps non-LLM translation, custom prompts, cache hits, automatic page translation, Translation Hub, input translation, and subtitles outside experiment exposure.
- Preserves only approved analytics and feature-flag metadata; no URL, source text, prompt body, provider ID, or credentials are captured.

The production PostHog experiment remains draft and its flag remains inactive. It should be launched only when the release artifact is ready for store submission.

## Related Issue

Related discussion: https://github.com/mengxi-ream/read-frog/discussions/820

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation completed:

- `SKIP_FREE_API=true pnpm test`: 209 test files passed, 1951 tests passed, 4 intentionally skipped
- `pnpm type-check`
- `pnpm fmt:check`
- Chrome MV3 production build with non-secret validation environment values
- Real Chrome/Puppeteer validation against the isolated Read Frog Test Project
- All four variants verified through final LLM request bodies
- Seven-node page translation verified as three LLM batches with one native exposure and one `translation_prompt_used`
- Full-cache repeat verified with no additional LLM request, exposure, or prompt-used event
- Non-LLM, custom-prompt, analytics-disabled, old-install, invalid/unavailable flag, and action-cleanup cases verified
- Three concurrent batches for one page session verified as three silent lookups, one exposing lookup, and one `translation_prompt_used`

## Screenshots

Not applicable; this change affects prompt selection and analytics instrumentation rather than UI.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- Includes a minor changeset for `@read-frog/extension`.
- QA experiment: Read Frog Test Project experiment `385573`.
- Production experiment: Read Frog Extension experiment `385569` (draft; do not launch at merge time).
