### PR TITLE
fix(translation): translate edited Discord messages without timestamp…

### DIFF
--- a/.changeset/fix-discord-edited-messages.md
+++ b/.changeset/fix-discord-edited-messages.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): translate edited Discord messages without timestamp metadata

--- a/src/utils/host/dom/__tests__/discord.test.ts
+++ b/src/utils/host/dom/__tests__/discord.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { PARAGRAPH_ATTRIBUTE, WALKED_ATTRIBUTE } from "@/utils/constants/dom-labels"
+import { unwrapDeepestOnlyHTMLChild } from "../find"
+import { extractTextContent, walkAndLabelElement } from "../traversal"
+
+function setDiscordUrl() {
+  Object.defineProperty(window, "location", {
+    value: new URL("https://discord.com/channels/1371229720942874646/1529001476482011136"),
+    writable: true,
+  })
+}
+
+describe("Discord translation rules", () => {
+  afterEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("keeps edited-message metadata out of the translation unit (issue #1927)", () => {
+    setDiscordUrl()
+    document.body.innerHTML = `
+      <li id="chat-messages-1529001476482011136-1529199071137370203">
+        <div id="message-content-1529199071137370203" class="markup__75297 messageContent_c19a55">
+          <span id="message-body">Read Frog edited-message DOM test</span>
+          <span id="edited-metadata" class="timestamp_c19a55">
+            <span>
+              <time datetime="2026-07-21T18:51:53.357Z">
+                <span class="edited_c19a55">(edited)</span>
+              </time>
+            </span>
+            <span class="hiddenVisually_b18fe2">Tuesday, July 21, 2026 at 11:51 AM</span>
+          </span>
+        </div>
+      </li>
+    `
+
+    const config = structuredClone(DEFAULT_CONFIG)
+    const messageContent = document.querySelector<HTMLElement>("[id^='message-content']")!
+    const messageBody = document.querySelector<HTMLElement>("#message-body")!
+    const editedMetadata = document.querySelector<HTMLElement>("#edited-metadata")!
+
+    walkAndLabelElement(document.body, "discord-edited-message", config)
+
+    expect(messageContent.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(true)
+    expect(editedMetadata.hasAttribute(WALKED_ATTRIBUTE)).toBe(false)
+    expect(extractTextContent(messageContent, config).trim()).toBe(messageBody.textContent)
+    expect(unwrapDeepestOnlyHTMLChild(messageContent, config)).toBe(messageBody)
+  })
+})

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -4345,6 +4345,7 @@
     "excludeSelectors": [
       "[id^=\"message-username\"]",
       "span[class*=\"-timestamp\"]",
+      "div[id^=\"message-content\"] > span[class*=\"timestamp_\"]",
       "div[class*=\"-repliedMessage\"]",
       "li[class*=\"-containerDefault\"]",
       "[class*=\"-subtitleContainer\"]",


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Discord appends an edited timestamp subtree directly inside a message's content container after the message is edited. The existing Discord exclusion matched the legacy `-timestamp` class pattern, but not the current `timestamp_*` classes, so Read Frog included `(edited)` and Discord's visually hidden full date in the translation input.

This change:

- excludes the current edited-message timestamp container while retaining the legacy selector;
- scopes the selector to direct timestamp children of Discord message-content containers;
- adds regression coverage based on the live Discord DOM, verifying that the message remains translatable while edited metadata is excluded from traversal, extracted text, and translation placement;
- adds a patch changeset for `@read-frog/extension`.

## Related Issue

Closes #1927

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Validation performed:

- `SKIP_FREE_API=true pnpm test`
- `pnpm type-check`
- `pnpm build`
- repository pre-push checks (`nx fmt:check`, `nx lint`, and `nx test` with the live free API test excluded)

## Screenshots

Not applicable. The affected Discord DOM and reporter screenshot are documented in #1927.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The new selector is deliberately scoped to `div[id^="message-content"]` so unrelated Discord timestamps remain unaffected. The existing legacy timestamp selector is preserved for backward compatibility.
