### PR TITLE
fix(site-rules): restore content hidden by migrated selector scopes

### DIFF
--- a/.changeset/migrated-selector-scopes.md
+++ b/.changeset/migrated-selector-scopes.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(site-rules): restore content hidden by migrated selector scopes

--- a/src/utils/site-rules/__tests__/built-in.test.ts
+++ b/src/utils/site-rules/__tests__/built-in.test.ts
@@ -142,4 +142,38 @@ describe("built-in site rules", () => {
     expect(resolved.excludeSelector).toContain(".forum-topbar")
     expect(resolved.excludeSelector).toContain(".forum-bottombar")
   })
+
+  it("does not restrict migrated article sites to stale include selectors", () => {
+    const restoredSites = [
+      ["newyorker", "https://www.newyorker.com/news/the-lede/example"],
+      ["scmp", "https://www.scmp.com/news/china/politics/article/example"],
+      ["android", "https://developer.android.com/develop/ui/compose/documentation"],
+      ["thehackernews", "https://thehackernews.com/2026/07/example.html"],
+    ] as const
+
+    for (const [id, url] of restoredSites) {
+      const resolved = resolveSiteRule(url, BUILT_IN_SITE_RULES, [], [])
+      expect(resolved.matchedRuleIds).toContain(id)
+      expect(resolved.includeSelector).toBeNull()
+    }
+  })
+
+  it("retains include scopes that still define intentional content roots", () => {
+    const paulGraham = resolveSiteRule(
+      "https://paulgraham.com/greatwork.html",
+      BUILT_IN_SITE_RULES,
+      [],
+      [],
+    )
+    expect(paulGraham.includeSelector).toBe("font[face=verdana]")
+
+    const construct = resolveSiteRule(
+      "https://www.construct.net/en/make-games/manuals/construct-3",
+      BUILT_IN_SITE_RULES,
+      [],
+      [],
+    )
+    expect(construct.includeSelector).toContain("aside")
+    expect(construct.includeSelector).toContain("div.manualContent")
+  })
 })

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -1234,8 +1234,7 @@
   {
     "id": "newyorker",
     "matches": "www.newyorker.com",
-    "excludeSelectors": ["[data-testid=PersistentTop]", "[data-testid=StackedNavigationHeader]"],
-    "includeSelectors": ["h1", "[data-testid=SummaryItemHed]"]
+    "excludeSelectors": ["[data-testid=PersistentTop]", "[data-testid=StackedNavigationHeader]"]
   },
   {
     "id": "typora",
@@ -1255,7 +1254,6 @@
   {
     "id": "scmp",
     "matches": "www.scmp.com",
-    "includeSelectors": [".info__subHeadline", ".section-content h2"],
     "injectedCss": ".topic__article-list { height: unset; }\n.adverisers__adveriser { height: unset; }\n.advertiser__content { height: unset; }\n.content-title__link { display:unset;overflow:unset;-webkit-line-clamp:unset; }\n.title__text { max-height:unset; -webkit-line-clamp:unset; }\n.news-list-item__news-title { max-height:unset; -webkit-line-clamp:unset; }\na[class*='link'] > .link__headline { max-height:unset; -webkit-line-clamp:unset; }"
   },
   {
@@ -1728,8 +1726,7 @@
   },
   {
     "id": "android",
-    "matches": ["developer.android.google.cn", "developer.android.com"],
-    "includeSelectors": ["aside", "google-codelab-step"]
+    "matches": ["developer.android.google.cn", "developer.android.com"]
   },
   {
     "id": "ft",
@@ -1967,8 +1964,7 @@
   {
     "id": "thehackernews",
     "matches": "thehackernews.com",
-    "excludeSelectors": ["span#blog-pager-older-link", "span.h-datetime"],
-    "includeSelectors": [".pop-title"]
+    "excludeSelectors": ["span#blog-pager-older-link", "span.h-datetime"]
   },
   {
     "id": "brown",


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Four migrated built-in site rules used narrow, stale `includeSelectors` as strict traversal whitelists. That excluded the current article or documentation body on The New Yorker, South China Morning Post, Android Developers, and The Hacker News.

This change removes only those four invalid include scopes. It deliberately retains the Paul Graham and Construct scopes, which still identify intentional content roots, and leaves five rules that could not yet be validated unchanged.

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

- `SKIP_FREE_API=true pnpm test` — 2008 passed, 4 intentionally skipped
- `pnpm fmt:check`
- `pnpm lint`
- `pnpm type-check`
- `pnpm build:edge`
- Fresh anonymous browser audit on representative current pages:
  - The New Yorker: the old include covered `0/8` meaningful visible paragraphs (`0/1,182` characters)
  - South China Morning Post: both old selectors matched `0`; all `6` meaningful paragraphs (`1,103` characters) were outside the include
  - Android Developers: about `91%` of the visible article text, including the main headings and paragraphs, was outside the old include
  - The Hacker News: the old selector targeted Popular Posts, while all `11` article paragraphs (`2,634` characters) were outside it

All four pages returned HTTP 200 without bot challenges. The New Yorker and SCMP exposed anonymous/paywalled excerpts, which were sufficient to verify the selector boundary.

## Screenshots

Not applicable; this fixes DOM extraction scopes rather than extension UI.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

`includeSelectors` remains a strict whitelist. The fix removes obsolete site-specific restrictions rather than broadening the global contract.
