### PR TITLE
fix(selection-toolbar): keep the toolbar visible when selected text m…

### DIFF
--- a/.changeset/calm-frogs-stay.md
+++ b/.changeset/calm-frogs-stay.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection-toolbar): keep the toolbar visible when selected text moves offscreen

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/positioning.test.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/positioning.test.ts
@@ -175,11 +175,79 @@ describe("selection toolbar positioning", () => {
     })
   })
 
-  it("reports when the selection is completely outside the viewport", () => {
+  it.each([
+    ["above", createRect({ left: 100, top: -100, width: 120, height: 24 }), { x: 210, y: -76 }],
+    ["below", createRect({ left: 100, top: 900, width: 120, height: 24 }), { x: 210, y: 924 }],
+    ["left", createRect({ left: -200, top: 100, width: 120, height: 24 }), { x: -90, y: 124 }],
+    ["right", createRect({ left: 1300, top: 100, width: 120, height: 24 }), { x: 1410, y: 124 }],
+    [
+      "diagonally",
+      createRect({ left: 1300, top: 900, width: 120, height: 24 }),
+      { x: 1410, y: 924 },
+    ],
+  ])("keeps an anchor when the selection moves %s offscreen", (_, rect, expectedAnchor) => {
     const tracker = createSelectionAnchorTracker([rangeSnapshot], { x: 210, y: 124 })
-    rangeRects = [createRect({ left: 100, top: -100, width: 120, height: 24 })]
+    rangeRects = [rect]
 
-    expect(measureSelectionAnchor(tracker!, viewport)).toEqual({ status: "offscreen" })
+    expect(measureSelectionAnchor(tracker!, viewport)).toMatchObject({
+      status: "offscreen",
+      anchor: expectedAnchor,
+      tracker: { lastAnchor: expectedAnchor },
+    })
+  })
+
+  it("tracks an offscreen reference rect while another selection rect remains visible", () => {
+    rangeRects = [
+      createRect({ left: 100, top: 100, width: 120, height: 24 }),
+      createRect({ left: 100, top: 130, width: 80, height: 24 }),
+    ]
+    const tracker = createSelectionAnchorTracker([rangeSnapshot], { x: 175, y: 150 })
+    expect(tracker?.reference.rectIndex).toBe(1)
+
+    rangeRects = [
+      createRect({ left: 100, top: 100, width: 120, height: 24 }),
+      createRect({ left: 100, top: 900, width: 80, height: 24 }),
+    ]
+
+    expect(measureSelectionAnchor(tracker!, viewport)).toMatchObject({
+      status: "visible",
+      anchor: { x: 175, y: 920 },
+      tracker: { reference: { rectIndex: 1 }, lastAnchor: { x: 175, y: 920 } },
+    })
+  })
+
+  it("falls back to the nearest offscreen rect when wrapping changes", () => {
+    rangeRects = [
+      createRect({ left: 100, top: 100, width: 120, height: 24 }),
+      createRect({ left: 100, top: 130, width: 80, height: 24 }),
+    ]
+    const tracker = createSelectionAnchorTracker([rangeSnapshot], { x: 175, y: 150 })
+    expect(tracker?.reference.rectIndex).toBe(1)
+
+    rangeRects = [createRect({ left: 100, top: -100, width: 160, height: 24 })]
+
+    expect(measureSelectionAnchor(tracker!, viewport)).toMatchObject({
+      status: "offscreen",
+      anchor: { x: 175, y: -76 },
+      tracker: {
+        reference: { rectIndex: 0, offsetX: 75, offsetY: 24 },
+        lastAnchor: { x: 175, y: -76 },
+      },
+    })
+  })
+
+  it("preserves the last anchor while a connected range has no geometry", () => {
+    const tracker = createSelectionAnchorTracker([rangeSnapshot], { x: 210, y: 124 })
+    rangeRects = []
+
+    const measurement = measureSelectionAnchor(tracker!, viewport)
+
+    expect(measurement).toEqual({
+      status: "offscreen",
+      anchor: { x: 210, y: 124 },
+      tracker,
+    })
+    expect(measurement.status === "invalid" ? null : measurement.tracker).toBe(tracker)
   })
 
   it("reports invalid detached ranges", () => {

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
@@ -846,8 +846,28 @@ describe("selectionToolbar - positioning logic", () => {
     await triggerMouseDownAndUp(target, 100, 100, 200, 200)
 
     const slot = dialog.querySelector(`[${MODAL_DIALOG_HOST_SLOT_ATTRIBUTE}]`)
+    const toolbar = shadowRoot.querySelector<HTMLElement>(".absolute.z-2147483647")
     expect(slot?.contains(extensionHost)).toBe(true)
-    expect(shadowRoot.querySelector(".absolute.z-2147483647")).toHaveClass("opacity-100")
+    expect(toolbar).toHaveClass("opacity-100")
+
+    if (!toolbar) {
+      throw new Error("Selection toolbar is missing from the modal host")
+    }
+
+    mockToolbarDimensions(toolbar, 200, 50)
+    selectionRects = [createRect({ left: 100, top: -200, width: 100, height: 100 })]
+
+    await act(async () => {
+      document.body.dispatchEvent(new Event("scroll"))
+      const callbacks = [...rafCallbacks]
+      rafCallbacks = []
+      callbacks.forEach((callback) => callback(0))
+    })
+
+    expect(slot?.contains(extensionHost)).toBe(true)
+    expect(toolbar).toHaveClass("pointer-events-auto", "opacity-100")
+    expect(toolbar).not.toHaveAttribute("inert")
+    expect(toolbar.style.top).toBe("25px")
     matchesSpy.mockRestore()
   })
 
@@ -1241,7 +1261,7 @@ describe("selectionToolbar - positioning logic", () => {
     expect(Number.parseInt(toolbar.style.top, 10)).toBe(initialTop - 80)
   })
 
-  it("should close after the selection leaves the viewport and stay closed", async () => {
+  it("should pin above-viewport selections to the top edge and resume tracking on re-entry", async () => {
     render(
       <div>
         <SelectionToolbar />
@@ -1252,6 +1272,7 @@ describe("selectionToolbar - positioning logic", () => {
 
     await triggerMouseDownAndUp(screen.getByTestId("test-element"), 100, 100, 200, 200)
     const toolbar = getToolbarElement()
+    mockToolbarDimensions(toolbar, 200, 50)
     selectionRects = [createRect({ left: 100, top: -200, width: 100, height: 100 })]
 
     await act(async () => {
@@ -1261,10 +1282,14 @@ describe("selectionToolbar - positioning logic", () => {
       callbacks.forEach((callback) => callback(0))
     })
 
-    expect(toolbar).toHaveClass("pointer-events-none", "opacity-0")
+    expect(toolbar).toHaveClass("pointer-events-auto", "opacity-100")
+    expect(toolbar).not.toHaveAttribute("inert")
+    expect(screen.getByTitle("Close selection toolbar")).toBeEnabled()
+    expect(toolbar.style.left).toBe("200px")
+    expect(toolbar.style.top).toBe("25px")
     expect(screen.getByTestId("selection-session")).toHaveTextContent(MOCK_SELECTED_TEXT)
 
-    selectionRects = [createRect({ left: 100, top: 100, width: 100, height: 100 })]
+    selectionRects = [createRect({ left: 300, top: 300, width: 100, height: 100 })]
     await act(async () => {
       document.body.dispatchEvent(new Event("scroll"))
       const callbacks = [...rafCallbacks]
@@ -1272,10 +1297,41 @@ describe("selectionToolbar - positioning logic", () => {
       callbacks.forEach((callback) => callback(0))
     })
 
-    expect(toolbar).toHaveClass("pointer-events-none", "opacity-0")
+    expect(toolbar).toHaveClass("pointer-events-auto", "opacity-100")
+    expect(toolbar.style.left).toBe("400px")
+    expect(toolbar.style.top).toBe("420px")
+    expect(screen.getByTestId("selection-session")).toHaveTextContent(MOCK_SELECTED_TEXT)
   })
 
-  it("should clear a selection session when its range becomes invalid", async () => {
+  it("should pin a diagonally offscreen selection to the bottom-right corner", async () => {
+    render(
+      <div>
+        <SelectionToolbar />
+        <SelectionSessionProbe />
+        <div data-testid="test-element">Test content</div>
+      </div>,
+    )
+
+    await triggerMouseDownAndUp(screen.getByTestId("test-element"), 100, 100, 200, 200)
+    const toolbar = getToolbarElement()
+    mockToolbarDimensions(toolbar, 200, 50)
+    selectionRects = [createRect({ left: 1400, top: 900, width: 100, height: 100 })]
+
+    await act(async () => {
+      document.body.dispatchEvent(new Event("scroll"))
+      const callbacks = [...rafCallbacks]
+      rafCallbacks = []
+      callbacks.forEach((callback) => callback(0))
+    })
+
+    expect(toolbar).toHaveClass("pointer-events-auto", "opacity-100")
+    expect(toolbar).not.toHaveAttribute("inert")
+    expect(toolbar.style.left).toBe("975px")
+    expect(toolbar.style.top).toBe("725px")
+    expect(screen.getByTestId("selection-session")).toHaveTextContent(MOCK_SELECTED_TEXT)
+  })
+
+  it("should still hide and clear a selection session when its range becomes invalid", async () => {
     render(
       <div>
         <SelectionToolbar />
@@ -1296,6 +1352,7 @@ describe("selectionToolbar - positioning logic", () => {
     })
 
     expect(getToolbarElement()).toHaveClass("pointer-events-none", "opacity-0")
+    expect(getToolbarElement()).toHaveAttribute("inert")
     expect(screen.getByTestId("selection-session")).toHaveTextContent("empty")
   })
 

--- a/src/entrypoints/selection.content/selection-toolbar/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/index.tsx
@@ -244,14 +244,6 @@ export function SelectionToolbar() {
           return
         }
 
-        if (measurement.status === "offscreen") {
-          selectionAnchorTrackerRef.current = null
-          selectionScrollTargetsRef.current = []
-          selectionPositionRef.current = null
-          setIsSelectionToolbarVisible(false)
-          return
-        }
-
         selectionAnchorTrackerRef.current = measurement.tracker
         selectionPositionRef.current = measurement.anchor
       }

--- a/src/entrypoints/selection.content/selection-toolbar/positioning.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/positioning.ts
@@ -28,11 +28,10 @@ export interface SelectionAnchorTracker {
 
 export type SelectionAnchorMeasurement =
   | {
-      status: "visible"
+      status: "visible" | "offscreen"
       anchor: ViewportPoint
       tracker: SelectionAnchorTracker
     }
-  | { status: "offscreen" }
   | { status: "invalid" }
 
 export enum SelectionDirection {
@@ -248,12 +247,17 @@ export function measureSelectionAnchor(
     return { status: "invalid" }
   }
 
-  const visibleRects = rects.filter(({ rect }) => isRectVisible(rect, viewport))
-  if (visibleRects.length === 0) {
-    return { status: "offscreen" }
+  const status = rects.some(({ rect }) => isRectVisible(rect, viewport)) ? "visible" : "offscreen"
+
+  if (rects.length === 0) {
+    return {
+      status,
+      anchor: tracker.lastAnchor,
+      tracker,
+    }
   }
 
-  const referenceRect = visibleRects.find(
+  const referenceRect = rects.find(
     ({ rangeIndex, rectIndex }) =>
       rangeIndex === tracker.reference.rangeIndex && rectIndex === tracker.reference.rectIndex,
   )
@@ -265,7 +269,7 @@ export function measureSelectionAnchor(
     }
 
     return {
-      status: "visible",
+      status,
       anchor,
       tracker: {
         ...tracker,
@@ -274,9 +278,13 @@ export function measureSelectionAnchor(
     }
   }
 
-  const fallbackRect = getNearestRect(visibleRects, tracker.lastAnchor)
+  const fallbackRect = getNearestRect(rects, tracker.lastAnchor)
   if (!fallbackRect) {
-    return { status: "offscreen" }
+    return {
+      status,
+      anchor: tracker.lastAnchor,
+      tracker,
+    }
   }
 
   const anchor = {
@@ -285,7 +293,7 @@ export function measureSelectionAnchor(
   }
 
   return {
-    status: "visible",
+    status,
     anchor,
     tracker: {
       ranges: tracker.ranges,


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Keep the selection toolbar available when its selected text moves outside the viewport.

Previously, a fully offscreen selection was treated as terminal: the toolbar discarded its Range tracker and faded out permanently. This change keeps connected, readable selections tracked while offscreen and feeds their live anchor through the existing viewport clamp, pinning the toolbar to the nearest edge or corner with the existing 25px margin. When the selection returns to the viewport, the toolbar automatically resumes following its Range-relative position.

The toolbar remains visible, interactive, and backed by the original selection session while pinned. Detached or unreadable Ranges still clear the session and hide the toolbar. Connected Ranges that temporarily return no geometry retain their last anchor until a later scroll or viewport update can measure them again.

The ordinary-page stacking and native `<dialog>` host placement introduced by #1924 are unchanged. Modal selections continue using the dialog-local host slot while edge-pinned and restore the host normally when the dialog closes.

This includes a patch changeset for `@read-frog/extension`.

## Related Issue

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

- Added measurement coverage for selections moving above, below, left, right, and diagonally outside the viewport; reference-rect changes; connected zero-geometry Ranges; and invalid Ranges.
- Added component coverage for top-edge pinning, bottom-right corner pinning, pointer interactivity, selection-session retention, viewport re-entry, invalid cleanup, and native modal host retention.
- Focused Vitest suite: 2 files, 60 tests passed.
- Pre-push validation: formatting, type-aware lint, 212 test files, and 2018 tests passed.
- Production builds passed for Chrome, Edge, and Firefox.
- Headed Edge 150 validation against the unpacked production build covered ordinary-page top/bottom pins, nested scrolling, real pointer interaction, native modal host retention, viewport re-entry, and dialog-close host restoration.

## Screenshots

Not included. This behavior is interaction-dependent and was verified against the production extension with real browser hit testing.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The offscreen-hide behavior originated in #1865. It is independent of #1924's stacking-context and native-dialog fixes; this PR only changes the Range-tracking visibility policy and its regression coverage.
