### PR TITLE
fix(selection-toolbar): handle page stacking and modal dialog layers

### DIFF
--- a/.changeset/bright-frogs-layer.md
+++ b/.changeset/bright-frogs-layer.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection-toolbar): keep selection tools above page stacking contexts

--- a/.changeset/calm-frogs-modal.md
+++ b/.changeset/calm-frogs-modal.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection-toolbar): keep selection tools interactive in modal dialogs

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/modal-dialog-host.test.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/modal-dialog-host.test.ts
@@ -1,0 +1,403 @@
+// @vitest-environment jsdom
+import type { SelectionRangeSnapshot } from "../../utils"
+import type { ModalDialogHostController } from "../modal-dialog-host"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { NOTRANSLATE_CLASS } from "@/utils/constants/dom-labels"
+import {
+  calibrateModalDialogHostSlot,
+  createModalDialogHostController,
+  createModalDialogHostSlot,
+  findSelectionModalDialog,
+  MODAL_DIALOG_HOST_SLOT_ATTRIBUTE,
+} from "../modal-dialog-host"
+
+function createRange(
+  startContainer: Node,
+  endContainer: Node = startContainer,
+): SelectionRangeSnapshot {
+  return {
+    startContainer,
+    startOffset: 0,
+    endContainer,
+    endOffset: endContainer.textContent?.length ?? 0,
+  }
+}
+
+function createActiveDialog() {
+  const dialog = document.createElement("dialog")
+  let active = true
+  const matches = dialog.matches.bind(dialog)
+
+  dialog.open = true
+  document.body.append(dialog)
+  vi.spyOn(dialog, "matches").mockImplementation((selector) =>
+    selector === ":modal" ? active : matches(selector),
+  )
+
+  return {
+    dialog,
+    setActive: (value: boolean) => {
+      active = value
+    },
+  }
+}
+
+describe("modal dialog host placement", () => {
+  let animationFrameCallbacks: Map<number, FrameRequestCallback>
+  let nextAnimationFrameId: number
+  let scrollXDescriptor: PropertyDescriptor | undefined
+  let scrollYDescriptor: PropertyDescriptor | undefined
+  const controllers: ModalDialogHostController[] = []
+
+  beforeEach(() => {
+    animationFrameCallbacks = new Map()
+    nextAnimationFrameId = 1
+    scrollXDescriptor = Object.getOwnPropertyDescriptor(window, "scrollX")
+    scrollYDescriptor = Object.getOwnPropertyDescriptor(window, "scrollY")
+    Object.defineProperty(window, "scrollX", { configurable: true, value: 0 })
+    Object.defineProperty(window, "scrollY", { configurable: true, value: 0 })
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      const id = nextAnimationFrameId
+      nextAnimationFrameId += 1
+      animationFrameCallbacks.set(id, callback)
+      return id
+    })
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation((id) => {
+      animationFrameCallbacks.delete(id)
+    })
+  })
+
+  afterEach(() => {
+    for (const controller of controllers) {
+      controller.dispose()
+    }
+    controllers.length = 0
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    if (scrollXDescriptor) {
+      Object.defineProperty(window, "scrollX", scrollXDescriptor)
+    } else {
+      Reflect.deleteProperty(window, "scrollX")
+    }
+    if (scrollYDescriptor) {
+      Object.defineProperty(window, "scrollY", scrollYDescriptor)
+    } else {
+      Reflect.deleteProperty(window, "scrollY")
+    }
+    document.documentElement.innerHTML = "<head></head><body></body>"
+  })
+
+  const trackController = (host: HTMLElement) => {
+    const controller = createModalDialogHostController(host)
+    controllers.push(controller)
+    return controller
+  }
+
+  const flushAnimationFrames = () => {
+    const callbacks = [...animationFrameCallbacks.values()]
+    animationFrameCallbacks.clear()
+    callbacks.forEach((callback) => callback(performance.now()))
+  }
+
+  const flushMutationSync = async () => {
+    await Promise.resolve()
+    flushAnimationFrames()
+    await Promise.resolve()
+  }
+
+  it("finds the native modal shared by every selection boundary", () => {
+    const { dialog } = createActiveDialog()
+    const first = document.createTextNode("First")
+    const second = document.createTextNode("Second")
+    dialog.append(first, second)
+
+    expect(findSelectionModalDialog([createRange(first), createRange(second)])).toBe(dialog)
+  })
+
+  it("walks across a shadow root to find the native modal", () => {
+    const { dialog } = createActiveDialog()
+    const shadowHost = document.createElement("fixture-shadow-host")
+    const shadow = shadowHost.attachShadow({ mode: "open" })
+    const selectedText = document.createTextNode("Selected inside shadow")
+    shadow.append(selectedText)
+    dialog.append(shadowHost)
+
+    expect(findSelectionModalDialog([createRange(selectedText)])).toBe(dialog)
+  })
+
+  it("rejects non-modal dialogs, custom modal elements, and mixed boundaries", () => {
+    const { dialog, setActive } = createActiveDialog()
+    const modalText = document.createTextNode("Modal")
+    const outsideText = document.createTextNode("Outside")
+    const customModal = document.createElement("div")
+    const customText = document.createTextNode("Custom")
+    customModal.setAttribute("role", "dialog")
+    customModal.append(customText)
+    dialog.append(modalText)
+    document.body.append(outsideText, customModal)
+
+    expect(findSelectionModalDialog([createRange(modalText, outsideText)])).toBeNull()
+    expect(findSelectionModalDialog([createRange(customText)])).toBeNull()
+
+    setActive(false)
+    expect(findSelectionModalDialog([createRange(modalText)])).toBeNull()
+  })
+
+  it("creates an out-of-flow, zero-sized, non-translatable slot", () => {
+    const slot = createModalDialogHostSlot(document)
+
+    expect(slot).toHaveAttribute(MODAL_DIALOG_HOST_SLOT_ATTRIBUTE)
+    expect(slot).toHaveClass(NOTRANSLATE_CLASS)
+    for (const [property, value] of [
+      ["display", "block"],
+      ["position", "absolute"],
+      ["width", "0px"],
+      ["height", "0px"],
+      ["overflow", "visible"],
+      ["pointer-events", "none"],
+      ["z-index", "2147483647"],
+    ]) {
+      expect(slot.style.getPropertyValue(property)).toBe(value)
+      expect(slot.style.getPropertyPriority(property)).toBe("important")
+    }
+  })
+
+  it("calibrates an offset dialog slot to the document origin", () => {
+    Object.defineProperty(window, "scrollX", { configurable: true, value: 100 })
+    Object.defineProperty(window, "scrollY", { configurable: true, value: 900 })
+    const slot = createModalDialogHostSlot(document)
+    vi.spyOn(slot, "getBoundingClientRect").mockImplementation(() => {
+      const left = 330 + Number.parseFloat(slot.style.left)
+      const top = 120 + Number.parseFloat(slot.style.top)
+      return DOMRect.fromRect({ x: left, y: top })
+    })
+
+    const calibration = calibrateModalDialogHostSlot(slot)
+
+    expect(calibration).toMatchObject({ aligned: true, errorX: 0, errorY: 0 })
+    expect(slot.style.left).toBe("-430px")
+    expect(slot.style.top).toBe("-1020px")
+    expect(slot.style.getPropertyPriority("left")).toBe("important")
+    expect(slot.style.getPropertyPriority("top")).toBe("important")
+  })
+
+  it("retries a residual calibration once on the next animation frame", () => {
+    const host = document.createElement("read-frog-selection")
+    document.body.append(host)
+    const { dialog } = createActiveDialog()
+    const selectedText = document.createTextNode("Selected")
+    dialog.append(selectedText)
+    const slotOffsets = [10, 5, 2, 0]
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        if (this.hasAttribute(MODAL_DIALOG_HOST_SLOT_ATTRIBUTE)) {
+          return DOMRect.fromRect({ x: slotOffsets.shift() ?? 0, y: 0 })
+        }
+
+        return DOMRect.fromRect()
+      },
+    )
+    const controller = trackController(host)
+
+    controller.placeForRanges([createRange(selectedText)])
+    expect(animationFrameCallbacks.size).toBe(1)
+
+    flushAnimationFrames()
+    expect(animationFrameCallbacks.size).toBe(0)
+    expect(slotOffsets).toEqual([])
+  })
+
+  it("cancels queued placement work and listeners when disposed", () => {
+    const host = document.createElement("read-frog-selection")
+    document.body.append(host)
+    const { dialog } = createActiveDialog()
+    const selectedText = document.createTextNode("Selected")
+    dialog.append(selectedText)
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        return this.hasAttribute(MODAL_DIALOG_HOST_SLOT_ATTRIBUTE)
+          ? DOMRect.fromRect({ x: 10, y: 10 })
+          : DOMRect.fromRect()
+      },
+    )
+    const controller = trackController(host)
+
+    controller.placeForRanges([createRange(selectedText)])
+    expect(animationFrameCallbacks.size).toBe(1)
+
+    controller.dispose()
+    expect(animationFrameCallbacks.size).toBe(0)
+    window.dispatchEvent(new Event("resize"))
+    dialog.dispatchEvent(new Event("scroll"))
+    expect(animationFrameCallbacks.size).toBe(0)
+  })
+
+  it("moves the same host into a modal slot and restores its original order", () => {
+    const host = document.createElement("read-frog-selection")
+    const marker = document.createElement("div")
+    document.body.append(host, marker)
+    const { dialog } = createActiveDialog()
+    const selectedText = document.createTextNode("Selected")
+    const outsideText = document.createTextNode("Outside")
+    dialog.append(selectedText)
+    document.body.append(outsideText)
+    const controller = trackController(host)
+
+    expect(controller.placeForRanges([createRange(selectedText)])).toBe(true)
+    const slot = dialog.querySelector<HTMLElement>(`[${MODAL_DIALOG_HOST_SLOT_ATTRIBUTE}]`)
+    expect(slot).not.toBeNull()
+    expect(host.parentElement).toBe(slot)
+
+    expect(controller.placeForRanges([createRange(outsideText)])).toBe(false)
+    expect(host.parentNode).toBe(document.body)
+    expect(host.nextSibling).toBe(marker)
+    expect(slot?.isConnected).toBe(false)
+  })
+
+  it("switches between native modal dialogs without changing the original restore target", () => {
+    const host = document.createElement("read-frog-selection")
+    document.body.append(host)
+    const first = createActiveDialog().dialog
+    const second = createActiveDialog().dialog
+    const firstText = document.createTextNode("First")
+    const secondText = document.createTextNode("Second")
+    first.append(firstText)
+    second.append(secondText)
+    const controller = trackController(host)
+
+    controller.placeForRanges([createRange(firstText)])
+    const firstSlot = first.querySelector(`[${MODAL_DIALOG_HOST_SLOT_ATTRIBUTE}]`)
+    controller.placeForRanges([createRange(secondText)])
+
+    expect(firstSlot?.isConnected).toBe(false)
+    expect(second.querySelector(`[${MODAL_DIALOG_HOST_SLOT_ATTRIBUTE}]`)?.contains(host)).toBe(true)
+
+    controller.restore()
+    expect(host.parentNode).toBe(document.body)
+  })
+
+  it("keeps the host in the modal until placement or modal lifecycle explicitly changes", async () => {
+    const host = document.createElement("read-frog-selection")
+    document.body.append(host)
+    const { dialog } = createActiveDialog()
+    const selectedText = document.createTextNode("Selected")
+    dialog.append(selectedText)
+    const controller = trackController(host)
+
+    controller.placeForRanges([createRange(selectedText)])
+    await flushMutationSync()
+
+    expect(dialog.contains(host)).toBe(true)
+  })
+
+  it("restores a disconnected host when the site removes the modal subtree", async () => {
+    const host = document.createElement("read-frog-selection")
+    const marker = document.createElement("div")
+    document.body.append(host, marker)
+    const { dialog } = createActiveDialog()
+    const selectedText = document.createTextNode("Selected")
+    dialog.append(selectedText)
+    const controller = trackController(host)
+    controller.placeForRanges([createRange(selectedText)])
+
+    dialog.remove()
+    expect(host.isConnected).toBe(false)
+    await flushMutationSync()
+
+    expect(host.isConnected).toBe(true)
+    expect(host.parentNode).toBe(document.body)
+    expect(host.nextSibling).toBe(marker)
+  })
+
+  it("restores when a modal is removed from inside a shadow root", async () => {
+    const host = document.createElement("read-frog-selection")
+    const shadowHost = document.createElement("fixture-shadow-host")
+    const shadow = shadowHost.attachShadow({ mode: "open" })
+    document.body.append(host, shadowHost)
+    const { dialog } = createActiveDialog()
+    const selectedText = document.createTextNode("Selected")
+    dialog.append(selectedText)
+    shadow.append(dialog)
+    const controller = trackController(host)
+    controller.placeForRanges([createRange(selectedText)])
+
+    dialog.remove()
+    expect(host.isConnected).toBe(false)
+    await flushMutationSync()
+
+    expect(host.isConnected).toBe(true)
+    expect(host.parentNode).toBe(document.body)
+  })
+
+  it("self-heals when the site removes the active slot", async () => {
+    const host = document.createElement("read-frog-selection")
+    document.body.append(host)
+    const { dialog } = createActiveDialog()
+    const selectedText = document.createTextNode("Selected")
+    dialog.append(selectedText)
+    const controller = trackController(host)
+    controller.placeForRanges([createRange(selectedText)])
+    const slot = dialog.querySelector<HTMLElement>(`[${MODAL_DIALOG_HOST_SLOT_ATTRIBUTE}]`)!
+
+    slot.remove()
+    expect(host.isConnected).toBe(false)
+    await flushMutationSync()
+
+    expect(slot.parentNode).toBe(dialog)
+    expect(host.parentNode).toBe(slot)
+    expect(host.isConnected).toBe(true)
+  })
+
+  it("restores when the dialog closes or loses its native modal state", async () => {
+    const host = document.createElement("read-frog-selection")
+    document.body.append(host)
+    const { dialog, setActive } = createActiveDialog()
+    const selectedText = document.createTextNode("Selected")
+    dialog.append(selectedText)
+    const controller = trackController(host)
+
+    controller.placeForRanges([createRange(selectedText)])
+    dialog.dispatchEvent(new Event("close"))
+    expect(host.parentNode).toBe(document.body)
+
+    controller.placeForRanges([createRange(selectedText)])
+    setActive(false)
+    dialog.removeAttribute("open")
+    await flushMutationSync()
+    expect(host.parentNode).toBe(document.body)
+  })
+
+  it("falls back to a replacement body when the original body is removed", async () => {
+    const originalBody = document.body
+    const host = document.createElement("read-frog-selection")
+    originalBody.append(host)
+    const { dialog } = createActiveDialog()
+    const selectedText = document.createTextNode("Selected")
+    dialog.append(selectedText)
+    const controller = trackController(host)
+    controller.placeForRanges([createRange(selectedText)])
+
+    const replacementBody = document.createElement("body")
+    originalBody.replaceWith(replacementBody)
+    await flushMutationSync()
+
+    expect(host.parentNode).toBe(replacementBody)
+    expect(host.isConnected).toBe(true)
+  })
+
+  it("coalesces repeated geometry events into one animation frame", () => {
+    const host = document.createElement("read-frog-selection")
+    document.body.append(host)
+    const { dialog } = createActiveDialog()
+    const selectedText = document.createTextNode("Selected")
+    dialog.append(selectedText)
+    const controller = trackController(host)
+    controller.placeForRanges([createRange(selectedText)])
+
+    window.dispatchEvent(new Event("resize"))
+    window.dispatchEvent(new Event("resize"))
+    dialog.dispatchEvent(new Event("scroll"))
+
+    expect(animationFrameCallbacks.size).toBe(1)
+  })
+})

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { SELECTION_CONTENT_OVERLAY_ROOT_ATTRIBUTE } from "@/entrypoints/selection.content/overlay-layers"
 import { selectionSessionAtom } from "../atoms"
 import { SelectionToolbar } from "../index"
+import { MODAL_DIALOG_HOST_SLOT_ATTRIBUTE } from "../modal-dialog-host"
 
 const MOCK_SELECTED_TEXT = "Selected Text"
 
@@ -810,6 +811,44 @@ describe("selectionToolbar - positioning logic", () => {
       "pointer-events-none",
       "z-2147483647",
     )
+  })
+
+  it("moves its shadow host into a selected native modal before showing the toolbar", async () => {
+    const extensionHost = document.createElement("read-frog-selection")
+    const shadowRoot = extensionHost.attachShadow({ mode: "open" })
+    const mount = document.createElement("div")
+    shadowRoot.append(mount)
+    document.body.append(extensionHost)
+
+    const dialog = document.createElement("dialog")
+    const selectedText = document.createTextNode("Selected inside modal")
+    const target = document.createElement("p")
+    target.append(selectedText)
+    dialog.append(target)
+    dialog.open = true
+    document.body.append(dialog)
+    const matches = dialog.matches.bind(dialog)
+    const matchesSpy = vi
+      .spyOn(dialog, "matches")
+      .mockImplementation((selector) => (selector === ":modal" ? true : matches(selector)))
+    window.getSelection = vi.fn<(...args: any[]) => any>(() => ({
+      toString: () => MOCK_SELECTED_TEXT,
+      getRangeAt: () => ({
+        startContainer: selectedText,
+        startOffset: 0,
+        endContainer: selectedText,
+        endOffset: selectedText.length,
+      }),
+      containsNode: () => true,
+    }))
+
+    render(<SelectionToolbar />, { container: mount })
+    await triggerMouseDownAndUp(target, 100, 100, 200, 200)
+
+    const slot = dialog.querySelector(`[${MODAL_DIALOG_HOST_SLOT_ATTRIBUTE}]`)
+    expect(slot?.contains(extensionHost)).toBe(true)
+    expect(shadowRoot.querySelector(".absolute.z-2147483647")).toHaveClass("opacity-100")
+    matchesSpy.mockRestore()
   })
 
   it("should keep the bottom-right toolbar below the cursor to reduce accidental clicks", async () => {

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
@@ -801,10 +801,15 @@ describe("selectionToolbar - positioning logic", () => {
     })
   })
 
-  it("renders inside a fixed viewport host", () => {
+  it("renders inside the highest fixed viewport layer", () => {
     render(<SelectionToolbar />)
 
-    expect(getToolbarElement().parentElement).toHaveClass("fixed", "inset-0", "pointer-events-none")
+    expect(getToolbarElement().parentElement).toHaveClass(
+      "fixed",
+      "inset-0",
+      "pointer-events-none",
+      "z-2147483647",
+    )
   })
 
   it("should keep the bottom-right toolbar below the cursor to reduce accidental clicks", async () => {

--- a/src/entrypoints/selection.content/selection-toolbar/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/index.tsx
@@ -1,3 +1,4 @@
+import type { ModalDialogHostController } from "./modal-dialog-host"
 import { useAtom, useAtomValue, useSetAtom } from "jotai"
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react"
 import {
@@ -17,6 +18,7 @@ import {
 } from "./atoms"
 import { CloseButton, DropEvent } from "./close-button"
 import { SelectionToolbarCustomActionButtons } from "./custom-action-button"
+import { createModalDialogHostController } from "./modal-dialog-host"
 import {
   collectSelectionScrollTargets,
   createSelectionAnchorTracker,
@@ -185,6 +187,7 @@ export function SelectionToolbar() {
   const selectionDirectionRef = useRef<SelectionDirection>(SelectionDirection.BOTTOM_RIGHT) // store selection direction
   const selectionAnchorTrackerRef = useRef<ReturnType<typeof createSelectionAnchorTracker>>(null)
   const selectionScrollTargetsRef = useRef<Array<Element | ShadowRoot>>([])
+  const modalDialogHostControllerRef = useRef<ModalDialogHostController>(null)
   const isPointerDownInsideOverlayRef = useRef(false)
   const preserveSelectionStateRef = useRef(false)
   const [isSelectionToolbarVisible, setIsSelectionToolbarVisible] = useAtom(
@@ -194,6 +197,27 @@ export function SelectionToolbar() {
   const clearSelectionState = useSetAtom(clearSelectionStateAtom)
   const selectionToolbar = useAtomValue(configFieldsAtomMap.selectionToolbar)
   const dropdownOpenRef = useRef(false)
+
+  const placeHostForSelection = useCallback(
+    (ranges: Parameters<ModalDialogHostController["placeForRanges"]>[0]) => {
+      const root = tooltipContainerRef.current?.getRootNode()
+      if (!(root instanceof ShadowRoot) || !(root.host instanceof HTMLElement)) {
+        return
+      }
+
+      modalDialogHostControllerRef.current ??= createModalDialogHostController(root.host)
+      modalDialogHostControllerRef.current.placeForRanges(ranges)
+    },
+    [],
+  )
+
+  useEffect(
+    () => () => {
+      modalDialogHostControllerRef.current?.dispose()
+      modalDialogHostControllerRef.current = null
+    },
+    [],
+  )
 
   const updatePosition = useCallback(
     ({ remeasureSelection = false }: { remeasureSelection?: boolean } = {}) => {
@@ -362,6 +386,8 @@ export function SelectionToolbar() {
 
         if (selectionSnapshot) {
           preserveSelectionStateRef.current = false
+          // Enter a native modal's top layer before React measures or shows the toolbar.
+          placeHostForSelection(selectionSnapshot.ranges)
           setSelectionState({
             selection: selectionSnapshot,
             context: buildContextSnapshot(selectionSnapshot),
@@ -458,7 +484,7 @@ export function SelectionToolbar() {
       document.removeEventListener("mousedown", handleMouseDown)
       document.removeEventListener("selectionchange", handleSelectionChange)
     }
-  }, [clearSelectionState, setIsSelectionToolbarVisible, setSelectionState])
+  }, [clearSelectionState, placeHostForSelection, setIsSelectionToolbarVisible, setSelectionState])
 
   useEffect(() => {
     const handler = (e: Event) => {

--- a/src/entrypoints/selection.content/selection-toolbar/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/index.tsx
@@ -482,7 +482,7 @@ export function SelectionToolbar() {
   return (
     <div
       ref={tooltipContainerRef}
-      className={`${NOTRANSLATE_CLASS} pointer-events-none fixed inset-0`}
+      className={`${NOTRANSLATE_CLASS} pointer-events-none fixed inset-0 ${SELECTION_CONTENT_OVERLAY_LAYERS.selectionOverlay}`}
       {...{ [SELECTION_CONTENT_OVERLAY_ROOT_ATTRIBUTE]: "" }}
     >
       {selectionToolbar.enabled && !isSiteDisabled && hasAnyEnabledFeature && (

--- a/src/entrypoints/selection.content/selection-toolbar/modal-dialog-host.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/modal-dialog-host.ts
@@ -1,0 +1,363 @@
+import type { SelectionRangeSnapshot } from "../utils"
+import { NOTRANSLATE_CLASS } from "@/utils/constants/dom-labels"
+
+export const MODAL_DIALOG_HOST_SLOT_ATTRIBUTE = "data-read-frog-modal-dialog-host-slot"
+
+const MAX_OVERLAY_Z_INDEX = "2147483647"
+const CALIBRATION_TOLERANCE = 1
+const CALIBRATION_PASSES = 2
+
+const MODAL_HOST_SLOT_STYLES = [
+  ["display", "block"],
+  ["position", "absolute"],
+  ["top", "0px"],
+  ["right", "auto"],
+  ["bottom", "auto"],
+  ["left", "0px"],
+  ["box-sizing", "border-box"],
+  ["width", "0px"],
+  ["min-width", "0px"],
+  ["max-width", "0px"],
+  ["height", "0px"],
+  ["min-height", "0px"],
+  ["max-height", "0px"],
+  ["margin", "0px"],
+  ["padding", "0px"],
+  ["border", "0px"],
+  ["overflow", "visible"],
+  ["pointer-events", "none"],
+  ["z-index", MAX_OVERLAY_Z_INDEX],
+] as const
+
+export interface ModalDialogHostSlotCalibration {
+  aligned: boolean
+  errorX: number
+  errorY: number
+}
+
+export interface ModalDialogHostController {
+  placeForRanges: (ranges: SelectionRangeSnapshot[]) => boolean
+  restore: () => void
+  dispose: () => void
+}
+
+function getParentNodeAcrossShadow(node: Node) {
+  if (node.parentNode) {
+    return node.parentNode
+  }
+
+  const root = node.getRootNode()
+  return root instanceof ShadowRoot ? root.host : null
+}
+
+function isActiveModalDialog(node: Node): node is HTMLDialogElement {
+  if (!(node instanceof HTMLDialogElement) || !node.open || !node.isConnected) {
+    return false
+  }
+
+  try {
+    return node.matches(":modal")
+  } catch {
+    return false
+  }
+}
+
+function findNearestModalDialog(node: Node) {
+  let current: Node | null = node
+
+  while (current) {
+    if (isActiveModalDialog(current)) {
+      return current
+    }
+
+    current = getParentNodeAcrossShadow(current)
+  }
+
+  return null
+}
+
+function collectMutationObserverTargets(dialog: HTMLDialogElement) {
+  const targets = new Set<Node>([dialog.ownerDocument.documentElement])
+  let current: Node = dialog
+
+  // Document observers do not see mutations inside shadow trees. Observe every
+  // shadow boundary so removing either the dialog or one of its hosts is caught.
+  while (true) {
+    const root = current.getRootNode()
+    if (!(root instanceof ShadowRoot)) {
+      break
+    }
+
+    targets.add(root)
+    current = root.host
+  }
+
+  return targets
+}
+
+export function findSelectionModalDialog(ranges: SelectionRangeSnapshot[]) {
+  const boundaryNodes = new Set<Node>()
+
+  for (const range of ranges) {
+    boundaryNodes.add(range.startContainer)
+    boundaryNodes.add(range.endContainer)
+  }
+
+  if (boundaryNodes.size === 0) {
+    return null
+  }
+
+  let resolvedDialog: HTMLDialogElement | null = null
+
+  for (const boundaryNode of boundaryNodes) {
+    const dialog = findNearestModalDialog(boundaryNode)
+    if (!dialog || (resolvedDialog && resolvedDialog !== dialog)) {
+      return null
+    }
+
+    resolvedDialog = dialog
+  }
+
+  return resolvedDialog
+}
+
+export function createModalDialogHostSlot(document: Document) {
+  const slot = document.createElement("read-frog-modal-dialog-host-slot")
+  slot.classList.add(NOTRANSLATE_CLASS)
+  slot.setAttribute(MODAL_DIALOG_HOST_SLOT_ATTRIBUTE, "")
+
+  for (const [property, value] of MODAL_HOST_SLOT_STYLES) {
+    slot.style.setProperty(property, value, "important")
+  }
+
+  return slot
+}
+
+function readPixelStyle(element: HTMLElement, property: "left" | "top") {
+  const value = Number.parseFloat(element.style.getPropertyValue(property))
+  return Number.isFinite(value) ? value : 0
+}
+
+export function calibrateModalDialogHostSlot(slot: HTMLElement): ModalDialogHostSlotCalibration {
+  const view = slot.ownerDocument.defaultView
+  if (!view) {
+    return { aligned: false, errorX: Number.POSITIVE_INFINITY, errorY: Number.POSITIVE_INFINITY }
+  }
+
+  // WXT's absolute Shadow <html> expects the document origin. Recreate that
+  // origin after the host moves under an offset dialog containing block.
+  const targetX = -view.scrollX
+  const targetY = -view.scrollY
+
+  for (let pass = 0; pass < CALIBRATION_PASSES; pass += 1) {
+    const rect = slot.getBoundingClientRect()
+    const errorX = targetX - rect.left
+    const errorY = targetY - rect.top
+
+    if (Math.abs(errorX) <= CALIBRATION_TOLERANCE && Math.abs(errorY) <= CALIBRATION_TOLERANCE) {
+      return { aligned: true, errorX, errorY }
+    }
+
+    slot.style.setProperty("left", `${readPixelStyle(slot, "left") + errorX}px`, "important")
+    slot.style.setProperty("top", `${readPixelStyle(slot, "top") + errorY}px`, "important")
+  }
+
+  const rect = slot.getBoundingClientRect()
+  const errorX = targetX - rect.left
+  const errorY = targetY - rect.top
+
+  return {
+    aligned: Math.abs(errorX) <= CALIBRATION_TOLERANCE && Math.abs(errorY) <= CALIBRATION_TOLERANCE,
+    errorX,
+    errorY,
+  }
+}
+
+export function createModalDialogHostController(host: HTMLElement): ModalDialogHostController {
+  const ownerDocument = host.ownerDocument
+  const view = ownerDocument.defaultView
+  const originalParent = host.parentNode
+  const originalNextSibling = host.nextSibling
+  let activeDialog: HTMLDialogElement | null = null
+  let slot: HTMLElement | null = null
+  let mutationObserver: MutationObserver | null = null
+  let resizeObserver: ResizeObserver | null = null
+  let animationFrameId: number | null = null
+  let scheduledCalibrationRetry = false
+  let disposed = false
+  const handlePlacementChange = () => scheduleSync()
+
+  const cancelScheduledSync = () => {
+    if (animationFrameId === null || !view) {
+      return
+    }
+
+    view.cancelAnimationFrame(animationFrameId)
+    animationFrameId = null
+    scheduledCalibrationRetry = false
+  }
+
+  const detachPlacementListeners = () => {
+    cancelScheduledSync()
+    mutationObserver?.disconnect()
+    mutationObserver = null
+    resizeObserver?.disconnect()
+    resizeObserver = null
+
+    if (!view || !activeDialog) {
+      return
+    }
+
+    const visualViewport = view.visualViewport
+    activeDialog.removeEventListener("close", restore)
+    activeDialog.removeEventListener("scroll", handlePlacementChange, true)
+    view.removeEventListener("scroll", handlePlacementChange)
+    view.removeEventListener("resize", handlePlacementChange)
+    visualViewport?.removeEventListener("scroll", handlePlacementChange)
+    visualViewport?.removeEventListener("resize", handlePlacementChange)
+  }
+
+  const restoreHostToOriginalPosition = () => {
+    // A site may remove the whole modal subtree (including our host), so do not
+    // require the host itself to still be connected before restoring it.
+    const parent = originalParent?.isConnected
+      ? originalParent
+      : (ownerDocument.body ?? ownerDocument.documentElement)
+
+    if (!parent) {
+      return
+    }
+
+    if (originalNextSibling?.parentNode === parent) {
+      parent.insertBefore(host, originalNextSibling)
+    } else {
+      parent.appendChild(host)
+    }
+  }
+
+  function restore() {
+    if (!activeDialog && !slot) {
+      return
+    }
+
+    const previousSlot = slot
+    detachPlacementListeners()
+    activeDialog = null
+    slot = null
+    restoreHostToOriginalPosition()
+    previousSlot?.remove()
+  }
+
+  const syncPlacement = (retryIfNeeded: boolean) => {
+    if (disposed || !activeDialog || !slot) {
+      return
+    }
+
+    if (!isActiveModalDialog(activeDialog)) {
+      restore()
+      return
+    }
+
+    if (slot.parentNode !== activeDialog) {
+      activeDialog.appendChild(slot)
+    }
+
+    if (host.parentNode !== slot) {
+      slot.appendChild(host)
+    }
+
+    const calibration = calibrateModalDialogHostSlot(slot)
+    if (!calibration.aligned && retryIfNeeded) {
+      scheduleSync(false)
+    }
+  }
+
+  function scheduleSync(retryIfNeeded = true) {
+    if (!view || disposed || !activeDialog) {
+      return
+    }
+
+    scheduledCalibrationRetry ||= retryIfNeeded
+    if (animationFrameId !== null) {
+      return
+    }
+
+    animationFrameId = view.requestAnimationFrame(() => {
+      animationFrameId = null
+      const shouldRetry = scheduledCalibrationRetry
+      scheduledCalibrationRetry = false
+      syncPlacement(shouldRetry)
+    })
+  }
+
+  const attachPlacementListeners = () => {
+    if (!view || !activeDialog) {
+      return
+    }
+
+    const visualViewport = view.visualViewport
+    activeDialog.addEventListener("close", restore)
+    activeDialog.addEventListener("scroll", handlePlacementChange, {
+      capture: true,
+      passive: true,
+    })
+    view.addEventListener("scroll", handlePlacementChange, { passive: true })
+    view.addEventListener("resize", handlePlacementChange)
+    visualViewport?.addEventListener("scroll", handlePlacementChange, { passive: true })
+    visualViewport?.addEventListener("resize", handlePlacementChange)
+
+    mutationObserver = new MutationObserver(handlePlacementChange)
+    for (const target of collectMutationObserverTargets(activeDialog)) {
+      mutationObserver.observe(target, {
+        childList: true,
+        subtree: true,
+      })
+    }
+    mutationObserver.observe(activeDialog, {
+      attributes: true,
+      attributeFilter: ["class", "open", "style"],
+    })
+
+    if (typeof ResizeObserver !== "undefined") {
+      resizeObserver = new ResizeObserver(handlePlacementChange)
+      resizeObserver.observe(activeDialog)
+    }
+  }
+
+  const placeForRanges = (ranges: SelectionRangeSnapshot[]) => {
+    if (disposed) {
+      return false
+    }
+
+    const dialog = findSelectionModalDialog(ranges)
+    if (!dialog) {
+      restore()
+      return false
+    }
+
+    if (dialog === activeDialog && slot) {
+      syncPlacement(true)
+      return true
+    }
+
+    restore()
+    activeDialog = dialog
+    slot = createModalDialogHostSlot(ownerDocument)
+    activeDialog.appendChild(slot)
+    slot.appendChild(host)
+    syncPlacement(true)
+    attachPlacementListeners()
+    return true
+  }
+
+  const dispose = () => {
+    if (disposed) {
+      return
+    }
+
+    restore()
+    disposed = true
+  }
+
+  return { placeForRanges, restore, dispose }
+}


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

This fixes two selection-toolbar failures that look identical to users—the toolbar is visibly behind website UI and cannot be clicked—but happen in two different browser layering systems.

### Why one PR needs two fixes

| Issue | Page mechanism | Why the toolbar lost | Fix |
| --- | --- | --- | --- |
| #1916 / Effect | Ordinary document stacking contexts | The `fixed inset-0` viewport root introduced by #1865 became a `z-index: auto` stacking context. The inner `z-2147483647` toolbar could not escape that context, so page layers with `z-index >= 1` painted above the whole extension subtree. | Put `SELECTION_CONTENT_OVERLAY_LAYERS.selectionOverlay` on the existing fixed viewport root itself. |
| #1917 / Steam | Native `showModal()` `<dialog>` in the browser top layer | A body child cannot paint above a top-layer dialog at any z-index. The rest of the document is also inert while the modal is open, so a merely visible body overlay would still not be interactive. | Move the existing selection Shadow host into a calibrated, zero-sized slot inside the selected native modal dialog, then restore it when that dialog goes away. |

### #1916: raise the stacking context that already exists

#1865 changed the selection viewport wrapper to `position: fixed` so the toolbar remains anchored while the document or a nested selection container scrolls. A fixed element creates a stacking context even when its z-index is `auto`:

```text
document root
├─ website fixed/sticky layer (z-index: 1+)
└─ selection viewport root (position: fixed; z-index: auto)
   └─ toolbar (z-index: 2147483647, but only inside its parent context)
```

`z-index` is compared between sibling stacking contexts, not globally. Raising the inner toolbar therefore cannot beat the website sibling. This PR adds max z-index to the already-fixed viewport root, changing only that context's rank. It does not create another containing block, change layout, or make the pointer-transparent viewport surface consume outside clicks.

### #1917: enter the native modal's top layer

Steam's news reader is a real `<dialog>` opened with `showModal()`. The browser promotes it to the top layer and makes the rest of the document inert. No document z-index can cross that boundary, and Popover API alone would only make the extension visible while its body host remained inert.

The new selection-only controller:

1. resolves every Range start/end boundary across open ShadowRoots;
2. accepts only a common `HTMLDialogElement` that is connected, open, and matches `:modal`;
3. creates an out-of-flow 0×0 absolute slot inside that dialog with inline-important geometry, transparent pointer behavior, visible overflow, and max z-index;
4. moves the existing host—not a second React/ShadowRoot instance—into the slot before the toolbar is measured or shown;
5. calibrates the slot rect to `(-scrollX, -scrollY)`, preserving the document-coordinate origin expected by WXT's absolute Shadow `<html>` and Base UI portals;
6. coalesces dialog/window/visualViewport scroll and resize, ResizeObserver updates, and relevant DOM mutations through `requestAnimationFrame`;
7. restores the same host to its original parent/sibling when the dialog closes, loses `:modal`, is removed, selection moves to another target, or the extension unmounts.

The controller also self-heals if the site removes the slot or host while the modal remains active. Steam removes the entire dialog subtree instead of only closing it, so restoration deliberately works even when the host is already disconnected. Mutation observation crosses every ShadowRoot on the dialog's ancestor path, while document-level attribute churn is not observed.

The detector intentionally does **not** infer modal state from `.modal`, `role="dialog"`, visibility, or z-index. `<dialog open>` created with `show()` and arbitrary custom modal `<div>` elements stay on the ordinary z-index path. Popover and fullscreen top-layer owners are outside this PR's scope.

### Why each `position` value is different

| Element | Position | Responsibility |
| --- | --- | --- |
| Selection viewport root | `fixed` | Remain viewport-sized and keep #1865 Range/nested-scroll positioning behavior. |
| Shared Shadow host | `static` | Stay 0×0 and never become the containing block for absolute Base UI portals, preserving #1888 and #1906. |
| Modal coordinate slot | `absolute` | Be out of flow (no flex/grid gap item) while recreating the document origin inside an offset dialog. |

The shared host CSS remains unchanged:

```css
:host {
  display: block !important;
  height: 0 !important;
  overflow: visible !important;
  position: static !important;
  width: 0 !important;
}
```

This matters because:

- #1888 restored a 0×0, transparent overlay host after WXT's `all: initial !important` reset caused hosts to expand and intercept pages.
- #1906 changed that host from `relative` to `static`; a body-tail relative host had become the containing block for absolute tooltip/provider portals and shifted them far down long pages.
- This PR never applies relative/absolute positioning or max z-index to the host and does not modify shared `OVERLAY_SHADOW_ROOT_CSS` or the Side UI host.

### Alternatives intentionally not used

- **Max z-index on the Shadow host:** cannot beat a native top-layer dialog and risks changing shared selection/Side behavior.
- **Relative/absolute host:** recreates #1906 by making the host a portal containing block.
- **Direct static host reparent without a slot:** enters the top layer, but WXT's absolute Shadow `<html>` inherits the dialog origin, offsetting tooltip, select, combobox, and popover portals.
- **`.modal` / `role="dialog"` heuristics:** site-specific and produces false positives for ordinary in-document overlays.
- **Changing every Base UI `positionMethod`:** broad, fragile, and does not solve top-layer inertness.
- **Popover API:** can paint in the top layer but does not make a body-hosted extension subtree non-inert.
- **Global Escape interception:** would prevent users from closing the website dialog. Existing Base UI dismissal handles the first Escape; the browser receives the next one.

## Related Issue

Closes #1916

Closes #1917

Context:

- #1865 — introduced the fixed viewport root for scroll anchoring
- #1888 — restored zero-sized, transparent Shadow overlay hosts
- #1906 — made overlay hosts static so absolute portals remain viewport-aligned

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual/automated real-browser testing

### Repository checks

| Command | Result |
| --- | --- |
| `pnpm fmt:check` | Passed; 1,131 files checked |
| `pnpm lint` | Passed (`oxlint --type-aware --type-check`) |
| `pnpm type-check` | Passed (`oxlint --type-aware --type-check`) |
| `SKIP_FREE_API=true pnpm test` | Passed: 210 test files / 1,990 tests; 1 file / 4 tests intentionally skipped |
| `pnpm build` | Passed: Chrome MV3 production build |
| `pnpm build:edge` | Passed: Edge MV3 production build |
| `pnpm build:firefox` | Passed: Firefox MV3 production build |
| `git push` pre-push hook | Passed repository fmt/lint plus the unskipped suite: 211 test files / 1,994 tests |

`src/utils/host/translate/api/__tests__/free-api.test.ts` is the intentionally skipped file under `SKIP_FREE_API=true`; it calls live external translation services, as documented by the repository testing notes.

The modal suite covers native `dialog:modal` detection, non-modal/custom-modal rejection, Range boundaries across ShadowRoots, slot style priorities, document-origin calibration, the >1px next-frame retry, rAF coalescing/cancellation, dialog switching/close/remove, lost modal state, disconnected-host recovery, replacement body fallback, site deletion/self-healing, ShadowRoot dialog removal, and unmount restoration. A real ShadowRoot toolbar integration test locks the mouseup wiring.

### Clean production browser matrix

No browser result below uses a runtime CSS/source override. Chrome, Edge, and Firefox artifacts were rebuilt from the two commits in this PR before testing.

| Scenario | Browser / extension | Actual result |
| --- | --- | --- |
| Effect / #1916 | Chrome 150.0.7871.129 / Read Frog 1.42.1 | `scrollY=823`; document `1400×5134`; host `static`, 0×0, `overflow:visible`; fixed root `1400×900`, z=2147483647; document hit host + Shadow hit Translation button; real click opened `500×245` popover; tooltip/popover inside viewport; outside page click succeeded; scroll/document metrics unchanged; modal count 0. |
| Long-page #1888/#1906 fixture | Chrome 150.0.7871.129 / Read Frog 1.42.1 | `scrollY=899`; host and Shadow html/body 0×0; tooltip and `500×285` popover stayed aligned; center hit page `P#target`; page marker received a real click; document geometry unchanged. |
| Offset native modal pressure fixture | Chrome 150.0.7871.129 / Read Frog 1.42.1 | Page `scrollY=900`; dialog `(330,120) 720×500`; slot `(0,-900)` with origin error `(0,0)`; host `static` 0×0; real nested wheel `+70` moved Range/toolbar `-70/-70` (0px error); tooltip, close menu, language combobox, provider select, and `498×225` SelectionPopover were visible/focusable/hittable; layout stable; first Escape kept modal open, second closed it; direct removal restored host. |
| Steam / #1917 | Chrome 150.0.7871.129 / Read Frog 1.42.1 | One native modal; slot origin error `(0,0)`; host `static` 0×0; toolbar `(470,193) 104×30` hit in document + Shadow; real wheel `+60` moved Range/toolbar `-60/-60` (0px error); tooltip and `498×225` popover inside viewport and hittable; extension click/Escape kept Steam modal count 1; clicking Steam's real X removed the reader and restored the connected host to body/static/0×0. |
| Offset native modal pressure fixture | Firefox 152.0.6 / Read Frog 1.42.1 | Foreground/focus asserted; page `scrollY=900`; dialog `(330,120) 720×500`; slot `(0,-900)` with origin error `(0,0)`; host `static` 0×0; original `transition-opacity` completed to computed opacity 1; document + Shadow hit-tests passed; nested scroll `+70` moved Range `-70` and toolbar `-70.0333` (0.0333px error); real click opened `498×225` popover; first/second Escape and direct-removal recovery passed. |
| Steam / #1917 | Firefox 152.0.6 / Read Frog 1.42.1 | Exact reported target selected; one native modal; slot origin error `(0,0)`; host `static` 0×0; original opacity transition completed and hit-tests passed; first W3C element-origin wheel scrolled `+80`, moving Range `-80` and toolbar `-80.0333` (0.0333px error); tooltip and `498×225` popover were visible/hittable; extension click/Escape kept Steam open; Steam's real X removed the reader and restored body/static/0×0 host. |
| Shared Side UI host | Chrome 150.0.7871.129 / Read Frog 1.42.1 | Side host and Shadow html/body remained static/0×0/visible-overflow; `scrollY=1001`; document `1400×3229` and body `1400×3230` stayed unchanged through hover, menu, and outside click; menu `(1198,631) 128.75×58.28` was usable; marker real click succeeded. While the Base UI modal dropdown is open its expected dismissal layer owns center hit-testing; after dismissal, the page immediately owns it again. |

The Chrome artifact used for the Effect and long-page runs had `selection.js` SHA-256 `82e9d4f3b7bf4311db8204f9de647bb8f8f4e803159afbdd9daebfc68b39a6db`.

The headful Firefox runs used a temporary production XPI with SHA-256 `d9c6bb91c5be658aff8de4644b4d324d29730d27d2ea1b8dfc5048f2b150a78d`. Temporary installation opens Read Frog's Guide in a new active tab, so the harness waited for that side effect, switched back to the saved target handle, and required `document.visibilityState === "visible" && document.hasFocus()` before selecting. This prevents a hidden-tab Firefox timeline/input pause from being misreported as a toolbar opacity or wheel regression; no runtime style/source override was used.

## Screenshots

### Effect / #1916

| Before (issue evidence) | After (clean production build) |
| --- | --- |
| ![Effect page before the stacking-context fix](https://mengxi-public.s3.us-west-004.backblazeb2.com/codex-assets/0c/0c2549079595ee9d4b48.png) | ![Effect page after the stacking-context fix](https://mengxi-public.s3.us-west-004.backblazeb2.com/codex-assets/75/7512a317ecd4d311ebcc.png) |

### Steam / #1917

| Before (toolbar behind native dialog) | After (clean production build, interactive translation popover) |
| --- | --- |
| ![Steam reader before native modal support](https://mengxi-public.s3.us-west-004.backblazeb2.com/codex-assets/99/9997cd48800da1772514.png) | ![Steam reader after native modal support](https://mengxi-public.s3.us-west-004.backblazeb2.com/codex-assets/a5/a55fc8453a37263564c5.png) |

### Stress and shared-host fixtures

| Offset native modal | Shared Side UI host/menu |
| --- | --- |
| ![Offset native dialog translation popover regression fixture](https://mengxi-public.s3.us-west-004.backblazeb2.com/codex-assets/d9/d92a6d877da6adb3e640.png) | ![Shared Side UI host regression fixture](https://mengxi-public.s3.us-west-004.backblazeb2.com/codex-assets/6e/6ed0ddc877e9fee4a09a.png) |

## Regression Protection

| History | Invariant kept | Automated / browser protection |
| --- | --- | --- |
| #1865 | Range-based viewport anchoring follows window and nested scrollers. | Existing positioning tests remain; modal fixture and Steam real-wheel tests both produced 0px Range/toolbar tracking error. |
| #1888 | Selection and Side hosts remain transparent, static 0×0 shells with visible overflow and do not alter page geometry/hit-testing. | Existing Shadow-root CSS test plus modal lifecycle tests; Effect, long-page, offset dialog, Steam, and Side clean-build geometry/hit checks. |
| #1906 | Host never becomes a containing block; absolute Base UI portals remain aligned on deep/offset pages. | CSS test rejects `position:relative`; host is never mutated; long-page tooltip/popover plus offset-dialog tooltip/menu/combobox/select/popover checks. |

Shared `OVERLAY_SHADOW_ROOT_CSS` and Side UI source are unchanged. The only z-index change is on the existing selection fixed viewport root; the only reparenting controller is selection-specific.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- No public API, config schema, storage, or migration changes.
- No shared Side UI host change.
- Includes two independent patch changesets for `@read-frog/extension`:
  - `fix(selection-toolbar): keep selection tools above page stacking contexts`
  - `fix(selection-toolbar): keep selection tools interactive in modal dialogs`
- Includes two independently reviewable commits:
  - `fix(selection-toolbar): keep toolbar above page stacking contexts`
  - `fix(selection-toolbar): support native modal dialog layers`
- Modal detection is deliberately limited to native `<dialog>:modal`; arbitrary website modals, Popover API, and fullscreen are not guessed or changed.
