### PR TITLE
feat(model): add gemini-3.6-flash, gemini-3.5-flash-lite and versionless aliases 

### DIFF
--- a/.changeset/tidy-moons-search.md
+++ b/.changeset/tidy-moons-search.md
@@ -2,4 +2,4 @@
 "@read-frog/extension": patch
 ---
 
-feat(model): add gemini-3.6-flash and gemini-3.5-flash-lite
+feat(model): add gemini-3.6-flash, gemini-3.5-flash-lite, and the versionless gemini-*-latest aliases

--- a/.changeset/tidy-moons-search.md
+++ b/.changeset/tidy-moons-search.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(model): add gemini-3.6-flash and gemini-3.5-flash-lite

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -74,6 +74,27 @@ describe("getProviderOptions", () => {
         thinkingLevel: "minimal",
         includeThoughts: false,
       })
+
+      const thinkingLevelFlashLatestOptions = getProviderOptions("gemini-flash-latest", "google")
+      expect(thinkingLevelFlashLatestOptions.google?.thinkingConfig).toMatchObject({
+        thinkingLevel: "minimal",
+        includeThoughts: false,
+      })
+
+      const thinkingLevelFlashLiteLatestOptions = getProviderOptions(
+        "gemini-flash-lite-latest",
+        "google",
+      )
+      expect(thinkingLevelFlashLiteLatestOptions.google?.thinkingConfig).toMatchObject({
+        thinkingLevel: "minimal",
+        includeThoughts: false,
+      })
+
+      const thinkingLevelProLatestOptions = getProviderOptions("gemini-pro-latest", "google")
+      expect(thinkingLevelProLatestOptions.google?.thinkingConfig).toMatchObject({
+        thinkingLevel: "low",
+        includeThoughts: false,
+      })
     })
 
     it("should return options for claude models", () => {

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -62,6 +62,18 @@ describe("getProviderOptions", () => {
         thinkingLevel: "minimal",
         includeThoughts: false,
       })
+
+      const thinkingLevel35FlashLiteOptions = getProviderOptions("gemini-3.5-flash-lite", "google")
+      expect(thinkingLevel35FlashLiteOptions.google?.thinkingConfig).toMatchObject({
+        thinkingLevel: "minimal",
+        includeThoughts: false,
+      })
+
+      const thinkingLevel36FlashOptions = getProviderOptions("gemini-3.6-flash", "google")
+      expect(thinkingLevel36FlashOptions.google?.thinkingConfig).toMatchObject({
+        thinkingLevel: "minimal",
+        includeThoughts: false,
+      })
     })
 
     it("should return options for claude models", () => {

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -62,7 +62,9 @@ export const LLM_PROVIDER_MODELS = {
   ],
   deepseek: ["deepseek-v4-flash", "deepseek-v4-pro", "deepseek-chat", "deepseek-reasoner"],
   google: [
+    "gemini-3.6-flash",
     "gemini-3.5-flash",
+    "gemini-3.5-flash-lite",
     "gemini-3.1-pro-preview",
     "gemini-3.1-flash-image-preview",
     "gemini-3.1-flash-lite-preview",

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -62,6 +62,9 @@ export const LLM_PROVIDER_MODELS = {
   ],
   deepseek: ["deepseek-v4-flash", "deepseek-v4-pro", "deepseek-chat", "deepseek-reasoner"],
   google: [
+    "gemini-flash-lite-latest",
+    "gemini-flash-latest",
+    "gemini-pro-latest",
     "gemini-3.6-flash",
     "gemini-3.5-flash",
     "gemini-3.5-flash-lite",
@@ -467,6 +470,16 @@ export const LLM_MODEL_OPTIONS: Array<{
   options: Record<string, JSONValue>
 }> = [
   // Gemini - specific patterns first
+  // The versionless aliases track the newest generation, which uses thinkingLevel;
+  // the pro tier does not accept "minimal".
+  {
+    pattern: /^gemini-pro-latest$/i,
+    options: { thinkingConfig: { thinkingLevel: "low", includeThoughts: false } },
+  },
+  {
+    pattern: /^gemini-flash(?:-lite)?-latest$/i,
+    options: { thinkingConfig: { thinkingLevel: "minimal", includeThoughts: false } },
+  },
   {
     pattern: /^gemini-3(?:\.\d+)?-.*?(?:-preview(?:-customtools)?)?$/i,
     options: { thinkingConfig: { thinkingLevel: "minimal", includeThoughts: false } },


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Follow-up to #1937 per maintainer feedback — this PR only updates the hardcoded Gemini model list, no dynamic fetching.

Adds the text models currently missing from `LLM_PROVIDER_MODELS.google`:

- `gemini-3.6-flash` and `gemini-3.5-flash-lite` (synced from the AI SDK docs via `pnpm scrape:ai-sdk-models`)
- the Google-maintained versionless aliases `gemini-flash-lite-latest`, `gemini-flash-latest`, `gemini-pro-latest`, which always point at the newest release of each tier, so users keep access to new generations without waiting for a list update

The aliases get their own `LLM_MODEL_OPTIONS` recommendations: the alias tiers run on the current generation, which uses `thinkingLevel` (and the pro tier rejects `"minimal"`, so it recommends `"low"`).

No models were removed, so no config migration is needed. The default model is unchanged.

> Note: `@ai-sdk/google` currently maps top-level reasoning for the versionless aliases through its Gemini 2.5 path (`thinkingBudget`) because its `isGemini3Model` check only matches `gemini-3*` ids. Alias users with reasoning "none" may need "provider-default" until that's fixed upstream; worth an upstream issue.

## Related Issue

Closes #1938

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Full suite: 213 test files / 2028 tests pass, `oxlint --type-aware` clean.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.
