### PR TITLE
fix(translate): lower default request burst to 20

### DIFF
--- a/.changeset/low-default-translation-burst.md
+++ b/.changeset/low-default-translation-burst.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): reduce the default request burst capacity to 20

--- a/src/utils/constants/translate.ts
+++ b/src/utils/constants/translate.ts
@@ -4,7 +4,7 @@ export const MIN_BATCH_CHARACTERS = 1
 export const MIN_BATCH_ITEMS = 1
 
 export const DEFAULT_REQUEST_RATE = 8
-export const DEFAULT_REQUEST_CAPACITY = 60
+export const DEFAULT_REQUEST_CAPACITY = 20
 
 export const DEFAULT_MAX_CHARACTER_PER_BATCH = 1000
 export const DEFAULT_MAX_ITEMS_PER_BATCH = 4


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Lower the default webpage and subtitle translation request-bucket capacity from 60 to 20 while retaining the default refill rate of 8 requests per second.

This keeps enough initial capacity to dispatch up to 80 translation items when the normal four-item batch size applies, while avoiding the previous 60-request cold-start spike. Existing persisted queue settings are unchanged; the new value applies to fresh default configuration only.

## Related Issue

Closes #

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through static checks

No dedicated test is needed for this default-only constant change. Formatting and type checks pass.

## Screenshots

Not applicable.

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The historical v050-to-v051 config migration intentionally retains its literal capacity of 60 because migration scripts are frozen snapshots. No migration is added for this default-only change, so user-customized values are preserved.
