### PR TITLE
fix(translate): restore ChatGPT assistant response translation

### DIFF
--- a/.changeset/fuzzy-frogs-chat.md
+++ b/.changeset/fuzzy-frogs-chat.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): restore ChatGPT assistant response translation

--- a/src/utils/host/dom/__tests__/custom-dont-walk.test.ts
+++ b/src/utils/host/dom/__tests__/custom-dont-walk.test.ts
@@ -7,6 +7,7 @@ import {
   isDontWalkIntoAndDontTranslateAsChildElement,
   isSiteRuleExcludedElement,
 } from "../filter"
+import { extractTextContent } from "../traversal"
 
 function setHost(host: string) {
   // jsdom exposes location as read-only; override via defineProperty
@@ -64,6 +65,38 @@ describe("isSiteRuleExcludedElement", () => {
     expect(isSiteRuleExcludedElement(other, DEFAULT_CONFIG)).toBe(false)
     expect(isDontWalkIntoAndDontTranslateAsChildElement(proseMirror, DEFAULT_CONFIG)).toBe(true)
     expect(isDontWalkIntoAndDontTranslateAsChildElement(other, DEFAULT_CONFIG)).toBe(false)
+  })
+
+  it("walks ChatGPT assistant prose while keeping editors and code blocks protected (#1912)", () => {
+    setHost("chatgpt.com")
+
+    const assistantResponse = document.createElement("div")
+    assistantResponse.className = "markdown prose"
+
+    const paragraph = document.createElement("p")
+    paragraph.textContent = "Readable assistant response"
+
+    const pre = document.createElement("pre")
+    const code = document.createElement("code")
+    code.textContent = "const shouldStayUntranslated = true"
+    pre.appendChild(code)
+
+    const promptEditor = document.createElement("div")
+    promptEditor.className = "ProseMirror"
+    promptEditor.textContent = "User prompt"
+
+    assistantResponse.append(paragraph, pre)
+    document.body.append(assistantResponse, promptEditor)
+
+    expect(isSiteRuleExcludedElement(paragraph, DEFAULT_CONFIG)).toBe(false)
+    expect(isDontWalkIntoAndDontTranslateAsChildElement(paragraph, DEFAULT_CONFIG)).toBe(false)
+    expect(extractTextContent(assistantResponse, DEFAULT_CONFIG)).toBe(
+      "Readable assistant response",
+    )
+
+    expect(isDontWalkIntoAndDontTranslateAsChildElement(pre, DEFAULT_CONFIG)).toBe(true)
+    expect(isSiteRuleExcludedElement(promptEditor, DEFAULT_CONFIG)).toBe(true)
+    expect(isDontWalkIntoAndDontTranslateAsChildElement(promptEditor, DEFAULT_CONFIG)).toBe(true)
   })
 
   it("still matches when the URL includes a port (host !== hostname)", () => {

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -1694,7 +1694,6 @@
       "div#headlessui-portal-root",
       "nav",
       "ul[aria-multiselectable]",
-      ".markdown *",
       "div[class='flex flex-col items-start']",
       "div[class='flex items-center justify-center gap-1 border-b border-black/10 bg-gray-50 p-3 text-gray-500 dark:border-gray-900/50 dark:bg-gray-700 dark:text-gray-300']"
     ],


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Restores page translation for ChatGPT assistant responses.

The built-in `chatOpenai` site rule excluded `.markdown *`, which now matches every descendant in ChatGPT's assistant response container. Those nodes were discarded before walk labeling, so no translation requests were issued even while other page content translated normally.

This change:

- removes only the over-broad `.markdown *` exclusion while preserving the remaining ChatGPT UI exclusions;
- keeps the `.ProseMirror` prompt editor excluded by the dedicated Read Frog rule;
- keeps `PRE` code blocks protected by the global DOM traversal rules;
- adds regression coverage for assistant prose, prompt editors, and code blocks;
- adds a patch changeset for `@read-frog/extension`.

## Related Issue

Closes #1912

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation completed:

- focused DOM and built-in site-rule tests: 18/18 passed;
- local full suite with `SKIP_FREE_API=true`: 1974 passed, 4 intentionally skipped;
- pre-push full suite: 1978/1978 passed;
- format check and type-aware lint/type-check passed;
- production Chrome extension build passed;
- built-extension Puppeteer fixture on `chatgpt.com` verified assistant translation, code/editor protection, and restoration;
- real anonymous `https://chatgpt.com/` verification in a fresh isolated Chrome profile translated a live assistant response, left the prompt editor untouched, restored the original response when disabled, and recorded zero page errors.

## Screenshots

N/A — behavior is covered by DOM assertions and real-browser verification.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The regression was introduced when the per-site rule engine shipped in v1.39.0. Versions 1.40.2 and 1.42.0 both contain the affected rule.
