### PR TITLE
fix(toast): centralize notification dismiss delays

### DIFF
--- a/.changeset/small-toasts-wait.md
+++ b/.changeset/small-toasts-wait.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(toast): standardize notification dismiss delays

--- a/src/components/prompt-configurator/__tests__/import-prompts.test.tsx
+++ b/src/components/prompt-configurator/__tests__/import-prompts.test.tsx
@@ -57,7 +57,6 @@ describe("ImportPrompts", () => {
         data: { tooltipStyle: true },
         id: "prompt-import-feedback",
         positionerProps: { anchor: importButton, sideOffset: 6 },
-        timeout: 2000,
         title: "options.translation.personalizedPrompts.importSuccess !",
       })
     })
@@ -78,7 +77,6 @@ describe("ImportPrompts", () => {
       expect(anchoredToastAddMock).toHaveBeenCalledWith({
         id: "prompt-import-feedback",
         positionerProps: { anchor: importButton, sideOffset: 6 },
-        timeout: 5000,
         title: "Invalid prompt file",
         type: "error",
       })

--- a/src/components/prompt-configurator/import-prompts.tsx
+++ b/src/components/prompt-configurator/import-prompts.tsx
@@ -46,7 +46,6 @@ export function ImportPrompts() {
             anchor: importButtonRef.current,
             sideOffset: 6,
           },
-          timeout: 2000,
           title: `${i18n.t("options.translation.personalizedPrompts.importSuccess")} !`,
         })
       }
@@ -58,7 +57,6 @@ export function ImportPrompts() {
             anchor: importButtonRef.current,
             sideOffset: 6,
           },
-          timeout: 5000,
           type: "error",
           title: error instanceof Error ? error.message : "Something went error when importing",
         })

--- a/src/components/ui/base-ui/__tests__/toast.test.tsx
+++ b/src/components/ui/base-ui/__tests__/toast.test.tsx
@@ -37,6 +37,7 @@ function renderAnchoredToastProvider(
 }
 
 afterEach(() => {
+  vi.useRealTimers()
   act(() => toastManager.close())
   act(() => anchoredToastManager.close())
   shadowHost?.remove()
@@ -44,6 +45,25 @@ afterEach(() => {
 })
 
 describe("ToastProvider", () => {
+  it("auto-dismisses non-anchored toasts after five seconds by default", () => {
+    vi.useFakeTimers()
+    renderToastProvider()
+    const onClose = vi.fn<() => void>()
+
+    act(() => {
+      toastManager.add({ onClose, title: "Default timeout" })
+      vi.advanceTimersByTime(4999)
+    })
+
+    expect(onClose).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
   it("portals a bottom-right viewport into the requested shadow root", () => {
     const shadowRoot = renderToastProvider({
       className: "custom-viewport",
@@ -129,6 +149,32 @@ describe("ToastProvider", () => {
 })
 
 describe("AnchoredToastProvider", () => {
+  it("auto-dismisses anchored toasts after three seconds by default", () => {
+    vi.useFakeTimers()
+    renderAnchoredToastProvider()
+    const anchor = document.createElement("button")
+    const onClose = vi.fn<() => void>()
+    document.body.append(anchor)
+
+    act(() => {
+      anchoredToastManager.add({
+        onClose,
+        positionerProps: { anchor },
+        title: "Anchored default timeout",
+      })
+      vi.advanceTimersByTime(2999)
+    })
+
+    expect(onClose).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+
+    expect(onClose).toHaveBeenCalledOnce()
+    anchor.remove()
+  })
+
   it("portals a tooltip-style toast into the requested shadow root", async () => {
     const shadowRoot = renderAnchoredToastProvider()
     const anchor = document.createElement("button")

--- a/src/components/ui/base-ui/toast.tsx
+++ b/src/components/ui/base-ui/toast.tsx
@@ -261,6 +261,9 @@ export const toastManager: ReturnType<typeof Toast.createToastManager> = Toast.c
 export const anchoredToastManager: ReturnType<typeof Toast.createToastManager> =
   Toast.createToastManager()
 
+const DEFAULT_TOAST_TIMEOUT = 5000
+const DEFAULT_ANCHORED_TOAST_TIMEOUT = 3000
+
 export interface ToastProviderProps extends Toast.Provider.Props {
   position?: ToastPosition
   portalProps?: ComponentProps<typeof Toast.Portal>
@@ -271,11 +274,12 @@ export function ToastProvider({
   children,
   position = "bottom-right",
   portalProps,
+  timeout = DEFAULT_TOAST_TIMEOUT,
   viewportProps,
   ...props
 }: ToastProviderProps): ReactElement {
   return (
-    <Toast.Provider toastManager={toastManager} {...props}>
+    <Toast.Provider toastManager={toastManager} timeout={timeout} {...props}>
       {children}
       <Toasts position={position} portalProps={portalProps} viewportProps={viewportProps} />
     </Toast.Provider>
@@ -289,10 +293,11 @@ export interface AnchoredToastProviderProps extends Toast.Provider.Props {
 export function AnchoredToastProvider({
   children,
   portalProps,
+  timeout = DEFAULT_ANCHORED_TOAST_TIMEOUT,
   ...props
 }: AnchoredToastProviderProps): ReactElement {
   return (
-    <Toast.Provider toastManager={anchoredToastManager} {...props}>
+    <Toast.Provider toastManager={anchoredToastManager} timeout={timeout} {...props}>
       {children}
       <AnchoredToasts portalProps={portalProps} />
     </Toast.Provider>

--- a/src/entrypoints/options/pages/api-providers/__tests__/providers-config.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/__tests__/providers-config.test.tsx
@@ -158,7 +158,6 @@ describe("ProvidersConfig", () => {
     expect(anchoredToastAddMock).toHaveBeenCalledWith({
       id: "provider-disable-provider-1",
       positionerProps: { anchor: providerSwitch, sideOffset: 6 },
-      timeout: 5000,
       title: "options.apiProviders.form.providerInUseCannotDisable:Long Provider Name|1",
       type: "error",
     })

--- a/src/entrypoints/options/pages/api-providers/providers-config.tsx
+++ b/src/entrypoints/options/pages/api-providers/providers-config.tsx
@@ -165,7 +165,6 @@ function ProviderCard({ providerConfig }: { providerConfig: APIProviderConfig })
           anchor: switchRef.current,
           sideOffset: 6,
         },
-        timeout: 5000,
         type: "error",
         title: i18n.t("options.apiProviders.form.providerInUseCannotDisable", [
           name,

--- a/src/entrypoints/side.content/components/floating-button/__tests__/index.test.tsx
+++ b/src/entrypoints/side.content/components/floating-button/__tests__/index.test.tsx
@@ -285,7 +285,6 @@ describe("floatingButton controls", () => {
         side: "left",
         sideOffset: 8,
       },
-      timeout: 8000,
       type: "info",
       title: expect.anything(),
     })

--- a/src/entrypoints/side.content/components/floating-button/index.tsx
+++ b/src/entrypoints/side.content/components/floating-button/index.tsx
@@ -185,7 +185,6 @@ export default function FloatingButton() {
             side: floatingButtonSide === "right" ? "left" : "right",
             sideOffset: 8,
           },
-          timeout: 8000,
           type: "info",
           title: <FirefoxSidebarHelpToast />,
         })

--- a/src/entrypoints/translation-hub/components/__tests__/translation-card.test.tsx
+++ b/src/entrypoints/translation-hub/components/__tests__/translation-card.test.tsx
@@ -100,7 +100,6 @@ describe("TranslationCard copy feedback", () => {
       data: { tooltipStyle: true },
       id: "translation-copy-provider-1",
       positionerProps: { anchor: copyButton, sideOffset: 6 },
-      timeout: 2000,
       title: "translationHub.copiedToClipboard",
     })
   })

--- a/src/entrypoints/translation-hub/components/translation-card.tsx
+++ b/src/entrypoints/translation-hub/components/translation-card.tsx
@@ -106,7 +106,6 @@ export function TranslationCard({
           anchor: copyButtonRef.current,
           sideOffset: 6,
         },
-        timeout: 2000,
         title: i18n.t("translationHub.copiedToClipboard"),
       })
     }


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

- Centralize Toast dismissal timing in the shared Base UI providers.
- Use a 3-second default for anchored Toasts and a 5-second default for ordinary Toasts.
- Remove per-call timeout overrides so all feedback follows the corresponding global default.
- Add lifecycle tests for both defaults.

## Related Issue

Closes #1926

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

## Screenshots

Not applicable.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Includes a patch changeset for `@read-frog/extension`.