### PR TITLE
fix(providers): remove Atlas Cloud credential workaround

### DIFF
--- a/.changeset/quiet-frogs-smile.md
+++ b/.changeset/quiet-frogs-smile.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(providers): remove the Atlas Cloud credential workaround after the upstream fix

--- a/src/utils/providers/__tests__/model.test.ts
+++ b/src/utils/providers/__tests__/model.test.ts
@@ -104,22 +104,6 @@ function createOpenRouterProviderConfig(headers?: Record<string, unknown>) {
   }
 }
 
-function createAtlasCloudProviderConfig() {
-  return {
-    id: "atlascloud-default",
-    name: "Atlas Cloud",
-    enabled: true,
-    provider: "atlascloud",
-    apiKey: "test-key",
-    baseURL: "https://api.atlascloud.ai/v1",
-    model: {
-      model: "deepseek-ai/deepseek-v4-flash",
-      isCustomModel: false,
-      customModel: null,
-    },
-  }
-}
-
 function createOllamaProviderConfig(providerOptions?: Record<string, unknown>) {
   return {
     id: "ollama-default",
@@ -184,47 +168,7 @@ describe("getModelById", () => {
         supportsStructuredOutputs: true,
       }),
     )
-    expect(createOpenAICompatibleMock.mock.calls[0]?.[0]).not.toHaveProperty("fetch")
     expect(openAICompatibleLanguageModelMock).toHaveBeenCalledWith("x-ai/grok-4-fast:free")
-  })
-
-  it("omits browser credentials only for Atlas Cloud requests", async () => {
-    getStorageItemMock.mockResolvedValue({
-      providersConfig: [createAtlasCloudProviderConfig()],
-    })
-
-    const { getModelById } = await import("../model")
-    const result = await getModelById("atlascloud-default")
-
-    expect(result).toBe("custom-model")
-    expect(createOpenAICompatibleMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "atlascloud",
-        baseURL: "https://api.atlascloud.ai/v1",
-        apiKey: "test-key",
-        fetch: expect.any(Function),
-      }),
-    )
-
-    const atlasFetch = createOpenAICompatibleMock.mock.calls[0]?.[0]?.fetch as typeof fetch
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response())
-
-    await atlasFetch("https://api.atlascloud.ai/v1/chat/completions", {
-      method: "POST",
-      credentials: "include",
-      headers: {
-        Authorization: "Bearer test-key",
-      },
-    })
-
-    expect(fetchMock).toHaveBeenCalledWith("https://api.atlascloud.ai/v1/chat/completions", {
-      method: "POST",
-      credentials: "omit",
-      headers: {
-        Authorization: "Bearer test-key",
-      },
-    })
-    fetchMock.mockRestore()
   })
 
   it("passes Ollama root base URL and disables think on the language model", async () => {

--- a/src/utils/providers/model.ts
+++ b/src/utils/providers/model.ts
@@ -61,14 +61,6 @@ const CREATE_AI_MAPPER = {
   huggingface: createHuggingFace,
 } as const
 
-// TODO(#1907): Remove this workaround once Atlas Cloud no longer lets website session cookies
-// interfere with API-key authentication.
-const fetchAtlasCloudWithoutCredentials: typeof globalThis.fetch = (input, init) =>
-  globalThis.fetch(input, {
-    ...init,
-    credentials: "omit",
-  })
-
 function getProviderSpecificSettings(providerConfig: LLMProviderConfig) {
   const settings =
     "providerSpecificSettings" in providerConfig
@@ -116,9 +108,6 @@ async function getLanguageModelById(providerId: string) {
         supportsStructuredOutputs: true,
         ...(providerConfig.apiKey && { apiKey: providerConfig.apiKey }),
         ...(headers && { headers }),
-        ...(providerConfig.provider === "atlascloud" && {
-          fetch: fetchAtlasCloudWithoutCredentials,
-        }),
       })
     : CREATE_AI_MAPPER[providerConfig.provider]({
         ...providerSpecificSettings,


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix
- [x] ✅ Test update

## Description

Atlas Cloud confirmed that the upstream website-cookie/API-key authentication conflict tracked in #1907 has been fixed.

This PR:

- removes the Atlas Cloud-only custom fetch that forced `credentials: "omit"`;
- removes the temporary TODO and workaround-specific regression test introduced in #1908;
- returns Atlas Cloud to the normal OpenAI-compatible provider fetch behavior;
- keeps the standard `https://api.atlascloud.ai/v1` base URL unchanged;
- adds a patch changeset for `@read-frog/extension`.

## Impact

Atlas Cloud requests no longer require a Read Frog-specific browser credential workaround now that the upstream conflict is resolved.

## Validation

- `SKIP_FREE_API=true pnpm test src/utils/providers/__tests__/model.test.ts` — 8 tests passed
- `pnpm type-check`
- pre-push `fmt:check`
- pre-push type-aware lint/type-check
- pre-push full test suite — 210 files and 1976 tests passed

## Related Issues

- Resolves #1907
- Reverts the temporary workaround from #1908