### PR TITLE
fix(selection): keep shadow-root popups anchored to the viewport

### DIFF
--- a/.changeset/fix-selection-overlay-positioning.md
+++ b/.changeset/fix-selection-overlay-positioning.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection): keep shadow-root popups anchored to the viewport

--- a/src/utils/__tests__/shadow-root.test.ts
+++ b/src/utils/__tests__/shadow-root.test.ts
@@ -27,17 +27,19 @@ describe("insertShadowRootUIWrapperInto", () => {
     document.body.innerHTML = ""
   })
 
-  it("defines overlay geometry inside the Shadow DOM cascade", () => {
+  it("defines zero-sized overlay geometry without creating a portal containing block", () => {
     for (const declaration of [
       "display: block !important",
       "height: 0 !important",
       "overflow: visible !important",
-      "position: relative !important",
+      "position: static !important",
       "width: 0 !important",
       "background-color: transparent !important",
     ]) {
       expect(OVERLAY_SHADOW_ROOT_CSS).toContain(declaration)
     }
+
+    expect(OVERLAY_SHADOW_ROOT_CSS).not.toContain("position: relative !important")
   })
 
   it("marks the shadow host and wrapper as non-translatable", () => {

--- a/src/utils/shadow-root.ts
+++ b/src/utils/shadow-root.ts
@@ -1,14 +1,15 @@
 import { NOTRANSLATE_CLASS } from "@/utils/constants/dom-labels"
 
 // WXT prepends `:host { all: initial !important }` inside each isolated UI.
-// These declarations must live in the same Shadow DOM cascade (and after that
-// reset) to restore WXT's intended zero-sized overlay geometry.
+// These declarations must live after that reset to restore the zero-sized
+// overlay geometry. Keep the host static so a host appended to the end of the
+// page cannot become the containing block for absolutely positioned portals.
 export const OVERLAY_SHADOW_ROOT_CSS = `
 :host {
   display: block !important;
   height: 0 !important;
   overflow: visible !important;
-  position: relative !important;
+  position: static !important;
   width: 0 !important;
 }
 


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fixes selection-translation popups being positioned below the page after the overlay Shadow host became a positioned containing block.

- keeps the WXT overlay host zero-sized and transparent while changing it from `position: relative` to `position: static`;
- prevents Base UI tooltip and provider-menu positioners from being offset by the host at the end of `body`;
- preserves the overlay protections added for Alibaba Cloud so the extension host cannot cover or intercept the page;
- adds regression coverage requiring the static positioning invariant and rejecting `position: relative`.

## Related Issue

Closes #1905

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Automated validation:

- `pnpm exec vitest run src/utils/__tests__/shadow-root.test.ts` — 3 tests passed
- `pnpm fmt:check`
- `pnpm lint`
- `pnpm type-check`
- `SKIP_FREE_API=true pnpm test` — 209 test files passed, 1 intentionally skipped; 1,972 tests passed
- pre-push validation — 210 test files and 1,976 tests passed
- `pnpm build`
- `pnpm build:edge`
- `pnpm build:firefox`

Real-browser regression validation with the production Chrome MV3 build:

- Wikipedia reproduction page: Copy, Speak, Context, and Regenerate tooltips stayed inside the viewport; the provider menu opened, focused Microsoft Translator, and successfully switched to Google Translate without changing page scroll or document height.
- Side UI: the floating button menu stayed inside the viewport without changing page scroll or document height.
- Authenticated Alibaba Cloud Digital Certificate Management Overview: page translation produced 53 bilingual wrappers, stopping translation removed all wrappers, and refreshing kept the console visible and interactive.
- On Alibaba Cloud, the selection host and its Shadow `html`/`body` remained `0 × 0` and transparent, center-page hit testing contained only Alibaba elements, and the selection Context tooltip and provider menu stayed inside the viewport without scrolling the page.

## Screenshots

Not included; viewport bounds, scroll positions, document heights, hit-testing results, and overlay geometry were asserted directly in the real-browser harness.

## Checklist

- [x] I have tested these changes locally
- [x] Documentation was reviewed; no documentation changes are required
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary

## Additional Information

No public API, configuration, storage, or migration changes are introduced. A patch changeset is included for `@read-frog/extension`.
