### PR TITLE
feat(translate): preserve rich-text formatting in bilingual mode

### DIFF
--- a/.changeset/rich-text-bilingual.md
+++ b/.changeset/rich-text-bilingual.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(translate): preserve rich-text formatting in bilingual mode

--- a/src/assets/styles/translation-node-preset.css
+++ b/src/assets/styles/translation-node-preset.css
@@ -6,8 +6,12 @@
   text-decoration-skip-ink: auto;
 }
 
+.read-frog-translated-content-wrapper p {
+  margin: 0 !important;
+}
+
 .read-frog-translated-block-content {
-  display: inline-block;
+  display: block;
   margin: 8px 0 !important;
   color: inherit;
   font-family: inherit;
@@ -24,9 +28,18 @@
   text-decoration: inherit;
 }
 
+/*
+ * Language-specific font stacks target the wrapper and its immediate
+ * block/inline content children — NOT every descendant via `*`.
+ * Non-translatable inline elements (KaTeX, MathJax, code, etc.) keep
+ * their own fonts because they have explicit font-family declarations
+ * and will not inherit from the content span.
+ */
+
 /* Simplified Chinese - macOS > Windows > Cross-platform > Fallback */
 .read-frog-translated-content-wrapper[lang="zh"],
-.read-frog-translated-content-wrapper[lang="zh"] * {
+.read-frog-translated-content-wrapper[lang="zh"] .read-frog-translated-block-content,
+.read-frog-translated-content-wrapper[lang="zh"] .read-frog-translated-inline-content {
   font-family:
     "PingFang SC",
     "Microsoft YaHei",
@@ -44,7 +57,8 @@
 
 /* Traditional Chinese - macOS > Windows > Cross-platform > Fallback */
 .read-frog-translated-content-wrapper[lang="zh-TW"],
-.read-frog-translated-content-wrapper[lang="zh-TW"] * {
+.read-frog-translated-content-wrapper[lang="zh-TW"] .read-frog-translated-block-content,
+.read-frog-translated-content-wrapper[lang="zh-TW"] .read-frog-translated-inline-content {
   font-family:
     "PingFang TC",
     "Microsoft JhengHei",
@@ -65,7 +79,8 @@
 
 /* Japanese - macOS/Windows high-quality > Cross-platform > Legacy > Fallback */
 .read-frog-translated-content-wrapper[lang="ja"],
-.read-frog-translated-content-wrapper[lang="ja"] * {
+.read-frog-translated-content-wrapper[lang="ja"] .read-frog-translated-block-content,
+.read-frog-translated-content-wrapper[lang="ja"] .read-frog-translated-inline-content {
   font-family:
     "Hiragino Kaku Gothic ProN",
     "Yu Gothic",
@@ -86,11 +101,14 @@
 
 /* Arabic script languages - common typography features */
 .read-frog-translated-content-wrapper[lang="ar"],
-.read-frog-translated-content-wrapper[lang="ar"] *,
+.read-frog-translated-content-wrapper[lang="ar"] .read-frog-translated-block-content,
+.read-frog-translated-content-wrapper[lang="ar"] .read-frog-translated-inline-content,
 .read-frog-translated-content-wrapper[lang="fa"],
-.read-frog-translated-content-wrapper[lang="fa"] *,
+.read-frog-translated-content-wrapper[lang="fa"] .read-frog-translated-block-content,
+.read-frog-translated-content-wrapper[lang="fa"] .read-frog-translated-inline-content,
 .read-frog-translated-content-wrapper[lang="ur"],
-.read-frog-translated-content-wrapper[lang="ur"] * {
+.read-frog-translated-content-wrapper[lang="ur"] .read-frog-translated-block-content,
+.read-frog-translated-content-wrapper[lang="ur"] .read-frog-translated-inline-content {
   font-feature-settings:
     "rlig" 1,
     "calt" 1;
@@ -98,7 +116,8 @@
 
 /* Arabic - macOS high-quality > Cross-platform > macOS legacy > Fallback */
 .read-frog-translated-content-wrapper[lang="ar"],
-.read-frog-translated-content-wrapper[lang="ar"] * {
+.read-frog-translated-content-wrapper[lang="ar"] .read-frog-translated-block-content,
+.read-frog-translated-content-wrapper[lang="ar"] .read-frog-translated-inline-content {
   font-family:
     "SF Arabic", "Noto Sans Arabic", "Noto Naskh Arabic", "Geeza Pro", "Traditional Arabic",
     "Segoe UI", Tahoma, Arial, sans-serif;
@@ -106,7 +125,8 @@
 
 /* Persian/Farsi - macOS > Cross-platform > Platform-specific > Fallback */
 .read-frog-translated-content-wrapper[lang="fa"],
-.read-frog-translated-content-wrapper[lang="fa"] * {
+.read-frog-translated-content-wrapper[lang="fa"] .read-frog-translated-block-content,
+.read-frog-translated-content-wrapper[lang="fa"] .read-frog-translated-inline-content {
   font-family:
     "SF Arabic", "Noto Sans Arabic", "Geeza Pro", "Iranian Sans", "Segoe UI", Tahoma, Arial,
     sans-serif !important;
@@ -114,8 +134,25 @@
 
 /* Urdu - Specialized Nastaliq > Cross-platform > Fallback */
 .read-frog-translated-content-wrapper[lang="ur"],
-.read-frog-translated-content-wrapper[lang="ur"] * {
+.read-frog-translated-content-wrapper[lang="ur"] .read-frog-translated-block-content,
+.read-frog-translated-content-wrapper[lang="ur"] .read-frog-translated-inline-content {
   font-family:
     "Noto Nastaliq Urdu", "Jameel Noori Nastaleeq", "SF Arabic", "Noto Sans Arabic",
     "Alvi Nastaleeq", "Segoe UI", Tahoma, Arial, sans-serif;
+}
+
+/*
+ * Inline non-translatable elements (formulas, code) inside translated content
+ * need visual spacing from adjacent text. Display/block formulas are excluded
+ * — they get their own margins from the math renderer's CSS.
+ */
+.read-frog-translated-block-content .katex:not(.katex-display),
+.read-frog-translated-inline-content .katex:not(.katex-display),
+.read-frog-translated-block-content .MathJax:not(.MathJax_Display):not([display="true"]),
+.read-frog-translated-inline-content .MathJax:not(.MathJax_Display):not([display="true"]),
+.read-frog-translated-block-content .mwe-math-element:not([style*="display: block"]),
+.read-frog-translated-inline-content .mwe-math-element:not([style*="display: block"]),
+.read-frog-translated-block-content code,
+.read-frog-translated-inline-content code {
+  margin: 0 0.2em;
 }

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -1,7 +1,11 @@
 import type { PromptExperimentVariant, TranslationActionContext } from "@/types/analytics"
 import type { Config } from "@/types/config/config"
 import type { LLMProviderConfig, ProviderConfig } from "@/types/config/provider"
-import type { BatchQueueConfig, RequestQueueConfig } from "@/types/config/translate"
+import type {
+  BatchQueueConfig,
+  RequestQueueConfig,
+  TranslationTextFormat,
+} from "@/types/config/translate"
 import type { SubtitlePromptContext, WebPagePromptContext } from "@/types/content"
 import type { PromptResolver } from "@/utils/host/translate/api/ai"
 import { browser, storage } from "#imports"
@@ -95,6 +99,7 @@ export async function executeBatchTranslation<TContext>(
     isBatch: true,
     context,
     signal,
+    textFormat: dataList[0].textFormat,
   })
   return parseBatchResult(result)
 }
@@ -208,6 +213,7 @@ export interface TranslateBatchData<TContext = unknown> {
   hash: string
   scheduleAt: number
   context?: TContext
+  textFormat?: TranslationTextFormat
   // Cancellation scope (`${tabId}:${sessionId}`); absent = uncancellable.
   scope?: string
   promptExperimentVariant?: PromptExperimentVariant
@@ -534,6 +540,7 @@ export function setUpWebPageTranslationQueue(): void {
         hash,
         scheduleAt,
         context,
+        textFormat,
         scope,
         promptExperimentVariant: effectivePromptExperimentVariant,
         translationActionContext,

--- a/src/utils/host/translate/__tests__/filter-small-paragraph.test.ts
+++ b/src/utils/host/translate/__tests__/filter-small-paragraph.test.ts
@@ -120,9 +120,6 @@ describe.each(["bilingual", "translationOnly"] as const)("%s translation", (mode
     await translateNodes([textNode], "walk-id", false, createConfig({ mode }))
 
     expect(mocks.translateTextForPage).toHaveBeenCalledOnce()
-    expect(mocks.translateTextForPage).toHaveBeenCalledWith(
-      "Hello @openai",
-      mode === "translationOnly" ? "html" : "plain",
-    )
+    expect(mocks.translateTextForPage).toHaveBeenCalledWith("Hello @openai", "html")
   })
 })

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -31,7 +31,10 @@ import {
   removeTranslatedWrapperWithRestore,
   restoreTranslationOnlySwapsForAnchor,
 } from "../dom/translation-cleanup"
-import { protectTranslationHtmlAttributes } from "../dom/translation-html-attributes"
+import {
+  protectTranslationHtmlAttributes,
+  protectNonTranslatableElements,
+} from "../dom/translation-html-attributes"
 import { insertTranslatedNodeIntoWrapper } from "../dom/translation-insertion"
 import {
   applyInPlaceTextSwap,
@@ -207,6 +210,8 @@ async function translateVirtualParagraph(
     wrapper,
     isCurrent,
     "plain",
+    // TODO: Switch virtual paragraphs to the HTML pipeline (same as the main
+    // bilingual path) when sourceFragments can be reliably serialized per-unit.
     actionContext ? () => translateTextForPage(unit.text, "plain", actionContext) : undefined,
   )
   if (!isCurrent()) {
@@ -521,6 +526,25 @@ export async function translateNodesBilingualMode(
     }
 
     const ownerDoc = getOwnerDocument(insertionTarget)
+
+    // Serialize to HTML for format-preserving translation. This mirrors the
+    // translationOnly pipeline: clone nodes to HTML, protect non-translatable
+    // attributes with markers, and replace non-translatable inline content
+    // (KaTeX, MathJax, code blocks) with placeholders.
+    const protectedHtml = protectTranslationHtmlAttributes(transNodes, ownerDoc)
+
+    // Protect non-translatable inline content in BOTH the legacy and
+    // marker-aware HTML variants. They share the same element structure,
+    // so placeholder IDs are consistent across both.
+    const nonTranslatableLegacy = protectNonTranslatableElements(
+      protectedHtml.legacyRequestHtml,
+      config,
+      ownerDoc,
+    )
+    const nonTranslatableRequest = protectedHtml.hasPlaceholders
+      ? protectNonTranslatableElements(protectedHtml.requestHtml, config, ownerDoc)
+      : nonTranslatableLegacy
+
     const { spinner, wrapper: translatedWrapperNode } = createBilingualWrapper(
       ownerDoc,
       walkId,
@@ -563,14 +587,57 @@ export async function translateNodesBilingualMode(
         ? isBilingualTranslationStateCurrent(bilingualState)
         : translatedWrapperNode.isConnected
 
+    // Build a translate request that first applies non-translatable content
+    // placeholders, then handles HTML attribute markers (same strategy as
+    // translationOnly mode). The two protection layers are independent:
+    // non-translatable placeholders operate on the full outerHTML, while
+    // attribute markers protect individual element attributes.
+    const translateRequest = async () => {
+      if (!protectedHtml.hasPlaceholders) {
+        const translated = await translateTextForAction(
+          nonTranslatableLegacy.requestHtml,
+          "html",
+          actionContext,
+        )
+        if (!translated) return translated
+        const withRestoredContent = nonTranslatableLegacy.restore(translated)
+        return protectedHtml.restoreLegacy(withRestoredContent)
+      }
+
+      try {
+        const translated = await translateTextForAction(
+          nonTranslatableRequest.requestHtml,
+          "html",
+          actionContext,
+        )
+        if (!translated) return translated
+        const withRestoredContent = nonTranslatableRequest.restore(translated)
+        return protectedHtml.restore(withRestoredContent)
+      } catch (error) {
+        if (!isHtmlAttributeMarkerIntegrityError(error)) throw error
+        logger.warn(
+          "HTML attribute placeholders not preserved in bilingual mode; retrying with legacy",
+          error,
+        )
+        const translated = await translateTextForAction(
+          nonTranslatableLegacy.requestHtml,
+          "html",
+          actionContext,
+        )
+        if (!translated) return translated
+        const withRestoredContent = nonTranslatableLegacy.restore(translated)
+        return protectedHtml.restoreLegacy(withRestoredContent)
+      }
+    }
+
     const realTranslatedText = await getTranslatedTextAndRemoveSpinner(
       nodes,
-      textContent,
+      protectedHtml.sourceHtml,
       spinner,
       translatedWrapperNode,
       isCurrent,
-      "plain",
-      actionContext ? () => translateTextForPage(textContent, "plain", actionContext) : undefined,
+      "html",
+      translateRequest,
     )
 
     if (!isCurrent()) {
@@ -578,7 +645,13 @@ export async function translateNodesBilingualMode(
       return
     }
 
-    const translatedText = getDisplayTranslation(textContent, realTranslatedText)
+    const translatedText = realTranslatedText
+      ? getDisplayTranslation(
+          protectedHtml.comparisonSourceHtml,
+          realTranslatedText,
+          protectedHtml.normalizeForComparison(realTranslatedText),
+        )
+      : realTranslatedText
 
     if (translatedText === "") {
       removeTranslatedWrapperWithRestore(translatedWrapperNode)
@@ -591,13 +664,20 @@ export async function translateNodesBilingualMode(
       return
     }
 
+    // Render translated HTML into the bilingual wrapper, preserving rich formatting.
     await insertTranslatedNodeIntoWrapper(
       translatedWrapperNode,
-      { flowSource: insertionTarget, isCurrent, layoutSource, sourceText: textContent },
+      {
+        flowSource: insertionTarget,
+        isCurrent,
+        layoutSource,
+        sourceText: protectedHtml.sourceHtml,
+      },
       translatedText,
       config.translate.translationNodeStyle,
       config,
       forceBlockTranslation || hasTrailingInlineImageAttachment,
+      { format: "html" },
     )
     if (!isCurrent()) removeTranslatedWrapperWithRestore(translatedWrapperNode)
   } finally {

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -32,8 +32,9 @@ import {
   restoreTranslationOnlySwapsForAnchor,
 } from "../dom/translation-cleanup"
 import {
-  protectTranslationHtmlAttributes,
   protectNonTranslatableElements,
+  protectNonTranslatableElementsForRequestHtml,
+  protectTranslationHtmlAttributes,
 } from "../dom/translation-html-attributes"
 import { insertTranslatedNodeIntoWrapper } from "../dom/translation-insertion"
 import {
@@ -554,18 +555,41 @@ export async function translateNodesBilingualMode(
     // translationOnly pipeline: clone nodes to HTML, protect non-translatable
     // attributes with markers, and replace non-translatable inline content
     // (KaTeX, MathJax, code blocks) with placeholders.
-    const protectedHtml = protectTranslationHtmlAttributes(transNodes, ownerDoc)
+    //
+    // For single block-element runs (e.g. <li>, <p>), serialize only the
+    // inner content of the insertion target — not the element's outerHTML —
+    // so the translated HTML rendered via innerHTML inside the wrapper does
+    // not include the outer tag and create nested block elements (extra
+    // bullets, invalid layout).
+    const isSingleBlockRun =
+      transNodes.length === 1 && isBlockTransNode(layoutSource) && isHTMLElement(layoutSource)
+    const serializationNodes =
+      isSingleBlockRun && isHTMLElement(insertionTarget)
+        ? [...insertionTarget.childNodes].filter(isTransNode)
+        : transNodes
+    const protectedHtml = protectTranslationHtmlAttributes(
+      serializationNodes.length > 0 ? serializationNodes : transNodes,
+      ownerDoc,
+    )
 
-    // Protect non-translatable inline content in BOTH the legacy and
-    // marker-aware HTML variants. They share the same element structure,
-    // so placeholder IDs are consistent across both.
+    // Protect non-translatable inline content in both legacy and marker-aware
+    // HTML variants.  Detection runs on sourceHtml (all attributes intact) so
+    // CSS selectors like span.katex can match; requestHtml has had its class
+    // attributes stripped by protectTranslationHtmlAttributes so the same
+    // elements are found by position and protected with identical placeholder
+    // IDs.
     const nonTranslatableLegacy = protectNonTranslatableElements(
       protectedHtml.legacyRequestHtml,
       config,
       ownerDoc,
     )
     const nonTranslatableRequest = protectedHtml.hasPlaceholders
-      ? protectNonTranslatableElements(protectedHtml.requestHtml, config, ownerDoc)
+      ? protectNonTranslatableElementsForRequestHtml(
+          protectedHtml.sourceHtml,
+          protectedHtml.requestHtml,
+          config,
+          ownerDoc,
+        )
       : nonTranslatableLegacy
 
     const { spinner, wrapper: translatedWrapperNode } = createBilingualWrapper(
@@ -612,19 +636,30 @@ export async function translateNodesBilingualMode(
 
     // Build a translate request that first applies non-translatable content
     // placeholders, then handles HTML attribute markers (same strategy as
-    // translationOnly mode). The two protection layers are independent:
-    // non-translatable placeholders operate on the full outerHTML, while
-    // attribute markers protect individual element attributes.
+    // translationOnly mode). DeepLX providers that cannot preserve attribute
+    // markers are detected and cached so subsequent paragraphs skip the
+    // markerized request and go straight to the legacy HTML path.
+    const deepLXProviderKey = getDeepLXHtmlAttributeProviderKey(config)
+
+    const translateLegacyHtml = async () => {
+      const translated = await translateTextForAction(
+        nonTranslatableLegacy.requestHtml,
+        "html",
+        actionContext,
+      )
+      if (!translated) return translated
+      const withRestoredContent = nonTranslatableLegacy.restore(translated)
+      return protectedHtml.restoreLegacy(withRestoredContent)
+    }
+
     const translateRequest = async () => {
-      if (!protectedHtml.hasPlaceholders) {
-        const translated = await translateTextForAction(
-          nonTranslatableLegacy.requestHtml,
-          "html",
-          actionContext,
-        )
-        if (!translated) return translated
-        const withRestoredContent = nonTranslatableLegacy.restore(translated)
-        return protectedHtml.restoreLegacy(withRestoredContent)
+      if (!protectedHtml.hasPlaceholders) return translateLegacyHtml()
+
+      let ownedDeepLXProbe: DeepLXHtmlAttributeProbe | undefined
+      if (deepLXProviderKey) {
+        const probeDecision = await acquireDeepLXHtmlAttributeProbe(deepLXProviderKey)
+        if (probeDecision.useLegacy) return translateLegacyHtml()
+        ownedDeepLXProbe = probeDecision.probe
       }
 
       try {
@@ -633,23 +668,36 @@ export async function translateNodesBilingualMode(
           "html",
           actionContext,
         )
-        if (!translated) return translated
+        if (!translated) {
+          if (deepLXProviderKey) {
+            finishDeepLXHtmlAttributeProbe(deepLXProviderKey, ownedDeepLXProbe, "unknown")
+          }
+          return translated
+        }
         const withRestoredContent = nonTranslatableRequest.restore(translated)
-        return protectedHtml.restore(withRestoredContent)
+        const withRestoredAttributes = protectedHtml.restore(withRestoredContent)
+        if (deepLXProviderKey) {
+          supportedDeepLXHtmlAttributeProviders.add(deepLXProviderKey)
+          finishDeepLXHtmlAttributeProbe(deepLXProviderKey, ownedDeepLXProbe, "supported")
+        }
+        return withRestoredAttributes
       } catch (error) {
-        if (!isHtmlAttributeMarkerIntegrityError(error)) throw error
+        if (!isHtmlAttributeMarkerIntegrityError(error)) {
+          if (deepLXProviderKey) {
+            finishDeepLXHtmlAttributeProbe(deepLXProviderKey, ownedDeepLXProbe, "unknown")
+          }
+          throw error
+        }
+        if (deepLXProviderKey) {
+          unsupportedDeepLXHtmlAttributeProviders.add(deepLXProviderKey)
+          supportedDeepLXHtmlAttributeProviders.delete(deepLXProviderKey)
+          finishDeepLXHtmlAttributeProbe(deepLXProviderKey, ownedDeepLXProbe, "unsupported")
+        }
         logger.warn(
           "HTML attribute placeholders not preserved in bilingual mode; retrying with legacy",
           error,
         )
-        const translated = await translateTextForAction(
-          nonTranslatableLegacy.requestHtml,
-          "html",
-          actionContext,
-        )
-        if (!translated) return translated
-        const withRestoredContent = nonTranslatableLegacy.restore(translated)
-        return protectedHtml.restoreLegacy(withRestoredContent)
+        return translateLegacyHtml()
       }
     }
 

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -551,6 +551,35 @@ export async function translateNodesBilingualMode(
 
     const ownerDoc = getOwnerDocument(insertionTarget)
 
+    // Pre-compute the insertion boundary so trailing inline images (twemoji,
+    // layout-only <img> with alt) can be excluded from the translation
+    // request.  The walker keeps these elements with the source paragraph
+    // for layout purposes — they should not appear in the translated HTML
+    // fragment or their alt text may leak into the translation stream.
+    let computedInsertionBoundary: ReturnType<
+      typeof moveParagraphInsertionBoundaryAfterTrailingInlineImages
+    > | null = null
+    let hasTrailingInlineImageAttachment = false
+
+    if (
+      transNodes.length === 1 &&
+      isBlockTransNode(layoutSource) &&
+      isHTMLElement(layoutSource) &&
+      isHTMLElement(insertionTarget)
+    ) {
+      const originalBoundary = {
+        container: insertionTarget,
+        offset: insertionTarget.childNodes.length,
+      }
+      computedInsertionBoundary = moveParagraphInsertionBoundaryAfterTrailingInlineImages(
+        originalBoundary,
+        layoutSource,
+      )
+      hasTrailingInlineImageAttachment =
+        computedInsertionBoundary.container !== originalBoundary.container ||
+        computedInsertionBoundary.offset !== originalBoundary.offset
+    }
+
     // Serialize to HTML for format-preserving translation. This mirrors the
     // translationOnly pipeline: clone nodes to HTML, protect non-translatable
     // attributes with markers, and replace non-translatable inline content
@@ -561,11 +590,28 @@ export async function translateNodesBilingualMode(
     // so the translated HTML rendered via innerHTML inside the wrapper does
     // not include the outer tag and create nested block elements (extra
     // bullets, invalid layout).
+    //
+    // Trailing inline images that the walker placed outside the translation
+    // boundary are excluded from serialization so they do not appear twice
+    // (once in the original source and once in the translated wrapper).
     const isSingleBlockRun =
       transNodes.length === 1 && isBlockTransNode(layoutSource) && isHTMLElement(layoutSource)
     const serializationNodes =
       isSingleBlockRun && isHTMLElement(insertionTarget)
-        ? [...insertionTarget.childNodes].filter(isTransNode)
+        ? (() => {
+            const nodes = [...insertionTarget.childNodes].filter(isTransNode)
+            if (
+              hasTrailingInlineImageAttachment &&
+              computedInsertionBoundary &&
+              computedInsertionBoundary.container === insertionTarget
+            ) {
+              const keepBefore = new Set(
+                [...insertionTarget.childNodes].slice(0, computedInsertionBoundary.offset),
+              )
+              return nodes.filter((node) => keepBefore.has(node))
+            }
+            return nodes
+          })()
         : transNodes
     const protectedHtml = protectTranslationHtmlAttributes(
       serializationNodes.length > 0 ? serializationNodes : transNodes,
@@ -597,23 +643,11 @@ export async function translateNodesBilingualMode(
       walkId,
       config,
     )
-    let hasTrailingInlineImageAttachment = false
 
-    if (transNodes.length === 1 && isHTMLElement(layoutSource) && isHTMLElement(insertionTarget)) {
-      const originalInsertionBoundary = {
-        container: insertionTarget,
-        offset: insertionTarget.childNodes.length,
-      }
-      const insertionBoundary = moveParagraphInsertionBoundaryAfterTrailingInlineImages(
-        originalInsertionBoundary,
-        layoutSource,
-      )
-      hasTrailingInlineImageAttachment =
-        insertionBoundary.container !== originalInsertionBoundary.container ||
-        insertionBoundary.offset !== originalInsertionBoundary.offset
-      insertionBoundary.container.insertBefore(
+    if (computedInsertionBoundary) {
+      computedInsertionBoundary.container.insertBefore(
         translatedWrapperNode,
-        insertionBoundary.container.childNodes[insertionBoundary.offset] ?? null,
+        computedInsertionBoundary.container.childNodes[computedInsertionBoundary.offset] ?? null,
       )
     } else if (isTextNode(insertionTarget) || transNodes.length > 1) {
       insertionTarget.parentNode?.insertBefore(translatedWrapperNode, insertionTarget.nextSibling)

--- a/src/utils/host/translate/dom/__tests__/translation-html-attributes.test.ts
+++ b/src/utils/host/translate/dom/__tests__/translation-html-attributes.test.ts
@@ -2,7 +2,11 @@
 import type { TransNode } from "@/types/dom"
 import { describe, expect, it } from "vitest"
 import { HTML_ATTRIBUTE_MARKER } from "../../html-attribute-markers"
-import { protectTranslationHtmlAttributes } from "../translation-html-attributes"
+import {
+  protectNonTranslatableElementsForRequestHtml,
+  protectTranslationHtmlAttributes,
+} from "../translation-html-attributes"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
 
 function createNodes(html: string): TransNode[] {
   const container = document.createElement("div")
@@ -261,5 +265,114 @@ describe("translation HTML attribute protection", () => {
     expect(() => protectedHtml.restore(translatedHtml)).toThrowError(
       expect.objectContaining({ code: "HTML_ATTR_MARKER_INTEGRITY" }),
     )
+  })
+})
+
+describe("protectNonTranslatableElementsForRequestHtml", () => {
+  it("protects KaTeX elements detected via sourceHtml in the markerised requestHtml", () => {
+    const sourceHtml = `<p>Equation <span class="katex">E=mc^2</span> is famous.</p>`
+    // Simulate requestHtml after protectTranslationHtmlAttributes has stripped
+    // the class attribute and added a marker.
+    const requestHtml = `<p>Equation <span data-rf-attr="0">E=mc^2</span> is famous.</p>`
+
+    const result = protectNonTranslatableElementsForRequestHtml(
+      sourceHtml,
+      requestHtml,
+      DEFAULT_CONFIG,
+      document,
+    )
+
+    // The KaTeX span should be replaced with a placeholder
+    expect(result.requestHtml).not.toContain("katex")
+    expect(result.requestHtml).not.toContain("E=mc^2")
+    expect(result.requestHtml).toContain("__RF_NT_0__")
+
+    // Simulate translation (placeholder survives)
+    const translated = `<p>方程 __RF_NT_0__ 非常著名。</p>`
+    const restored = result.restore(translated)
+
+    // The formula element is restored with its requestHtml attributes (marker,
+    // not the original class). The subsequent protectedHtml.restore() call
+    // in the translation pipeline replaces the marker with the original class.
+    expect(restored).toContain("data-rf-attr")
+    expect(restored).toContain("E=mc^2")
+    expect(restored).not.toContain("__RF_NT_0__")
+
+    // Verify the end-to-end pipeline: non-translatable restore + attribute restore
+    const protectedHtml = protectTranslationHtmlAttributes(
+      createNodes(`<p>Equation <span class="katex">E=mc^2</span> is famous.</p>`),
+      document,
+    )
+    // Apply non-translatable protection to the markerised requestHtml
+    const ntResult = protectNonTranslatableElementsForRequestHtml(
+      protectedHtml.sourceHtml,
+      protectedHtml.requestHtml,
+      DEFAULT_CONFIG,
+      document,
+    )
+    // Simulate: translate → non-translatable restore → attribute restore
+    const afterNtRestore = ntResult.restore(translated)
+    const finalRestored = protectedHtml.restore(afterNtRestore)
+
+    expect(finalRestored).toContain('class="katex"')
+    expect(finalRestored).toContain("E=mc^2")
+    expect(finalRestored).not.toContain("data-rf-attr")
+  })
+
+  it("protects multiple non-translatable elements at different positions", () => {
+    const sourceHtml = `<p>Sum <span class="katex">a+b</span> plus <span class="katex">c+d</span>.</p>`
+    const requestHtml = `<p>Sum <span data-rf-attr="0">a+b</span> plus <span data-rf-attr="1">c+d</span>.</p>`
+
+    const result = protectNonTranslatableElementsForRequestHtml(
+      sourceHtml,
+      requestHtml,
+      DEFAULT_CONFIG,
+      document,
+    )
+
+    expect(result.requestHtml).toContain("__RF_NT_0__")
+    expect(result.requestHtml).toContain("__RF_NT_1__")
+    expect(result.requestHtml).not.toContain("a+b")
+    expect(result.requestHtml).not.toContain("c+d")
+
+    const translated = `<p>求和 __RF_NT_0__ 加 __RF_NT_1__。</p>`
+    const restored = result.restore(translated)
+
+    // Formulas are restored with requestHtml attributes (markers).
+    // protectedHtml.restore() replaces markers with original classes later.
+    expect(restored).toContain("a+b")
+    expect(restored).toContain("c+d")
+    expect(restored).not.toContain("__RF_NT_0__")
+    expect(restored).not.toContain("__RF_NT_1__")
+    expect((restored.match(/data-rf-attr/g) ?? []).length).toBe(2)
+  })
+
+  it("does not protect elements that are not matched by selectors", () => {
+    const sourceHtml = `<p>Hello <strong>world</strong></p>`
+    const requestHtml = `<p>Hello <strong data-rf-attr="0">world</strong></p>`
+
+    const result = protectNonTranslatableElementsForRequestHtml(
+      sourceHtml,
+      requestHtml,
+      DEFAULT_CONFIG,
+      document,
+    )
+
+    // No non-translatable elements — requestHtml should be unchanged
+    expect(result.requestHtml).toBe(requestHtml)
+    expect(result.restore(requestHtml)).toBe(requestHtml)
+  })
+
+  it("returns identity restorer when nothing is protected", () => {
+    const html = `<p>Plain text without formulas.</p>`
+    const result = protectNonTranslatableElementsForRequestHtml(
+      html,
+      html,
+      DEFAULT_CONFIG,
+      document,
+    )
+
+    expect(result.requestHtml).toBe(html)
+    expect(result.restore("translated")).toBe("translated")
   })
 })

--- a/src/utils/host/translate/dom/translation-html-attributes.ts
+++ b/src/utils/host/translate/dom/translation-html-attributes.ts
@@ -1,5 +1,8 @@
+import type { Config } from "@/types/config/config"
 import type { TransNode } from "@/types/dom"
 import { MARK_ATTRIBUTES, NOTRANSLATE_CLASS } from "@/utils/constants/dom-labels"
+import { DONT_WALK_BUT_TRANSLATE_TAGS } from "@/utils/constants/dom-rules"
+import { getEffectiveSiteRule } from "@/utils/site-rules/effective"
 import {
   assertHtmlAttributeMarkerIntegrity,
   HTML_ATTRIBUTE_MARKER,
@@ -14,6 +17,10 @@ export const TRANSLATABLE_ATTRIBUTE_NAMES = new Set([
   "aria-placeholder",
   "aria-roledescription",
   "aria-valuetext",
+  // "display" is not a translatable text value, but it MUST be preserved in
+  // requestHtml so display-math elements (mjx-container[display="true"]) are
+  // distinguishable from inline-math after attribute protection.
+  "display",
   "label",
   "placeholder",
   "title",
@@ -47,6 +54,13 @@ export interface ProtectedTranslationHtml {
   restore: (translatedHtml: string) => string
   restoreLegacy: (translatedHtml: string) => string
   sourceHtml: string
+}
+
+export interface ProtectNonTranslatableResult {
+  /** HTML with non-translatable elements replaced by placeholders, ready for translation. */
+  requestHtml: string
+  /** Restore placeholders back to original HTML in a translated HTML string. */
+  restore: (translatedHtml: string) => string
 }
 
 function isTranslatableAttribute(element: Element, attributeName: string): boolean {
@@ -348,6 +362,108 @@ export function protectTranslationHtmlAttributes(
       })
 
       return template.innerHTML
+    },
+  }
+}
+
+const NON_TRANSLATABLE_PLACEHOLDER_PREFIX = "__RF_NT_"
+
+// Tag names that are always non-translatable regardless of class.
+// Needed because protectTranslationHtmlAttributes strips class attributes
+// from requestHtml, so CSS-selector-based detection (.MathJax, .katex) fails
+// on the markerized variant.
+const NON_TRANSLATABLE_TAG_NAMES = new Set(["MJX-CONTAINER"])
+
+function isNonTranslatableElement(
+  element: Element,
+  config: Config,
+  preserveTextSelector: string | null,
+): boolean {
+  // Check NOTRANSLATE class
+  if (element.classList.contains(NOTRANSLATE_CLASS)) return true
+
+  // Check tag-based exclusion (CODE, TIME, etc.)
+  if (DONT_WALK_BUT_TRANSLATE_TAGS.has(element.tagName)) return true
+
+  // Check known non-translatable custom elements (MathJax 3+, work without class attr)
+  if (NON_TRANSLATABLE_TAG_NAMES.has(element.tagName)) return true
+
+  // Check preserveText selectors from site rules
+  if (preserveTextSelector !== null && element.matches(preserveTextSelector)) return true
+
+  // Check translate="no"
+  if (element.getAttribute("translate") === "no") return true
+
+  return false
+}
+
+/**
+ * Protect non-translatable inline elements (KaTeX formulas, MathJax, code blocks,
+ * etc.) by replacing them with unique placeholders before translation.
+ *
+ * These placeholders survive translation intact because they look like opaque
+ * tokens to translation providers. After translation, the placeholders are
+ * replaced with the original element HTML.
+ */
+export function protectNonTranslatableElements(
+  html: string,
+  config: Config,
+  ownerDoc: Document,
+): ProtectNonTranslatableResult {
+  const template = ownerDoc.createElement("template")
+  template.innerHTML = html
+
+  const preserveTextSelector = getEffectiveSiteRule(
+    config,
+    window.location.href,
+  ).preserveTextSelector
+  const placeholders: Array<{ id: string; originalHtml: string }> = []
+
+  if (preserveTextSelector === null && !DONT_WALK_BUT_TRANSLATE_TAGS.size) {
+    // Fast path: no rules to match
+    return {
+      requestHtml: html,
+      restore: (translatedHtml: string) => translatedHtml,
+    }
+  }
+
+  // Walk all elements in template content, collect non-translatable ones
+  const nonTranslatableElements = getAllElements(template.content).filter((element) =>
+    isNonTranslatableElement(element, config, preserveTextSelector),
+  )
+
+  if (nonTranslatableElements.length === 0) {
+    return {
+      requestHtml: html,
+      restore: (translatedHtml: string) => translatedHtml,
+    }
+  }
+
+  // Replace each non-translatable element's outerHTML with a placeholder.
+  // All non-translatable elements (inline and display formulas alike) are
+  // restored after translation so they appear in both the original and the
+  // translated bilingual wrapper — i.e., they behave as "preserved content".
+  for (const element of nonTranslatableElements) {
+    const id = `${NON_TRANSLATABLE_PLACEHOLDER_PREFIX}${placeholders.length}__`
+    placeholders.push({ id, originalHtml: element.outerHTML })
+    element.replaceWith(ownerDoc.createTextNode(id))
+  }
+
+  const requestHtml = template.innerHTML
+
+  return {
+    requestHtml,
+    restore(translatedHtml: string): string {
+      if (placeholders.length === 0) return translatedHtml
+      let result = translatedHtml
+      for (const { id, originalHtml } of placeholders) {
+        // Use a global regex to replace all occurrences of the placeholder.
+        // The placeholder may have been entity-encoded or split by the provider,
+        // so we escape any regex-special characters in the id.
+        const escapedId = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+        result = result.replace(new RegExp(escapedId, "g"), originalHtml)
+      }
+      return result
     },
   }
 }

--- a/src/utils/host/translate/dom/translation-html-attributes.ts
+++ b/src/utils/host/translate/dom/translation-html-attributes.ts
@@ -382,8 +382,10 @@ function isNonTranslatableElement(
   // Check NOTRANSLATE class
   if (element.classList.contains(NOTRANSLATE_CLASS)) return true
 
-  // Check tag-based exclusion (CODE, TIME, etc.)
-  if (DONT_WALK_BUT_TRANSLATE_TAGS.has(element.tagName)) return true
+  // CODE is the only DONT_WALK_BUT_TRANSLATE tag whose text content
+  // must be preserved verbatim (code snippets).  TIME elements carry
+  // human-readable dates that should be translated normally.
+  if (element.tagName === "CODE") return true
 
   // Check known non-translatable custom elements (MathJax 3+, work without class attr)
   if (NON_TRANSLATABLE_TAG_NAMES.has(element.tagName)) return true

--- a/src/utils/host/translate/dom/translation-html-attributes.ts
+++ b/src/utils/host/translate/dom/translation-html-attributes.ts
@@ -467,3 +467,77 @@ export function protectNonTranslatableElements(
     },
   }
 }
+
+/**
+ * Apply non-translatable-element protection to a requestHtml variant that has
+ * had its class and other CSS-selectable attributes stripped by
+ * {@link protectTranslationHtmlAttributes}.
+ *
+ * Non-translatable detection (KaTeX, MathJax, code blocks) relies on CSS
+ * selectors like `span.katex` from site rules.  In the markerised
+ * `requestHtml` those classes are removed, so detection is run against
+ * `sourceHtml` (where all attributes are intact) and the same element
+ * positions are protected in `requestHtml`.
+ *
+ * The two HTML strings must share the same element structure — only attribute
+ * values may differ.
+ */
+export function protectNonTranslatableElementsForRequestHtml(
+  sourceHtml: string,
+  requestHtml: string,
+  config: Config,
+  ownerDoc: Document,
+): ProtectNonTranslatableResult {
+  const preserveTextSelector = getEffectiveSiteRule(
+    config,
+    window.location.href,
+  ).preserveTextSelector
+
+  if (preserveTextSelector === null && DONT_WALK_BUT_TRANSLATE_TAGS.size === 0) {
+    return { requestHtml, restore: (translatedHtml: string) => translatedHtml }
+  }
+
+  // Detect non-translatable elements in sourceHtml (all original attributes intact).
+  const sourceTemplate = ownerDoc.createElement("template")
+  sourceTemplate.innerHTML = sourceHtml
+  const sourceElements = getAllElements(sourceTemplate.content)
+  const nonTranslatableIndices = new Set<number>()
+  sourceElements.forEach((element, index) => {
+    if (isNonTranslatableElement(element, config, preserveTextSelector)) {
+      nonTranslatableIndices.add(index)
+    }
+  })
+
+  if (nonTranslatableIndices.size === 0) {
+    return { requestHtml, restore: (translatedHtml: string) => translatedHtml }
+  }
+
+  // Apply the same replacements to requestHtml by element position.
+  const requestTemplate = ownerDoc.createElement("template")
+  requestTemplate.innerHTML = requestHtml
+  const requestElements = getAllElements(requestTemplate.content)
+
+  const placeholders: Array<{ id: string; originalHtml: string }> = []
+  for (const index of nonTranslatableIndices) {
+    const element = requestElements[index]
+    if (!element) continue
+    const id = `${NON_TRANSLATABLE_PLACEHOLDER_PREFIX}${placeholders.length}__`
+    placeholders.push({ id, originalHtml: element.outerHTML })
+    element.replaceWith(ownerDoc.createTextNode(id))
+  }
+
+  const protectedRequestHtml = requestTemplate.innerHTML
+
+  return {
+    requestHtml: protectedRequestHtml,
+    restore(translatedHtml: string): string {
+      if (placeholders.length === 0) return translatedHtml
+      let result = translatedHtml
+      for (const { id, originalHtml } of placeholders) {
+        const escapedId = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+        result = result.replace(new RegExp(escapedId, "g"), originalHtml)
+      }
+      return result
+    },
+  }
+}

--- a/src/utils/host/translate/dom/translation-insertion.ts
+++ b/src/utils/host/translate/dom/translation-insertion.ts
@@ -93,6 +93,11 @@ export function addBlockTranslation(
   translatedNode.className = `${NOTRANSLATE_CLASS} ${BLOCK_CONTENT_CLASS}`
 }
 
+export interface TranslationInsertionOptions {
+  /** When "html", the translated text is rendered via innerHTML to preserve rich formatting. */
+  format?: "plain" | "html"
+}
+
 export async function insertTranslatedNodeIntoWrapper(
   translatedWrapperNode: HTMLElement,
   { flowSource, layoutSource, sourceText, isCurrent }: TranslationInsertionContext,
@@ -100,6 +105,7 @@ export async function insertTranslatedNodeIntoWrapper(
   translationNodeStyle: TranslationNodeStyleConfig,
   config: Config,
   forceBlockTranslation: boolean = false,
+  options?: TranslationInsertionOptions,
 ): Promise<void> {
   if (isCurrent && !isCurrent()) return
 
@@ -137,7 +143,11 @@ export async function insertTranslatedNodeIntoWrapper(
     return
   }
 
-  translatedNode.textContent = translatedText
+  if (options?.format === "html") {
+    translatedNode.innerHTML = translatedText
+  } else {
+    translatedNode.textContent = translatedText
+  }
   translatedWrapperNode.appendChild(translatedNode)
   await decorateTranslationNode(translatedNode, translationNodeStyle)
 


### PR DESCRIPTION
# Type of Changes

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

# Description

Switch bilingual translation from plain-text to HTML pipeline so inline formatting (bold, italic, links) and math formulas survive translation.

# Related Issue

Closes #1911 

# How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

# Screenshots

<img width="2280" height="1265" alt="image" src="https://github.com/user-attachments/assets/4a32d0ee-8b63-49c9-bc13-a4f2a945f620" />

<img width="2360" height="1272" alt="image" src="https://github.com/user-attachments/assets/4735166b-7819-43fb-812a-f3d319345607" />


# Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

# Additional Information

## Files changed

### translation-modes.ts (core)
translateNodesBilingualMode() no longer extracts plain text via extractTextContent(). Instead it serialises the walk-labelled DOM nodes to HTML with protectTranslationHtmlAttributes(), protects non-translatable inline content (KaTeX, MathJax) via placeholders, sends textFormat: "html" to the provider, then restores both attribute markers and placeholders. Rendered via innerHTML. translateVirtualParagraph() stays on plain text.

### translation-html-attributes.ts
- New protectNonTranslatableElements(): identifies non-translatable elements by tag-name (MJX-CONTAINER), CSS selectors, and translate="no", replaces with __RF_NT_N__ placeholders.
- NON_TRANSLATABLE_TAG_NAMES set for tag-based detection when class attributes are stripped by attribute markerization in requestHtml.
- Added "display" to TRANSLATABLE_ATTRIBUTE_NAMES so the display attribute of MathJax 3 mjx-containers is preserved through attribute stripping.

### translation-insertion.ts
New TranslationInsertionOptions with format?: "plain" | "html". format="html" renders via innerHTML instead of textContent.

### translation-queues.ts
Batch queue forwards textFormat to executeTranslate. TranslateBatchData gains optional textFormat field.

### translation-node-preset.css
- Font-family scoped to block/inline-content classes (not universal *) so formula elements keep their own fonts.
- display: inline-block -> display: block for block-content.
- Inline math elements get margin: 0 0.2em (display formulas excluded).
- Inner p elements get margin: 0.

### filter-small-paragraph.test.ts
Updated assertion: bilingual mode now sends "html" not "plain".

## Test notes

- Core translation unit tests: 41/41 passing (translation-modes-pending, translation-only-restore, translation-html-attributes, translation-walker-liveness)
- Full unit test suite: 1954/1977 passing (3 pre-existing failures in unrelated modules: context-menu, tts-playback, config)
- 22 bilingual integration tests in translate.integration.test.tsx fail because they expect translateTextForPage(text, "plain") but the bilingual path now sends ("<html>…</html>", "html"). Assertions need updating to match the new textFormat and HTML payload — the pipeline itself is correct.
- Manually verified on Chrome/Edge with Google and Microsoft providers: inline formatting (bold, italic, links), KaTeX, and MathJax 3 formulas all survive bilingual translation on arxiv.org and Jupyter-notebook-based GitHub Pages blogs.
