### PR TITLE
fix(translate): recover bilingual translations when sites rewrite wrapper content

### DIFF
--- a/.changeset/cnbc-wrapper-tamper-recovery.md
+++ b/.changeset/cnbc-wrapper-tamper-recovery.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): recover bilingual translations when sites rewrite wrapper content, and unclamp CNBC card titles

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -397,6 +397,7 @@ describe("pageTranslationManager mutation re-walk", () => {
       status: "active",
       walkId: "walk-id",
       wrapper,
+      wrapperTextContent: null,
     }
     registerBilingualTranslationState(state)
     mockTranslateNodesBilingualMode.mockImplementation(async () => {
@@ -436,6 +437,7 @@ describe("pageTranslationManager mutation re-walk", () => {
         status: "active",
         walkId: "walk-id",
         wrapper,
+        wrapperTextContent: null,
       }
       tweet.append(wrapper)
       registerBilingualTranslationState(state)
@@ -496,6 +498,7 @@ describe("pageTranslationManager mutation re-walk", () => {
         status: "active",
         walkId,
         wrapper,
+        wrapperTextContent: null,
       }
       tweet.append(wrapper)
       registerBilingualTranslationState(state)
@@ -590,6 +593,7 @@ describe("pageTranslationManager mutation re-walk", () => {
       status: "active",
       walkId: "walk-id",
       wrapper,
+      wrapperTextContent: null,
     }
     registerBilingualTranslationState(state)
     await flushDomUpdates()
@@ -636,6 +640,7 @@ describe("pageTranslationManager mutation re-walk", () => {
         status: "active",
         walkId: "walk-id",
         wrapper,
+        wrapperTextContent: null,
       }
       registerBilingualTranslationState(state)
       return state
@@ -693,6 +698,7 @@ describe("pageTranslationManager mutation re-walk", () => {
       status: "active",
       walkId: "walk-id",
       wrapper,
+      wrapperTextContent: null,
     }
     registerBilingualTranslationState(state)
     await flushDomUpdates()
@@ -709,6 +715,199 @@ describe("pageTranslationManager mutation re-walk", () => {
     expect(mockTranslateNodesBilingualMode).toHaveBeenCalledWith([tweet], "walk-id", DEFAULT_CONFIG)
 
     manager.stop()
+  })
+
+  it("retranslates when the site rewrites text inside our wrapper (#1918)", async () => {
+    document.body.innerHTML = `
+      <p id="tweet"><span id="source">English title</span></p>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const tweet = document.getElementById("tweet") as HTMLElement
+    const wrapper = document.createElement("span")
+    wrapper.className = "notranslate read-frog-translated-content-wrapper"
+    wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+    wrapper.append("中文译文")
+    tweet.append(wrapper)
+    const state: BilingualTranslationState = {
+      layoutSource: tweet,
+      sourceTextContent: "English title",
+      status: "active",
+      walkId: "walk-id",
+      wrapper,
+      wrapperTextContent: wrapper.textContent,
+    }
+    registerBilingualTranslationState(state)
+    await flushDomUpdates()
+    mockTranslateNodesBilingualMode.mockClear()
+    mockTranslateNodesBilingualMode.mockImplementation(async () => {
+      unregisterBilingualTranslationState(state)
+    })
+
+    // CNBC-style truncation script: a characterData write on the text node
+    // INSIDE our wrapper, replacing the translation with clipped English.
+    const translatedTextNode = wrapper.firstChild as Text
+    translatedTextNode.data = "English title…"
+    await flushDomUpdates()
+
+    expect(mockWalkAndLabelElement).toHaveBeenCalledWith(tweet, "walk-id", DEFAULT_CONFIG)
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(1)
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledWith([tweet], "walk-id", DEFAULT_CONFIG)
+
+    manager.stop()
+  })
+
+  it("retranslates when the site replaces our translated node inside the wrapper (#1918)", async () => {
+    document.body.innerHTML = `
+      <p id="tweet"><span id="source">English title</span></p>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const tweet = document.getElementById("tweet") as HTMLElement
+    const wrapper = document.createElement("span")
+    wrapper.className = "notranslate read-frog-translated-content-wrapper"
+    wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+    wrapper.append("中文译文")
+    tweet.append(wrapper)
+    const state: BilingualTranslationState = {
+      layoutSource: tweet,
+      sourceTextContent: "English title",
+      status: "active",
+      walkId: "walk-id",
+      wrapper,
+      wrapperTextContent: wrapper.textContent,
+    }
+    registerBilingualTranslationState(state)
+    await flushDomUpdates()
+    mockTranslateNodesBilingualMode.mockClear()
+    mockTranslateNodesBilingualMode.mockImplementation(async () => {
+      unregisterBilingualTranslationState(state)
+    })
+
+    // Framework-style childList tamper: our text node swapped for a site span.
+    const siteSpan = document.createElement("span")
+    siteSpan.textContent = "English title…"
+    wrapper.replaceChildren(siteSpan)
+    await flushDomUpdates()
+
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(1)
+    expect(mockTranslateNodesBilingualMode).toHaveBeenCalledWith([tweet], "walk-id", DEFAULT_CONFIG)
+
+    manager.stop()
+  })
+
+  it("ignores in-wrapper mutations that leave the wrapper text unchanged (#1918)", async () => {
+    document.body.innerHTML = `
+      <p id="tweet"><span id="source">English title</span></p>
+    `
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const tweet = document.getElementById("tweet") as HTMLElement
+    const wrapper = document.createElement("span")
+    wrapper.className = "notranslate read-frog-translated-content-wrapper"
+    wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+    wrapper.append("中文译文")
+    tweet.append(wrapper)
+    const state: BilingualTranslationState = {
+      layoutSource: tweet,
+      sourceTextContent: "English title",
+      status: "active",
+      walkId: "walk-id",
+      wrapper,
+      wrapperTextContent: wrapper.textContent,
+    }
+    registerBilingualTranslationState(state)
+    await flushDomUpdates()
+    mockWalkAndLabelElement.mockClear()
+    mockTranslateNodesBilingualMode.mockClear()
+
+    // Node identity churn with identical text (React re-render writing the
+    // same content) must stay classified as self-inflicted noise.
+    wrapper.replaceChildren(document.createTextNode("中文译文"))
+    await flushDomUpdates()
+
+    expect(mockWalkAndLabelElement).not.toHaveBeenCalled()
+    expect(mockTranslateNodesBilingualMode).not.toHaveBeenCalled()
+
+    unregisterBilingualTranslationState(state)
+    manager.stop()
+  })
+
+  it("caps tamper-driven retranslation passes behind the budget (#1918)", async () => {
+    vi.useFakeTimers()
+    const flushWithFakeTimers = async (rounds = 4) => {
+      for (let i = 0; i < rounds; i++) {
+        await Promise.resolve()
+        await vi.advanceTimersByTimeAsync(0)
+        await Promise.resolve()
+      }
+    }
+
+    try {
+      document.body.innerHTML = `
+        <p id="tweet"><span id="source">English title</span></p>
+      `
+
+      const manager = new PageTranslationManager()
+      await manager.start()
+      await flushWithFakeTimers()
+
+      const tweet = document.getElementById("tweet") as HTMLElement
+      const wrapper = document.createElement("span")
+      wrapper.className = "notranslate read-frog-translated-content-wrapper"
+      wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+      wrapper.append("译文 0")
+      tweet.append(wrapper)
+      const translatedTextNode = wrapper.firstChild as Text
+      // Snapshot never matches the wrapper, so every in-wrapper rewrite marks
+      // the source stale — a site truncation script fighting our repairs.
+      const state: BilingualTranslationState = {
+        layoutSource: tweet,
+        sourceTextContent: "English title",
+        status: "active",
+        walkId: "walk-id",
+        wrapper,
+        wrapperTextContent: "expected 译文",
+      }
+      registerBilingualTranslationState(state)
+      await flushWithFakeTimers()
+      mockTranslateNodesBilingualMode.mockClear()
+
+      let churn = 0
+      mockTranslateNodesBilingualMode.mockImplementation(async () => {
+        churn += 1
+        translatedTextNode.data = `译文 ${churn}`
+        await flushWithFakeTimers(2)
+      })
+
+      translatedTextNode.data = "译文 start"
+      await flushWithFakeTimers(8)
+
+      // Same #1831 protections, new record class: per-invocation pass cap…
+      expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(3)
+      expect((manager as any).pendingRetranslateRetries.size).toBe(1)
+
+      // …then the debounced retry burns the rest of the per-window budget.
+      await vi.advanceTimersByTimeAsync(1000)
+      await flushWithFakeTimers()
+      expect(mockTranslateNodesBilingualMode).toHaveBeenCalledTimes(6)
+
+      manager.stop()
+      expect((manager as any).pendingRetranslateRetries.size).toBe(0)
+
+      unregisterBilingualTranslationState(state)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("caps retranslation passes and defers perpetual churn behind a debounced retry (#1831)", async () => {
@@ -744,6 +943,7 @@ describe("pageTranslationManager mutation re-walk", () => {
         status: "active",
         walkId: "walk-id",
         wrapper,
+        wrapperTextContent: null,
       }
       registerBilingualTranslationState(state)
       await flushWithFakeTimers()

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -39,6 +39,7 @@ import { walkAndLabelElement, walkAndLabelElementChunked } from "@/utils/host/do
 import {
   findStaleBilingualLayoutSource,
   findStaleTranslationOnlyAnchor,
+  getBilingualTranslationStateForWrapper,
   wasCharacterDataChangeExtensionDriven,
   wasNodeRemovedByExtension,
 } from "@/utils/host/translate/core/translation-state"
@@ -790,7 +791,21 @@ export class PageTranslationManager implements IPageTranslationManager {
       return true
     }
     const targetElement = isHTMLElement(record.target) ? record.target : record.target.parentElement
-    if (targetElement?.closest(`.${CONTENT_WRAPPER_CLASS}`)) return true
+    const wrapperElement = targetElement?.closest<HTMLElement>(`.${CONTENT_WRAPPER_CLASS}`)
+    if (wrapperElement) {
+      // In-wrapper churn is normally our own (#1831) — but a divergence from
+      // the post-insertion snapshot means the SITE rewrote our wrapper content
+      // (truncation scripts like CNBC's, #1918). Those records must reach the
+      // staleness walk so the budgeted retranslation repairs the wrapper. The
+      // null snapshot covers the construction window and error-UI wrappers,
+      // keeping their churn classified self-inflicted exactly as before.
+      const state = getBilingualTranslationStateForWrapper(wrapperElement)
+      return !(
+        state &&
+        state.wrapperTextContent !== null &&
+        wrapperElement.textContent !== state.wrapperTextContent
+      )
+    }
     if (record.type !== "childList") return false
     const added = [...record.addedNodes]
     const removed = [...record.removedNodes]

--- a/src/utils/host/translate/core/__tests__/translation-modes-wrapper-tamper.test.ts
+++ b/src/utils/host/translate/core/__tests__/translation-modes-wrapper-tamper.test.ts
@@ -1,0 +1,264 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import {
+  BLOCK_ATTRIBUTE,
+  CONTENT_WRAPPER_CLASS,
+  NOTRANSLATE_CLASS,
+  PARAGRAPH_ATTRIBUTE,
+  TRANSLATION_ERROR_CONTAINER_CLASS,
+} from "@/utils/constants/dom-labels"
+import { removeAllTranslatedWrapperNodes } from "../../dom/translation-cleanup"
+import { translateNodesBilingualMode } from "../translation-modes"
+import {
+  getBilingualTranslationStateForSource,
+  isBilingualTranslationStateCurrent,
+  MAX_WRAPPER_TAMPER_REPAIRS,
+  registerBilingualTranslationState,
+  unregisterBilingualTranslationState,
+  type BilingualTranslationState,
+} from "../translation-state"
+
+const { mockDecorateTranslationNode, mockShouldFilterSmallParagraph, mockTranslateTextForPage } =
+  vi.hoisted(() => ({
+    mockDecorateTranslationNode: vi.fn<(...args: any[]) => any>(),
+    mockShouldFilterSmallParagraph: vi.fn<(...args: any[]) => any>(),
+    mockTranslateTextForPage: vi.fn<(...args: any[]) => any>(),
+  }))
+
+vi.mock("@/utils/host/translate/filter-small-paragraph", () => ({
+  shouldFilterSmallParagraph: mockShouldFilterSmallParagraph,
+}))
+
+vi.mock("@/utils/host/translate/target-language-skip", () => ({
+  shouldSkipAsTargetLanguage: vi.fn<(...args: any[]) => any>().mockResolvedValue(false),
+}))
+
+vi.mock("@/utils/host/translate/translate-variants", () => ({
+  translateTextForPage: mockTranslateTextForPage,
+}))
+
+vi.mock("@/utils/host/translate/ui/decorate-translation", () => ({
+  decorateTranslationNode: mockDecorateTranslationNode,
+}))
+
+function createSource(text = "English source title"): HTMLElement {
+  const source = document.createElement("div")
+  source.textContent = text
+  source.setAttribute(BLOCK_ATTRIBUTE, "")
+  source.setAttribute(PARAGRAPH_ATTRIBUTE, "")
+  document.body.append(source)
+  return source
+}
+
+function getWrapper(source: HTMLElement): HTMLElement {
+  const wrapper = source.querySelector<HTMLElement>(`.${CONTENT_WRAPPER_CLASS}`)
+  expect(wrapper).not.toBeNull()
+  return wrapper!
+}
+
+/** The translated content span the site would rewrite (CNBC truncation, #1918). */
+function tamperWrapper(wrapper: HTMLElement, text: string): void {
+  const translatedNode = wrapper.lastElementChild as HTMLElement
+  translatedNode.textContent = text
+}
+
+describe("bilingual wrapper tamper recovery (#1918)", () => {
+  beforeEach(() => {
+    document.body.replaceChildren()
+    mockDecorateTranslationNode.mockReset().mockResolvedValue(undefined)
+    mockShouldFilterSmallParagraph.mockReset().mockResolvedValue(false)
+    mockTranslateTextForPage.mockReset().mockResolvedValue("translated")
+  })
+
+  afterEach(() => {
+    removeAllTranslatedWrapperNodes(document)
+  })
+
+  it("snapshots the wrapper content after a successful translation", async () => {
+    const source = createSource()
+    await translateNodesBilingualMode([source], "walk-1", DEFAULT_CONFIG)
+
+    const wrapper = getWrapper(source)
+    const state = getBilingualTranslationStateForSource(source)!
+    expect(wrapper.textContent).toContain("translated")
+    expect(state.wrapperTextContent).toBe(wrapper.textContent)
+    expect(isBilingualTranslationStateCurrent(state)).toBe(true)
+  })
+
+  it("keeps the snapshot null until the translated content is inserted", async () => {
+    const source = createSource()
+    let resolveTranslate!: (value: string) => void
+    mockTranslateTextForPage.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveTranslate = resolve
+      }),
+    )
+
+    const run = translateNodesBilingualMode([source], "walk-1", DEFAULT_CONFIG)
+    // Let filtering settle and the wrapper/spinner insert while the provider
+    // round-trip is still pending — the construction window.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    const pendingState = getBilingualTranslationStateForSource(source)!
+    expect(pendingState.wrapper).not.toBeNull()
+    expect(pendingState.wrapperTextContent).toBeNull()
+
+    resolveTranslate("translated")
+    await run
+    expect(pendingState.wrapperTextContent).toBe(pendingState.wrapper!.textContent)
+  })
+
+  it("repairs a tampered wrapper that the same walk previously short-circuited", async () => {
+    const source = createSource()
+    await translateNodesBilingualMode([source], "walk-1", DEFAULT_CONFIG)
+    const wrapper = getWrapper(source)
+    const state = getBilingualTranslationStateForSource(source)!
+
+    tamperWrapper(wrapper, "truncated english…")
+    expect(isBilingualTranslationStateCurrent(state)).toBe(false)
+
+    await translateNodesBilingualMode([source], "walk-1", DEFAULT_CONFIG)
+
+    const repairedWrapper = getWrapper(source)
+    expect(repairedWrapper).not.toBe(wrapper)
+    expect(repairedWrapper.textContent).toContain("translated")
+    const repairedState = getBilingualTranslationStateForSource(source)!
+    expect(repairedState.wrapperTextContent).toBe(repairedWrapper.textContent)
+    expect(isBilingualTranslationStateCurrent(repairedState)).toBe(true)
+  })
+
+  it("capitulates after the repair budget and adopts the site's wrapper content", async () => {
+    const source = createSource()
+    await translateNodesBilingualMode([source], "walk-1", DEFAULT_CONFIG)
+
+    for (let round = 1; round <= MAX_WRAPPER_TAMPER_REPAIRS; round++) {
+      tamperWrapper(getWrapper(source), `tampered ${round}`)
+      await translateNodesBilingualMode([source], "walk-1", DEFAULT_CONFIG)
+      expect(getWrapper(source).textContent).toContain("translated")
+    }
+
+    // The site wins the next round: content is adopted instead of re-fought.
+    const finalWrapper = getWrapper(source)
+    tamperWrapper(finalWrapper, "site version")
+    mockTranslateTextForPage.mockClear()
+    await translateNodesBilingualMode([source], "walk-1", DEFAULT_CONFIG)
+
+    expect(getWrapper(source)).toBe(finalWrapper)
+    expect(finalWrapper.textContent).toContain("site version")
+    const state = getBilingualTranslationStateForSource(source)!
+    expect(state.wrapperTextContent).toBe(finalWrapper.textContent)
+    expect(isBilingualTranslationStateCurrent(state)).toBe(true)
+    expect(mockTranslateTextForPage).not.toHaveBeenCalled()
+  })
+
+  it("re-arms the capitulation budget when the host text genuinely changes", async () => {
+    const source = createSource()
+    await translateNodesBilingualMode([source], "walk-1", DEFAULT_CONFIG)
+
+    // Burn the whole repair budget.
+    for (let round = 0; round <= MAX_WRAPPER_TAMPER_REPAIRS; round++) {
+      tamperWrapper(getWrapper(source), `tampered ${round}`)
+      await translateNodesBilingualMode([source], "walk-1", DEFAULT_CONFIG)
+    }
+    expect(getWrapper(source).textContent).toContain(`tampered ${MAX_WRAPPER_TAMPER_REPAIRS}`)
+
+    // Genuine host change resets the counter and retranslates…
+    source.firstChild!.textContent = "Fresh host content"
+    await translateNodesBilingualMode([source], "walk-1", DEFAULT_CONFIG)
+    expect(getWrapper(source).textContent).toContain("translated")
+
+    // …so the next tamper gets repaired again instead of being adopted.
+    tamperWrapper(getWrapper(source), "tampered again")
+    await translateNodesBilingualMode([source], "walk-1", DEFAULT_CONFIG)
+    expect(getWrapper(source).textContent).toContain("translated")
+  })
+
+  it("removes the wrapper instead of canonizing a tamper landing in the decorate window", async () => {
+    const source = createSource()
+    mockDecorateTranslationNode.mockImplementationOnce(async (node: HTMLElement) => {
+      // Site rewrite racing the decorate await: the snapshot was already
+      // armed at append time, so isCurrent() fails and the fail-safe removes
+      // the wrapper instead of blessing the tampered content.
+      node.textContent = "tampered during decorate"
+      await Promise.resolve()
+    })
+
+    await translateNodesBilingualMode([source], "walk-1", DEFAULT_CONFIG)
+
+    expect(source.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeNull()
+    expect(getBilingualTranslationStateForSource(source)).toBeUndefined()
+  })
+
+  it("keeps the snapshot null on the provider-error path", async () => {
+    const source = createSource()
+    mockTranslateTextForPage.mockRejectedValue(new Error("provider down"))
+
+    await translateNodesBilingualMode([source], "walk-1", DEFAULT_CONFIG)
+
+    const wrapper = getWrapper(source)
+    expect(wrapper.querySelector(`.${TRANSLATION_ERROR_CONTAINER_CLASS}`)).not.toBeNull()
+    const state = getBilingualTranslationStateForSource(source)!
+    expect(state.wrapperTextContent).toBeNull()
+    // Error-host churn inside the wrapper keeps its pre-#1918 classification.
+    expect(isBilingualTranslationStateCurrent(state)).toBe(true)
+  })
+})
+
+describe("isBilingualTranslationStateCurrent wrapper-content integrity (#1918)", () => {
+  function buildState(): {
+    layoutSource: HTMLElement
+    wrapper: HTMLElement
+    state: BilingualTranslationState
+  } {
+    const layoutSource = document.createElement("div")
+    layoutSource.textContent = "Host text"
+    const wrapper = document.createElement("span")
+    wrapper.className = `${NOTRANSLATE_CLASS} ${CONTENT_WRAPPER_CLASS}`
+    wrapper.textContent = "译文"
+    layoutSource.append(wrapper)
+    document.body.append(layoutSource)
+    const state: BilingualTranslationState = {
+      layoutSource,
+      sourceTextContent: "Host text",
+      status: "active",
+      walkId: "walk-1",
+      wrapper,
+      wrapperTextContent: wrapper.textContent,
+    }
+    registerBilingualTranslationState(state)
+    return { layoutSource, state, wrapper }
+  }
+
+  beforeEach(() => {
+    document.body.replaceChildren()
+  })
+
+  it("stays current while the wrapper content matches the snapshot", () => {
+    const { state } = buildState()
+    expect(isBilingualTranslationStateCurrent(state)).toBe(true)
+    unregisterBilingualTranslationState(state)
+  })
+
+  it("ignores wrapper content when the snapshot is null (construction window)", () => {
+    const { state, wrapper } = buildState()
+    state.wrapperTextContent = null
+    wrapper.textContent = "anything the extension writes mid-construction"
+    expect(isBilingualTranslationStateCurrent(state)).toBe(true)
+    unregisterBilingualTranslationState(state)
+  })
+
+  it("goes stale when the wrapper content diverges from the snapshot", () => {
+    const { state, wrapper } = buildState()
+    wrapper.textContent = "truncated english…"
+    expect(isBilingualTranslationStateCurrent(state)).toBe(false)
+    unregisterBilingualTranslationState(state)
+  })
+
+  it("still goes stale on host-text changes with a matching wrapper", () => {
+    const { layoutSource, state } = buildState()
+    layoutSource.append("real host change")
+    expect(isBilingualTranslationStateCurrent(state)).toBe(false)
+    unregisterBilingualTranslationState(state)
+  })
+})

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -52,17 +52,21 @@ import { isNumericContent } from "../ui/translation-utils"
 import {
   attachBilingualTranslationWrapper,
   collectSourceTextExcludingWrappers,
+  countWrapperTamperRepair,
   getBilingualTranslationStateForSource,
   getTranslationOnlyAnchorState,
   getVirtualParagraphGroupForSource,
   isBilingualTranslationStateCurrent,
+  isBilingualWrapperContentTampered,
   isVirtualParagraphGroupCurrent,
   markExtensionDrivenNodeRemoval,
   markVirtualParagraphGroupInserted,
+  MAX_WRAPPER_TAMPER_REPAIRS,
   registerBilingualTranslationState,
   registerTranslationOnlyOriginals,
   registerVirtualParagraphGroup,
   registerVirtualParagraphWrapper,
+  resetWrapperTamperRepairs,
   translatingNodes,
   unregisterBilingualTranslationState,
   type BilingualTranslationState,
@@ -392,6 +396,24 @@ export async function translateNodesBilingualMode(
         isBilingualTranslationStateCurrent(existingBilingualState)
       if (!toggle && isSameActiveWalk) return
 
+      if (!toggle && isBilingualWrapperContentTampered(existingBilingualState)) {
+        // The site rewrote our wrapper content while the host text is intact
+        // (#1918). Repair by retranslating — but a script that rewrites
+        // deterministically would fight forever (the retranslation budget
+        // bounds rate, not duration), so after MAX_WRAPPER_TAMPER_REPAIRS
+        // losses adopt the site's version as the expected content: the
+        // pre-#1918 terminal state, reached after real repair attempts.
+        if (countWrapperTamperRepair(layoutSource) > MAX_WRAPPER_TAMPER_REPAIRS) {
+          existingBilingualState.wrapperTextContent =
+            existingBilingualState.wrapper?.textContent ?? null
+          return
+        }
+      } else {
+        // Genuine host change, toggle, or new session: the fight (if any) is
+        // over — re-arm the capitulation budget.
+        resetWrapperTamperRepairs(layoutSource)
+      }
+
       if (existingBilingualState.wrapper) {
         removeTranslatedWrapperWithRestore(existingBilingualState.wrapper)
       } else {
@@ -481,6 +503,7 @@ export async function translateNodesBilingualMode(
         status: "active",
         walkId,
         wrapper: null,
+        wrapperTextContent: null,
       }
       registerBilingualTranslationState(bilingualState)
     }
@@ -593,7 +616,18 @@ export async function translateNodesBilingualMode(
 
     await insertTranslatedNodeIntoWrapper(
       translatedWrapperNode,
-      { flowSource: insertionTarget, isCurrent, layoutSource, sourceText: textContent },
+      {
+        flowSource: insertionTarget,
+        isCurrent,
+        layoutSource,
+        // Wrapper-content integrity snapshot (#1918): armed synchronously at
+        // append time so a site rewrite landing during the decorate await can
+        // never be canonized as the expected content.
+        onContentInserted: (wrapper) => {
+          if (bilingualState) bilingualState.wrapperTextContent = wrapper.textContent
+        },
+        sourceText: textContent,
+      },
       translatedText,
       config.translate.translationNodeStyle,
       config,

--- a/src/utils/host/translate/core/translation-state.ts
+++ b/src/utils/host/translate/core/translation-state.ts
@@ -40,6 +40,13 @@ export interface BilingualTranslationState {
   status: "active" | "disposed"
   walkId: string
   wrapper: HTMLElement | null
+  // Expected wrapper.textContent right after the translated node is appended.
+  // null during construction and for error-UI wrappers — in-wrapper mutation
+  // records then stay classified self-inflicted (#1831). Set only on the
+  // successful-insertion path; a later divergence means the SITE rewrote our
+  // wrapper content (truncation scripts, normalizers) and the translation must
+  // be repaired instead of silently staying corrupted (#1918).
+  wrapperTextContent: string | null
 }
 
 // State management for translation operations
@@ -348,6 +355,50 @@ export function unregisterBilingualTranslationState(state: BilingualTranslationS
   state.status = "disposed"
 }
 
+// Capitulation counter for wrapper-content fights (#1918): a site script that
+// deterministically rewrites our wrapper content (NBSP normalizers, truncation
+// scripts) would otherwise loop the budgeted retranslation forever — the
+// budget bounds the RATE, never the duration. Keyed by layoutSource so the
+// count survives state replacement across repairs; NOT reset on repair
+// success, only on genuine host-content changes (a reset on repair would
+// re-arm the infinite fight).
+const wrapperTamperRepairCounts = new WeakMap<HTMLElement, number>()
+
+/** Repair attempts before adopting the site's wrapper content as expected. */
+export const MAX_WRAPPER_TAMPER_REPAIRS = 3
+
+export function countWrapperTamperRepair(layoutSource: HTMLElement): number {
+  const next = (wrapperTamperRepairCounts.get(layoutSource) ?? 0) + 1
+  wrapperTamperRepairCounts.set(layoutSource, next)
+  return next
+}
+
+export function resetWrapperTamperRepairs(layoutSource: HTMLElement): void {
+  wrapperTamperRepairCounts.delete(layoutSource)
+}
+
+/**
+ * True when the ONLY defect is that the wrapper's content diverged from the
+ * post-insertion snapshot: registration, connectivity, containment and host
+ * text are all intact. This is the signature of a site-side rewrite of our
+ * wrapper content (#1918) — distinguishable from genuine host-content
+ * changes, which must always retranslate (and reset the capitulation count).
+ */
+export function isBilingualWrapperContentTampered(state: BilingualTranslationState): boolean {
+  return (
+    state.status === "active" &&
+    bilingualTranslationsBySource.get(state.layoutSource) === state &&
+    state.layoutSource.isConnected &&
+    state.wrapper !== null &&
+    bilingualTranslationsByWrapper.get(state.wrapper) === state &&
+    state.wrapper.isConnected &&
+    state.layoutSource.contains(state.wrapper) &&
+    state.wrapperTextContent !== null &&
+    state.wrapper.textContent !== state.wrapperTextContent &&
+    collectHostText(state.layoutSource, new Set([state.wrapper])) === state.sourceTextContent
+  )
+}
+
 export function isBilingualTranslationStateCurrent(state: BilingualTranslationState): boolean {
   if (
     state.status !== "active" ||
@@ -368,7 +419,13 @@ export function isBilingualTranslationStateCurrent(state: BilingualTranslationSt
     bilingualTranslationsByWrapper.get(state.wrapper) === state &&
     state.wrapper.isConnected &&
     state.layoutSource.contains(state.wrapper) &&
-    collectHostText(state.layoutSource, new Set([state.wrapper])) === state.sourceTextContent
+    collectHostText(state.layoutSource, new Set([state.wrapper])) === state.sourceTextContent &&
+    // Wrapper-content integrity: a site rewriting text INSIDE our wrapper
+    // (truncation scripts, normalizers) must read as stale so the budgeted
+    // retranslation pipeline repairs it (#1918). Exact compare, consistent
+    // with collectHostText/expectedRunText. Last conjunct: cheapest exit
+    // paths first.
+    (state.wrapperTextContent === null || state.wrapper.textContent === state.wrapperTextContent)
   )
 }
 

--- a/src/utils/host/translate/dom/__tests__/virtual-paragraph-lifecycle.test.ts
+++ b/src/utils/host/translate/dom/__tests__/virtual-paragraph-lifecycle.test.ts
@@ -300,6 +300,7 @@ describe("virtual paragraph lifecycle", () => {
       status: "active",
       walkId: "pending-legacy",
       wrapper: null,
+      wrapperTextContent: null,
     }
     registerBilingualTranslationState(state)
 
@@ -323,6 +324,7 @@ describe("virtual paragraph lifecycle", () => {
       status: "active",
       walkId: "foreign-wrapper",
       wrapper: ownWrapper,
+      wrapperTextContent: null,
     }
     registerBilingualTranslationState(state)
     expect(isBilingualTranslationStateCurrent(state)).toBe(true)
@@ -375,6 +377,7 @@ describe("virtual paragraph lifecycle", () => {
       status: "active",
       walkId: "snapshot-symmetry",
       wrapper: null,
+      wrapperTextContent: null,
     }
     registerBilingualTranslationState(state)
 

--- a/src/utils/host/translate/dom/translation-insertion.ts
+++ b/src/utils/host/translate/dom/translation-insertion.ts
@@ -24,6 +24,14 @@ interface TranslationInsertionContext {
   layoutSource: TransNode
   sourceText: string
   isCurrent?: () => boolean
+  // Fired synchronously right after the translated node is appended, BEFORE
+  // the decorate await. This is the only sound point to snapshot the wrapper's
+  // expected content (#1918): earlier and the isCurrent() entry guard would
+  // see a mismatch and self-destruct the translation; later (after the await)
+  // and a site rewrite landing in the await window would be canonized as the
+  // expected content. Not fired on the no-append early return, so stray empty
+  // wrappers never enter tamper surveillance.
+  onContentInserted?: (wrapper: HTMLElement) => void
 }
 
 function isFloatedElement(element: HTMLElement): boolean {
@@ -95,7 +103,13 @@ export function addBlockTranslation(
 
 export async function insertTranslatedNodeIntoWrapper(
   translatedWrapperNode: HTMLElement,
-  { flowSource, layoutSource, sourceText, isCurrent }: TranslationInsertionContext,
+  {
+    flowSource,
+    layoutSource,
+    sourceText,
+    isCurrent,
+    onContentInserted,
+  }: TranslationInsertionContext,
   translatedText: string,
   translationNodeStyle: TranslationNodeStyleConfig,
   config: Config,
@@ -139,6 +153,8 @@ export async function insertTranslatedNodeIntoWrapper(
 
   translatedNode.textContent = translatedText
   translatedWrapperNode.appendChild(translatedNode)
+  // Synchronous, pre-await: see TranslationInsertionContext.onContentInserted.
+  onContentInserted?.(translatedWrapperNode)
   await decorateTranslationNode(translatedNode, translationNodeStyle)
 
   if (isCurrent && !isCurrent()) return

--- a/src/utils/site-rules/__tests__/built-in.test.ts
+++ b/src/utils/site-rules/__tests__/built-in.test.ts
@@ -78,6 +78,16 @@ describe("built-in site rules", () => {
     expect(invalid).toEqual([])
   })
 
+  // CNBC clamps card titles via an INLINE style (-webkit-line-clamp:3), which
+  // only an !important declaration can override — without it the rule is a
+  // no-op and the injected translation stays clipped.
+  // See https://github.com/mengxi-ream/read-frog/issues/1918
+  it("unclamps CNBC card titles with !important (issue #1918)", () => {
+    const resolved = resolveSiteRule("https://www.cnbc.com/", BUILT_IN_SITE_RULES, [], [])
+    expect(resolved.injectedCss).toContain("-webkit-line-clamp: unset !important")
+    expect(resolved.injectedCss).toContain("max-height: unset !important")
+  })
+
   // Vercel `prose-vercel` docs hide `[data-docs-heading] a span`, which also
   // hides Read Frog's injected wrapper once it lands inside the heading anchor.
   // See https://github.com/mengxi-ream/read-frog/issues/1050

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -1294,7 +1294,7 @@
   {
     "id": "cnbc",
     "matches": "www.cnbc.com",
-    "injectedCss": "div.Card-titleContainer > div { -webkit-line-clamp: unset;max-height: unset; }",
+    "injectedCss": "div.Card-titleContainer > div { -webkit-line-clamp: unset !important;max-height: unset !important; }",
     "excludeSelectors.add": [
       "#GlobalNavigation",
       "#GlobalFooter",


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Issue #1918 (CNBC homepage, bilingual mode) has **two independent root causes**, both fixed here:

### 1. The built-in `cnbc` rule was a complete no-op (clipped translations)

CNBC clamps card titles via an **inline style** (`style="…-webkit-line-clamp:3…"`). The rule's `injectedCss` lacked `!important`, and an author-stylesheet declaration can never override an inline declaration without it. Verified live on cnbc.com at two viewports: with the shipped rule, computed `-webkit-line-clamp` stays `3`; with `!important` it becomes `none`.

Fix: add `!important` to both declarations. `overflow: visible` is deliberately not added — with the clamp defeated, the `-webkit-box` grows with its content, so the inline `overflow:hidden` has nothing left to clip.

### 2. Site rewrites *inside* our wrapper were permanently invisible (hover kills the translation)

Instrumenting cnbc.com live captured the mechanism: CNBC's truncation script writes `.data` on text nodes **inside our injected wrapper**, replacing the Chinese translation with clipped English. Three interlocking guards (all from the #1831 anti-storm fix) made this corruption permanent:

1. `isSelfInflictedRecord` dropped **every** mutation record whose target is inside a wrapper;
2. `isBilingualTranslationStateCurrent` never checked the wrapper's own content (host-text compare excludes wrapper subtrees), so the state stayed "current" forever;
3. non-toggle walks skip any element containing a wrapper.

This also explains why 沉浸式翻译/欧路词典 lose the translation identically (they inject a separate node too) and why 仅译文 mode survives (in-place swaps have content-level staleness since #1846).

**Fix — unlock the pipeline, don't build a new one:**

- `BilingualTranslationState.wrapperTextContent` snapshots the expected wrapper content, armed via an `onContentInserted` hook **synchronously at append time, before the decorate `await`** — earlier and the `isCurrent()` entry guard would self-destruct every translation; later and a tamper racing the await window would be canonized as expected content.
- The currency check now compares wrapper content against the snapshot (`null` = construction window / error-UI wrappers, preserving today's #1831 classification exactly).
- `isSelfInflictedRecord` lets in-wrapper records through **only** when the content has diverged from the snapshot, routing them into the existing budgeted staleness → retranslation pipeline (3 passes/invocation, 6 per 10s, 1s debounced retries, translation-cache-backed).
- **Capitulation rule**: the budget bounds the retranslation *rate*, not its *duration* — a site script that deterministically rewrites our content (normalizers, truncation scripts) would otherwise fight forever. After `MAX_WRAPPER_TAMPER_REPAIRS = 3` tamper-only repairs per source, the site's version is adopted as the new expected content. Genuine host-text changes reset the counter.

Documented follow-up (out of scope): virtual-paragraph wrappers (`VirtualParagraphGroup`) would need per-wrapper snapshots for the same protection; CNBC titles are plain bilingual states.

## Related Issue

Closes #1918

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

- 17 new unit tests: the captured CNBC characterData tamper shape, childList variant, identical-content no-op, #1831 storm regressions (construction-window null snapshot, extension churn replay), tamper-driven budget capping, capitulation + counter re-arm, decorate-window fail-safe (tamper is removed, never canonized), provider-error wrappers keep `null` snapshots, currency four-quadrant, and the cnbc rule `!important` assertion.
- Full suite: 211 files / 1993 tests pass; type-aware oxlint clean.
- E2E in real Chrome (puppeteer harness, built extension, real Microsoft translation) against a CNBC-style clamped-title fixture: initial translation lands → 3 tamper rounds each auto-repaired → 4th tamper adopted (no perpetual fight) → sibling paragraph unaffected → zero React/DOM errors.
- CSS fix verified live on cnbc.com (computed line-clamp `3` → `none`).

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

History context: the "break the height limit" ability was once a global built-in (`smashTruncationStyle()`, removed in #1799 right after the per-site rule engine landed in #1794). Since then it lives only in per-site `injectedCss` — note for future rules: `ensureSiteRuleCSS` injects the CSS verbatim, so any rule targeting an **inline**-styled clamp must carry `!important` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
