### PR TITLE
fix(providers): drop stale Gemini thinking options that current models reject

### DIFF
--- a/.changeset/brave-otters-think.md
+++ b/.changeset/brave-otters-think.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(providers): stop sending stale Gemini thinking options that current models reject

--- a/src/utils/config/__tests__/example/v087.ts
+++ b/src/utils/config/__tests__/example/v087.ts
@@ -1722,9 +1722,7 @@ export const testSeries: TestSeriesObject = {
           enabled: true,
           name: "Gemini",
           provider: "google",
-          providerOptions: {
-            thinkingConfig: { thinkingBudget: 0, includeThoughts: false },
-          },
+          reasoning: "none",
           apiKey: "goog-key",
           model: {
             model: "gemini-2.5-pro",

--- a/src/utils/config/__tests__/migration-scripts/v086-to-v087.test.ts
+++ b/src/utils/config/__tests__/migration-scripts/v086-to-v087.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+import { migrate } from "../../migration-scripts/v086-to-v087"
+
+describe("v086-to-v087 migration", () => {
+  it("drops the stale thinkingBudget recommendation from Google providers", () => {
+    const migrated = migrate({
+      providersConfig: [
+        {
+          id: "google-default",
+          provider: "google",
+          reasoning: "none",
+          providerOptions: { thinkingConfig: { thinkingBudget: 0, includeThoughts: false } },
+        },
+      ],
+    })
+
+    expect(migrated.providersConfig[0].providerOptions).toBeUndefined()
+    expect(migrated.providersConfig[0].reasoning).toBe("none")
+  })
+
+  it("drops the stale thinkingLevel recommendation and defaults reasoning to none", () => {
+    const migrated = migrate({
+      providersConfig: [
+        {
+          id: "google-default",
+          provider: "google",
+          providerOptions: { thinkingConfig: { thinkingLevel: "minimal", includeThoughts: false } },
+        },
+      ],
+    })
+
+    expect(migrated.providersConfig[0].providerOptions).toBeUndefined()
+    expect(migrated.providersConfig[0].reasoning).toBe("none")
+  })
+
+  it("keeps hand-written Google provider options and existing reasoning", () => {
+    const migrated = migrate({
+      providersConfig: [
+        {
+          id: "google-custom",
+          provider: "google",
+          reasoning: "low",
+          providerOptions: { thinkingConfig: { thinkingBudget: 8192, includeThoughts: false } },
+        },
+        {
+          id: "google-extra-keys",
+          provider: "google",
+          providerOptions: {
+            thinkingConfig: { thinkingBudget: 0, includeThoughts: false },
+            safetySettings: [],
+          },
+        },
+      ],
+    })
+
+    expect(migrated.providersConfig[0].providerOptions).toEqual({
+      thinkingConfig: { thinkingBudget: 8192, includeThoughts: false },
+    })
+    expect(migrated.providersConfig[0].reasoning).toBe("low")
+    expect(migrated.providersConfig[1].providerOptions).toEqual({
+      thinkingConfig: { thinkingBudget: 0, includeThoughts: false },
+      safetySettings: [],
+    })
+    expect(migrated.providersConfig[1].reasoning).toBeUndefined()
+  })
+
+  it("leaves non-Google providers untouched", () => {
+    const migrated = migrate({
+      providersConfig: [
+        {
+          id: "openai-default",
+          provider: "openai",
+          providerOptions: { thinkingConfig: { thinkingBudget: 0, includeThoughts: false } },
+        },
+      ],
+    })
+
+    expect(migrated.providersConfig[0].providerOptions).toEqual({
+      thinkingConfig: { thinkingBudget: 0, includeThoughts: false },
+    })
+  })
+
+  it("is idempotent", () => {
+    const once = migrate({
+      providersConfig: [
+        {
+          id: "google-default",
+          provider: "google",
+          providerOptions: { thinkingConfig: { thinkingBudget: 0, includeThoughts: false } },
+        },
+      ],
+    })
+    const twice = migrate(once)
+
+    expect(twice).toEqual(once)
+  })
+
+  it("returns non-object input unchanged", () => {
+    expect(migrate(null)).toBeNull()
+    expect(migrate(undefined)).toBeUndefined()
+    expect(migrate({ uiLanguage: "ja" })).toEqual({ uiLanguage: "ja" })
+  })
+})

--- a/src/utils/config/migration-scripts/v086-to-v087.ts
+++ b/src/utils/config/migration-scripts/v086-to-v087.ts
@@ -1,0 +1,66 @@
+/**
+ * Migration script from v086 to v087
+ * - Drops stale auto-recommended Gemini thinkingConfig provider options from
+ *   Google providers. The old recommendations pinned `thinkingBudget`/`thinkingLevel`
+ *   values that current Gemini models reject with INVALID_ARGUMENT (Gemini 3.x
+ *   rejects `thinkingBudget`, and combining it with `thinkingLevel` is always
+ *   rejected). Affected providers fall back to top-level reasoning ("none" when
+ *   unset), which the AI SDK maps to a valid thinking config per model.
+ * - Hand-written provider options that do not exactly match an old
+ *   recommendation are left untouched.
+ *
+ * IMPORTANT: All values are hardcoded inline. Migration scripts are frozen
+ * snapshots - never import constants or helpers that may change.
+ */
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isStaleRecommendedThinkingConfig(providerOptions: unknown): boolean {
+  if (!isRecord(providerOptions) || Object.keys(providerOptions).length !== 1) {
+    return false
+  }
+
+  const thinkingConfig = providerOptions.thinkingConfig
+  if (!isRecord(thinkingConfig) || Object.keys(thinkingConfig).length !== 2) {
+    return false
+  }
+
+  if (thinkingConfig.includeThoughts !== false) {
+    return false
+  }
+
+  return thinkingConfig.thinkingBudget === 0 || thinkingConfig.thinkingLevel === "minimal"
+}
+
+function migrateProvider(provider: any): any {
+  if (!isRecord(provider) || provider.provider !== "google") {
+    return provider
+  }
+
+  if (!isStaleRecommendedThinkingConfig(provider.providerOptions)) {
+    return provider
+  }
+
+  const { providerOptions: _providerOptions, ...rest } = provider
+  return {
+    ...rest,
+    reasoning: provider.reasoning ?? "none",
+  }
+}
+
+export function migrate(oldConfig: any): any {
+  if (!oldConfig || typeof oldConfig !== "object") {
+    return oldConfig
+  }
+
+  if (!Array.isArray(oldConfig.providersConfig)) {
+    return oldConfig
+  }
+
+  return {
+    ...oldConfig,
+    providersConfig: oldConfig.providersConfig.map(migrateProvider),
+  }
+}

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -38,13 +38,13 @@ describe("getProviderOptions", () => {
 
       const thinkingLevelProOptions = getProviderOptions("gemini-3-pro-preview", "google")
       expect(thinkingLevelProOptions.google?.thinkingConfig).toMatchObject({
-        thinkingLevel: "minimal",
+        thinkingLevel: "low",
         includeThoughts: false,
       })
 
       const thinkingLevel31ProOptions = getProviderOptions("gemini-3.1-pro-preview", "google")
       expect(thinkingLevel31ProOptions.google?.thinkingConfig).toMatchObject({
-        thinkingLevel: "minimal",
+        thinkingLevel: "low",
         includeThoughts: false,
       })
 

--- a/src/utils/constants/config.ts
+++ b/src/utils/constants/config.ts
@@ -39,7 +39,7 @@ export const GOOGLE_DRIVE_TOKEN_STORAGE_KEY = "__googleDriveToken"
 
 export const THEME_STORAGE_KEY = "theme"
 export const DEFAULT_DETECTED_CODE = "eng" as const
-export const CONFIG_SCHEMA_VERSION = 86
+export const CONFIG_SCHEMA_VERSION = 87
 
 export const DEFAULT_FLOATING_BUTTON_POSITION = 0.66
 export const DEFAULT_FLOATING_BUTTON_SIDE: FloatingButtonSide = "right"

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -465,6 +465,11 @@ export const LLM_MODEL_OPTIONS: Array<{
   options: Record<string, JSONValue>
 }> = [
   // Gemini - specific patterns first
+  // Gemini 3 Pro models only support thinkingLevel low/medium/high; "minimal" is rejected.
+  {
+    pattern: /^gemini-3(?:\.\d+)?-pro(?:-|$)/i,
+    options: { thinkingConfig: { thinkingLevel: "low", includeThoughts: false } },
+  },
   {
     pattern: /^gemini-3(?:\.\d+)?-.*?(?:-preview(?:-customtools)?)?$/i,
     options: { thinkingConfig: { thinkingLevel: "minimal", includeThoughts: false } },


### PR DESCRIPTION
## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Companion to #1942 (no dynamic fetching here either — a config migration plus a pattern fix).

Adding the latest Gemini models to the list is not enough for configs that saved the old auto-recommended provider options: `thinkingConfig: { thinkingBudget: 0, includeThoughts: false }`. When such a config is used with a Gemini 3.x model, `@ai-sdk/google` merges the saved `thinkingBudget` with the `thinkingLevel` it derives from the top-level reasoning setting, so the request carries both `thinking_budget` and `thinking_level` — a combination the Gemini API always rejects with "Request contains an invalid argument" (and Gemini 3.x rejects `thinking_budget` on its own as well). This is the request-time failure reported in #1938.

Changes:

- **Config migration (v086 → v087)**: for Google providers whose `providerOptions` exactly match an old auto-recommendation (`thinkingBudget: 0` or `thinkingLevel: "minimal"`, each with `includeThoughts: false`), drop the options and fall back to top-level reasoning (defaulting to `"none"`), which the AI SDK maps to a valid thinking config per model. Hand-written provider options are left untouched.
- **`LLM_MODEL_OPTIONS`**: Gemini 3 Pro models only support `thinkingLevel` low/medium/high, so the recommendation for `gemini-3*-pro*` now uses `"low"` instead of the rejected `"minimal"`.

## Related Issue

Refs #1938

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Migration unit tests (stale shapes dropped, custom options preserved, idempotency), a new `v086`/`v087` example series exercising the migration chain, and updated model recommendation tests. Full suite: 214 test files / 2036 tests pass, `oxlint --type-aware` clean.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.
