### PR TITLE
fix(providers): load Gemini models dynamically to keep the list current

### DIFF
--- a/.changeset/curvy-pandas-remember.md
+++ b/.changeset/curvy-pandas-remember.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(providers): load Gemini models dynamically

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ai-sdk/deepinfra": "^3.0.12",
     "@ai-sdk/deepseek": "^3.0.12",
     "@ai-sdk/fireworks": "^3.0.13",
-    "@ai-sdk/google": "^4.0.18",
+    "@ai-sdk/google": "^4.0.21",
     "@ai-sdk/groq": "^4.0.12",
     "@ai-sdk/huggingface": "^2.0.12",
     "@ai-sdk/mistral": "^4.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^3.0.13
         version: 3.0.13(zod@4.4.3)
       '@ai-sdk/google':
-        specifier: ^4.0.18
-        version: 4.0.18(zod@4.4.3)
+        specifier: ^4.0.21
+        version: 4.0.21(zod@4.4.3)
       '@ai-sdk/groq':
         specifier: ^4.0.12
         version: 4.0.12(zod@4.4.3)
@@ -468,8 +468,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@4.0.18':
-    resolution: {integrity: sha512-NRbXRAasXLgFLiZDTsDUiTUuQtEUDVZoqruB5Px3geltTEqOzOo2eHN5WnDp0/OgxwnrNH4olV/TVetza0PzmQ==}
+  '@ai-sdk/google@4.0.21':
+    resolution: {integrity: sha512-ijIvZnnSmLKT2yXnd4Aym0sM3/CsBHx1U7H/++wTUOdbIMKn8pbfsnGArLXksjlHUxWagFMh7zdGhj5Vb5cQeA==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -524,6 +524,12 @@ packages:
 
   '@ai-sdk/provider-utils@5.0.11':
     resolution: {integrity: sha512-7/96wE+ZsKB35iS9ASyllrE4Ym/EolXEB7AkuJ5FI++fmS85BVTAs77890C+1Z2jwHfBKjBQSBmsliOsAh0iFQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.12':
+    resolution: {integrity: sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -7056,10 +7062,10 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/google@4.0.18(zod@4.4.3)':
+  '@ai-sdk/google@4.0.21(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.3
-      '@ai-sdk/provider-utils': 5.0.11(zod@4.4.3)
+      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/groq@4.0.12(zod@4.4.3)':
@@ -7114,6 +7120,14 @@ snapshots:
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.11(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.3
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.12(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.3
       '@standard-schema/spec': 1.1.0

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx
@@ -1,16 +1,28 @@
 // @vitest-environment jsdom
 import type { APIProviderConfig } from "@/types/config/provider"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { useSelector } from "@tanstack/react-store"
-import { act, fireEvent, render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { useEffect, useState } from "react"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { formOpts, useAppForm } from "../form"
 import { TranslateModelSelector } from "../translate-model-selector"
+
+const { fetchGoogleModelsMock } = vi.hoisted(() => ({
+  fetchGoogleModelsMock:
+    vi.fn<
+      (options: { apiKey: string; baseURL: string; signal?: AbortSignal }) => Promise<string[]>
+    >(),
+}))
 
 vi.mock("#imports", () => ({
   i18n: {
     t: (key: string) => key,
   },
+}))
+
+vi.mock("@/utils/providers/google-models", () => ({
+  fetchGoogleModels: fetchGoogleModelsMock,
 }))
 
 vi.mock("../components/provider-options-recommendation-trigger", () => ({
@@ -109,9 +121,33 @@ function TranslateModelSelectorHarness({
   )
 }
 
+function renderTranslateModelSelector(initialConfig?: APIProviderConfig) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: 0,
+        retry: false,
+      },
+    },
+  })
+
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <TranslateModelSelectorHarness initialConfig={initialConfig} />
+      </QueryClientProvider>,
+    ),
+  }
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
 describe("translateModelSelector", () => {
   it("keeps invalid form values while staging recommended provider options", async () => {
-    render(<TranslateModelSelectorHarness />)
+    renderTranslateModelSelector()
 
     fireEvent.change(screen.getByLabelText("provider-name"), {
       target: { value: duplicateProviderName },
@@ -135,7 +171,7 @@ describe("translateModelSelector", () => {
   })
 
   it("persists staged recommendations after the validation error is fixed", async () => {
-    render(<TranslateModelSelectorHarness />)
+    renderTranslateModelSelector()
 
     fireEvent.change(screen.getByLabelText("provider-name"), {
       target: { value: duplicateProviderName },
@@ -158,7 +194,7 @@ describe("translateModelSelector", () => {
   })
 
   it("submits recommendations immediately when the form is valid", async () => {
-    render(<TranslateModelSelectorHarness />)
+    renderTranslateModelSelector()
 
     fireEvent.click(screen.getByRole("button", { name: "apply-recommendation" }))
     await flushUpdates()
@@ -168,5 +204,44 @@ describe("translateModelSelector", () => {
       '{"reasoningEffort":"minimal"}',
     )
     expect(screen.getByLabelText("submit-count")).toHaveTextContent("1")
+  })
+
+  it("loads Google models without putting the API key in the query cache key", async () => {
+    const apiKey = "google-secret-api-key"
+    fetchGoogleModelsMock.mockResolvedValue(["gemini-future-flash"])
+
+    const { queryClient } = renderTranslateModelSelector({
+      id: "google-provider",
+      name: "Google",
+      enabled: true,
+      provider: "google",
+      apiKey,
+      model: {
+        model: "gemini-flash-latest",
+        isCustomModel: false,
+        customModel: null,
+      },
+    })
+
+    await waitFor(() => {
+      expect(fetchGoogleModelsMock).toHaveBeenCalledWith({
+        apiKey,
+        baseURL: "https://generativelanguage.googleapis.com/v1beta",
+        signal: expect.any(AbortSignal),
+      })
+    })
+
+    fireEvent.click(screen.getByRole("combobox"))
+    expect(await screen.findByRole("option", { name: "gemini-future-flash" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "gemini-flash-latest" })).toBeInTheDocument()
+
+    const queryKey = queryClient.getQueryCache().getAll()[0]?.queryKey
+    expect(queryKey).toEqual([
+      "google-models",
+      "google-provider",
+      "https://generativelanguage.googleapis.com/v1beta",
+      expect.any(String),
+    ])
+    expect(JSON.stringify(queryKey)).not.toContain(apiKey)
   })
 })

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/temperature-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/temperature-field.tsx
@@ -11,7 +11,7 @@ export const TemperatureField = withForm({
     const providerConfig = useSelector(form.store, (state) => state.values)
     const isLLMProvider = isLLMProviderConfig(providerConfig)
 
-    if (!isLLMProvider) {
+    if (!isLLMProvider || providerConfig.provider === "google") {
       return null
     }
 

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
@@ -1,6 +1,8 @@
 import type { APIProviderConfig } from "@/types/config/provider"
+import { useQuery } from "@tanstack/react-query"
 import { useSelector } from "@tanstack/react-store"
 import { useSetAtom } from "jotai"
+import { sha256 } from "js-sha256"
 import { Checkbox } from "@/components/ui/base-ui/checkbox"
 import {
   SelectContent,
@@ -10,27 +12,65 @@ import {
   SelectValue,
 } from "@/components/ui/base-ui/select"
 import { toastManager } from "@/components/ui/base-ui/toast"
+import { useDebouncedValue } from "@/hooks/use-debounced-value"
 import {
   isCustomLLMProviderConfig,
   isLLMProviderConfig,
   LLM_PROVIDER_MODELS,
 } from "@/types/config/provider"
 import { providerConfigAtom, updateLLMProviderConfig } from "@/utils/atoms/provider"
+import { PROVIDER_BASE_URL_PLACEHOLDERS } from "@/utils/constants/providers"
 import { i18n } from "@/utils/i18n"
+import { fetchGoogleModels } from "@/utils/providers/google-models"
 import { resolveModelId } from "@/utils/providers/model-id"
 import { ModelSuggestionButton } from "./components/model-suggestion-button"
 import { ProviderOptionsRecommendationTrigger } from "./components/provider-options-recommendation-trigger"
 import { withForm } from "./form"
+
+function getSecretFingerprint(value: string) {
+  return value ? sha256(value).slice(0, 12) : ""
+}
 
 export const TranslateModelSelector = withForm({
   ...{ defaultValues: {} as APIProviderConfig },
   render: function Render({ form }) {
     const providerConfig = useSelector(form.store, (state) => state.values)
     const setProviderConfig = useSetAtom(providerConfigAtom(providerConfig.id))
+    const isGoogleProvider = providerConfig.provider === "google"
+    const googleApiKey = isGoogleProvider ? (providerConfig.apiKey?.trim() ?? "") : ""
+    const debouncedGoogleApiKey = useDebouncedValue(googleApiKey, 500)
+    const googleBaseURL = isGoogleProvider
+      ? providerConfig.baseURL?.trim() || PROVIDER_BASE_URL_PLACEHOLDERS.google || ""
+      : ""
+    const { data: googleModels } = useQuery({
+      queryKey: [
+        "google-models",
+        providerConfig.id,
+        googleBaseURL,
+        getSecretFingerprint(debouncedGoogleApiKey),
+      ],
+      queryFn: ({ signal }) =>
+        fetchGoogleModels({
+          apiKey: debouncedGoogleApiKey,
+          baseURL: googleBaseURL,
+          signal,
+        }),
+      enabled: isGoogleProvider && Boolean(debouncedGoogleApiKey && googleBaseURL),
+      meta: { suppressToast: true },
+      retry: false,
+      staleTime: 60 * 60 * 1000,
+    })
     if (!isLLMProviderConfig(providerConfig)) return null
 
     const modelId = resolveModelId(providerConfig.model)
     const { isCustomModel, customModel, model } = providerConfig.model
+    const availableModelOptions =
+      providerConfig.provider === "google" && googleModels?.length
+        ? googleModels
+        : LLM_PROVIDER_MODELS[providerConfig.provider]
+    const modelOptions = availableModelOptions.includes(model)
+      ? availableModelOptions
+      : [model, ...availableModelOptions]
 
     const applyRecommendedProviderOptions = (options: Record<string, unknown>) => {
       form.setFieldValue("providerOptions", options)
@@ -88,7 +128,7 @@ export const TranslateModelSelector = withForm({
                 </SelectTrigger>
                 <SelectContent>
                   <SelectGroup>
-                    {LLM_PROVIDER_MODELS[providerConfig.provider].map((modelOption) => (
+                    {modelOptions.map((modelOption) => (
                       <SelectItem key={modelOption} value={modelOption}>
                         {modelOption}
                       </SelectItem>

--- a/src/types/config/provider/__tests__/schemas.test.ts
+++ b/src/types/config/provider/__tests__/schemas.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { apiProviderConfigItemSchema, llmProviderModelsSchema } from "../schemas"
+
+const dynamicGoogleModel = {
+  model: "gemini-future-text",
+  isCustomModel: false,
+  customModel: null,
+}
+
+describe("Google provider model schemas", () => {
+  it("accepts model ids discovered from the Google API", () => {
+    expect(
+      apiProviderConfigItemSchema.parse({
+        id: "google-provider",
+        name: "Google",
+        enabled: true,
+        provider: "google",
+        model: dynamicGoogleModel,
+      }),
+    ).toEqual(expect.objectContaining({ model: dynamicGoogleModel }))
+
+    expect(llmProviderModelsSchema.shape.google.parse(dynamicGoogleModel)).toEqual(
+      dynamicGoogleModel,
+    )
+  })
+
+  it("keeps enum validation for providers with static model lists", () => {
+    expect(() => llmProviderModelsSchema.shape.openai.parse(dynamicGoogleModel)).toThrow(
+      /Invalid option/,
+    )
+  })
+})

--- a/src/types/config/provider/schemas.ts
+++ b/src/types/config/provider/schemas.ts
@@ -35,6 +35,12 @@ function createProviderModelSchema<T extends LLMProviderTypes>(provider: T) {
   })
 }
 
+const googleProviderModelSchema = z.object({
+  model: z.string().nonempty(),
+  isCustomModel: z.boolean(),
+  customModel: z.string().nullable(),
+})
+
 // Base schema without models
 export const baseProviderConfigSchema = z.strictObject({
   id: z.string().nonempty(),
@@ -105,7 +111,7 @@ const llmProviderConfigSchemaList = [
   }),
   baseAPIProviderConfigSchema.extend({
     provider: z.literal("google"),
-    model: createProviderModelSchema<"google">("google"),
+    model: googleProviderModelSchema,
     ...topLevelReasoningConfigSchema,
   }),
   baseAPIProviderConfigSchema.extend({
@@ -287,10 +293,13 @@ function buildProviderModelsSchema<M extends Record<string, ModelTuple>>(models:
   )
 }
 
-const { "openai-compatible": _, ...modelsWithoutOpenaiCompatible } = LLM_PROVIDER_MODELS
-export const llmProviderModelsSchema = buildProviderModelsSchema(
-  modelsWithoutOpenaiCompatible,
-).extend({
+const {
+  google: _googleModels,
+  "openai-compatible": _openaiCompatibleModels,
+  ...modelsWithEnumeratedIds
+} = LLM_PROVIDER_MODELS
+export const llmProviderModelsSchema = buildProviderModelsSchema(modelsWithEnumeratedIds).extend({
+  google: googleProviderModelSchema,
   "openai-compatible": z.object({
     model: z.enum(LLM_PROVIDER_MODELS["openai-compatible"]),
     isCustomModel: z.literal(true),

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -8,60 +8,8 @@ import { LLM_PROVIDER_MODELS } from "../models"
 
 describe("getProviderOptions", () => {
   describe("model pattern matching", () => {
-    it("should return options for gemini models", () => {
-      const options = getProviderOptions("gemini-2.5-pro", "google")
-      expect(options.google).toBeDefined()
-      expect(options.google?.thinkingConfig).toMatchObject({
-        thinkingBudget: 0,
-        includeThoughts: false,
-      })
-
-      const mixedCaseOptions = getProviderOptions("Gemini-2.5-Pro", "google")
-      expect(mixedCaseOptions.google?.thinkingConfig).toMatchObject({
-        thinkingBudget: 0,
-        includeThoughts: false,
-      })
-    })
-
-    it("should handle thinking models correctly", () => {
-      const thinkingOptions = getProviderOptions("gemini-2.5-pro", "google")
-      expect(thinkingOptions.google?.thinkingConfig).toMatchObject({ thinkingBudget: 0 })
-
-      const nonThinkingOptions = getProviderOptions("gemini-2.5-flash", "google")
-      expect(nonThinkingOptions.google?.thinkingConfig).toMatchObject({ thinkingBudget: 0 })
-
-      const thinkingLevelFlashOptions = getProviderOptions("gemini-3-flash-preview", "google")
-      expect(thinkingLevelFlashOptions.google?.thinkingConfig).toMatchObject({
-        thinkingLevel: "minimal",
-        includeThoughts: false,
-      })
-
-      const thinkingLevelProOptions = getProviderOptions("gemini-3-pro-preview", "google")
-      expect(thinkingLevelProOptions.google?.thinkingConfig).toMatchObject({
-        thinkingLevel: "minimal",
-        includeThoughts: false,
-      })
-
-      const thinkingLevel31ProOptions = getProviderOptions("gemini-3.1-pro-preview", "google")
-      expect(thinkingLevel31ProOptions.google?.thinkingConfig).toMatchObject({
-        thinkingLevel: "minimal",
-        includeThoughts: false,
-      })
-
-      const thinkingLevel31FlashLiteOptions = getProviderOptions(
-        "gemini-3.1-flash-lite-preview",
-        "google",
-      )
-      expect(thinkingLevel31FlashLiteOptions.google?.thinkingConfig).toMatchObject({
-        thinkingLevel: "minimal",
-        includeThoughts: false,
-      })
-
-      const thinkingLevel35FlashOptions = getProviderOptions("gemini-3.5-flash", "google")
-      expect(thinkingLevel35FlashOptions.google?.thinkingConfig).toMatchObject({
-        thinkingLevel: "minimal",
-        includeThoughts: false,
-      })
+    it("should leave Gemini reasoning settings to the provider", () => {
+      expect(getProviderOptions("gemini-future-flash", "google")).toEqual({})
     })
 
     it("should return options for claude models", () => {
@@ -98,6 +46,14 @@ describe("getProviderOptions", () => {
           "gpt-5.3-chat-latest",
         ]),
       )
+    })
+
+    it("should keep versionless Gemini aliases as offline fallbacks", () => {
+      expect(LLM_PROVIDER_MODELS.google).toEqual([
+        "gemini-flash-lite-latest",
+        "gemini-flash-latest",
+        "gemini-pro-latest",
+      ])
     })
 
     it("should expose Azure shortcut deployment names for GPT, DeepSeek, and Grok", () => {

--- a/src/utils/constants/__tests__/providers.test.ts
+++ b/src/utils/constants/__tests__/providers.test.ts
@@ -97,9 +97,11 @@ describe("provider constants", () => {
     expect(API_PROVIDER_TYPES.indexOf("azure")).toBe(API_PROVIDER_TYPES.indexOf("bedrock") - 1)
   })
 
-  it("defaults top-level reasoning providers to none", () => {
+  it("uses provider-default reasoning for Google and none for other providers", () => {
     for (const provider of TOP_LEVEL_REASONING_PROVIDER_TYPES) {
-      expect(DEFAULT_PROVIDER_CONFIG[provider].reasoning).toBe("none")
+      expect(DEFAULT_PROVIDER_CONFIG[provider].reasoning).toBe(
+        provider === "google" ? "provider-default" : "none",
+      )
       expect(apiProviderConfigItemSchema.parse(DEFAULT_PROVIDER_CONFIG[provider])).toEqual(
         DEFAULT_PROVIDER_CONFIG[provider],
       )

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -61,20 +61,7 @@ export const LLM_PROVIDER_MODELS = {
     "grok-code-fast-1",
   ],
   deepseek: ["deepseek-v4-flash", "deepseek-v4-pro", "deepseek-chat", "deepseek-reasoner"],
-  google: [
-    "gemini-3.5-flash",
-    "gemini-3.1-pro-preview",
-    "gemini-3.1-flash-image-preview",
-    "gemini-3.1-flash-lite-preview",
-    "gemini-3-pro-preview",
-    "gemini-3-pro-image-preview",
-    "gemini-3-flash-preview",
-    "gemini-2.5-pro",
-    "gemini-2.5-flash",
-    "gemini-2.5-flash-lite",
-    "gemini-2.5-flash-lite-preview-06-17",
-    "gemini-2.0-flash",
-  ],
+  google: ["gemini-flash-lite-latest", "gemini-flash-latest", "gemini-pro-latest"],
   anthropic: [
     "claude-fable-5",
     "claude-opus-4-8",
@@ -464,21 +451,6 @@ export const LLM_MODEL_OPTIONS: Array<{
   pattern: RegExp
   options: Record<string, JSONValue>
 }> = [
-  // Gemini - specific patterns first
-  {
-    pattern: /^gemini-3(?:\.\d+)?-.*?(?:-preview(?:-customtools)?)?$/i,
-    options: { thinkingConfig: { thinkingLevel: "minimal", includeThoughts: false } },
-  },
-  {
-    pattern: /^gemini-2\.5-/i,
-    options: { thinkingConfig: { thinkingBudget: 0, includeThoughts: false } },
-  },
-  {
-    // Default for all other Gemini models
-    pattern: /^gemini-/i,
-    options: { thinkingConfig: { thinkingBudget: 0, includeThoughts: false } },
-  },
-
   // Claude - disable thinking
   {
     pattern: /^claude-/i,

--- a/src/utils/constants/providers.ts
+++ b/src/utils/constants/providers.ts
@@ -60,7 +60,7 @@ export const DEFAULT_LLM_PROVIDER_MODELS: LLMProviderModels = {
     customModel: null,
   },
   google: {
-    model: "gemini-2.5-flash-lite",
+    model: "gemini-flash-lite-latest",
     isCustomModel: false,
     customModel: null,
   },
@@ -419,7 +419,7 @@ export const DEFAULT_PROVIDER_CONFIG = {
     enabled: true,
     provider: "google",
     model: DEFAULT_LLM_PROVIDER_MODELS.google,
-    reasoning: "none",
+    reasoning: "provider-default",
   },
   anthropic: {
     id: "anthropic-default",

--- a/src/utils/providers/__tests__/google-models.test.ts
+++ b/src/utils/providers/__tests__/google-models.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { fetchGoogleModels } from "../google-models"
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  })
+}
+
+describe("fetchGoogleModels", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("discovers arbitrary future models without a version allowlist", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        models: [
+          {
+            name: "models/gemini-42-flash",
+            supportedGenerationMethods: ["generateContent"],
+          },
+          {
+            name: "models/gemini-100-flash-lite",
+            supportedGenerationMethods: ["countTokens", "generateContent"],
+          },
+          {
+            name: "models/gemini-42-flash",
+            supportedGenerationMethods: ["generateContent"],
+          },
+          {
+            name: "models/gemini-102-flash",
+            supportedGenerationMethods: ["countTokens"],
+          },
+          {
+            name: "models/gemma-103-it",
+            supportedGenerationMethods: ["generateContent"],
+          },
+        ],
+      }),
+    )
+
+    await expect(
+      fetchGoogleModels({
+        baseURL: "https://generativelanguage.googleapis.com/v1beta",
+        apiKey: "test-key",
+      }),
+    ).resolves.toEqual(["gemini-100-flash-lite", "gemini-42-flash"])
+  })
+
+  it("paginates the official endpoint and sends the API key header", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({
+          models: [
+            {
+              name: "models/gemini-20-flash",
+              supportedGenerationMethods: ["generateContent"],
+            },
+          ],
+          nextPageToken: "second-page",
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          models: [
+            {
+              name: "models/gemini-21-flash",
+              supportedGenerationMethods: ["generateContent"],
+            },
+          ],
+        }),
+      )
+
+    const models = await fetchGoogleModels({
+      baseURL: "https://generativelanguage.googleapis.com/v1beta/",
+      apiKey: "secret-key",
+    })
+
+    expect(models).toEqual(["gemini-21-flash", "gemini-20-flash"])
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      1,
+      new URL("https://generativelanguage.googleapis.com/v1beta/models?pageSize=1000"),
+      expect.objectContaining({
+        method: "GET",
+        headers: { "x-goog-api-key": "secret-key" },
+      }),
+    )
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      new URL(
+        "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1000&pageToken=second-page",
+      ),
+      expect.objectContaining({
+        method: "GET",
+        headers: { "x-goog-api-key": "secret-key" },
+      }),
+    )
+  })
+
+  it("surfaces an HTTP error from the Google API", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(
+        {
+          error: { message: "API key is invalid" },
+        },
+        {
+          status: 403,
+          statusText: "Forbidden",
+        },
+      ),
+    )
+
+    await expect(
+      fetchGoogleModels({
+        baseURL: "https://generativelanguage.googleapis.com/v1beta",
+        apiKey: "invalid-key",
+      }),
+    ).rejects.toThrow("Failed to fetch Google models: API key is invalid")
+  })
+})

--- a/src/utils/providers/__tests__/model-id.test.ts
+++ b/src/utils/providers/__tests__/model-id.test.ts
@@ -8,7 +8,7 @@ describe("resolveModelId", () => {
         isCustomModel: false,
         model: " gpt-4.1-mini ",
         customModel: "",
-      } as unknown as Parameters<typeof resolveModelId>[0]),
+      }),
     ).toBe("gpt-4.1-mini")
   })
 
@@ -18,7 +18,7 @@ describe("resolveModelId", () => {
         isCustomModel: true,
         model: "",
         customModel: " custom-model ",
-      } as unknown as Parameters<typeof resolveModelId>[0]),
+      }),
     ).toBe("custom-model")
   })
 

--- a/src/utils/providers/__tests__/model.test.ts
+++ b/src/utils/providers/__tests__/model.test.ts
@@ -8,16 +8,20 @@ const {
   anthropicLanguageModelMock,
   azureChatModelMock,
   azureLanguageModelMock,
+  googleLanguageModelMock,
   openAICompatibleLanguageModelMock,
   ollamaLanguageModelMock,
   createAnthropicMock,
   createAzureMock,
+  createGoogleMock,
   createOllamaMock,
   createOpenAICompatibleMock,
+  wrapLanguageModelMock,
 } = vi.hoisted(() => {
   const innerAnthropicLanguageModelMock = vi.fn<(...args: any[]) => any>()
   const innerAzureChatModelMock = vi.fn<(...args: any[]) => any>()
   const innerAzureLanguageModelMock = vi.fn<(...args: any[]) => any>()
+  const innerGoogleLanguageModelMock = vi.fn<(...args: any[]) => any>()
   const innerOpenAICompatibleLanguageModelMock = vi.fn<(...args: any[]) => any>()
   const innerOllamaLanguageModelMock = vi.fn<(...args: any[]) => any>()
   const innerCreateAnthropicMock = vi.fn<(...args: any[]) => any>(
@@ -31,6 +35,11 @@ const {
       languageModel: innerAzureLanguageModelMock,
     }),
   )
+  const innerCreateGoogleMock = vi.fn<(...args: any[]) => any>(
+    (_options?: Record<string, unknown>) => ({
+      languageModel: innerGoogleLanguageModelMock,
+    }),
+  )
   const innerCreateOpenAICompatibleMock = vi.fn<(...args: any[]) => any>(
     (_options?: Record<string, unknown>) => ({
       languageModel: innerOpenAICompatibleLanguageModelMock,
@@ -41,17 +50,21 @@ const {
       languageModel: innerOllamaLanguageModelMock,
     }),
   )
+  const innerWrapLanguageModelMock = vi.fn<(...args: any[]) => any>(() => "wrapped-google-model")
 
   return {
     anthropicLanguageModelMock: innerAnthropicLanguageModelMock,
     azureChatModelMock: innerAzureChatModelMock,
     azureLanguageModelMock: innerAzureLanguageModelMock,
+    googleLanguageModelMock: innerGoogleLanguageModelMock,
     openAICompatibleLanguageModelMock: innerOpenAICompatibleLanguageModelMock,
     ollamaLanguageModelMock: innerOllamaLanguageModelMock,
     createAnthropicMock: innerCreateAnthropicMock,
     createAzureMock: innerCreateAzureMock,
+    createGoogleMock: innerCreateGoogleMock,
     createOllamaMock: innerCreateOllamaMock,
     createOpenAICompatibleMock: innerCreateOpenAICompatibleMock,
+    wrapLanguageModelMock: innerWrapLanguageModelMock,
   }
 })
 
@@ -63,12 +76,20 @@ vi.mock("@ai-sdk/azure", () => ({
   createAzure: createAzureMock,
 }))
 
+vi.mock("@ai-sdk/google", () => ({
+  createGoogleGenerativeAI: createGoogleMock,
+}))
+
 vi.mock("@ai-sdk/openai-compatible", () => ({
   createOpenAICompatible: createOpenAICompatibleMock,
 }))
 
 vi.mock("ai-sdk-ollama", () => ({
   createOllama: createOllamaMock,
+}))
+
+vi.mock("ai", () => ({
+  wrapLanguageModel: wrapLanguageModelMock,
 }))
 
 function createAnthropicProviderConfig(headers?: Record<string, unknown>) {
@@ -120,12 +141,29 @@ function createOllamaProviderConfig(providerOptions?: Record<string, unknown>) {
   }
 }
 
+function createGoogleProviderConfig() {
+  return {
+    id: "google-default",
+    name: "Gemini",
+    enabled: true,
+    provider: "google",
+    apiKey: "test-key",
+    model: {
+      model: "gemini-flash-latest",
+      isCustomModel: false,
+      customModel: null,
+    },
+    reasoning: "provider-default",
+  }
+}
+
 describe("getModelById", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     anthropicLanguageModelMock.mockReturnValue("anthropic-model")
     azureChatModelMock.mockReturnValue("azure-chat-model")
     azureLanguageModelMock.mockReturnValue("azure-model")
+    googleLanguageModelMock.mockReturnValue("google-model")
     openAICompatibleLanguageModelMock.mockReturnValue("custom-model")
     ollamaLanguageModelMock.mockReturnValue("ollama-model")
     getStorageItemMock = vi.fn<(...args: any[]) => any>()
@@ -184,6 +222,31 @@ describe("getModelById", () => {
       baseURL: "http://127.0.0.1:11434/",
     })
     expect(ollamaLanguageModelMock).toHaveBeenCalledWith("gemma3:4b", { think: false })
+  })
+
+  it("removes deprecated sampling settings from every Google model request", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [createGoogleProviderConfig()],
+    })
+
+    const { getModelById } = await import("../model")
+    const result = await getModelById("google-default")
+
+    expect(result).toBe("wrapped-google-model")
+    expect(createGoogleMock).toHaveBeenCalledWith({ apiKey: "test-key" })
+    expect(googleLanguageModelMock).toHaveBeenCalledWith("gemini-flash-latest")
+
+    const middleware = wrapLanguageModelMock.mock.calls[0]?.[0].middleware
+    const transformed = await middleware.transformParams({
+      params: { temperature: 0.7, topP: 0.9, topK: 40, maxOutputTokens: 100 },
+    })
+
+    expect(transformed).toEqual({
+      temperature: undefined,
+      topP: undefined,
+      topK: undefined,
+      maxOutputTokens: 100,
+    })
   })
 
   it("passes Azure settings and resolves the deployment name with languageModel", async () => {

--- a/src/utils/providers/google-models.ts
+++ b/src/utils/providers/google-models.ts
@@ -1,0 +1,79 @@
+import { z } from "zod"
+import { extractErrorMessage } from "@/utils/error/extract-message"
+
+const googleModelSchema = z.object({
+  name: z.string(),
+  supportedGenerationMethods: z.array(z.string()).default([]),
+})
+
+const googleModelsResponseSchema = z.object({
+  models: z.array(googleModelSchema).default([]),
+  nextPageToken: z.string().optional(),
+})
+
+const modelIdCollator = new Intl.Collator("en", {
+  numeric: true,
+  sensitivity: "variant",
+})
+
+interface FetchGoogleTextModelsOptions {
+  baseURL: string
+  apiKey: string
+  signal?: AbortSignal
+}
+
+function toModelId(name: string): string {
+  return name.replace(/^models\//, "")
+}
+
+function supportsGenerateContent(
+  name: string,
+  supportedGenerationMethods: readonly string[],
+): boolean {
+  const modelId = toModelId(name)
+
+  return modelId.startsWith("gemini-") && supportedGenerationMethods.includes("generateContent")
+}
+
+export async function fetchGoogleModels({
+  baseURL,
+  apiKey,
+  signal,
+}: FetchGoogleTextModelsOptions): Promise<string[]> {
+  const modelIds = new Set<string>()
+  let pageToken: string | undefined
+
+  do {
+    const url = new URL(`${baseURL.replace(/\/+$/, "")}/models`)
+    url.searchParams.set("pageSize", "1000")
+
+    if (pageToken) {
+      url.searchParams.set("pageToken", pageToken)
+    }
+
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "x-goog-api-key": apiKey,
+      },
+      signal,
+    })
+
+    if (!response.ok) {
+      const message = await extractErrorMessage(response)
+      throw new Error(`Failed to fetch Google models: ${message}`)
+    }
+
+    const page = googleModelsResponseSchema.parse(await response.json())
+
+    for (const model of page.models) {
+      if (supportsGenerateContent(model.name, model.supportedGenerationMethods)) {
+        modelIds.add(toModelId(model.name))
+      }
+    }
+
+    pageToken = page.nextPageToken
+  } while (pageToken)
+
+  return [...modelIds].sort((left, right) => modelIdCollator.compare(right, left))
+}

--- a/src/utils/providers/model.ts
+++ b/src/utils/providers/model.ts
@@ -1,3 +1,4 @@
+import type { LanguageModelMiddleware } from "ai"
 import type { Config } from "@/types/config/config"
 import type { AzureApiMode, LLMProviderConfig } from "@/types/config/provider"
 import { createAlibaba } from "@ai-sdk/alibaba"
@@ -21,6 +22,7 @@ import { createReplicate } from "@ai-sdk/replicate"
 import { createTogetherAI } from "@ai-sdk/togetherai"
 import { createVercel } from "@ai-sdk/vercel"
 import { createXai } from "@ai-sdk/xai"
+import { wrapLanguageModel } from "ai"
 import { createOllama } from "ai-sdk-ollama"
 import { storage } from "#imports"
 import { DEFAULT_AZURE_API_MODE, isCustomLLMProvider } from "@/types/config/provider"
@@ -60,6 +62,15 @@ const CREATE_AI_MAPPER = {
   moonshotai: createMoonshotAI,
   huggingface: createHuggingFace,
 } as const
+
+const googleSamplingCompatibilityMiddleware = {
+  transformParams: async ({ params }) => ({
+    ...params,
+    temperature: undefined,
+    topP: undefined,
+    topK: undefined,
+  }),
+} satisfies LanguageModelMiddleware
 
 function getProviderSpecificSettings(providerConfig: LLMProviderConfig) {
   const settings =
@@ -130,7 +141,11 @@ async function getLanguageModelById(providerId: string) {
     return (provider as ReturnType<typeof createOllama>).languageModel(modelId, { think: false })
   }
 
-  return provider.languageModel(modelId)
+  const model = provider.languageModel(modelId)
+
+  return providerConfig.provider === "google"
+    ? wrapLanguageModel({ model, middleware: googleSamplingCompatibilityMiddleware })
+    : model
 }
 
 export async function getModelById(providerId: string) {


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

### Problems

1. **The hardcoded Gemini model list was outdated.** Every time Google ships a new model, the extension needs a code change and a release before users can select it.
2. **The newest models were unusable** — e.g. `gemini-3.6-flash` was not in the list at all.
3. **`gemini-3.5-flash-lite` failed at request time**, because the extension hardcoded per-version `thinkingConfig` provider options (`thinkingBudget: 0` / `thinkingLevel: "minimal"`) and sampling parameters that newer Gemini models reject.

### Fix — stop hardcoding, ask the API instead

Rather than patching the static list again (which would break again with the next model generation), this PR makes the Google provider self-updating:

- **Dynamic model discovery**: the model selector now fetches the available models from Google's official [`GET /models`](https://ai.google.dev/api/models#method:-models.list) endpoint (paginated, filtered to `gemini-*` models that support `generateContent`), so newly released models show up automatically. Results are cached for 1 hour via TanStack Query. The API key is debounced and only a truncated SHA-256 fingerprint of it is used in the query cache key, so the key itself never enters the cache.
- **Offline fallback**: the static list is reduced to the three versionless aliases Google keeps up to date themselves (`gemini-flash-lite-latest`, `gemini-flash-latest`, `gemini-pro-latest`), used when the dynamic fetch is unavailable. The default model is now `gemini-flash-lite-latest`.
- **No more per-version thinking hacks**: the hardcoded Gemini `thinkingConfig` patterns are removed and the Google default reasoning is now `provider-default`, letting the Gemini API pick the correct thinking behavior for each model instead of us guessing per version.
- **Strip unsupported sampling params**: Google requests go through a `wrapLanguageModel` middleware that drops `temperature` / `topP` / `topK` (rejected by the newest models), and the temperature field is hidden for the Google provider in the options UI.
- **Schema**: the Google model schema is relaxed from a hardcoded enum to a non-empty string so dynamically discovered model ids validate; all other providers keep strict enum validation.
- Bumps `@ai-sdk/google` to `^4.0.21`.

## Related Issue

Closes #1938

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

New tests cover the `fetchGoogleModels` fetcher (pagination, filtering, dedup, error surfacing), the model selector (dynamic options, API key kept out of the cache key), the relaxed Google schema, and the sampling-param-stripping middleware. Full suite: 215 test files / 2035 tests pass, `oxlint --type-aware` clean.

## Screenshots

See the reproduction screenshot in #1938.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

One follow-up worth discussing: existing users still have `reasoning: "none"` saved from the previous default. For the versionless aliases, `@ai-sdk/google` maps `"none"` to `thinkingConfig: { thinkingBudget: 0 }`, which the newest models reject — so those users would need to switch reasoning to "provider-default" manually if they pick an alias model. If you'd like, I can add a config migration (v86 → v87) that moves Google providers from `"none"` to `"provider-default"` in this PR or a follow-up.

