### PR TITLE
fix(site-rules): restore Steam store page translation

### DIFF
--- a/.changeset/steam-store-page-translation.md
+++ b/.changeset/steam-store-page-translation.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(site-rules): restore Steam store page translation

--- a/src/utils/host/dom/__tests__/include-scope.test.ts
+++ b/src/utils/host/dom/__tests__/include-scope.test.ts
@@ -7,8 +7,12 @@ import { PARAGRAPH_ATTRIBUTE, WALKED_ATTRIBUTE } from "@/utils/constants/dom-lab
 import { walkAndLabelElement } from "../traversal"
 
 function setHost(host: string) {
+  setUrl(`https://${host}/some/path`)
+}
+
+function setUrl(url: string) {
   Object.defineProperty(window, "location", {
-    value: new URL(`https://${host}/some/path`),
+    value: new URL(url),
     writable: true,
   })
 }
@@ -55,6 +59,20 @@ describe("includeSelectors whitelist", () => {
 
     expect(document.querySelector("#inside")!.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(true)
     expect(document.querySelector("#outside")!.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(true)
+  })
+
+  it("labels Steam app descriptions without the obsolete iframe include (issue #1923)", () => {
+    setUrl("https://store.steampowered.com/app/2453660/Hoop_Land/")
+    document.body.innerHTML = `
+      <div class="game_description_snippet">
+        <p id="description">Build a basketball legacy across seasons and leagues.</p>
+      </div>
+    `
+
+    walkAndLabelElement(document.body, "w1", structuredClone(DEFAULT_CONFIG))
+
+    expect(document.querySelector("#description")!.hasAttribute(WALKED_ATTRIBUTE)).toBe(true)
+    expect(document.querySelector("#description")!.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(true)
   })
 
   it("lets excludeSelectors carve holes inside the whitelisted subtree", () => {

--- a/src/utils/site-rules/__tests__/built-in.test.ts
+++ b/src/utils/site-rules/__tests__/built-in.test.ts
@@ -104,6 +104,18 @@ describe("built-in site rules", () => {
     }
   })
 
+  it("does not restrict Steam app pages to an obsolete iframe include (issue #1923)", () => {
+    const resolved = resolveSiteRule(
+      "https://store.steampowered.com/app/2453660/Hoop_Land/",
+      BUILT_IN_SITE_RULES,
+      [],
+      [],
+    )
+
+    expect(resolved.matchedRuleIds).toContain("steampoweredApp")
+    expect(resolved.includeSelector).toBeNull()
+  })
+
   it("keeps the youtube rule in sync with the subtitle class constants", () => {
     const youtube = BUILT_IN_SITE_RULES.find((rule) => rule.id === "readfrog-youtube")
     expect(youtube).toBeDefined()

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -1824,7 +1824,6 @@
       ".ReviewContentCtn .title",
       ".author_counts,.control_block,.vote_info"
     ],
-    "includeSelectors": [".game_page_autocollapse_ctn iframe"],
     "forceInlineSelectors": [".pulldown"],
     "injectedCss": ".game_description_snippet { max-height:unset; overflow: scroll; }\n.game_purchase_area_friends_want { height: auto; padding-bottom: 6px; }\n.div.early_access_banner { height: 84px; }\n.franchise_notice > * { height: 84px; }"
   },


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Steam app pages inherited an obsolete iframe selector as a strict `includeSelectors` whitelist. Current Steam pages do not contain that iframe, so traversal produced no translation candidates and page translation appeared to do nothing.

This change removes only the invalid Steam include scope. Existing Steam exclusions, inline rendering adaptation, and injected CSS remain unchanged. Regression coverage verifies both the resolved rule and real DOM traversal on a Steam app URL.

## Related Issue

Closes #1923

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

- `SKIP_FREE_API=true pnpm test` — 2008 passed, 4 intentionally skipped
- `pnpm fmt:check`
- `pnpm lint`
- `pnpm type-check`
- `pnpm build:edge`
- Fresh-profile Edge + unpacked `.output/edge-mv3` on all three reported Steam URLs:
  - Franchise Hockey Manager 12: `20` description paragraphs and `16` system-requirement paragraphs; both regions produced Chinese wrappers
  - Coastal Summit Sports: `15` description paragraphs and `18` system-requirement paragraphs; both regions produced Chinese wrappers
  - Hoop Land: `12` description paragraphs and `20` system-requirement paragraphs; both regions produced Chinese wrappers
  - All three pages had `0` obsolete iframe matches and `0` translation errors

The live run used an explicit English-to-Chinese configuration and scrolled both lazy-translated regions into view before asserting translated output. A separate paid DeepSeek API probe also returned Chinese successfully with the extension's default `deepseek-v4-flash` model.

## Screenshots

Not applicable; this fixes content extraction rather than extension UI.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

`includeSelectors` remains a strict whitelist. The fix corrects the migrated Steam rule instead of weakening the global include contract.
