### PR TITLE
feat(analytics): track providers in feature usage events

### DIFF
--- a/src/entrypoints/background/__tests__/analytics.test.ts
+++ b/src/entrypoints/background/__tests__/analytics.test.ts
@@ -1,4 +1,4 @@
-import type { PostHog } from "posthog-js/dist/module.no-external"
+import type { CaptureResult, PostHog } from "posthog-js/dist/module.no-external"
 import type { FeatureUsageCache } from "../analytics-feature-cache"
 import type {
   FeatureUsedEventProperties,
@@ -21,6 +21,11 @@ type MessageHandler<TData, TResult = void> = (message: {
 type PostHogCaptureMock = (...args: Parameters<PostHog["capture"]>) => void
 type PostHogInitMock = (...args: Parameters<PostHog["init"]>) => void
 type PostHogRegisterMock = (...args: Parameters<PostHog["register"]>) => void
+
+const DEFAULT_FEATURE_PROVIDER = {
+  provider: "openai",
+  backend_kind: "llm",
+} as const
 
 describe("background analytics", () => {
   let trackFeatureUsedEventHandler: MessageHandler<FeatureUsedEventProperties> | undefined
@@ -159,6 +164,7 @@ describe("background analytics", () => {
         surface: "popup",
         outcome: "success",
         latency_ms: 1_500,
+        ...DEFAULT_FEATURE_PROVIDER,
       },
     })
 
@@ -191,9 +197,34 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 1_500,
+      ...DEFAULT_FEATURE_PROVIDER,
       target_language: "cmn",
     })
     expect(storageSetItemMock).not.toHaveBeenCalled()
+  })
+
+  it("downgrades legacy feature messages without provider fields to unknown/unknown", async () => {
+    storageGetItemMock.mockResolvedValueOnce(true).mockResolvedValueOnce("install-123")
+
+    const { setupAnalyticsMessageHandlers } = createAnalytics()
+    setupAnalyticsMessageHandlers()
+
+    const handler = requireMessageHandler(trackFeatureUsedEventHandler, "trackFeatureUsedEvent")
+    const legacyProperties = {
+      feature: "page_translation",
+      surface: "popup",
+      outcome: "success",
+      latency_ms: 250,
+    } as unknown as FeatureUsedEventProperties
+
+    await handler({ data: legacyProperties })
+
+    expect(posthogCaptureMock).toHaveBeenCalledWith("feature_used", {
+      ...legacyProperties,
+      provider: "unknown",
+      backend_kind: "unknown",
+      target_language: "cmn",
+    })
   })
 
   it("adds the configured target language to non-translation feature events", async () => {
@@ -205,6 +236,7 @@ describe("background analytics", () => {
       surface: "tts_settings",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
     })
 
     expect(posthogCaptureMock).toHaveBeenCalledWith("feature_used", {
@@ -212,6 +244,7 @@ describe("background analytics", () => {
       surface: "tts_settings",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
       target_language: "cmn",
     })
   })
@@ -224,6 +257,7 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
     }
 
     await captureFeatureUsedEventInBackground(properties)
@@ -244,6 +278,7 @@ describe("background analytics", () => {
       surface: "context_menu",
       outcome: "failure",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
       action_id: "dictionary",
       action_name: "Dictionary",
     })
@@ -252,6 +287,7 @@ describe("background analytics", () => {
       surface: "selection_toolbar",
       outcome: "success",
       latency_ms: 200,
+      ...DEFAULT_FEATURE_PROVIDER,
       action_id: "explain",
       action_name: "Explain",
     })
@@ -262,6 +298,7 @@ describe("background analytics", () => {
       surface: "context_menu",
       outcome: "failure",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
       action_id: "dictionary",
       action_name: "Dictionary",
       target_language: "cmn",
@@ -281,12 +318,14 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
     })
     await captureFeatureUsedEventInBackground({
       feature: "text_to_speech",
       surface: "tts_settings",
       outcome: "success",
       latency_ms: 200,
+      ...DEFAULT_FEATURE_PROVIDER,
     })
 
     expect(posthogCaptureMock).toHaveBeenCalledTimes(2)
@@ -305,6 +344,7 @@ describe("background analytics", () => {
       surface: "selection_toolbar",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
       action_id: "suggestion_shown",
     })
     await captureFeatureUsedEventInBackground({
@@ -312,6 +352,7 @@ describe("background analytics", () => {
       surface: "selection_toolbar",
       outcome: "success",
       latency_ms: 200,
+      ...DEFAULT_FEATURE_PROVIDER,
       action_id: "suggestion_accepted",
     })
 
@@ -334,6 +375,7 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
     }
 
     await captureFeatureUsedEventInBackground(properties)
@@ -357,6 +399,7 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
     }
 
     await Promise.all([
@@ -377,6 +420,7 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
     }
 
     await createAnalytics({ featureUsageCache: cache }).captureFeatureUsedEventInBackground(
@@ -406,6 +450,7 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
     })
 
     expect(posthogCaptureMock).toHaveBeenCalledOnce()
@@ -433,6 +478,7 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
     })
 
     expect(posthogCaptureMock).toHaveBeenCalledOnce()
@@ -456,6 +502,7 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
     }
 
     await captureFeatureUsedEventInBackground(properties)
@@ -474,6 +521,7 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 1_500,
+      ...DEFAULT_FEATURE_PROVIDER,
     })
 
     expect(posthogInitMock).not.toHaveBeenCalled()
@@ -492,6 +540,7 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
     })
 
     expect(cache.getLastReportedDay).not.toHaveBeenCalled()
@@ -509,6 +558,7 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
     })
 
     expect(posthogInitMock).not.toHaveBeenCalled()
@@ -524,6 +574,7 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
     })
 
     expect(storageSetItemMock).toHaveBeenCalledWith(
@@ -557,6 +608,7 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
     })
 
     expect(posthogInitMock).toHaveBeenCalledWith(
@@ -581,6 +633,7 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "success",
       latency_ms: 100,
+      ...DEFAULT_FEATURE_PROVIDER,
     })
 
     expect(posthogInitMock).toHaveBeenCalledWith(
@@ -608,6 +661,7 @@ describe("background analytics", () => {
       surface: "popup",
       outcome: "failure",
       latency_ms: 42,
+      ...DEFAULT_FEATURE_PROVIDER,
     })
 
     expect(posthogInitMock).not.toHaveBeenCalled()
@@ -616,67 +670,167 @@ describe("background analytics", () => {
     expect(loggerWarnMock).toHaveBeenCalledOnce()
   })
 
-  it("filters PostHog properties down to the allowlist", () => {
-    expect(
-      filterAnalyticsCaptureResult({
-        event: "feature_used",
-        properties: {
-          token: "phc_test",
-          distinct_id: "install-123",
-          feature: "custom_ai_action",
-          surface: "context_menu",
-          outcome: "success",
-          latency_ms: 250,
-          action_id: "dictionary",
-          action_name: "Dictionary",
-          target_language: "cmn",
-          $browser: "Chrome",
-          $browser_version: "145.0.0.0",
-          $insert_id: "insert-123",
-          $time: 1234,
-          $lib: "web",
-          $lib_version: "1.360.2",
-          $process_person_profile: false,
-          extension_version: "1.0.0",
-          backend_kind: "llm",
-          configured_prompt: "default",
-          cohort: "new_user_prompt_experiment_v1",
-          prompt_exposure_age: "d1_d7",
-          $feature_flag: "new-user-default-translate-prompt-v1",
-          $feature_flag_response: "control",
-          $feature_flag_payload: { private: true },
-          $current_url: "chrome-extension://abc/background.js",
-          $raw_user_agent: "Mozilla/5.0",
-          $timezone: "America/Vancouver",
-        },
-        timestamp: new Date("2026-03-16T19:02:43.960Z"),
-        uuid: "test-uuid",
-      }).properties,
-    ).toEqual({
+  it("keeps new safe business properties and coarse runtime information by default", () => {
+    const filtered = filterAnalyticsCaptureResult({
+      event: "feature_used",
+      properties: {
+        token: "phc_test",
+        distinct_id: "install-123",
+        feature: "custom_ai_action",
+        surface: "context_menu",
+        outcome: "success",
+        latency_ms: 250,
+        ...DEFAULT_FEATURE_PROVIDER,
+        new_safe_business_field: "automatically-kept",
+        action_id: "dictionary",
+        action_name: "Dictionary",
+        target_language: "cmn",
+        $browser: "Chrome",
+        $browser_version: "145.0.0.0",
+        $os: "Mac OS X",
+        $os_version: "15.5",
+        $device_type: "Desktop",
+        $timezone: "America/Vancouver",
+        $timezone_offset: 420,
+        $browser_language: "en-US",
+        $insert_id: "insert-123",
+        $time: 1234,
+        $lib: "web",
+        $lib_version: "1.360.2",
+        $process_person_profile: false,
+        extension_version: "1.0.0",
+        configured_prompt: "default",
+        cohort: "new_user_prompt_experiment_v1",
+        prompt_exposure_age: "d1_d7",
+        $feature_flag: "new-user-default-translate-prompt-v1",
+        $feature_flag_response: "control",
+      },
+      timestamp: new Date("2026-03-16T19:02:43.960Z"),
+      uuid: "test-uuid",
+    }).properties
+
+    expect(filtered).toEqual({
       token: "phc_test",
       distinct_id: "install-123",
       feature: "custom_ai_action",
       surface: "context_menu",
       outcome: "success",
       latency_ms: 250,
+      ...DEFAULT_FEATURE_PROVIDER,
+      new_safe_business_field: "automatically-kept",
       action_id: "dictionary",
       action_name: "Dictionary",
       target_language: "cmn",
       $browser: "Chrome",
       $browser_version: "145.0.0.0",
+      $os: "Mac OS X",
+      $os_version: "15.5",
+      $device_type: "Desktop",
+      $timezone: "America/Vancouver",
+      $timezone_offset: 420,
+      $browser_language: "en-US",
       $insert_id: "insert-123",
       $time: 1234,
       $lib: "web",
       $lib_version: "1.360.2",
       $process_person_profile: false,
       extension_version: "1.0.0",
-      backend_kind: "llm",
       configured_prompt: "default",
       cohort: "new_user_prompt_experiment_v1",
       prompt_exposure_age: "d1_d7",
       $feature_flag: "new-user-default-translate-prompt-v1",
       $feature_flag_response: "control",
     })
+  })
+
+  it("recursively removes sensitive, identifying, page, and SDK-internal properties", () => {
+    const captureResult = {
+      event: "feature_used",
+      properties: {
+        token: "phc_root_token_must_survive",
+        distinct_id: "install-123",
+        provider: "openai",
+        backend_kind: "llm",
+        $current_url: "https://private.example/path",
+        page_url: "https://private.example/another-path",
+        href: "https://private.example/link",
+        $host: "private.example",
+        $pathname: "/path",
+        $referrer: "https://referrer.example",
+        title: "Private page title",
+        $raw_user_agent: "full user agent",
+        $device: "Exact hardware model",
+        $screen_width: 3_456,
+        $viewport_height: 1_234,
+        $device_id: "device-id",
+        $session_id: "session-id",
+        $window_id: "window-id",
+        $pageview_id: "pageview-id",
+        $initial_current_url: "https://private.example/initial",
+        $prev_pageview_pathname: "/previous-private-path",
+        $sdk_debug_retry_queue: ["debug"],
+        $config_defaults: "2025-11-30",
+        $lib_custom_api_host: "https://analytics.example",
+        $active_feature_flags: ["flag-a"],
+        $enabled_feature_flags: ["flag-a"],
+        $feature_flag_payload: { private: true },
+        model: "private-model",
+        model_name: "another-private-model",
+        prompt: "private prompt",
+        system_prompt: "private system prompt",
+        provider_options: { private: true },
+        nested: {
+          safe_nested_business_field: true,
+          api_key: "secret-key",
+          access_token: "secret-token",
+          headers: { authorization: "Bearer secret" },
+          rows: [
+            {
+              variant: "control",
+              selection: "private selected text",
+            },
+          ],
+        },
+        $set: {
+          safe_set_property: "kept",
+          content: "private content",
+        },
+        $set_once: {
+          safe_set_once_property: "kept",
+          password: "private password",
+        },
+      },
+      $set: {
+        safe_top_level_set: "kept",
+        base_url: "https://private-provider.example",
+      },
+      $set_once: {
+        safe_top_level_set_once: "kept",
+        instructions: "private instructions",
+      },
+      timestamp: new Date("2026-03-16T19:02:43.960Z"),
+      uuid: "test-uuid",
+    } as unknown as CaptureResult
+
+    const filtered = filterAnalyticsCaptureResult(captureResult) as CaptureResult & {
+      $set?: Record<string, unknown>
+      $set_once?: Record<string, unknown>
+    }
+
+    expect(filtered.properties).toEqual({
+      token: "phc_root_token_must_survive",
+      distinct_id: "install-123",
+      provider: "openai",
+      backend_kind: "llm",
+      nested: {
+        safe_nested_business_field: true,
+        rows: [{ variant: "control" }],
+      },
+      $set: { safe_set_property: "kept" },
+      $set_once: { safe_set_once_property: "kept" },
+    })
+    expect(filtered.$set).toEqual({ safe_top_level_set: "kept" })
+    expect(filtered.$set_once).toEqual({ safe_top_level_set_once: "kept" })
   })
 
   it("enrolls only an explicit fresh install marker without initializing PostHog", async () => {

--- a/src/entrypoints/background/analytics.ts
+++ b/src/entrypoints/background/analytics.ts
@@ -19,6 +19,7 @@ import {
   PROMPT_EXPERIMENT_COHORT,
   PROMPT_EXPERIMENT_VARIANTS,
 } from "@/types/analytics"
+import { normalizeFeatureProviderAnalytics } from "@/utils/analytics-provider"
 import { getLocalConfig } from "@/utils/config/storage"
 import {
   ANALYTICS_ENABLED_STORAGE_KEY,
@@ -226,14 +227,144 @@ function createDefaultRuntime(): BackgroundAnalyticsRuntime {
 
 type AnalyticsCaptureProperties = Record<string, unknown>
 
-function setPropertyIfDefined(
-  properties: AnalyticsCaptureProperties,
-  key: string,
-  value: unknown,
-): void {
-  if (value !== undefined) {
-    properties[key] = value
+const BLOCKED_ANALYTICS_PROPERTY_KEYS = new Set([
+  "currenturl",
+  "host",
+  "pathname",
+  "referrer",
+  "referringdomain",
+  "url",
+  "href",
+  "title",
+  "rawuseragent",
+  "device",
+  "screenheight",
+  "screenwidth",
+  "viewportheight",
+  "viewportwidth",
+  "deviceid",
+  "sessionid",
+  "windowid",
+  "pageviewid",
+  "configdefaults",
+  "libcustomapihost",
+  "activefeatureflags",
+  "enabledfeatureflags",
+  "featureflagpayload",
+  "featureflagpayloads",
+  "authorization",
+  "credential",
+  "credentials",
+  "secret",
+  "password",
+  "header",
+  "headers",
+  "baseurl",
+  "providerconfig",
+  "provideroptions",
+  "prompt",
+  "instructions",
+  "input",
+  "output",
+  "text",
+  "content",
+  "selection",
+  "html",
+  "model",
+  "modelid",
+])
+
+function normalizeAnalyticsPropertyKey(key: string): string {
+  return key.replaceAll(/[$_\-\s]/g, "").toLowerCase()
+}
+
+function isBlockedAnalyticsProperty(key: string, preserveRootToken: boolean): boolean {
+  const normalizedKey = normalizeAnalyticsPropertyKey(key)
+
+  if (preserveRootToken && key === "token") return false
+  if (BLOCKED_ANALYTICS_PROPERTY_KEYS.has(normalizedKey)) return true
+  if (normalizedKey.startsWith("sdkdebug")) return true
+  if (normalizedKey.startsWith("prevpageview") || normalizedKey.startsWith("previouspageview")) {
+    return true
   }
+  if (normalizedKey.startsWith("screen") || normalizedKey.startsWith("viewport")) return true
+  if (
+    ["url", "href", "host", "hostname", "pathname", "referrer", "title"].some((suffix) =>
+      normalizedKey.endsWith(suffix),
+    )
+  ) {
+    return true
+  }
+  if (
+    normalizedKey.startsWith("initial") &&
+    ["url", "host", "path", "referrer", "domain", "title"].some((part) =>
+      normalizedKey.includes(part),
+    )
+  ) {
+    return true
+  }
+  if (
+    normalizedKey.endsWith("deviceid") ||
+    normalizedKey.endsWith("sessionid") ||
+    normalizedKey.endsWith("windowid") ||
+    normalizedKey.endsWith("pageviewid")
+  ) {
+    return true
+  }
+  if (
+    normalizedKey.endsWith("apikey") ||
+    normalizedKey.endsWith("token") ||
+    normalizedKey.includes("credential") ||
+    normalizedKey.endsWith("secret") ||
+    normalizedKey.endsWith("password") ||
+    normalizedKey.endsWith("authorization") ||
+    normalizedKey.endsWith("header") ||
+    normalizedKey.endsWith("headers") ||
+    normalizedKey.endsWith("providerconfig") ||
+    normalizedKey.endsWith("provideroptions")
+  ) {
+    return true
+  }
+  if (
+    normalizedKey.includes("instructions") ||
+    (normalizedKey.endsWith("prompt") && normalizedKey !== "configuredprompt") ||
+    normalizedKey.endsWith("prompttext") ||
+    normalizedKey.endsWith("inputtext") ||
+    normalizedKey.endsWith("outputtext") ||
+    normalizedKey.endsWith("content") ||
+    normalizedKey.endsWith("selection") ||
+    normalizedKey.endsWith("html") ||
+    normalizedKey.includes("model")
+  ) {
+    return true
+  }
+
+  return false
+}
+
+function sanitizeAnalyticsValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeAnalyticsValue)
+  }
+  if (typeof value !== "object" || value === null) {
+    return value
+  }
+
+  return sanitizeAnalyticsProperties(value as AnalyticsCaptureProperties, false)
+}
+
+function sanitizeAnalyticsProperties(
+  properties: AnalyticsCaptureProperties,
+  preserveRootToken: boolean,
+): AnalyticsCaptureProperties {
+  const sanitizedProperties: AnalyticsCaptureProperties = {}
+
+  for (const [key, value] of Object.entries(properties)) {
+    if (isBlockedAnalyticsProperty(key, preserveRootToken)) continue
+    sanitizedProperties[key] = sanitizeAnalyticsValue(value)
+  }
+
+  return sanitizedProperties
 }
 
 export function filterAnalyticsCaptureResult(data: CaptureResult): CaptureResult
@@ -242,45 +373,27 @@ export function filterAnalyticsCaptureResult(data: CaptureResult | null): Captur
 export function filterAnalyticsCaptureResult(data: CaptureResult | null): CaptureResult | null {
   if (data === null) return null
 
-  const properties = data.properties ?? {}
-  const filteredProperties: AnalyticsCaptureProperties = {}
-
-  setPropertyIfDefined(filteredProperties, "token", properties.token)
-  setPropertyIfDefined(filteredProperties, "distinct_id", properties.distinct_id)
-  setPropertyIfDefined(filteredProperties, "feature", properties.feature)
-  setPropertyIfDefined(filteredProperties, "surface", properties.surface)
-  setPropertyIfDefined(filteredProperties, "outcome", properties.outcome)
-  setPropertyIfDefined(filteredProperties, "latency_ms", properties.latency_ms)
-  setPropertyIfDefined(filteredProperties, "action_id", properties.action_id)
-  setPropertyIfDefined(filteredProperties, "action_name", properties.action_name)
-  setPropertyIfDefined(filteredProperties, "target_language", properties.target_language)
-  setPropertyIfDefined(filteredProperties, "backend_kind", properties.backend_kind)
-  setPropertyIfDefined(filteredProperties, "configured_prompt", properties.configured_prompt)
-  setPropertyIfDefined(filteredProperties, "cohort", properties.cohort)
-  setPropertyIfDefined(filteredProperties, "prompt_exposure_age", properties.prompt_exposure_age)
-  setPropertyIfDefined(filteredProperties, "$feature_flag", properties.$feature_flag)
-  setPropertyIfDefined(
-    filteredProperties,
-    "$feature_flag_response",
-    properties.$feature_flag_response,
-  )
-  setPropertyIfDefined(filteredProperties, "$browser", properties.$browser)
-  setPropertyIfDefined(filteredProperties, "$browser_version", properties.$browser_version)
-  setPropertyIfDefined(filteredProperties, "$insert_id", properties.$insert_id)
-  setPropertyIfDefined(filteredProperties, "$time", properties.$time)
-  setPropertyIfDefined(filteredProperties, "$lib", properties.$lib)
-  setPropertyIfDefined(filteredProperties, "$lib_version", properties.$lib_version)
-  setPropertyIfDefined(
-    filteredProperties,
-    "$process_person_profile",
-    properties.$process_person_profile,
-  )
-  setPropertyIfDefined(filteredProperties, "extension_version", properties.extension_version)
-
-  return {
+  const filteredData = {
     ...data,
-    properties: filteredProperties,
+    properties: sanitizeAnalyticsProperties(data.properties ?? {}, true),
   }
+
+  const mutableFilteredData = filteredData as CaptureResult & {
+    $set?: AnalyticsCaptureProperties
+    $set_once?: AnalyticsCaptureProperties
+  }
+  const captureData = data as CaptureResult & {
+    $set?: AnalyticsCaptureProperties
+    $set_once?: AnalyticsCaptureProperties
+  }
+  if (captureData.$set) {
+    mutableFilteredData.$set = sanitizeAnalyticsProperties(captureData.$set, false)
+  }
+  if (captureData.$set_once) {
+    mutableFilteredData.$set_once = sanitizeAnalyticsProperties(captureData.$set_once, false)
+  }
+
+  return mutableFilteredData
 }
 
 export function createBackgroundAnalytics(
@@ -652,6 +765,11 @@ export function createBackgroundAnalytics(
       return
     }
 
+    const normalizedProperties: FeatureUsedEventProperties = {
+      ...properties,
+      ...normalizeFeatureProviderAnalytics(properties.provider, properties.backend_kind),
+    }
+
     // Funnel features must record every step (e.g. save-suggestion shown vs
     // accepted), so they skip the once-per-day-per-feature adoption throttle —
     // the daily cache keys on feature only and would drop the second same-day
@@ -659,13 +777,13 @@ export function createBackgroundAnalytics(
     // cooldown), so bypassing does not inflate volume.
     if (
       !runtime.featureUsageCache ||
-      FEATURES_BYPASSING_DAILY_FEATURE_CACHE.has(properties.feature)
+      FEATURES_BYPASSING_DAILY_FEATURE_CACHE.has(normalizedProperties.feature)
     ) {
-      await captureFeatureUsedEvent(properties)
+      await captureFeatureUsedEvent(normalizedProperties)
       return
     }
 
-    await captureFeatureUsedEventWithCache(properties, runtime.featureUsageCache)
+    await captureFeatureUsedEventWithCache(normalizedProperties, runtime.featureUsageCache)
   }
 
   async function getBackgroundFeatureUsedEventProperties(): Promise<

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -13,6 +13,7 @@ import {
   trackFeatureUsed,
   trackTranslationRequested,
 } from "@/utils/analytics"
+import { classifyProviderConfig, UNKNOWN_FEATURE_PROVIDER } from "@/utils/analytics-provider"
 import { getLocalConfig } from "@/utils/config/storage"
 import {
   CONTENT_WRAPPER_CLASS,
@@ -182,6 +183,7 @@ export class PageTranslationManager implements IPageTranslationManager {
         }
         void trackFeatureUsed({
           ...trackedContext,
+          ...UNKNOWN_FEATURE_PROVIDER,
           outcome: "failure",
         })
       }
@@ -189,6 +191,7 @@ export class PageTranslationManager implements IPageTranslationManager {
     }
 
     const requestedProviderConfig = resolveProviderConfigOrNull(config, "translate")
+    const providerAnalytics = classifyProviderConfig(requestedProviderConfig)
     if (trackedContext && trackedContext.surface !== ANALYTICS_SURFACE.PAGE_AUTO) {
       await trackTranslationRequested({
         feature: TRANSLATION_REQUESTED_FEATURE.PAGE_TRANSLATION,
@@ -210,6 +213,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       if (trackedContext) {
         void trackFeatureUsed({
           ...trackedContext,
+          ...providerAnalytics,
           outcome: "failure",
         })
       }
@@ -304,6 +308,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       if (trackedContext) {
         void trackFeatureUsed({
           ...trackedContext,
+          ...providerAnalytics,
           outcome: "success",
         })
       }
@@ -311,6 +316,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       if (trackedContext) {
         void trackFeatureUsed({
           ...trackedContext,
+          ...providerAnalytics,
           outcome: "failure",
         })
       }

--- a/src/entrypoints/selection.content/input-translation/use-input-translation.ts
+++ b/src/entrypoints/selection.content/input-translation/use-input-translation.ts
@@ -2,7 +2,9 @@ import { useAtom } from "jotai"
 import { useCallback, useEffect, useRef } from "react"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext, trackFeatureAttempt } from "@/utils/analytics"
+import { classifyProviderConfig } from "@/utils/analytics-provider"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { getProviderConfigById } from "@/utils/config/helpers"
 import { INPUT_REPLACE_REQUEST_TYPE } from "@/utils/constants/input-injector"
 import { translateTextForInput } from "@/utils/host/translate/translate-variants"
 
@@ -121,6 +123,7 @@ function setTextWithUndo(
 
 export function useInputTranslation() {
   const [inputTranslationConfig] = useAtom(configFieldsAtomMap.inputTranslation)
+  const [providersConfig] = useAtom(configFieldsAtomMap.providersConfig)
   const spaceTimestampsRef = useRef<number[]>([])
   const isTranslatingRef = useRef(false)
 
@@ -183,10 +186,15 @@ export function useInputTranslation() {
 
       try {
         const translatedText = await trackFeatureAttempt(
-          createFeatureUsageContext(
-            ANALYTICS_FEATURE.INPUT_TRANSLATION,
-            ANALYTICS_SURFACE.INPUT_TRANSLATION,
-          ),
+          {
+            ...createFeatureUsageContext(
+              ANALYTICS_FEATURE.INPUT_TRANSLATION,
+              ANALYTICS_SURFACE.INPUT_TRANSLATION,
+            ),
+            ...classifyProviderConfig(
+              getProviderConfigById(providersConfig, inputTranslationConfig.providerId),
+            ),
+          },
           () => translateTextForInput(text, fromLang, toLang),
         )
 
@@ -215,6 +223,8 @@ export function useInputTranslation() {
       inputTranslationConfig.fromLang,
       inputTranslationConfig.toLang,
       inputTranslationConfig.enableCycle,
+      inputTranslationConfig.providerId,
+      providersConfig,
     ],
   )
 

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/provider.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/provider.tsx
@@ -6,6 +6,7 @@ import { toastManager } from "@/components/ui/base-ui/toast"
 import { SelectionPopover } from "@/components/ui/selection-popover"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
+import { classifyResolvedProvider, UNKNOWN_FEATURE_PROVIDER } from "@/utils/analytics-provider"
 import { configFieldsAtomMap, writeConfigAtom } from "@/utils/atoms/config"
 import { onMessage } from "@/utils/message"
 import {
@@ -260,6 +261,7 @@ export function SelectionCustomActionProvider({ children }: { children: ReactNod
               action_id: actionId,
             },
           ),
+          ...UNKNOWN_FEATURE_PROVIDER,
           outcome: "failure",
         })
         toastManager.add({ type: "error", title: nextError.description })
@@ -279,6 +281,13 @@ export function SelectionCustomActionProvider({ children }: { children: ReactNod
               action_name: action.name,
             },
           ),
+          ...classifyResolvedProvider(
+            resolveProviderRefForCapability(
+              "selectionToolbar.customAction",
+              providersConfig,
+              action.providerId,
+            ),
+          ),
           outcome: "failure",
         })
         toastManager.add({ type: "error", title: nextError.description })
@@ -292,7 +301,12 @@ export function SelectionCustomActionProvider({ children }: { children: ReactNod
         surface: ANALYTICS_SURFACE.CONTEXT_MENU,
       })
     },
-    [openActionRequest, resolveContextMenuOpenRequest, selectionToolbarConfig.customActions],
+    [
+      openActionRequest,
+      providersConfig,
+      resolveContextMenuOpenRequest,
+      selectionToolbarConfig.customActions,
+    ],
   )
 
   const handleProviderChange = useCallback(
@@ -361,6 +375,7 @@ export function SelectionCustomActionProvider({ children }: { children: ReactNod
 
     void trackFeatureUsed({
       ...analyticsContext,
+      ...classifyResolvedProvider(customActionRequest.provider),
       outcome: "failure",
     })
   }, [
@@ -370,6 +385,7 @@ export function SelectionCustomActionProvider({ children }: { children: ReactNod
     executionPlan.executionContext,
     isOpen,
     popoverSessionKey,
+    customActionRequest.provider,
     sourceSurface,
   ])
 

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/use-custom-action-execution.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/use-custom-action-execution.ts
@@ -2,7 +2,7 @@ import type { JSONValue } from "ai"
 import type { RefObject } from "react"
 import type { SelectionToolbarCustomActionRequestSlice } from "../atoms"
 import type { SelectionToolbarInlineError } from "../inline-error"
-import type { AnalyticsSurface } from "@/types/analytics"
+import type { AnalyticsSurface, FeatureProviderAnalytics } from "@/types/analytics"
 import type {
   BackgroundStructuredObjectStreamSnapshot,
   ThinkingSnapshot,
@@ -15,6 +15,7 @@ import { LANG_CODE_TO_EN_NAME } from "@read-frog/definitions"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { ANALYTICS_FEATURE } from "@/types/analytics"
 import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
+import { classifyResolvedProvider } from "@/utils/analytics-provider"
 import { streamBackgroundStructuredObject } from "@/utils/content-script/background-stream-client"
 import { getOrCreateWebPageContext } from "@/utils/host/translate/webpage-context"
 import { resolveModelId } from "@/utils/providers/model-id"
@@ -54,7 +55,7 @@ interface ResolvedWebPageContext {
 }
 
 interface CustomActionExecutionRequest {
-  analytics: {
+  analytics: FeatureProviderAnalytics & {
     actionId: string
     actionName: string
     surface: AnalyticsSurface
@@ -243,6 +244,7 @@ function buildCustomActionExecutionRequest({
       actionId: action.id,
       actionName: action.name,
       surface: analyticsSurface,
+      ...classifyResolvedProvider(provider),
     },
     key: stringifyExecutionRequestKey({
       actionId: action.id,
@@ -344,6 +346,10 @@ export function useCustomActionExecution({
         action_name: request.analytics.actionName,
       },
     )
+    const providerAnalytics: FeatureProviderAnalytics = {
+      provider: request.analytics.provider,
+      backend_kind: request.analytics.backend_kind,
+    }
 
     const run = async () => {
       setIsRunning(true)
@@ -376,6 +382,7 @@ export function useCustomActionExecution({
         setThinking(finalResult.thinking)
         void trackFeatureUsed({
           ...analyticsContext,
+          ...providerAnalytics,
           outcome: "success",
         })
       } catch (caughtError) {
@@ -391,6 +398,7 @@ export function useCustomActionExecution({
         setError(createSelectionToolbarRuntimeError("customAction", caughtError))
         void trackFeatureUsed({
           ...analyticsContext,
+          ...providerAnalytics,
           outcome: "failure",
         })
       } finally {

--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx
@@ -32,6 +32,7 @@ import {
   trackFeatureUsed,
   trackTranslationRequested,
 } from "@/utils/analytics"
+import { classifyProviderConfig } from "@/utils/analytics-provider"
 import { configFieldsAtomMap, writeConfigAtom } from "@/utils/atoms/config"
 import { buildFeatureProviderPatch } from "@/utils/constants/feature-providers"
 import { streamBackgroundText } from "@/utils/content-script/background-stream-client"
@@ -387,6 +388,7 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
 
       const requestedProvider =
         translateRequest.provider?.kind === "local" ? translateRequest.provider.config : null
+      const providerAnalytics = classifyProviderConfig(requestedProvider)
       const translationRequestedPromise = trackTranslationRequested({
         feature: TRANSLATION_REQUESTED_FEATURE.SELECTION_TRANSLATION,
         surface: sourceSurface,
@@ -409,6 +411,7 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
         }
         void trackFeatureUsed({
           ...analyticsContext,
+          ...providerAnalytics,
           outcome: "failure",
         })
         return
@@ -421,6 +424,7 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
         }
         void trackFeatureUsed({
           ...analyticsContext,
+          ...providerAnalytics,
           outcome: "failure",
         })
         return
@@ -434,6 +438,7 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
           }
           void trackFeatureUsed({
             ...analyticsContext,
+            ...providerAnalytics,
             outcome: "failure",
           })
           return
@@ -447,6 +452,7 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
           }
           void trackFeatureUsed({
             ...analyticsContext,
+            ...providerAnalytics,
             outcome: "failure",
           })
           return
@@ -496,6 +502,7 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
 
         void trackFeatureUsed({
           ...analyticsContext,
+          ...providerAnalytics,
           outcome: "success",
         })
       } catch (caughtError) {
@@ -507,6 +514,7 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
         if (!isAbortError(caughtError)) {
           void trackFeatureUsed({
             ...analyticsContext,
+            ...providerAnalytics,
             outcome: "failure",
           })
         }

--- a/src/entrypoints/subtitles.content/universal-adapter.ts
+++ b/src/entrypoints/subtitles.content/universal-adapter.ts
@@ -6,6 +6,7 @@ import type { SubtitlesFragment } from "@/utils/subtitles/types"
 import { toastManager } from "@/components/ui/base-ui/toast"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
+import { classifyProviderConfig, UNKNOWN_FEATURE_PROVIDER } from "@/utils/analytics-provider"
 import { getProviderConfigById } from "@/utils/config/helpers"
 import { getLocalConfig } from "@/utils/config/storage"
 import {
@@ -440,7 +441,18 @@ export class UniversalVideoAdapter {
   }
 
   private async startTranslation(analyticsContext?: FeatureUsageContext) {
+    let providerAnalytics = UNKNOWN_FEATURE_PROVIDER
+
     try {
+      const analyticsConfig = await getLocalConfig()
+      providerAnalytics = classifyProviderConfig(
+        analyticsConfig
+          ? getProviderConfigById(
+              analyticsConfig.providersConfig,
+              analyticsConfig.videoSubtitles.providerId,
+            )
+          : null,
+      )
       const currentVideoId = this.config.getVideoId?.() ?? ""
       const hasCurrentSession =
         this.sessionProcessedFragments.length > 0 && this.sessionVideoId === currentVideoId
@@ -462,6 +474,7 @@ export class UniversalVideoAdapter {
         if (analyticsContext) {
           void trackFeatureUsed({
             ...analyticsContext,
+            ...providerAnalytics,
             outcome: "success",
           })
         }
@@ -485,6 +498,7 @@ export class UniversalVideoAdapter {
       if (analyticsContext) {
         void trackFeatureUsed({
           ...analyticsContext,
+          ...providerAnalytics,
           outcome: "success",
         })
       }
@@ -492,6 +506,7 @@ export class UniversalVideoAdapter {
       if (analyticsContext) {
         void trackFeatureUsed({
           ...analyticsContext,
+          ...providerAnalytics,
           outcome: "failure",
         })
       }

--- a/src/entrypoints/translation-hub/components/translation-card.tsx
+++ b/src/entrypoints/translation-hub/components/translation-card.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/base-ui/button"
 import { anchoredToastManager } from "@/components/ui/base-ui/toast"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext, trackFeatureAttempt } from "@/utils/analytics"
+import { classifyProviderConfig } from "@/utils/analytics-provider"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { getProviderConfigById } from "@/utils/config/helpers"
 import { PROVIDER_ITEMS } from "@/utils/constants/providers"
@@ -51,10 +52,13 @@ export function TranslationCard({
     meta: { suppressToast: true },
     mutationFn: async (req: NonNullable<typeof request>) => {
       return await trackFeatureAttempt(
-        createFeatureUsageContext(
-          ANALYTICS_FEATURE.TRANSLATION_HUB,
-          ANALYTICS_SURFACE.TRANSLATION_HUB,
-        ),
+        {
+          ...createFeatureUsageContext(
+            ANALYTICS_FEATURE.TRANSLATION_HUB,
+            ANALYTICS_SURFACE.TRANSLATION_HUB,
+          ),
+          ...classifyProviderConfig(provider),
+        },
         async () => {
           if (!provider) throw new Error("Provider not found")
 

--- a/src/hooks/use-text-to-speech.tsx
+++ b/src/hooks/use-text-to-speech.tsx
@@ -1,4 +1,8 @@
-import type { AnalyticsSurface, FeatureUsageContext } from "@/types/analytics"
+import type {
+  AnalyticsSurface,
+  FeatureProviderAnalytics,
+  FeatureUsageContext,
+} from "@/types/analytics"
 import type { TTSConfig } from "@/types/config/tts"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useAtomValue } from "jotai"
@@ -6,6 +10,7 @@ import { useRef, useState } from "react"
 import { toastManager } from "@/components/ui/base-ui/toast"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
+import { EDGE_TTS_FEATURE_PROVIDER } from "@/utils/analytics-provider"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { detectLanguage } from "@/utils/content/language"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
@@ -17,7 +22,7 @@ import { splitTextByUtf8Bytes } from "@/utils/server/edge-tts/chunk"
 interface PlayAudioParams {
   text: string
   ttsConfig: TTSConfig
-  analyticsContext: FeatureUsageContext
+  analyticsContext: FeatureUsageContext & FeatureProviderAnalytics
   forcedVoice?: string
 }
 
@@ -279,7 +284,10 @@ export function useTextToSpeech(surface: AnalyticsSurface = ANALYTICS_SURFACE.SE
       text,
       ttsConfig,
       forcedVoice: options?.forcedVoice,
-      analyticsContext: createFeatureUsageContext(ANALYTICS_FEATURE.TEXT_TO_SPEECH, surface),
+      analyticsContext: {
+        ...createFeatureUsageContext(ANALYTICS_FEATURE.TEXT_TO_SPEECH, surface),
+        ...EDGE_TTS_FEATURE_PROVIDER,
+      },
     })
   }
 

--- a/src/types/analytics.ts
+++ b/src/types/analytics.ts
@@ -1,3 +1,5 @@
+import type { AllProviderTypes } from "@/types/config/provider"
+
 export const ANALYTICS_FEATURE = {
   PAGE_TRANSLATION: "page_translation",
   SELECTION_TRANSLATION: "selection_translation",
@@ -32,6 +34,23 @@ export type AnalyticsSurface = (typeof ANALYTICS_SURFACE)[keyof typeof ANALYTICS
 
 export type AnalyticsOutcome = "success" | "failure"
 
+export const ANALYTICS_PROVIDER = {
+  BUILT_IN_AI: "read-frog-built-in-ai",
+  EDGE_TTS: "edge-tts",
+  UNKNOWN: "unknown",
+} as const
+
+export type AnalyticsProvider =
+  | AllProviderTypes
+  | (typeof ANALYTICS_PROVIDER)[keyof typeof ANALYTICS_PROVIDER]
+
+export type AnalyticsBackendKind = "llm" | "non_llm" | "unknown"
+
+export interface FeatureProviderAnalytics {
+  provider: AnalyticsProvider
+  backend_kind: AnalyticsBackendKind
+}
+
 export interface FeatureUsageContext {
   feature: AnalyticsFeature
   surface: AnalyticsSurface
@@ -40,7 +59,7 @@ export interface FeatureUsageContext {
   action_name?: string
 }
 
-export interface FeatureUsedEventProperties {
+export interface FeatureUsedEventProperties extends FeatureProviderAnalytics {
   feature: AnalyticsFeature
   surface: AnalyticsSurface
   outcome: AnalyticsOutcome
@@ -58,7 +77,7 @@ export const TRANSLATION_REQUESTED_FEATURE = {
 export type TranslationRequestedFeature =
   (typeof TRANSLATION_REQUESTED_FEATURE)[keyof typeof TRANSLATION_REQUESTED_FEATURE]
 
-export type TranslationBackendKind = "llm" | "non_llm" | "unknown"
+export type TranslationBackendKind = AnalyticsBackendKind
 export type TranslationConfiguredPrompt = "default" | "custom" | "not_applicable" | "unknown"
 export type PromptExposureAge = "not_exposed" | "lt_24h" | "d1_d7" | "gt_7d"
 

--- a/src/utils/__tests__/analytics-provider.test.ts
+++ b/src/utils/__tests__/analytics-provider.test.ts
@@ -1,0 +1,76 @@
+import type { ProviderConfig } from "@/types/config/provider"
+import { describe, expect, it } from "vitest"
+import {
+  BUILT_IN_AI_FEATURE_PROVIDER,
+  classifyProviderConfig,
+  classifyResolvedProvider,
+  EDGE_TTS_FEATURE_PROVIDER,
+  normalizeFeatureProviderAnalytics,
+  UNKNOWN_FEATURE_PROVIDER,
+} from "@/utils/analytics-provider"
+import { BUILT_IN_AI_PROVIDER_ID } from "@/utils/providers/provider-registry"
+
+const openAIProvider = {
+  id: "openai-provider-id",
+  name: "Private provider name",
+  enabled: true,
+  provider: "openai",
+  model: {
+    model: "gpt-5.4-mini",
+    isCustomModel: false,
+    customModel: null,
+  },
+} satisfies ProviderConfig
+
+const googleTranslateProvider = {
+  id: "google-translate-provider-id",
+  name: "Another private provider name",
+  enabled: true,
+  provider: "google-translate",
+} satisfies ProviderConfig
+
+describe("feature provider analytics", () => {
+  it("classifies configured LLM providers using only their canonical provider type", () => {
+    expect(classifyProviderConfig(openAIProvider)).toEqual({
+      provider: "openai",
+      backend_kind: "llm",
+    })
+  })
+
+  it("classifies standard translation providers as non-LLM", () => {
+    expect(classifyProviderConfig(googleTranslateProvider)).toEqual({
+      provider: "google-translate",
+      backend_kind: "non_llm",
+    })
+  })
+
+  it("maps the persisted built-in provider ID to its analytics-only name", () => {
+    expect(
+      classifyResolvedProvider({
+        kind: "system",
+        id: BUILT_IN_AI_PROVIDER_ID,
+        name: "Built-in AI",
+      }),
+    ).toEqual(BUILT_IN_AI_FEATURE_PROVIDER)
+    expect(BUILT_IN_AI_FEATURE_PROVIDER).toEqual({
+      provider: "read-frog-built-in-ai",
+      backend_kind: "llm",
+    })
+  })
+
+  it("classifies Edge TTS as a non-LLM backend", () => {
+    expect(EDGE_TTS_FEATURE_PROVIDER).toEqual({
+      provider: "edge-tts",
+      backend_kind: "non_llm",
+    })
+  })
+
+  it("uses unknown/unknown for missing providers and invalid runtime combinations", () => {
+    expect(classifyProviderConfig(null)).toEqual(UNKNOWN_FEATURE_PROVIDER)
+    expect(classifyResolvedProvider(undefined)).toEqual(UNKNOWN_FEATURE_PROVIDER)
+    expect(normalizeFeatureProviderAnalytics("openai", "non_llm")).toEqual(UNKNOWN_FEATURE_PROVIDER)
+    expect(normalizeFeatureProviderAnalytics("not-a-provider", "llm")).toEqual(
+      UNKNOWN_FEATURE_PROVIDER,
+    )
+  })
+})

--- a/src/utils/__tests__/analytics.test.ts
+++ b/src/utils/__tests__/analytics.test.ts
@@ -39,12 +39,16 @@ describe("analytics helpers", () => {
         outcome: "success",
         startedAt: 0,
         finishedAt: 1_500,
+        provider: "openai",
+        backend_kind: "llm",
       }),
     ).toEqual({
       feature: ANALYTICS_FEATURE.PAGE_TRANSLATION,
       surface: ANALYTICS_SURFACE.POPUP,
       outcome: "success",
       latency_ms: 1_500,
+      provider: "openai",
+      backend_kind: "llm",
     })
   })
 
@@ -58,6 +62,8 @@ describe("analytics helpers", () => {
         finishedAt: 600,
         action_id: "dictionary",
         action_name: "Dictionary",
+        provider: "read-frog-built-in-ai",
+        backend_kind: "llm",
       }),
     ).toEqual({
       feature: ANALYTICS_FEATURE.CUSTOM_AI_ACTION,
@@ -66,6 +72,8 @@ describe("analytics helpers", () => {
       latency_ms: 500,
       action_id: "dictionary",
       action_name: "Dictionary",
+      provider: "read-frog-built-in-ai",
+      backend_kind: "llm",
     })
   })
 
@@ -78,6 +86,8 @@ describe("analytics helpers", () => {
       outcome: "success" as const,
       startedAt: 0,
       finishedAt: 1_500,
+      provider: "openai" as const,
+      backend_kind: "llm" as const,
     }
 
     await expect(trackFeatureUsed(input)).resolves.toBeUndefined()
@@ -99,6 +109,8 @@ describe("analytics helpers", () => {
         outcome: "failure",
         startedAt: 0,
         finishedAt: 1_500,
+        provider: "openai",
+        backend_kind: "llm",
       }),
     ).resolves.toBeUndefined()
 

--- a/src/utils/analytics-provider.ts
+++ b/src/utils/analytics-provider.ts
@@ -1,0 +1,81 @@
+import type {
+  AnalyticsBackendKind,
+  AnalyticsProvider,
+  FeatureProviderAnalytics,
+} from "@/types/analytics"
+import type { ProviderConfig } from "@/types/config/provider"
+import type { ResolvedProviderRef } from "@/utils/providers/provider-registry"
+import { ANALYTICS_PROVIDER } from "@/types/analytics"
+import { ALL_PROVIDER_TYPES, isLLMProvider, isLLMProviderConfig } from "@/types/config/provider"
+import { BUILT_IN_AI_PROVIDER_ID } from "@/utils/constants/provider-ids"
+
+const VALID_BACKEND_KINDS = new Set<AnalyticsBackendKind>(["llm", "non_llm", "unknown"])
+const VALID_CANONICAL_PROVIDERS = new Set<string>(ALL_PROVIDER_TYPES)
+
+export const UNKNOWN_FEATURE_PROVIDER: FeatureProviderAnalytics = {
+  provider: ANALYTICS_PROVIDER.UNKNOWN,
+  backend_kind: "unknown",
+}
+
+export const BUILT_IN_AI_FEATURE_PROVIDER: FeatureProviderAnalytics = {
+  provider: ANALYTICS_PROVIDER.BUILT_IN_AI,
+  backend_kind: "llm",
+}
+
+export const EDGE_TTS_FEATURE_PROVIDER: FeatureProviderAnalytics = {
+  provider: ANALYTICS_PROVIDER.EDGE_TTS,
+  backend_kind: "non_llm",
+}
+
+export function classifyProviderConfig(
+  providerConfig: ProviderConfig | null | undefined,
+): FeatureProviderAnalytics {
+  if (!providerConfig) return UNKNOWN_FEATURE_PROVIDER
+
+  return {
+    provider: providerConfig.provider,
+    backend_kind: isLLMProviderConfig(providerConfig) ? "llm" : "non_llm",
+  }
+}
+
+export function classifyResolvedProvider(
+  provider: ResolvedProviderRef | null | undefined,
+): FeatureProviderAnalytics {
+  if (!provider) return UNKNOWN_FEATURE_PROVIDER
+  if (provider.kind === "local") return classifyProviderConfig(provider.config)
+  if (provider.id === BUILT_IN_AI_PROVIDER_ID) return BUILT_IN_AI_FEATURE_PROVIDER
+  return UNKNOWN_FEATURE_PROVIDER
+}
+
+export function normalizeFeatureProviderAnalytics(
+  provider: unknown,
+  backendKind: unknown,
+): FeatureProviderAnalytics {
+  if (
+    typeof provider !== "string" ||
+    !VALID_BACKEND_KINDS.has(backendKind as AnalyticsBackendKind)
+  ) {
+    return UNKNOWN_FEATURE_PROVIDER
+  }
+
+  if (provider === ANALYTICS_PROVIDER.UNKNOWN && backendKind === "unknown") {
+    return UNKNOWN_FEATURE_PROVIDER
+  }
+  if (provider === ANALYTICS_PROVIDER.BUILT_IN_AI && backendKind === "llm") {
+    return BUILT_IN_AI_FEATURE_PROVIDER
+  }
+  if (provider === ANALYTICS_PROVIDER.EDGE_TTS && backendKind === "non_llm") {
+    return EDGE_TTS_FEATURE_PROVIDER
+  }
+  if (
+    VALID_CANONICAL_PROVIDERS.has(provider) &&
+    backendKind === (isLLMProvider(provider) ? "llm" : "non_llm")
+  ) {
+    return {
+      provider: provider as AnalyticsProvider,
+      backend_kind: backendKind as AnalyticsBackendKind,
+    }
+  }
+
+  return UNKNOWN_FEATURE_PROVIDER
+}

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,6 +1,7 @@
 import type {
   AnalyticsOutcome,
   AnalyticsSurface,
+  FeatureProviderAnalytics,
   FeatureUsageContext,
   FeatureUsedEventProperties,
   TranslationBackendKind,
@@ -14,7 +15,7 @@ import { ANALYTICS_FEATURE_USED_EVENT } from "@/utils/constants/analytics"
 import { logger } from "@/utils/logger"
 import { sendMessage } from "@/utils/message"
 
-export interface FeatureUsedEventInput extends FeatureUsageContext {
+export interface FeatureUsedEventInput extends FeatureUsageContext, FeatureProviderAnalytics {
   outcome: AnalyticsOutcome
   finishedAt?: number
 }
@@ -45,12 +46,16 @@ export function buildFeatureUsedEventProperties({
   finishedAt = Date.now(),
   action_id,
   action_name,
+  provider,
+  backend_kind,
 }: FeatureUsedEventInput): FeatureUsedEventProperties {
   return {
     feature,
     surface,
     outcome,
     latency_ms: getLatencyMs(startedAt, finishedAt),
+    provider,
+    backend_kind,
     ...(action_id !== undefined ? { action_id } : {}),
     ...(action_name !== undefined ? { action_name } : {}),
   }
@@ -106,7 +111,7 @@ export async function trackTranslationRequested(input: {
 }
 
 export async function trackFeatureAttempt<T>(
-  context: FeatureUsageContext,
+  context: FeatureUsageContext & FeatureProviderAnalytics,
   run: () => Promise<T>,
 ): Promise<T> {
   try {

--- a/src/utils/constants/provider-ids.ts
+++ b/src/utils/constants/provider-ids.ts
@@ -1,0 +1,2 @@
+// Keep the persisted provider ID stable so existing user configurations continue to work.
+export const BUILT_IN_AI_PROVIDER_ID = "read-frog-free-ai"

--- a/src/utils/providers/provider-registry.ts
+++ b/src/utils/providers/provider-registry.ts
@@ -8,10 +8,10 @@ import type {
 } from "@/utils/providers/provider-display"
 import readFrogLogo from "@/assets/providers/read-frog-provider.png?url&no-inline"
 import { isLLMProviderConfig, isTranslateProviderConfig } from "@/types/config/provider"
+import { BUILT_IN_AI_PROVIDER_ID } from "@/utils/constants/provider-ids"
 import { i18n } from "@/utils/i18n"
 
-// Keep the persisted provider ID stable so existing user configurations continue to work.
-export const BUILT_IN_AI_PROVIDER_ID = "read-frog-free-ai"
+export { BUILT_IN_AI_PROVIDER_ID } from "@/utils/constants/provider-ids"
 export const BUILT_IN_AI_PROVIDER_LOGO = readFrogLogo
 
 const BUILT_IN_AI_PROVIDER_NAME_KEY = "options.apiProviders.providers.name.builtInAi"

--- a/src/utils/save-suggestion/analytics.ts
+++ b/src/utils/save-suggestion/analytics.ts
@@ -1,5 +1,6 @@
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
+import { BUILT_IN_AI_FEATURE_PROVIDER } from "@/utils/analytics-provider"
 
 export type SaveSuggestionAnalyticsAction = "suggestion_shown" | "suggestion_accepted"
 
@@ -17,6 +18,7 @@ export function trackSaveSuggestionEvent(
         ...(options.actionName !== undefined ? { action_name: options.actionName } : {}),
       },
     ),
+    ...BUILT_IN_AI_FEATURE_PROVIDER,
     outcome: "success",
   })
 }


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Make `provider` and `backend_kind` required on newly generated `feature_used` events so feature adoption can be segmented by the configured backend while excluding Read Frog's built-in AI.

- Add a shared provider classifier for canonical configured providers, the analytics-only `read-frog-built-in-ai` alias, Edge TTS, and `unknown` fallbacks.
- Attach provider metadata to page, selection, input, Translation Hub, subtitle, custom action, save suggestion, and text-to-speech feature attempts.
- Validate provider/backend combinations at the background boundary and downgrade stale or invalid content-script messages to `unknown/unknown`.
- Replace the PostHog property allowlist with a recursive denylist for URLs, content, credentials, provider configuration, model names, fingerprints, session identifiers, and SDK-internal high-cardinality fields.
- Preserve root PostHog ingestion fields, coarse runtime metadata, experiment variants, and future safe business properties by default.
- Keep the daily feature cache key and deduplication behavior unchanged.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Automated verification:

- `SKIP_FREE_API=true pnpm test`
- `pnpm lint`
- `pnpm fmt:check`
- `pnpm build`
- Pre-push checks: formatting, lint, and all 2,087 tests passed

## Screenshots

N/A — internal analytics behavior only.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- No changeset is included because this is an internal analytics schema change with no user-facing release note.
- Existing historical events are not backfilled with provider metadata.
- GeoIP enrichment remains server-side and is unaffected by the client-side denylist.
