### PR TITLE
feat(providers): auto-discover available models

### DIFF
--- a/.changeset/eight-planets-listen.md
+++ b/.changeset/eight-planets-listen.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(providers): auto-discover available provider models

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx
@@ -317,28 +317,20 @@ describe("translateModelSelector", () => {
 
   it("loads public models automatically and routes a discovered id through custom model storage", async () => {
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
-      jsonResponse([
-        {
-          model_name: "new-chat-model",
-          reported_type: "text-generation",
-          deprecated: null,
-          private: 0,
-        },
-        {
-          model_name: "another-chat-model",
-          reported_type: "text-generation",
-          deprecated: null,
-          private: 0,
-        },
-        { model_name: "image-model", reported_type: "text-to-image" },
-      ]),
+      jsonResponse({
+        data: [
+          { id: "new-chat-model", metadata: { tags: ["chat"] } },
+          { id: "another-chat-model", metadata: { tags: ["chat"] } },
+          { id: "image-model", metadata: { tags: ["image-gen"] } },
+        ],
+      }),
     )
     vi.stubGlobal("fetch", fetchMock)
 
     renderSelector(deepInfraProviderConfig)
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith("https://api.deepinfra.com/models/list", {
+      expect(fetchMock).toHaveBeenCalledWith("https://api.deepinfra.com/v1/openai/models", {
         headers: {},
         signal: expect.any(AbortSignal),
       })
@@ -422,7 +414,7 @@ describe("translateModelSelector", () => {
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockResolvedValue(
-        jsonResponse([{ model_name: "new-chat-model", reported_type: "text-generation" }]),
+        jsonResponse({ data: [{ id: "new-chat-model", metadata: { tags: ["chat"] } }] }),
       )
     vi.stubGlobal("fetch", fetchMock)
 
@@ -446,7 +438,7 @@ describe("translateModelSelector", () => {
       vi
         .fn<typeof fetch>()
         .mockResolvedValue(
-          jsonResponse([{ model_name: "new-chat-model", reported_type: "text-generation" }]),
+          jsonResponse({ data: [{ id: "new-chat-model", metadata: { tags: ["chat"] } }] }),
         ),
     )
     renderSelector(deepInfraProviderConfig)
@@ -477,7 +469,7 @@ describe("translateModelSelector", () => {
       vi
         .fn<typeof fetch>()
         .mockResolvedValue(
-          jsonResponse([{ model_name: "new-chat-model", reported_type: "text-generation" }]),
+          jsonResponse({ data: [{ id: "new-chat-model", metadata: { tags: ["chat"] } }] }),
         ),
     )
     renderSelector(deepInfraProviderConfig)

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx
@@ -42,8 +42,17 @@ vi.mock("@/components/ui/base-ui/select", () => ({
 }))
 
 vi.mock("../components/model-suggestion-button", () => ({
-  ModelSuggestionButton: ({ onSelect }: { onSelect: (model: string) => void }) => (
+  ModelSuggestionButton: ({
+    onSelect,
+    fetchModels,
+  }: {
+    onSelect: (model: string) => void
+    fetchModels: () => Promise<string[]>
+  }) => (
     <div>
+      <button type="button" onClick={() => void fetchModels()}>
+        manual-fetch
+      </button>
       <button type="button" onClick={() => onSelect("gpt-4o")}>
         suggest-known-model
       </button>
@@ -284,6 +293,21 @@ describe("translateModelSelector", () => {
       '{"reasoningEffort":"minimal"}',
     )
     expect(screen.getByLabelText("submit-count")).toHaveTextContent("1")
+  })
+
+  it("fetches manually with the live form values, not the debounced ones", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(jsonResponse({ data: [] }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    renderSelector(customProviderConfig)
+
+    fireEvent.change(screen.getByLabelText("api-key"), { target: { value: "sk-fresh" } })
+    fireEvent.click(screen.getByRole("button", { name: "manual-fetch" }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:11434/v1/models", {
+      headers: { Authorization: "Bearer sk-fresh" },
+    })
   })
 
   it("updates the custom model from a discovered suggestion", async () => {

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import type { APIProviderConfig } from "@/types/config/provider"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { useSelector } from "@tanstack/react-store"
-import { act, fireEvent, render, screen } from "@testing-library/react"
-import { useEffect, useState } from "react"
-import { describe, expect, it, vi } from "vitest"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { type ReactNode, useEffect, useState } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { formOpts, useAppForm } from "../form"
 import { TranslateModelSelector } from "../translate-model-selector"
 
@@ -11,6 +12,46 @@ vi.mock("#imports", () => ({
   i18n: {
     t: (key: string) => key,
   },
+}))
+
+vi.mock("@/components/ui/base-ui/select", () => ({
+  Select: ({
+    children,
+    onValueChange,
+    value,
+  }: {
+    children: ReactNode
+    onValueChange?: (value: string) => void
+    value?: string
+  }) => (
+    <select
+      aria-label="model-select"
+      value={value}
+      onChange={(event) => onValueChange?.(event.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SelectGroup: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SelectItem: ({ children, value }: { children: ReactNode; value: string }) => (
+    <option value={value}>{children}</option>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+}))
+
+vi.mock("../components/model-suggestion-button", () => ({
+  ModelSuggestionButton: ({ onSelect }: { onSelect: (model: string) => void }) => (
+    <div>
+      <button type="button" onClick={() => onSelect("gpt-4o")}>
+        suggest-known-model
+      </button>
+      <button type="button" onClick={() => onSelect("brand-new-model")}>
+        suggest-unknown-model
+      </button>
+    </div>
+  ),
 }))
 
 vi.mock("../components/provider-options-recommendation-trigger", () => ({
@@ -45,6 +86,64 @@ const baseProviderConfig: APIProviderConfig = {
     customModel: "gpt-5-mini",
   },
   providerOptions: undefined,
+}
+
+const customProviderConfig: APIProviderConfig = {
+  id: "custom-provider",
+  name: "Custom",
+  enabled: true,
+  provider: "openai-compatible",
+  baseURL: "http://localhost:11434/v1",
+  model: {
+    model: "use-custom-model",
+    isCustomModel: true,
+    customModel: "local-model",
+  },
+}
+
+const deepInfraProviderConfig: APIProviderConfig = {
+  id: "deepinfra-default",
+  name: "DeepInfra",
+  enabled: true,
+  provider: "deepinfra",
+  model: {
+    model: "meta-llama/Llama-3.3-70B-Instruct",
+    isCustomModel: false,
+    customModel: null,
+  },
+}
+
+const openRouterProviderConfig: APIProviderConfig = {
+  id: "openrouter-default",
+  name: "OpenRouter",
+  enabled: true,
+  provider: "openrouter",
+  baseURL: "https://openrouter.ai/api/v1",
+  model: {
+    model: "x-ai/grok-4-fast:free",
+    isCustomModel: false,
+    customModel: null,
+  },
+}
+
+const googleProviderConfig: APIProviderConfig = {
+  id: "google-default",
+  name: "Google",
+  enabled: true,
+  provider: "google",
+  apiKey: "",
+  model: {
+    model: "gemini-flash-lite-latest",
+    isCustomModel: false,
+    customModel: null,
+  },
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
 }
 
 async function flushUpdates() {
@@ -95,6 +194,18 @@ function TranslateModelSelectorHarness({
           />
         )}
       </form.AppField>
+      <form.AppField name="apiKey">
+        {(field) => (
+          <input
+            aria-label="api-key"
+            value={field.state.value ?? ""}
+            onChange={(event) => {
+              field.handleChange(event.target.value)
+              void form.handleSubmit()
+            }}
+          />
+        )}
+      </form.AppField>
       <TranslateModelSelector form={form} />
       <output aria-label="form-name">{formValues.name}</output>
       <output aria-label="form-provider-options">
@@ -104,14 +215,32 @@ function TranslateModelSelectorHarness({
       <output aria-label="persisted-provider-options">
         {JSON.stringify(providerConfig.providerOptions ?? null)}
       </output>
+      <output aria-label="persisted-model">
+        {JSON.stringify("model" in providerConfig ? providerConfig.model : null)}
+      </output>
       <output aria-label="submit-count">{String(submitCount)}</output>
     </form.AppForm>
   )
 }
 
+function renderSelector(initialConfig?: APIProviderConfig) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { gcTime: 0, retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TranslateModelSelectorHarness initialConfig={initialConfig} />
+    </QueryClientProvider>,
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
 describe("translateModelSelector", () => {
   it("keeps invalid form values while staging recommended provider options", async () => {
-    render(<TranslateModelSelectorHarness />)
+    renderSelector()
 
     fireEvent.change(screen.getByLabelText("provider-name"), {
       target: { value: duplicateProviderName },
@@ -135,7 +264,7 @@ describe("translateModelSelector", () => {
   })
 
   it("persists staged recommendations after the validation error is fixed", async () => {
-    render(<TranslateModelSelectorHarness />)
+    renderSelector()
 
     fireEvent.change(screen.getByLabelText("provider-name"), {
       target: { value: duplicateProviderName },
@@ -157,8 +286,271 @@ describe("translateModelSelector", () => {
     expect(screen.getByLabelText("submit-count")).toHaveTextContent("1")
   })
 
+  it("updates the custom model from a discovered suggestion", async () => {
+    renderSelector(customProviderConfig)
+
+    fireEvent.click(screen.getByRole("button", { name: "suggest-unknown-model" }))
+    await flushUpdates()
+
+    expect(screen.getByLabelText("persisted-model")).toHaveTextContent(
+      JSON.stringify({
+        model: "use-custom-model",
+        isCustomModel: true,
+        customModel: "brand-new-model",
+      }),
+    )
+  })
+
+  it("selects a known model through the unchanged static model path", async () => {
+    renderSelector({
+      ...baseProviderConfig,
+      model: { model: "gpt-5-mini", isCustomModel: false, customModel: null },
+    })
+
+    fireEvent.change(screen.getByLabelText("model-select"), { target: { value: "gpt-4o" } })
+    await flushUpdates()
+
+    expect(screen.getByLabelText("persisted-model")).toHaveTextContent(
+      JSON.stringify({ model: "gpt-4o", isCustomModel: false, customModel: null }),
+    )
+  })
+
+  it("loads public models automatically and routes a discovered id through custom model storage", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse([
+        {
+          model_name: "new-chat-model",
+          type: "text-generation",
+          deprecated: false,
+          private: false,
+        },
+        {
+          model_name: "another-chat-model",
+          type: "text-generation",
+          deprecated: false,
+          private: false,
+        },
+        { model_name: "image-model", type: "text-to-image" },
+      ]),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    renderSelector(deepInfraProviderConfig)
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("https://api.deepinfra.com/models/list", {
+        headers: {},
+        signal: expect.any(AbortSignal),
+      })
+    })
+    expect(await screen.findByRole("option", { name: "new-chat-model" })).toBeInTheDocument()
+    expect(screen.queryByRole("option", { name: "image-model" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "suggest-unknown-model" })).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText("model-select"), {
+      target: { value: "new-chat-model" },
+    })
+    await flushUpdates()
+
+    expect(screen.getByLabelText("persisted-model")).toHaveTextContent(
+      JSON.stringify({
+        model: "meta-llama/Llama-3.3-70B-Instruct",
+        isCustomModel: true,
+        customModel: "new-chat-model",
+      }),
+    )
+
+    expect(screen.getByLabelText("model-select")).toHaveValue("new-chat-model")
+    expect(screen.getByRole("option", { name: "another-chat-model" })).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText("model-select"), {
+      target: { value: "another-chat-model" },
+    })
+    await flushUpdates()
+
+    expect(screen.getByLabelText("persisted-model")).toHaveTextContent(
+      JSON.stringify({
+        model: "meta-llama/Llama-3.3-70B-Instruct",
+        isCustomModel: true,
+        customModel: "another-chat-model",
+      }),
+    )
+
+    fireEvent.change(screen.getByLabelText("model-select"), {
+      target: { value: "meta-llama/Llama-3.3-70B-Instruct" },
+    })
+    await flushUpdates()
+
+    expect(screen.getByLabelText("persisted-model")).toHaveTextContent(
+      JSON.stringify({
+        model: "meta-llama/Llama-3.3-70B-Instruct",
+        isCustomModel: false,
+        customModel: null,
+      }),
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps the static dropdown for named custom providers and discovers their models", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse({ data: [{ id: "openrouter/new-model" }] }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    renderSelector(openRouterProviderConfig)
+
+    expect(screen.getByLabelText("model-select")).toHaveValue("x-ai/grok-4-fast:free")
+    expect(document.getElementById("model.customModel")).not.toBeInTheDocument()
+
+    expect(await screen.findByRole("option", { name: "openrouter/new-model" })).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText("model-select"), {
+      target: { value: "openrouter/new-model" },
+    })
+    await flushUpdates()
+
+    expect(screen.getByLabelText("persisted-model")).toHaveTextContent(
+      JSON.stringify({
+        model: "x-ai/grok-4-fast:free",
+        isCustomModel: true,
+        customModel: "openrouter/new-model",
+      }),
+    )
+  })
+
+  it("keeps an existing discovered custom id in the automatic model selector", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse([{ model_name: "new-chat-model", type: "text-generation" }]))
+    vi.stubGlobal("fetch", fetchMock)
+
+    renderSelector({
+      ...deepInfraProviderConfig,
+      model: {
+        model: "meta-llama/Llama-3.3-70B-Instruct",
+        isCustomModel: true,
+        customModel: "new-chat-model",
+      },
+    })
+
+    expect(screen.getByLabelText("model-select")).toHaveValue("new-chat-model")
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(await screen.findByRole("option", { name: "new-chat-model" })).toBeInTheDocument()
+  })
+
+  it("preserves a discovered selection when manual model entry is opened and closed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          jsonResponse([{ model_name: "new-chat-model", type: "text-generation" }]),
+        ),
+    )
+    renderSelector(deepInfraProviderConfig)
+
+    expect(await screen.findByRole("option", { name: "new-chat-model" })).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText("model-select"), {
+      target: { value: "new-chat-model" },
+    })
+    await flushUpdates()
+
+    fireEvent.click(screen.getByRole("checkbox"))
+    expect(document.getElementById("model.customModel")).toHaveValue("new-chat-model")
+
+    fireEvent.click(screen.getByRole("checkbox"))
+    expect(screen.getByLabelText("model-select")).toHaveValue("new-chat-model")
+    expect(screen.getByLabelText("persisted-model")).toHaveTextContent(
+      JSON.stringify({
+        model: "meta-llama/Llama-3.3-70B-Instruct",
+        isCustomModel: true,
+        customModel: "new-chat-model",
+      }),
+    )
+  })
+
+  it("restores the static model when manual model entry is cleared", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn<typeof fetch>()
+        .mockResolvedValue(
+          jsonResponse([{ model_name: "new-chat-model", type: "text-generation" }]),
+        ),
+    )
+    renderSelector(deepInfraProviderConfig)
+
+    expect(await screen.findByRole("option", { name: "new-chat-model" })).toBeInTheDocument()
+    fireEvent.change(screen.getByLabelText("model-select"), {
+      target: { value: "new-chat-model" },
+    })
+    await flushUpdates()
+
+    fireEvent.click(screen.getByRole("checkbox"))
+    const customModelInput = document.getElementById("model.customModel")
+    expect(customModelInput).toHaveValue("new-chat-model")
+    fireEvent.change(customModelInput!, { target: { value: "" } })
+    await flushUpdates()
+
+    fireEvent.click(screen.getByRole("checkbox"))
+    await flushUpdates()
+    expect(screen.getByLabelText("model-select")).toHaveValue("meta-llama/Llama-3.3-70B-Instruct")
+    expect(screen.getByLabelText("persisted-model")).toHaveTextContent(
+      JSON.stringify({
+        model: "meta-llama/Llama-3.3-70B-Instruct",
+        isCustomModel: false,
+        customModel: null,
+      }),
+    )
+  })
+
+  it("debounces and trims an API key before authenticated discovery", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        models: [
+          {
+            name: "models/gemini-future-flash",
+            supportedGenerationMethods: ["generateContent"],
+          },
+        ],
+      }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+    renderSelector(googleProviderConfig)
+
+    const apiKeyInput = screen.getByLabelText("api-key")
+    fireEvent.change(apiKeyInput, { target: { value: " goog" } })
+    fireEvent.change(apiKeyInput, { target: { value: " goog-key" } })
+    fireEvent.change(apiKeyInput, { target: { value: " goog-key " } })
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1), { timeout: 1_500 })
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("generativelanguage.googleapis.com/v1beta/models"),
+      {
+        headers: { "x-goog-api-key": "goog-key" },
+        signal: expect.any(AbortSignal),
+      },
+    )
+    expect(await screen.findByRole("option", { name: "gemini-future-flash" })).toBeInTheDocument()
+  })
+
+  it("keeps static options when automatic discovery fails", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(jsonResponse({ error: "failed" }, 403))
+    vi.stubGlobal("fetch", fetchMock)
+    renderSelector(deepInfraProviderConfig)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(
+      screen.getByRole("option", { name: "meta-llama/Llama-3.3-70B-Instruct" }),
+    ).toBeInTheDocument()
+    expect(screen.getByLabelText("model-select")).toHaveValue("meta-llama/Llama-3.3-70B-Instruct")
+  })
+
   it("submits recommendations immediately when the form is valid", async () => {
-    render(<TranslateModelSelectorHarness />)
+    renderSelector()
 
     fireEvent.click(screen.getByRole("button", { name: "apply-recommendation" }))
     await flushUpdates()

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/__tests__/translate-model-selector.test.tsx
@@ -320,17 +320,17 @@ describe("translateModelSelector", () => {
       jsonResponse([
         {
           model_name: "new-chat-model",
-          type: "text-generation",
-          deprecated: false,
-          private: false,
+          reported_type: "text-generation",
+          deprecated: null,
+          private: 0,
         },
         {
           model_name: "another-chat-model",
-          type: "text-generation",
-          deprecated: false,
-          private: false,
+          reported_type: "text-generation",
+          deprecated: null,
+          private: 0,
         },
-        { model_name: "image-model", type: "text-to-image" },
+        { model_name: "image-model", reported_type: "text-to-image" },
       ]),
     )
     vi.stubGlobal("fetch", fetchMock)
@@ -421,7 +421,9 @@ describe("translateModelSelector", () => {
   it("keeps an existing discovered custom id in the automatic model selector", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
-      .mockResolvedValue(jsonResponse([{ model_name: "new-chat-model", type: "text-generation" }]))
+      .mockResolvedValue(
+        jsonResponse([{ model_name: "new-chat-model", reported_type: "text-generation" }]),
+      )
     vi.stubGlobal("fetch", fetchMock)
 
     renderSelector({
@@ -444,7 +446,7 @@ describe("translateModelSelector", () => {
       vi
         .fn<typeof fetch>()
         .mockResolvedValue(
-          jsonResponse([{ model_name: "new-chat-model", type: "text-generation" }]),
+          jsonResponse([{ model_name: "new-chat-model", reported_type: "text-generation" }]),
         ),
     )
     renderSelector(deepInfraProviderConfig)
@@ -475,7 +477,7 @@ describe("translateModelSelector", () => {
       vi
         .fn<typeof fetch>()
         .mockResolvedValue(
-          jsonResponse([{ model_name: "new-chat-model", type: "text-generation" }]),
+          jsonResponse([{ model_name: "new-chat-model", reported_type: "text-generation" }]),
         ),
     )
     renderSelector(deepInfraProviderConfig)

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/model-suggestion-button.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/model-suggestion-button.tsx
@@ -11,56 +11,39 @@ import {
   ComboboxItem,
   ComboboxList,
 } from "@/components/ui/base-ui/combobox"
-import { extractErrorMessage } from "@/utils/error/extract-message"
 import { i18n } from "@/utils/i18n"
 
-interface ModelsResponse {
-  object: string
-  data: Array<{ id: string; object: string; created: number; owned_by: string }>
-}
-
 interface ModelSuggestionButtonProps {
-  baseURL: string
-  apiKey?: string
+  providerId: string
+  endpoint: string
+  fetchModels: () => Promise<string[]>
   onSelect: (model: string) => void
   disabled?: boolean
 }
 
 export function ModelSuggestionButton({
-  baseURL,
-  apiKey,
+  providerId,
+  endpoint,
+  fetchModels,
   onSelect,
   disabled,
 }: ModelSuggestionButtonProps) {
   const mutation = useMutation({
-    mutationKey: ["fetchModels", baseURL],
+    // for safety, we should not include apiKey in the mutationKey; the endpoint
+    // keeps a fetched list from surviving a baseURL change
+    mutationKey: ["fetchModels", providerId, endpoint],
     meta: {
       errorDescription: i18n.t("options.apiProviders.form.models.fetchError"),
     },
-    mutationFn: async () => {
-      if (!apiKey) {
-        throw new Error(i18n.t("options.apiProviders.form.models.apiKeyRequired"))
-      }
-
-      const response = await fetch(`${baseURL}/models`, {
-        headers: { Authorization: `Bearer ${apiKey}` },
-      })
-      if (!response.ok) {
-        throw new Error(await extractErrorMessage(response))
-      }
-
-      const data: ModelsResponse = await response.json()
-      return data.data.map((m) => m.id)
-    },
+    mutationFn: fetchModels,
   })
 
   const handleFetch = () => {
-    if (!baseURL) return
     mutation.reset()
     mutation.mutate()
   }
 
-  const isDisabled = disabled || !baseURL
+  const isDisabled = disabled
 
   // Idle state - show fetch button
   if (mutation.isIdle) {

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
@@ -1,6 +1,8 @@
-import type { APIProviderConfig } from "@/types/config/provider"
+import type { APIProviderConfig, LLMProviderConfig } from "@/types/config/provider"
+import { useQuery } from "@tanstack/react-query"
 import { useSelector } from "@tanstack/react-store"
 import { useSetAtom } from "jotai"
+import { useState } from "react"
 import { Checkbox } from "@/components/ui/base-ui/checkbox"
 import {
   SelectContent,
@@ -10,13 +12,16 @@ import {
   SelectValue,
 } from "@/components/ui/base-ui/select"
 import { toastManager } from "@/components/ui/base-ui/toast"
+import { useDebouncedValue } from "@/hooks/use-debounced-value"
 import {
   isCustomLLMProviderConfig,
   isLLMProviderConfig,
   LLM_PROVIDER_MODELS,
 } from "@/types/config/provider"
 import { providerConfigAtom, updateLLMProviderConfig } from "@/utils/atoms/provider"
+import { Sha256Hex } from "@/utils/hash"
 import { i18n } from "@/utils/i18n"
+import { getModelDiscovery, MODEL_DISCOVERY_DESCRIPTORS } from "@/utils/providers/model-discovery"
 import { resolveModelId } from "@/utils/providers/model-id"
 import { ModelSuggestionButton } from "./components/model-suggestion-button"
 import { ProviderOptionsRecommendationTrigger } from "./components/provider-options-recommendation-trigger"
@@ -27,10 +32,55 @@ export const TranslateModelSelector = withForm({
   render: function Render({ form }) {
     const providerConfig = useSelector(form.store, (state) => state.values)
     const setProviderConfig = useSetAtom(providerConfigAtom(providerConfig.id))
+    const [isManualModelEntry, setIsManualModelEntry] = useState(false)
+    const isLLM = isLLMProviderConfig(providerConfig)
+    const isCustomProvider = isLLM && isCustomLLMProviderConfig(providerConfig)
+    const apiKey = isLLM && "apiKey" in providerConfig ? providerConfig.apiKey?.trim() : undefined
+    const baseURL =
+      isLLM && "baseURL" in providerConfig ? providerConfig.baseURL?.trim() : undefined
+    const debouncedAPIKey = useDebouncedValue(apiKey, 500)
+    const debouncedBaseURL = useDebouncedValue(baseURL, 500)
+    const discoveryProviderConfig = isLLM
+      ? {
+          ...providerConfig,
+          ...("apiKey" in providerConfig ? { apiKey: debouncedAPIKey } : {}),
+          ...("baseURL" in providerConfig ? { baseURL: debouncedBaseURL } : {}),
+        }
+      : undefined
+    const modelDiscovery = discoveryProviderConfig
+      ? getModelDiscovery(discoveryProviderConfig)
+      : undefined
+    // openai-compatible stays on the manual custom-model path; every other provider
+    // with a discovery source gets the automatic dropdown.
+    const supportsAutomaticModelDiscovery =
+      isLLM &&
+      providerConfig.provider !== "openai-compatible" &&
+      (isCustomProvider || MODEL_DISCOVERY_DESCRIPTORS[providerConfig.provider] !== undefined)
+    const apiKeyHash = debouncedAPIKey ? Sha256Hex(debouncedAPIKey) : ""
+    const autoDiscoverModels = supportsAutomaticModelDiscovery && modelDiscovery !== undefined
+    const { data: discoveredModels = [] } = useQuery({
+      queryKey: ["providerModels", providerConfig.id, modelDiscovery?.endpoint, apiKeyHash],
+      queryFn: ({ signal }) => modelDiscovery!.fetchModels(signal),
+      enabled: autoDiscoverModels,
+      retry: false,
+      staleTime: 5 * 60 * 1000,
+      meta: { suppressToast: true },
+    })
+
     if (!isLLMProviderConfig(providerConfig)) return null
 
     const modelId = resolveModelId(providerConfig.model)
     const { isCustomModel, customModel, model } = providerConfig.model
+    const availableModelOptions = [
+      ...new Set([...LLM_PROVIDER_MODELS[providerConfig.provider], ...discoveredModels]),
+    ]
+    const modelOptions =
+      modelId && !availableModelOptions.includes(modelId)
+        ? [modelId, ...availableModelOptions]
+        : availableModelOptions
+    const showCustomModelInput =
+      providerConfig.provider === "openai-compatible" ||
+      (supportsAutomaticModelDiscovery ? isManualModelEntry : isCustomModel)
 
     const applyRecommendedProviderOptions = (options: Record<string, unknown>) => {
       form.setFieldValue("providerOptions", options)
@@ -46,9 +96,23 @@ export const TranslateModelSelector = withForm({
       />
     )
 
+    const handleModelChange = (selectedModel: string) => {
+      const knownModels: readonly string[] = LLM_PROVIDER_MODELS[providerConfig.provider]
+      if (knownModels.includes(selectedModel)) {
+        // The includes() check proves the id belongs to this provider's model enum.
+        form.setFieldValue("model.model", selectedModel as LLMProviderConfig["model"]["model"])
+        form.setFieldValue("model.isCustomModel", false)
+        form.setFieldValue("model.customModel", null)
+      } else {
+        form.setFieldValue("model.isCustomModel", true)
+        form.setFieldValue("model.customModel", selectedModel)
+      }
+      void form.handleSubmit()
+    }
+
     return (
       <div>
-        {isCustomModel ? (
+        {showCustomModelInput ? (
           <form.AppField name="model.customModel">
             {(field) => (
               <field.InputFieldAutoSave
@@ -57,10 +121,11 @@ export const TranslateModelSelector = withForm({
                 labelExtra={
                   <div className="flex items-center gap-2">
                     {recommendationTrigger}
-                    {isCustomLLMProviderConfig(providerConfig) && (
+                    {isCustomLLMProviderConfig(providerConfig) && modelDiscovery && (
                       <ModelSuggestionButton
-                        baseURL={providerConfig.baseURL}
-                        apiKey={providerConfig.apiKey}
+                        providerId={providerConfig.id}
+                        endpoint={modelDiscovery.endpoint}
+                        fetchModels={modelDiscovery.fetchModels}
                         onSelect={(selectedModel) => {
                           field.handleChange(selectedModel)
                           void form.handleSubmit()
@@ -80,6 +145,12 @@ export const TranslateModelSelector = withForm({
                 formForSubmit={form}
                 label={i18n.t("options.general.translationConfig.model.title")}
                 labelExtra={recommendationTrigger}
+                value={modelId}
+                onValueChange={(selectedModel) => {
+                  if (typeof selectedModel === "string") {
+                    handleModelChange(selectedModel)
+                  }
+                }}
               >
                 <SelectTrigger className="w-full">
                   <SelectValue
@@ -88,7 +159,7 @@ export const TranslateModelSelector = withForm({
                 </SelectTrigger>
                 <SelectContent>
                   <SelectGroup>
-                    {LLM_PROVIDER_MODELS[providerConfig.provider].map((modelOption) => (
+                    {modelOptions.map((modelOption) => (
                       <SelectItem key={modelOption} value={modelOption}>
                         {modelOption}
                       </SelectItem>
@@ -105,9 +176,23 @@ export const TranslateModelSelector = withForm({
               <div className="mt-2.5 flex items-center space-x-2">
                 <Checkbox
                   id="isCustomModel-translate"
-                  checked={field.state.value}
+                  checked={supportsAutomaticModelDiscovery ? isManualModelEntry : field.state.value}
                   onCheckedChange={(checked) => {
                     try {
+                      if (supportsAutomaticModelDiscovery) {
+                        setIsManualModelEntry(checked)
+                        if (checked && !providerConfig.model.isCustomModel) {
+                          form.setFieldValue("model.isCustomModel", true)
+                          form.setFieldValue("model.customModel", modelId ?? model)
+                          void form.handleSubmit()
+                        } else if (!checked && !modelId) {
+                          form.setFieldValue("model.isCustomModel", false)
+                          form.setFieldValue("model.customModel", null)
+                          void form.handleSubmit()
+                        }
+                        return
+                      }
+
                       if (!checked) {
                         void setProviderConfig(
                           updateLLMProviderConfig(providerConfig, {

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
@@ -60,6 +60,9 @@ export const TranslateModelSelector = withForm({
     const modelDiscovery = discoveryProviderConfig
       ? getModelDiscovery(discoveryProviderConfig)
       : undefined
+    // The debounce only paces the automatic query; the explicit fetch button
+    // must use whatever is in the form right now.
+    const manualModelDiscovery = isLLM ? getModelDiscovery(providerConfig) : undefined
     // openai-compatible stays on the manual custom-model path; every other provider
     // with a discovery source gets the automatic dropdown.
     const supportsAutomaticModelDiscovery =
@@ -136,11 +139,11 @@ export const TranslateModelSelector = withForm({
                 labelExtra={
                   <div className="flex items-center gap-2">
                     {recommendationTrigger}
-                    {isCustomLLMProviderConfig(providerConfig) && modelDiscovery && (
+                    {isCustomLLMProviderConfig(providerConfig) && manualModelDiscovery && (
                       <ModelSuggestionButton
                         providerId={providerConfig.id}
-                        endpoint={modelDiscovery.endpoint}
-                        fetchModels={modelDiscovery.fetchModels}
+                        endpoint={manualModelDiscovery.endpoint}
+                        fetchModels={manualModelDiscovery.fetchModels}
                         onSelect={(selectedModel) => {
                           field.handleChange(selectedModel)
                           void form.handleSubmit()

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/translate-model-selector.tsx
@@ -2,7 +2,7 @@ import type { APIProviderConfig, LLMProviderConfig } from "@/types/config/provid
 import { useQuery } from "@tanstack/react-query"
 import { useSelector } from "@tanstack/react-store"
 import { useSetAtom } from "jotai"
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { Checkbox } from "@/components/ui/base-ui/checkbox"
 import {
   SelectContent,
@@ -40,11 +40,21 @@ export const TranslateModelSelector = withForm({
       isLLM && "baseURL" in providerConfig ? providerConfig.baseURL?.trim() : undefined
     const debouncedAPIKey = useDebouncedValue(apiKey, 500)
     const debouncedBaseURL = useDebouncedValue(baseURL, 500)
+    const headersJSON = JSON.stringify(
+      isLLM && "headers" in providerConfig ? (providerConfig.headers ?? null) : null,
+    )
+    const debouncedHeadersJSON = useDebouncedValue(headersJSON, 500)
+    const debouncedHeaders = useMemo(
+      () =>
+        (JSON.parse(debouncedHeadersJSON) ?? undefined) as Record<string, unknown> | undefined,
+      [debouncedHeadersJSON],
+    )
     const discoveryProviderConfig = isLLM
       ? {
           ...providerConfig,
           ...("apiKey" in providerConfig ? { apiKey: debouncedAPIKey } : {}),
           ...("baseURL" in providerConfig ? { baseURL: debouncedBaseURL } : {}),
+          ...("headers" in providerConfig ? { headers: debouncedHeaders } : {}),
         }
       : undefined
     const modelDiscovery = discoveryProviderConfig
@@ -56,10 +66,15 @@ export const TranslateModelSelector = withForm({
       isLLM &&
       providerConfig.provider !== "openai-compatible" &&
       (isCustomProvider || MODEL_DISCOVERY_DESCRIPTORS[providerConfig.provider] !== undefined)
-    const apiKeyHash = debouncedAPIKey ? Sha256Hex(debouncedAPIKey) : ""
+    // Fingerprint of everything that authorizes discovery, so editing the key or
+    // headers refetches without the secrets themselves entering the cache key.
+    const credentialsHash =
+      debouncedAPIKey || debouncedHeadersJSON !== "null"
+        ? Sha256Hex(debouncedAPIKey ?? "", debouncedHeadersJSON)
+        : ""
     const autoDiscoverModels = supportsAutomaticModelDiscovery && modelDiscovery !== undefined
     const { data: discoveredModels = [] } = useQuery({
-      queryKey: ["providerModels", providerConfig.id, modelDiscovery?.endpoint, apiKeyHash],
+      queryKey: ["providerModels", providerConfig.id, modelDiscovery?.endpoint, credentialsHash],
       queryFn: ({ signal }) => modelDiscovery!.fetchModels(signal),
       enabled: autoDiscoverModels,
       retry: false,

--- a/src/utils/providers/__tests__/model-discovery.test.ts
+++ b/src/utils/providers/__tests__/model-discovery.test.ts
@@ -88,19 +88,33 @@ describe("fetchDeepInfraModels", () => {
       jsonResponse([
         {
           model_name: "chat-model",
+          reported_type: "text-generation",
           type: "text-generation",
-          deprecated: false,
-          private: false,
+          deprecated: null,
+          private: 0,
         },
-        { model_name: "image-model", type: "text-to-image" },
-        { model_name: "retired-model", type: "text-generation", deprecated: true },
-        { model_name: "private-model", type: "text-generation", private: true },
+        { model_name: "image-model", reported_type: "text-to-image", type: "text-to-image" },
+        {
+          model_name: "retired-model",
+          reported_type: "text-generation",
+          type: "text-generation",
+          deprecated: 1718830497,
+          private: 0,
+        },
+        {
+          model_name: "private-model",
+          reported_type: "text-generation",
+          type: "text-generation",
+          deprecated: null,
+          private: 1,
+        },
+        { model_name: "legacy-shape-model", type: "text-generation" },
       ]),
     )
 
     const models = await fetchDeepInfraModels("https://api.deepinfra.com/v1", "")
 
-    expect(models).toEqual(["chat-model"])
+    expect(models).toEqual(["chat-model", "legacy-shape-model"])
     expect(fetchMock).toHaveBeenCalledWith("https://api.deepinfra.com/models/list", {
       headers: {},
     })

--- a/src/utils/providers/__tests__/model-discovery.test.ts
+++ b/src/utils/providers/__tests__/model-discovery.test.ts
@@ -1,0 +1,349 @@
+import type { LLMProviderConfig } from "@/types/config/provider"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  fetchAnthropicModels,
+  fetchDeepInfraModels,
+  fetchGoogleModels,
+  fetchOpenAICompatibleModels,
+  getModelDiscovery,
+  MODEL_DISCOVERY_DESCRIPTORS,
+} from "../model-discovery"
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+function mockFetch(...responses: Response[]) {
+  const fetchMock = vi.fn<typeof fetch>()
+  for (const response of responses) {
+    fetchMock.mockResolvedValueOnce(response)
+  }
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("fetchOpenAICompatibleModels", () => {
+  it("parses the standard { data: [{ id }] } shape and sends bearer auth", async () => {
+    const fetchMock = mockFetch(
+      jsonResponse({ object: "list", data: [{ id: "gpt-test" }, { id: "gpt-mini" }] }),
+    )
+
+    const models = await fetchOpenAICompatibleModels("https://api.example.com/v1", "sk-test")
+
+    expect(models).toEqual(["gpt-test", "gpt-mini"])
+    expect(fetchMock).toHaveBeenCalledWith("https://api.example.com/v1/models", {
+      headers: { Authorization: "Bearer sk-test" },
+    })
+  })
+
+  it("tolerates bare arrays and name-keyed entries, deduping empty ids", async () => {
+    mockFetch(jsonResponse([{ name: "model-a" }, { id: "model-b" }, { id: "model-b" }, {}]))
+
+    const models = await fetchOpenAICompatibleModels("https://api.example.com/v1", "sk-test")
+
+    expect(models).toEqual(["model-a", "model-b"])
+  })
+
+  it("normalizes the base URL and omits entries explicitly marked as non-text models", async () => {
+    const fetchMock = mockFetch(
+      jsonResponse({
+        data: [
+          { id: "chat-model", capabilities: { completion_chat: true } },
+          { id: "embedding-model", type: "embedding" },
+          { id: "image-model", capabilities: { chat: false } },
+          { id: "audio-model", architecture: { output_modalities: ["audio"] } },
+          { id: "retired-model", deprecated: true },
+          { id: "trimmed-model " },
+        ],
+      }),
+    )
+
+    const models = await fetchOpenAICompatibleModels("https://api.example.com/v1/", "sk-test")
+
+    expect(models).toEqual(["chat-model", "trimmed-model"])
+    expect(fetchMock).toHaveBeenCalledWith("https://api.example.com/v1/models", {
+      headers: { Authorization: "Bearer sk-test" },
+    })
+  })
+
+  it("surfaces API error messages", async () => {
+    mockFetch(jsonResponse({ error: { message: "invalid key" } }, 401))
+
+    await expect(fetchOpenAICompatibleModels("https://api.example.com/v1", "bad")).rejects.toThrow(
+      "invalid key",
+    )
+  })
+})
+
+describe("fetchDeepInfraModels", () => {
+  it("uses the public catalog and keeps only available text-generation models", async () => {
+    const fetchMock = mockFetch(
+      jsonResponse([
+        {
+          model_name: "chat-model",
+          type: "text-generation",
+          deprecated: false,
+          private: false,
+        },
+        { model_name: "image-model", type: "text-to-image" },
+        { model_name: "retired-model", type: "text-generation", deprecated: true },
+        { model_name: "private-model", type: "text-generation", private: true },
+      ]),
+    )
+
+    const models = await fetchDeepInfraModels("https://api.deepinfra.com/v1", "")
+
+    expect(models).toEqual(["chat-model"])
+    expect(fetchMock).toHaveBeenCalledWith("https://api.deepinfra.com/models/list", {
+      headers: {},
+    })
+  })
+})
+
+describe("fetchGoogleModels", () => {
+  it("filters to generateContent models, strips the models/ prefix, and paginates", async () => {
+    const fetchMock = mockFetch(
+      jsonResponse({
+        models: [
+          { name: "models/gemini-test-flash", supportedGenerationMethods: ["generateContent"] },
+          { name: "models/embedding-001", supportedGenerationMethods: ["embedContent"] },
+        ],
+        nextPageToken: "page-2",
+      }),
+      jsonResponse({
+        models: [
+          { name: "models/gemini-test-pro", supportedGenerationMethods: ["generateContent"] },
+        ],
+      }),
+    )
+
+    const models = await fetchGoogleModels(
+      "https://generativelanguage.googleapis.com/v1beta",
+      "goog-key",
+    )
+
+    expect(models).toEqual(["gemini-test-flash", "gemini-test-pro"])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    // The API key must travel in a header, never in the URL.
+    expect(fetchMock).toHaveBeenNthCalledWith(1, expect.not.stringContaining("goog-key"), {
+      headers: { "x-goog-api-key": "goog-key" },
+    })
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("pageToken=page-2"),
+      expect.anything(),
+    )
+  })
+
+  it("supports the supportedActions capability field", async () => {
+    mockFetch(
+      jsonResponse({
+        models: [{ name: "models/gemini-test", supportedActions: ["generateContent"] }],
+      }),
+    )
+
+    const models = await fetchGoogleModels(
+      "https://generativelanguage.googleapis.com/v1beta",
+      "goog-key",
+    )
+
+    expect(models).toEqual(["gemini-test"])
+  })
+})
+
+describe("fetchAnthropicModels", () => {
+  it("collects ids across pages using after_id pagination", async () => {
+    const fetchMock = mockFetch(
+      jsonResponse({ data: [{ id: "claude-a" }], has_more: true, last_id: "claude-a" }),
+      jsonResponse({ data: [{ id: "claude-b" }], has_more: false, last_id: "claude-b" }),
+    )
+
+    const models = await fetchAnthropicModels("https://api.anthropic.com/v1", "sk-ant")
+
+    expect(models).toEqual(["claude-a", "claude-b"])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, expect.not.stringContaining("sk-ant"), {
+      headers: { "x-api-key": "sk-ant", "anthropic-version": "2023-06-01" },
+    })
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("after_id=claude-a"),
+      expect.anything(),
+    )
+  })
+})
+
+describe("getModelDiscovery", () => {
+  const googleConfig = {
+    id: "google-default",
+    name: "Gemini",
+    enabled: true,
+    provider: "google",
+    apiKey: "goog-key",
+    model: { model: "gemini-2.5-flash", isCustomModel: false, customModel: null },
+  } as unknown as LLMProviderConfig
+
+  it("uses the descriptor endpoint for built-in providers", async () => {
+    const fetchMock = mockFetch(jsonResponse({ models: [] }))
+
+    const discovery = getModelDiscovery(googleConfig)
+    expect(discovery?.endpoint).toBe("https://generativelanguage.googleapis.com/v1beta")
+    await discovery!.fetchModels()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("https://generativelanguage.googleapis.com/v1beta/models"),
+      expect.anything(),
+    )
+  })
+
+  it.each([["togetherai", "https://api.together.ai/v1"]] as const)(
+    "keeps the %s model-list endpoint separate from its provider client path",
+    async (provider, endpoint) => {
+      const fetchMock = mockFetch(jsonResponse({ data: [] }))
+      const config = {
+        ...googleConfig,
+        id: `${provider}-default`,
+        provider,
+      } as unknown as LLMProviderConfig
+
+      const discovery = getModelDiscovery(config)
+      expect(discovery?.endpoint).toBe(endpoint)
+      await discovery!.fetchModels()
+
+      expect(fetchMock).toHaveBeenCalledWith(`${endpoint}/models`, expect.anything())
+    },
+  )
+
+  it("discovers DeepInfra through its unauthenticated text-model catalog", async () => {
+    const fetchMock = mockFetch(jsonResponse([]))
+    const discovery = getModelDiscovery({
+      ...googleConfig,
+      id: "deepinfra-default",
+      provider: "deepinfra",
+      apiKey: undefined,
+    } as unknown as LLMProviderConfig)
+
+    expect(discovery?.endpoint).toBe("https://api.deepinfra.com/v1")
+    await discovery!.fetchModels()
+
+    expect(fetchMock).toHaveBeenCalledWith("https://api.deepinfra.com/models/list", {
+      headers: {},
+    })
+  })
+
+  it("discovers Hugging Face without an API key", async () => {
+    const fetchMock = mockFetch(jsonResponse({ data: [] }))
+    const discovery = getModelDiscovery({
+      ...googleConfig,
+      id: "huggingface-default",
+      provider: "huggingface",
+      apiKey: undefined,
+    } as unknown as LLMProviderConfig)
+
+    await discovery!.fetchModels()
+
+    expect(fetchMock).toHaveBeenCalledWith("https://router.huggingface.co/v1/models", {
+      headers: {},
+    })
+  })
+
+  it("sends the default provider headers alongside auth", async () => {
+    const fetchMock = mockFetch(jsonResponse({ data: [] }))
+
+    const anthropicConfig = {
+      id: "anthropic-default",
+      name: "Anthropic",
+      enabled: true,
+      provider: "anthropic",
+      apiKey: "sk-ant",
+      model: { model: "claude-haiku-4-5", isCustomModel: false, customModel: null },
+    } as unknown as LLMProviderConfig
+
+    await getModelDiscovery(anthropicConfig)!.fetchModels()
+
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("api.anthropic.com"), {
+      headers: {
+        "anthropic-dangerous-direct-browser-access": "true",
+        "x-api-key": "sk-ant",
+        "anthropic-version": "2023-06-01",
+      },
+    })
+  })
+
+  it("honors user-configured headers over the defaults", async () => {
+    const fetchMock = mockFetch(jsonResponse({ models: [] }))
+
+    await getModelDiscovery({
+      ...googleConfig,
+      headers: { "x-proxy-auth": "proxy-token" },
+    })!.fetchModels()
+
+    expect(fetchMock).toHaveBeenCalledWith(expect.anything(), {
+      headers: { "x-proxy-auth": "proxy-token", "x-goog-api-key": "goog-key" },
+    })
+  })
+
+  it("prefers a user-configured baseURL over the descriptor default", async () => {
+    const fetchMock = mockFetch(jsonResponse({ models: [] }))
+
+    const discovery = getModelDiscovery({
+      ...googleConfig,
+      baseURL: "https://proxy.example.com/v1beta",
+    })
+    expect(discovery?.endpoint).toBe("https://proxy.example.com/v1beta")
+    await discovery!.fetchModels()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("https://proxy.example.com/v1beta/models"),
+      expect.anything(),
+    )
+  })
+
+  it("uses the config baseURL for custom providers and hides the feature without one", async () => {
+    const customConfig = {
+      id: "custom-1",
+      name: "Custom",
+      enabled: true,
+      provider: "openai-compatible",
+      apiKey: "sk-custom",
+      baseURL: "https://custom.example.com/v1",
+      model: { model: "use-custom-model", isCustomModel: true, customModel: "my-model" },
+    } as unknown as LLMProviderConfig
+
+    expect(getModelDiscovery(customConfig)?.endpoint).toBe("https://custom.example.com/v1")
+    expect(getModelDiscovery({ ...customConfig, baseURL: "" })).toBeUndefined()
+
+    const fetchMock = mockFetch(jsonResponse({ data: [] }))
+    await getModelDiscovery({ ...customConfig, apiKey: undefined })!.fetchModels()
+    expect(fetchMock).toHaveBeenCalledWith("https://custom.example.com/v1/models", {
+      headers: {},
+    })
+  })
+
+  it("returns undefined for providers without a descriptor", () => {
+    const bedrockConfig = {
+      id: "bedrock-default",
+      name: "Bedrock",
+      enabled: true,
+      provider: "bedrock",
+      model: { model: "amazon.titan-tg1-large", isCustomModel: false, customModel: null },
+    } as unknown as LLMProviderConfig
+
+    expect(MODEL_DISCOVERY_DESCRIPTORS).not.toHaveProperty("bedrock")
+    expect(getModelDiscovery(bedrockConfig)).toBeUndefined()
+  })
+
+  it("does not enable authenticated discovery before an API key is configured", () => {
+    expect(getModelDiscovery({ ...googleConfig, apiKey: undefined })).toBeUndefined()
+    expect(getModelDiscovery({ ...googleConfig, apiKey: "   " })).toBeUndefined()
+  })
+})

--- a/src/utils/providers/__tests__/model-discovery.test.ts
+++ b/src/utils/providers/__tests__/model-discovery.test.ts
@@ -95,6 +95,18 @@ describe("fetchOpenAICompatibleModels", () => {
     expect(models).toEqual(["gpt-test"])
   })
 
+  it("lets a configured Authorization header override the api-key bearer, like the SDK clients", async () => {
+    const fetchMock = mockFetch(jsonResponse({ data: [] }))
+
+    await fetchOpenAICompatibleModels("https://proxy.example.com/v1", "dummy-key", {
+      Authorization: "Bearer proxy-token",
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith("https://proxy.example.com/v1/models", {
+      headers: { Authorization: "Bearer proxy-token" },
+    })
+  })
+
   it("surfaces API error messages", async () => {
     mockFetch(jsonResponse({ error: { message: "invalid key" } }, 401))
 

--- a/src/utils/providers/__tests__/model-discovery.test.ts
+++ b/src/utils/providers/__tests__/model-discovery.test.ts
@@ -2,7 +2,6 @@ import type { LLMProviderConfig } from "@/types/config/provider"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import {
   fetchAnthropicModels,
-  fetchDeepInfraModels,
   fetchGoogleModels,
   fetchOpenAICompatibleModels,
   getModelDiscovery,
@@ -105,40 +104,22 @@ describe("fetchOpenAICompatibleModels", () => {
   })
 })
 
-describe("fetchDeepInfraModels", () => {
-  it("uses the public catalog and keeps only available text-generation models", async () => {
+describe("fetchOpenAICompatibleModels with tagged catalogs", () => {
+  it("keeps only chat-tagged entries when metadata.tags is present", async () => {
     const fetchMock = mockFetch(
-      jsonResponse([
-        {
-          model_name: "chat-model",
-          reported_type: "text-generation",
-          type: "text-generation",
-          deprecated: null,
-          private: 0,
-        },
-        { model_name: "image-model", reported_type: "text-to-image", type: "text-to-image" },
-        {
-          model_name: "retired-model",
-          reported_type: "text-generation",
-          type: "text-generation",
-          deprecated: 1718830497,
-          private: 0,
-        },
-        {
-          model_name: "private-model",
-          reported_type: "text-generation",
-          type: "text-generation",
-          deprecated: null,
-          private: 1,
-        },
-        { model_name: "legacy-shape-model", type: "text-generation" },
-      ]),
+      jsonResponse({
+        data: [
+          { id: "chat-model", metadata: { tags: ["chat", "reasoning"] } },
+          { id: "embed-model", metadata: { tags: ["embed"] } },
+          { id: "speech-model", metadata: { tags: ["tts"] } },
+        ],
+      }),
     )
 
-    const models = await fetchDeepInfraModels("https://api.deepinfra.com/v1", "")
+    const models = await fetchOpenAICompatibleModels("https://api.deepinfra.com/v1/openai")
 
-    expect(models).toEqual(["chat-model", "legacy-shape-model"])
-    expect(fetchMock).toHaveBeenCalledWith("https://api.deepinfra.com/models/list", {
+    expect(models).toEqual(["chat-model"])
+    expect(fetchMock).toHaveBeenCalledWith("https://api.deepinfra.com/v1/openai/models", {
       headers: {},
     })
   })
@@ -260,8 +241,8 @@ describe("getModelDiscovery", () => {
     },
   )
 
-  it("discovers DeepInfra through its unauthenticated text-model catalog", async () => {
-    const fetchMock = mockFetch(jsonResponse([]))
+  it("discovers DeepInfra without an API key under its OpenAI-compatible base", async () => {
+    const fetchMock = mockFetch(jsonResponse({ data: [] }))
     const discovery = getModelDiscovery({
       ...googleConfig,
       id: "deepinfra-default",
@@ -269,12 +250,30 @@ describe("getModelDiscovery", () => {
       apiKey: undefined,
     } as unknown as LLMProviderConfig)
 
-    expect(discovery?.endpoint).toBe("https://api.deepinfra.com/v1")
+    expect(discovery?.endpoint).toBe("https://api.deepinfra.com/v1/openai")
     await discovery!.fetchModels()
 
-    expect(fetchMock).toHaveBeenCalledWith("https://api.deepinfra.com/models/list", {
+    expect(fetchMock).toHaveBeenCalledWith("https://api.deepinfra.com/v1/openai/models", {
       headers: {},
     })
+  })
+
+  it("keeps DeepInfra discovery under a proxied baseURL prefix", async () => {
+    const fetchMock = mockFetch(jsonResponse({ data: [] }))
+    const discovery = getModelDiscovery({
+      ...googleConfig,
+      id: "deepinfra-default",
+      provider: "deepinfra",
+      apiKey: undefined,
+      baseURL: "https://proxy.example.com/deepinfra/v1/openai",
+    } as unknown as LLMProviderConfig)
+
+    await discovery!.fetchModels()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://proxy.example.com/deepinfra/v1/openai/models",
+      { headers: {} },
+    )
   })
 
   it("discovers Hugging Face without an API key", async () => {

--- a/src/utils/providers/__tests__/model-discovery.test.ts
+++ b/src/utils/providers/__tests__/model-discovery.test.ts
@@ -73,6 +73,29 @@ describe("fetchOpenAICompatibleModels", () => {
     })
   })
 
+  it("drops well-known non-text model ids that carry no capability metadata", async () => {
+    mockFetch(
+      jsonResponse({
+        data: [
+          { id: "gpt-test" },
+          { id: "text-embedding-3-large" },
+          { id: "whisper-1" },
+          { id: "tts-1-hd" },
+          { id: "dall-e-3" },
+          { id: "omni-moderation-latest" },
+          { id: "gpt-4o-realtime-preview" },
+          { id: "gpt-4o-audio-preview" },
+          { id: "gpt-4o-transcribe" },
+          { id: "gpt-image-1" },
+        ],
+      }),
+    )
+
+    const models = await fetchOpenAICompatibleModels("https://api.openai.com/v1", "sk-test")
+
+    expect(models).toEqual(["gpt-test"])
+  })
+
   it("surfaces API error messages", async () => {
     mockFetch(jsonResponse({ error: { message: "invalid key" } }, 401))
 

--- a/src/utils/providers/model-discovery.ts
+++ b/src/utils/providers/model-discovery.ts
@@ -12,7 +12,7 @@ import { getProviderHeadersWithOverride } from "./headers"
  * the static `LLM_PROVIDER_MODELS` lists remain the source of truth.
  */
 
-type ModelDiscoveryKind = "openai-compatible" | "google" | "anthropic" | "deepinfra"
+type ModelDiscoveryKind = "openai-compatible" | "google" | "anthropic"
 
 interface ModelDiscoveryDescriptor {
   kind: ModelDiscoveryKind
@@ -37,8 +37,8 @@ export const MODEL_DISCOVERY_DESCRIPTORS: Partial<
   xai: { kind: "openai-compatible", baseURL: "https://api.x.ai/v1" },
   groq: { kind: "openai-compatible", baseURL: "https://api.groq.com/openai/v1" },
   deepinfra: {
-    kind: "deepinfra",
-    baseURL: "https://api.deepinfra.com/v1",
+    kind: "openai-compatible",
+    baseURL: "https://api.deepinfra.com/v1/openai",
     requiresAPIKey: false,
   },
   mistral: { kind: "openai-compatible", baseURL: "https://api.mistral.ai/v1" },
@@ -101,6 +101,11 @@ function supportsTextGeneration(entry: unknown): boolean {
     }
   }
 
+  const tags = asRecord(record.metadata)?.tags
+  if (Array.isArray(tags)) {
+    return tags.includes("chat")
+  }
+
   return true
 }
 
@@ -157,30 +162,6 @@ export async function fetchOpenAICompatibleModels(
   )
 }
 
-export async function fetchDeepInfraModels(
-  baseURL: string,
-  _apiKey: string,
-  extraHeaders?: Record<string, string>,
-  signal?: AbortSignal,
-): Promise<string[]> {
-  const url = new URL(baseURL)
-  url.pathname = "/models/list"
-  url.search = ""
-  url.hash = ""
-
-  const data = await fetchJSON(url.toString(), { ...extraHeaders }, signal)
-  const models = getModelEntries(data)
-    .filter((entry) => {
-      const record = asRecord(entry)
-      if (!record) return false
-      // `deprecated` is a unix timestamp (or null) and `private` is a 0/1 flag.
-      const reportedType = asString(record.reported_type) ?? asString(record.type)
-      return reportedType === "text-generation" && !record.deprecated && !record.private
-    })
-    .map((entry) => asString(asRecord(entry)?.model_name) ?? "")
-
-  return dedupe(models)
-}
 
 export async function fetchGoogleModels(
   baseURL: string,
@@ -274,7 +255,6 @@ const MODEL_FETCHERS: Record<
   "openai-compatible": fetchOpenAICompatibleModels,
   google: fetchGoogleModels,
   anthropic: fetchAnthropicModels,
-  deepinfra: fetchDeepInfraModels,
 }
 
 export interface ModelDiscovery {

--- a/src/utils/providers/model-discovery.ts
+++ b/src/utils/providers/model-discovery.ts
@@ -145,11 +145,13 @@ export async function fetchOpenAICompatibleModels(
   extraHeaders?: Record<string, string>,
   signal?: AbortSignal,
 ): Promise<string[]> {
+  // Auth first, then configured headers, so user headers can override the derived
+  // auth header — the same precedence the AI SDK provider clients use.
   const data = await fetchJSON(
     getModelsURL(baseURL),
     {
-      ...extraHeaders,
       ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+      ...extraHeaders,
     },
     signal,
   )
@@ -181,7 +183,7 @@ export async function fetchGoogleModels(
 
     const data = await fetchJSON(
       url.toString(),
-      { ...extraHeaders, "x-goog-api-key": apiKey },
+      { "x-goog-api-key": apiKey, ...extraHeaders },
       signal,
     )
     const records = asRecord(data)?.models
@@ -225,9 +227,9 @@ export async function fetchAnthropicModels(
     const data = await fetchJSON(
       url.toString(),
       {
-        ...extraHeaders,
         "x-api-key": apiKey,
         "anthropic-version": "2023-06-01",
+        ...extraHeaders,
       },
       signal,
     )

--- a/src/utils/providers/model-discovery.ts
+++ b/src/utils/providers/model-discovery.ts
@@ -22,6 +22,10 @@ interface ModelDiscoveryDescriptor {
 
 const MAX_PAGES = 10
 const UNSUPPORTED_MODEL_TYPES = new Set(["embedding", "image", "moderation", "rerank"])
+// Catalog entries without capability metadata (plain { id } shapes) are matched by
+// id against the common non-text model families instead.
+const NON_TEXT_MODEL_ID_PATTERN =
+  /\b(?:embed(?:ding)?s?|whisper|tts|dall-e|moderation|audio|realtime|transcribe|rerank(?:er)?|image|sora)\b/i
 
 export const MODEL_DISCOVERY_DESCRIPTORS: Partial<
   Record<NonCustomLLMProviderTypes, ModelDiscoveryDescriptor>
@@ -145,7 +149,12 @@ export async function fetchOpenAICompatibleModels(
     signal,
   )
   // Most providers return { data: [{ id }] }; a few return a bare array or use `name`.
-  return dedupe(getModelEntries(data).filter(supportsTextGeneration).map(getModelId))
+  return dedupe(
+    getModelEntries(data)
+      .filter(supportsTextGeneration)
+      .map(getModelId)
+      .filter((id) => !NON_TEXT_MODEL_ID_PATTERN.test(id)),
+  )
 }
 
 export async function fetchDeepInfraModels(

--- a/src/utils/providers/model-discovery.ts
+++ b/src/utils/providers/model-discovery.ts
@@ -163,9 +163,10 @@ export async function fetchDeepInfraModels(
   const models = getModelEntries(data)
     .filter((entry) => {
       const record = asRecord(entry)
-      return (
-        record?.type === "text-generation" && record.deprecated !== true && record.private !== true
-      )
+      if (!record) return false
+      // `deprecated` is a unix timestamp (or null) and `private` is a 0/1 flag.
+      const reportedType = asString(record.reported_type) ?? asString(record.type)
+      return reportedType === "text-generation" && !record.deprecated && !record.private
     })
     .map((entry) => asString(asRecord(entry)?.model_name) ?? "")
 

--- a/src/utils/providers/model-discovery.ts
+++ b/src/utils/providers/model-discovery.ts
@@ -1,0 +1,316 @@
+import type { LLMProviderConfig, NonCustomLLMProviderTypes } from "@/types/config/provider"
+import { isCustomLLMProviderConfig } from "@/types/config/provider"
+import { extractErrorMessage } from "@/utils/error/extract-message"
+import { getProviderHeadersWithOverride } from "./headers"
+
+/**
+ * Declarative model-discovery registry.
+ *
+ * Each entry describes where a provider exposes its "list models" API and which
+ * of the shared response shapes it uses. Fetched ids augment the existing model
+ * selector and selected unknown ids flow through the custom-model channel, so
+ * the static `LLM_PROVIDER_MODELS` lists remain the source of truth.
+ */
+
+type ModelDiscoveryKind = "openai-compatible" | "google" | "anthropic" | "deepinfra"
+
+interface ModelDiscoveryDescriptor {
+  kind: ModelDiscoveryKind
+  baseURL: string
+  requiresAPIKey?: boolean
+}
+
+const MAX_PAGES = 10
+const UNSUPPORTED_MODEL_TYPES = new Set(["embedding", "image", "moderation", "rerank"])
+
+export const MODEL_DISCOVERY_DESCRIPTORS: Partial<
+  Record<NonCustomLLMProviderTypes, ModelDiscoveryDescriptor>
+> = {
+  openai: { kind: "openai-compatible", baseURL: "https://api.openai.com/v1" },
+  deepseek: { kind: "openai-compatible", baseURL: "https://api.deepseek.com" },
+  google: { kind: "google", baseURL: "https://generativelanguage.googleapis.com/v1beta" },
+  anthropic: { kind: "anthropic", baseURL: "https://api.anthropic.com/v1" },
+  xai: { kind: "openai-compatible", baseURL: "https://api.x.ai/v1" },
+  groq: { kind: "openai-compatible", baseURL: "https://api.groq.com/openai/v1" },
+  deepinfra: {
+    kind: "deepinfra",
+    baseURL: "https://api.deepinfra.com/v1",
+    requiresAPIKey: false,
+  },
+  mistral: { kind: "openai-compatible", baseURL: "https://api.mistral.ai/v1" },
+  togetherai: { kind: "openai-compatible", baseURL: "https://api.together.ai/v1" },
+  cerebras: { kind: "openai-compatible", baseURL: "https://api.cerebras.ai/v1" },
+  alibaba: {
+    kind: "openai-compatible",
+    baseURL: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+  },
+  moonshotai: { kind: "openai-compatible", baseURL: "https://api.moonshot.ai/v1" },
+  huggingface: {
+    kind: "openai-compatible",
+    baseURL: "https://router.huggingface.co/v1",
+    requiresAPIKey: false,
+  },
+}
+
+function dedupe(models: string[]): string[] {
+  return [...new Set(models.map((model) => model.trim()).filter(Boolean))]
+}
+
+type UnknownRecord = Record<string, unknown>
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : undefined
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined
+}
+
+function supportsTextGeneration(entry: unknown): boolean {
+  const record = asRecord(entry)
+  if (!record) return true
+
+  if (record.deprecated === true) {
+    return false
+  }
+
+  const type = asString(record.type)?.toLowerCase()
+  if (type && UNSUPPORTED_MODEL_TYPES.has(type)) {
+    return false
+  }
+
+  const outputModalities = asRecord(record.architecture)?.output_modalities
+  if (
+    Array.isArray(outputModalities) &&
+    !outputModalities.some((modality) => modality === "text")
+  ) {
+    return false
+  }
+
+  const capabilities = asRecord(record.capabilities)
+  for (const key of ["completion_chat", "completion", "chat"]) {
+    const capability = capabilities?.[key]
+    if (typeof capability === "boolean") {
+      return capability
+    }
+  }
+
+  return true
+}
+
+function getModelEntries(data: unknown): unknown[] {
+  if (Array.isArray(data)) return data
+
+  const record = asRecord(data)
+  return Array.isArray(record?.data) ? record.data : []
+}
+
+function getModelId(entry: unknown): string {
+  if (typeof entry === "string") return entry
+
+  const record = asRecord(entry)
+  return asString(record?.id) ?? asString(record?.name) ?? ""
+}
+
+function getModelsURL(baseURL: string): string {
+  return `${baseURL.replace(/\/+$/, "")}/models`
+}
+
+async function fetchJSON(
+  url: string,
+  headers: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<unknown> {
+  const response = await fetch(url, { headers, ...(signal ? { signal } : {}) })
+  if (!response.ok) {
+    throw new Error(await extractErrorMessage(response))
+  }
+  return response.json()
+}
+
+export async function fetchOpenAICompatibleModels(
+  baseURL: string,
+  apiKey?: string,
+  extraHeaders?: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const data = await fetchJSON(
+    getModelsURL(baseURL),
+    {
+      ...extraHeaders,
+      ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
+    },
+    signal,
+  )
+  // Most providers return { data: [{ id }] }; a few return a bare array or use `name`.
+  return dedupe(getModelEntries(data).filter(supportsTextGeneration).map(getModelId))
+}
+
+export async function fetchDeepInfraModels(
+  baseURL: string,
+  _apiKey: string,
+  extraHeaders?: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const url = new URL(baseURL)
+  url.pathname = "/models/list"
+  url.search = ""
+  url.hash = ""
+
+  const data = await fetchJSON(url.toString(), { ...extraHeaders }, signal)
+  const models = getModelEntries(data)
+    .filter((entry) => {
+      const record = asRecord(entry)
+      return (
+        record?.type === "text-generation" && record.deprecated !== true && record.private !== true
+      )
+    })
+    .map((entry) => asString(asRecord(entry)?.model_name) ?? "")
+
+  return dedupe(models)
+}
+
+export async function fetchGoogleModels(
+  baseURL: string,
+  apiKey: string,
+  extraHeaders?: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const models: string[] = []
+  let pageToken: string | undefined
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const url = new URL(getModelsURL(baseURL))
+    url.searchParams.set("pageSize", "1000")
+    if (pageToken) {
+      url.searchParams.set("pageToken", pageToken)
+    }
+
+    const data = await fetchJSON(
+      url.toString(),
+      { ...extraHeaders, "x-goog-api-key": apiKey },
+      signal,
+    )
+    const records = asRecord(data)?.models
+    for (const model of Array.isArray(records) ? records : []) {
+      const record = asRecord(model)
+      const methods = [record?.supportedGenerationMethods, record?.supportedActions].flatMap(
+        (value) =>
+          (Array.isArray(value) ? value : []).filter(
+            (item): item is string => typeof item === "string",
+          ),
+      )
+      const name = asString(record?.name)
+      if (methods.includes("generateContent") && name) {
+        models.push(name.replace(/^models\//, ""))
+      }
+    }
+
+    pageToken = asString(asRecord(data)?.nextPageToken)
+    if (!pageToken) break
+  }
+
+  return dedupe(models)
+}
+
+export async function fetchAnthropicModels(
+  baseURL: string,
+  apiKey: string,
+  extraHeaders?: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const models: string[] = []
+  let afterId: string | undefined
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const url = new URL(getModelsURL(baseURL))
+    url.searchParams.set("limit", "1000")
+    if (afterId) {
+      url.searchParams.set("after_id", afterId)
+    }
+
+    const data = await fetchJSON(
+      url.toString(),
+      {
+        ...extraHeaders,
+        "x-api-key": apiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      signal,
+    )
+    for (const entry of getModelEntries(data)) {
+      models.push(getModelId(entry))
+    }
+
+    const record = asRecord(data)
+    afterId = record?.has_more === true ? asString(record.last_id) : undefined
+    if (!afterId) break
+  }
+
+  return dedupe(models)
+}
+
+const MODEL_FETCHERS: Record<
+  ModelDiscoveryKind,
+  (
+    baseURL: string,
+    apiKey: string,
+    extraHeaders?: Record<string, string>,
+    signal?: AbortSignal,
+  ) => Promise<string[]>
+> = {
+  "openai-compatible": fetchOpenAICompatibleModels,
+  google: fetchGoogleModels,
+  anthropic: fetchAnthropicModels,
+  deepinfra: fetchDeepInfraModels,
+}
+
+export interface ModelDiscovery {
+  /** Resolved list endpoint origin; also identifies the fetch target for cache resets. */
+  endpoint: string
+  fetchModels: (signal?: AbortSignal) => Promise<string[]>
+}
+
+/**
+ * Build a model-list fetcher for the given provider config, or return undefined
+ * when the provider has no known list endpoint.
+ */
+export function getModelDiscovery(providerConfig: LLMProviderConfig): ModelDiscovery | undefined {
+  const extraHeaders = getProviderHeadersWithOverride(
+    providerConfig.provider,
+    "headers" in providerConfig ? providerConfig.headers : undefined,
+  )
+
+  if (isCustomLLMProviderConfig(providerConfig)) {
+    const baseURL = providerConfig.baseURL?.trim()
+    const apiKey = providerConfig.apiKey?.trim()
+    if (!baseURL) {
+      return undefined
+    }
+    return {
+      endpoint: baseURL,
+      fetchModels: async (signal) =>
+        fetchOpenAICompatibleModels(baseURL, apiKey, extraHeaders, signal),
+    }
+  }
+
+  const descriptor = MODEL_DISCOVERY_DESCRIPTORS[providerConfig.provider]
+  if (!descriptor) {
+    return undefined
+  }
+
+  const configuredBaseURL = "baseURL" in providerConfig ? providerConfig.baseURL?.trim() : undefined
+  const baseURL = configuredBaseURL || descriptor.baseURL
+  const apiKey = "apiKey" in providerConfig ? providerConfig.apiKey?.trim() : undefined
+  if (descriptor.requiresAPIKey !== false && !apiKey) {
+    return undefined
+  }
+  const fetchModels = MODEL_FETCHERS[descriptor.kind]
+
+  return {
+    endpoint: baseURL,
+    fetchModels: async (signal) => fetchModels(baseURL, apiKey ?? "", extraHeaders, signal),
+  }
+}


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Fable 5, GPT-5.6 Sol Ultra 

## Type of Changes

- [x] ✨ New feature (feat)

## Description

The options page now quietly fetches each provider's current model list and merges it into the existing model dropdown, so newly released models are selectable without waiting for an extension release (the pain in #1938). No new UI and no user action needed.

**Design**

- One declarative registry (`MODEL_DISCOVERY_DESCRIPTORS`) maps a provider to `{ kind, baseURL }`; a `kind` is a shared response shape (`openai-compatible`, `google`, `anthropic`, `deepinfra`), not a per-provider code path. Adding/removing a provider is a one-line data change.
- Static `LLM_PROVIDER_MODELS` lists remain the source of truth and the always-available fallback; discovered ids only augment the dropdown. Picking an id outside the static enum persists through the existing `isCustomModel`/`customModel` channel — **no schema changes, no request-path changes**.
- Custom providers (OpenRouter, SiliconFlow, …) keep their static dropdown and join the same discovery path via their configured `baseURL`. Only `openai-compatible` keeps the manual custom-model input (its schema requires it), where the existing fetch button still works.
- Discovery reuses `getProviderHeadersWithOverride`, so default provider headers and user-configured `headers`/`baseURL` overrides behave exactly like translation requests.

**Performance / safety**

- Fetches only while the provider form is open, cached for 5 minutes per provider, in-flight requests cancelled via `AbortSignal` when the config changes, no retries.
- API key input is debounced and trimmed before any request; failures are silent and simply leave the static list in place (`meta.suppressToast`).
- Keys travel only in request headers — never in URLs; the react-query cache key uses a SHA-256 fingerprint, never the key itself.

Both Codex review points are addressed: DeepInfra discovery uses its public catalog (`/models/list`) instead of the chat-completions prefix, and named custom providers keep their static model dropdown.

## Related Issue

Refs #1938

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Unit tests cover the response shapes, pagination, capability filtering, header injection, baseURL overrides, and that keys never appear in URLs; component tests cover the automatic dropdown merge, custom-model routing, manual-entry toggle, debounce, and the silent-failure fallback. Full suite passes, `oxlint --type-aware` clean.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.
