### PR TITLE
fix(providers): omit Atlas Cloud website credentials

### DIFF
--- a/.changeset/quiet-frogs-omit-cookies.md
+++ b/.changeset/quiet-frogs-omit-cookies.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(providers): omit Atlas Cloud website credentials from API requests

--- a/src/utils/providers/__tests__/model.test.ts
+++ b/src/utils/providers/__tests__/model.test.ts
@@ -104,6 +104,22 @@ function createOpenRouterProviderConfig(headers?: Record<string, unknown>) {
   }
 }
 
+function createAtlasCloudProviderConfig() {
+  return {
+    id: "atlascloud-default",
+    name: "Atlas Cloud",
+    enabled: true,
+    provider: "atlascloud",
+    apiKey: "test-key",
+    baseURL: "https://api.atlascloud.ai/v1",
+    model: {
+      model: "deepseek-ai/deepseek-v4-flash",
+      isCustomModel: false,
+      customModel: null,
+    },
+  }
+}
+
 function createOllamaProviderConfig(providerOptions?: Record<string, unknown>) {
   return {
     id: "ollama-default",
@@ -168,7 +184,47 @@ describe("getModelById", () => {
         supportsStructuredOutputs: true,
       }),
     )
+    expect(createOpenAICompatibleMock.mock.calls[0]?.[0]).not.toHaveProperty("fetch")
     expect(openAICompatibleLanguageModelMock).toHaveBeenCalledWith("x-ai/grok-4-fast:free")
+  })
+
+  it("omits browser credentials only for Atlas Cloud requests", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [createAtlasCloudProviderConfig()],
+    })
+
+    const { getModelById } = await import("../model")
+    const result = await getModelById("atlascloud-default")
+
+    expect(result).toBe("custom-model")
+    expect(createOpenAICompatibleMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "atlascloud",
+        baseURL: "https://api.atlascloud.ai/v1",
+        apiKey: "test-key",
+        fetch: expect.any(Function),
+      }),
+    )
+
+    const atlasFetch = createOpenAICompatibleMock.mock.calls[0]?.[0]?.fetch as typeof fetch
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response())
+
+    await atlasFetch("https://api.atlascloud.ai/v1/chat/completions", {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Authorization: "Bearer test-key",
+      },
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith("https://api.atlascloud.ai/v1/chat/completions", {
+      method: "POST",
+      credentials: "omit",
+      headers: {
+        Authorization: "Bearer test-key",
+      },
+    })
+    fetchMock.mockRestore()
   })
 
   it("passes Ollama root base URL and disables think on the language model", async () => {

--- a/src/utils/providers/model.ts
+++ b/src/utils/providers/model.ts
@@ -61,6 +61,14 @@ const CREATE_AI_MAPPER = {
   huggingface: createHuggingFace,
 } as const
 
+// TODO(#1907): Remove this workaround once Atlas Cloud no longer lets website session cookies
+// interfere with API-key authentication.
+const fetchAtlasCloudWithoutCredentials: typeof globalThis.fetch = (input, init) =>
+  globalThis.fetch(input, {
+    ...init,
+    credentials: "omit",
+  })
+
 function getProviderSpecificSettings(providerConfig: LLMProviderConfig) {
   const settings =
     "providerSpecificSettings" in providerConfig
@@ -108,6 +116,9 @@ async function getLanguageModelById(providerId: string) {
         supportsStructuredOutputs: true,
         ...(providerConfig.apiKey && { apiKey: providerConfig.apiKey }),
         ...(headers && { headers }),
+        ...(providerConfig.provider === "atlascloud" && {
+          fetch: fetchAtlasCloudWithoutCredentials,
+        }),
       })
     : CREATE_AI_MAPPER[providerConfig.provider]({
         ...providerSpecificSettings,


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation update (docs)
- [ ] 🎨 Code style update (style)
- [ ] ♻️ Code refactor (refactor)
- [ ] ⚡️ Performance improvement (perf)
- [x] ✅ Test update (test)
- [ ] 🔧 Build/config update (chore)
- [ ] 🤖 CI/CD update (ci)

## Description

Atlas Cloud currently returns HTTP 404 when a valid API-key request also carries an Atlas website session cookie. This is profile-specific because browser cookies differ by profile.

This PR:

- adds an Atlas Cloud-only fetch override that forces `credentials: "omit"`;
- preserves explicit request headers, including `Authorization`;
- leaves every other API provider's fetch behavior unchanged;
- adds a TODO linked to #1907 so the workaround can be removed after Atlas Cloud fixes the upstream cookie/auth conflict;
- adds regression coverage and a patch changeset.

## Related Issue

Related to #1901  
Upstream tracking/TODO: #1907

Neither issue is closed by this PR because #1907 should remain open until Atlas Cloud resolves the upstream behavior.

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation performed:

- `SKIP_FREE_API=true pnpm test src/utils/providers/__tests__/model.test.ts` — 9 tests passed
- `SKIP_FREE_API=true pnpm test` — 209 files passed, 1 intentionally skipped; 1973 tests passed, 4 skipped
- `pnpm type-check`
- `pnpm exec oxfmt --check ...`
- `pnpm build`

Manual reproduction confirmed the same Atlas API request succeeds without the website session cookie and returns 404 with it. Clearing the Atlas cookie also restored the affected Brave profile.

## Screenshots

N/A — request behavior and regression tests cover this provider-level change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (not applicable; changeset and issue document the workaround)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes