### PR TITLE
fix(translate): preserve narration around inline dialogue

### DIFF
--- a/.changeset/tall-quotes-translate.md
+++ b/.changeset/tall-quotes-translate.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): 修复长内容中只翻译内联引用文本的问题

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -3,6 +3,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import {
+  BLOCK_ATTRIBUTE,
+  INLINE_ATTRIBUTE,
+  PARAGRAPH_ATTRIBUTE,
+  WALKED_ATTRIBUTE,
+} from "@/utils/constants/dom-labels"
+import {
   markExtensionDrivenNodeRemoval,
   registerBilingualTranslationState,
   unregisterBilingualTranslationState,
@@ -200,7 +206,7 @@ function walkAndLabelVisibleParagraphs(
     }
   }
 
-  element.setAttribute("data-read-frog-walked", walkId)
+  element.setAttribute(WALKED_ATTRIBUTE, walkId)
 
   for (const child of element.children) {
     if (child instanceof HTMLElement) {
@@ -209,7 +215,8 @@ function walkAndLabelVisibleParagraphs(
   }
 
   if (element.tagName === "P" && element.textContent?.trim()) {
-    element.setAttribute("data-read-frog-paragraph", "")
+    element.setAttribute(PARAGRAPH_ATTRIBUTE, "")
+    element.setAttribute(BLOCK_ATTRIBUTE, "")
   }
 
   return {
@@ -1055,16 +1062,19 @@ describe("pageTranslationManager mutation re-walk", () => {
     // inside. Built via DOM APIs — the HTML parser refuses nested <p>.
     const giant = document.createElement("p")
     giant.id = "giant"
-    giant.append("direct inline text of the giant")
+    const directText = document.createTextNode("direct inline text of the giant")
+    giant.append(directText)
     const inner1 = document.createElement("p")
     inner1.id = "inner1"
     inner1.textContent = "Nested paragraph one"
-    inner1.setAttribute("data-read-frog-block-node", "")
+    inner1.setAttribute(BLOCK_ATTRIBUTE, "")
     const inner2 = document.createElement("p")
     inner2.id = "inner2"
     inner2.textContent = "Nested paragraph two"
-    inner2.setAttribute("data-read-frog-block-node", "")
-    giant.append(inner1, inner2)
+    inner2.setAttribute(BLOCK_ATTRIBUTE, "")
+    const betweenBlocks = document.createTextNode("direct text between the nested paragraphs")
+    const afterBlocks = document.createTextNode("direct text after the nested paragraphs")
+    giant.append(inner1, betweenBlocks, inner2, afterBlocks)
 
     const unsplittable = document.createElement("p")
     unsplittable.id = "unsplittable"
@@ -1090,6 +1100,52 @@ describe("pageTranslationManager mutation re-walk", () => {
     // A giant with no nested paragraphs cannot be split — observed whole.
     expect(observed).toContain(unsplittable)
 
+    await observer.triggerIntersect(inner1)
+    await flushDomUpdates()
+
+    // Direct text remains owned by the giant, but is lazily triggered by its
+    // adjacent block instead of making the whole giant an eager target.
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(
+      giant,
+      "walk-id",
+      DEFAULT_CONFIG,
+      false,
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      { childRuns: [[directText]] },
+    )
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(
+      inner1,
+      "walk-id",
+      DEFAULT_CONFIG,
+      false,
+      expect.anything(),
+      expect.anything(),
+    )
+
+    await observer.triggerIntersect(inner2)
+    await flushDomUpdates()
+
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(
+      giant,
+      "walk-id",
+      DEFAULT_CONFIG,
+      false,
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      { childRuns: [[betweenBlocks], [afterBlocks]] },
+    )
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(
+      inner2,
+      "walk-id",
+      DEFAULT_CONFIG,
+      false,
+      expect.anything(),
+      expect.anything(),
+    )
+
     manager.stop()
   })
 
@@ -1103,7 +1159,7 @@ describe("pageTranslationManager mutation re-walk", () => {
     const dialogue = document.createElement("q")
     dialogue.id = "dialogue"
     dialogue.textContent = '"Quoted dialogue"'
-    dialogue.setAttribute("data-read-frog-inline-node", "")
+    dialogue.setAttribute(INLINE_ATTRIBUTE, "")
     message.append(dialogue, " Narration after the dialogue.")
     document.body.append(message)
 
@@ -1118,8 +1174,8 @@ describe("pageTranslationManager mutation re-walk", () => {
         options?: { onBlockedElement?: (blocked: HTMLElement) => void },
       ) => {
         const result = walkAndLabelVisibleParagraphs(element, walkId, options?.onBlockedElement)
-        dialogue.setAttribute("data-read-frog-walked", walkId)
-        dialogue.setAttribute("data-read-frog-paragraph", "")
+        dialogue.setAttribute(WALKED_ATTRIBUTE, walkId)
+        dialogue.setAttribute(PARAGRAPH_ATTRIBUTE, "")
         return result
       },
     )
@@ -1136,6 +1192,86 @@ describe("pageTranslationManager mutation re-walk", () => {
     manager.stop()
   })
 
+  it("preserves a giant paragraph's inline run when block paragraphs are split (#1951)", async () => {
+    const message = document.createElement("p")
+    message.id = "mixed-message"
+    const before = document.createTextNode("Narration before the dialogue. ")
+    const dialogue = document.createElement("q")
+    dialogue.id = "mixed-dialogue"
+    dialogue.textContent = '"Quoted dialogue"'
+    const after = document.createTextNode(" Narration after the dialogue.")
+    const block = document.createElement("p")
+    block.id = "mixed-block"
+    block.textContent = "A nested block paragraph"
+    message.append(before, dialogue, after, block)
+    document.body.append(message)
+
+    const tall = { height: 200_000 } as DOMRect
+    message.getBoundingClientRect = () => tall
+
+    mockWalkAndLabelElementChunked.mockImplementationOnce(
+      async (
+        element: HTMLElement,
+        walkId: string,
+        _config: unknown,
+        options?: { onBlockedElement?: (blocked: HTMLElement) => void },
+      ) => {
+        const result = walkAndLabelVisibleParagraphs(element, walkId, options?.onBlockedElement)
+        dialogue.setAttribute(WALKED_ATTRIBUTE, walkId)
+        dialogue.setAttribute(PARAGRAPH_ATTRIBUTE, "")
+        dialogue.setAttribute(INLINE_ATTRIBUTE, "")
+        block.setAttribute(BLOCK_ATTRIBUTE, "")
+        return result
+      },
+    )
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observer = intersectionObservers[0]
+    const observed = observer.observe.mock.calls.map((call) => call[0])
+    expect(observed).toContain(dialogue)
+    expect(observed).toContain(block)
+    expect(observed).not.toContain(message)
+
+    await observer.triggerIntersect(dialogue)
+    await flushDomUpdates()
+
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(
+      message,
+      "walk-id",
+      DEFAULT_CONFIG,
+      false,
+      expect.anything(),
+      expect.anything(),
+      undefined,
+      { childRuns: [[before, dialogue, after]] },
+    )
+    expect(mockTranslateWalkedElement).not.toHaveBeenCalledWith(
+      dialogue,
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    )
+
+    await observer.triggerIntersect(block)
+    await flushDomUpdates()
+
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(
+      block,
+      "walk-id",
+      DEFAULT_CONFIG,
+      false,
+      expect.anything(),
+      expect.anything(),
+    )
+
+    manager.stop()
+  })
+
   it("observes inline paragraphs in a nested shadow root independently from a giant host (#1951)", async () => {
     const manager = new PageTranslationManager()
     await manager.start()
@@ -1148,7 +1284,7 @@ describe("pageTranslationManager mutation re-walk", () => {
     const dialogue = document.createElement("q")
     dialogue.id = "shadow-dialogue"
     dialogue.textContent = '"Dialogue rendered in the shadow root"'
-    dialogue.setAttribute("data-read-frog-inline-node", "")
+    dialogue.setAttribute(INLINE_ATTRIBUTE, "")
     shadowRoot.append(dialogue)
 
     const tall = { height: 200_000 } as DOMRect
@@ -1162,8 +1298,8 @@ describe("pageTranslationManager mutation re-walk", () => {
         callbacks?: { onBlockedElement?: (blocked: HTMLElement) => void },
       ) => {
         const result = walkAndLabelVisibleParagraphs(element, walkId, callbacks?.onBlockedElement)
-        dialogue.setAttribute("data-read-frog-walked", walkId)
-        dialogue.setAttribute("data-read-frog-paragraph", "")
+        dialogue.setAttribute(WALKED_ATTRIBUTE, walkId)
+        dialogue.setAttribute(PARAGRAPH_ATTRIBUTE, "")
         return result
       },
     )

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -1059,9 +1059,11 @@ describe("pageTranslationManager mutation re-walk", () => {
     const inner1 = document.createElement("p")
     inner1.id = "inner1"
     inner1.textContent = "Nested paragraph one"
+    inner1.setAttribute("data-read-frog-block-node", "")
     const inner2 = document.createElement("p")
     inner2.id = "inner2"
     inner2.textContent = "Nested paragraph two"
+    inner2.setAttribute("data-read-frog-block-node", "")
     giant.append(inner1, inner2)
 
     const unsplittable = document.createElement("p")
@@ -1087,6 +1089,113 @@ describe("pageTranslationManager mutation re-walk", () => {
     expect(observed).not.toContain(giant)
     // A giant with no nested paragraphs cannot be split — observed whole.
     expect(observed).toContain(unsplittable)
+
+    manager.stop()
+  })
+
+  it("keeps a giant mixed-content paragraph whole when its only nested paragraph is inline (#1951)", async () => {
+    // SillyTavern renders quoted dialogue as an inline <q> inside a long
+    // message. Splitting on that inline paragraph drops the surrounding
+    // narration, which lives in direct text nodes owned by the message.
+    const message = document.createElement("p")
+    message.id = "message"
+    message.append("Narration before the dialogue. ")
+    const dialogue = document.createElement("q")
+    dialogue.id = "dialogue"
+    dialogue.textContent = '"Quoted dialogue"'
+    dialogue.setAttribute("data-read-frog-inline-node", "")
+    message.append(dialogue, " Narration after the dialogue.")
+    document.body.append(message)
+
+    const tall = { height: 200_000 } as DOMRect
+    message.getBoundingClientRect = () => tall
+
+    mockWalkAndLabelElementChunked.mockImplementationOnce(
+      async (
+        element: HTMLElement,
+        walkId: string,
+        _config: unknown,
+        options?: { onBlockedElement?: (blocked: HTMLElement) => void },
+      ) => {
+        const result = walkAndLabelVisibleParagraphs(element, walkId, options?.onBlockedElement)
+        dialogue.setAttribute("data-read-frog-walked", walkId)
+        dialogue.setAttribute("data-read-frog-paragraph", "")
+        return result
+      },
+    )
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observer = intersectionObservers[0]
+    const observed = observer.observe.mock.calls.map((call) => call[0])
+    expect(observed).toContain(message)
+    expect(observed).not.toContain(dialogue)
+
+    manager.stop()
+  })
+
+  it("observes inline paragraphs in a nested shadow root independently from a giant host (#1951)", async () => {
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const message = document.createElement("p")
+    message.id = "shadow-message"
+    message.append("Light-DOM narration that belongs to the message host.")
+    const shadowRoot = message.attachShadow({ mode: "open" })
+    const dialogue = document.createElement("q")
+    dialogue.id = "shadow-dialogue"
+    dialogue.textContent = '"Dialogue rendered in the shadow root"'
+    dialogue.setAttribute("data-read-frog-inline-node", "")
+    shadowRoot.append(dialogue)
+
+    const tall = { height: 200_000 } as DOMRect
+    message.getBoundingClientRect = () => tall
+
+    mockWalkAndLabelElement.mockImplementationOnce(
+      (
+        element: HTMLElement,
+        walkId: string,
+        _config: unknown,
+        callbacks?: { onBlockedElement?: (blocked: HTMLElement) => void },
+      ) => {
+        const result = walkAndLabelVisibleParagraphs(element, walkId, callbacks?.onBlockedElement)
+        dialogue.setAttribute("data-read-frog-walked", walkId)
+        dialogue.setAttribute("data-read-frog-paragraph", "")
+        return result
+      },
+    )
+
+    document.body.append(message)
+    await flushDomUpdates()
+
+    const observer = intersectionObservers[0]
+    const observed = observer.observe.mock.calls.map((call) => call[0])
+    expect(observed).toContain(message)
+    expect(observed).toContain(dialogue)
+
+    await observer.triggerIntersect(message)
+    await observer.triggerIntersect(dialogue)
+    await flushDomUpdates()
+
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(
+      message,
+      "walk-id",
+      DEFAULT_CONFIG,
+      false,
+      expect.anything(),
+      expect.anything(),
+    )
+    expect(mockTranslateWalkedElement).toHaveBeenCalledWith(
+      dialogue,
+      "walk-id",
+      DEFAULT_CONFIG,
+      false,
+      expect.anything(),
+      expect.anything(),
+    )
 
     manager.stop()
   })

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -78,6 +78,11 @@ interface RetranslationBudget {
   passes: number
 }
 
+interface ParagraphChildRunTask {
+  paragraph: HTMLElement
+  childRuns: ChildNode[][]
+}
+
 interface IPageTranslationManager {
   /**
    * Indicates whether the page translation is currently active
@@ -125,6 +130,8 @@ export class PageTranslationManager implements IPageTranslationManager {
 
   private isPageTranslating: boolean = false
   private intersectionObserver: IntersectionObserver | null = null
+  private fullParagraphTargets = new WeakSet<HTMLElement>()
+  private paragraphChildRunsByAnchor = new WeakMap<HTMLElement, ParagraphChildRunTask[]>()
   private mutationObservers: MutationObserver[] = []
   private observedMutationRoots = new WeakSet<Node>()
   private walkId: string | null = null
@@ -282,7 +289,30 @@ export class PageTranslationManager implements IPageTranslationManager {
           const pacer = createWorkPacer()
           const isWalkCurrent = () => this.walkId === walkId
           for (const target of targets) {
-            void translateWalkedElement(target, walkId, currentConfig, false, pacer, isWalkCurrent)
+            const childRunTasks = this.paragraphChildRunsByAnchor.get(target) ?? []
+            this.paragraphChildRunsByAnchor.delete(target)
+            for (const task of childRunTasks) {
+              void translateWalkedElement(
+                task.paragraph,
+                walkId,
+                currentConfig,
+                false,
+                pacer,
+                isWalkCurrent,
+                undefined,
+                { childRuns: task.childRuns },
+              )
+            }
+            if (this.fullParagraphTargets.has(target)) {
+              void translateWalkedElement(
+                target,
+                walkId,
+                currentConfig,
+                false,
+                pacer,
+                isWalkCurrent,
+              )
+            }
           }
         })()
       }, this.intersectionOptions)
@@ -366,6 +396,8 @@ export class PageTranslationManager implements IPageTranslationManager {
     this.isPageTranslating = false
     this.translationSessionVersion += 1
     this.walkId = null
+    this.fullParagraphTargets = new WeakSet()
+    this.paragraphChildRunsByAnchor = new WeakMap()
     this.walkBlockedElementsCache = new WeakSet()
     this.refreshingTranslatedSources = new WeakSet()
     this.translatedSourceMutationVersions = new WeakMap()
@@ -624,25 +656,114 @@ export class PageTranslationManager implements IPageTranslationManager {
     topLevelParagraphs.forEach((el) => this.observeParagraphUnit(el, walkId, 0))
   }
 
+  /** Register a normal paragraph target for full recursive translation. */
+  private observeFullParagraphUnit(element: HTMLElement): void {
+    const observer = this.intersectionObserver
+    if (!observer) return
+    this.fullParagraphTargets.add(element)
+    observer.observe(element)
+  }
+
+  /**
+   * Register a parent-owned child run against a viewport-local element inside
+   * or beside it. When that anchor enters the viewport, the parent paragraph
+   * translates the complete run without recursing into split block children.
+   */
+  private observeParagraphChildRun(
+    paragraph: HTMLElement,
+    anchor: HTMLElement,
+    childRun: ChildNode[],
+  ): void {
+    const observer = this.intersectionObserver
+    if (!observer) return
+
+    const tasks = this.paragraphChildRunsByAnchor.get(anchor) ?? []
+    let task = tasks.find((candidate) => candidate.paragraph === paragraph)
+    if (!task) {
+      task = { paragraph, childRuns: [] }
+      tasks.push(task)
+    }
+    const isAlreadyRegistered = task.childRuns.some(
+      (registered) =>
+        registered.length === childRun.length &&
+        registered.every((node, index) => node === childRun[index]),
+    )
+    if (!isAlreadyRegistered) task.childRuns.push(childRun)
+
+    this.paragraphChildRunsByAnchor.set(anchor, tasks)
+    observer.observe(anchor)
+  }
+
+  private collectParagraphChildRunTargets(
+    element: HTMLElement,
+    inlineParagraphs: HTMLElement[],
+    fallbackBlockAnchor: HTMLElement,
+  ): Array<{ anchor: HTMLElement; childRun: ChildNode[]; paragraphs: HTMLElement[] }> {
+    const targets: Array<{
+      anchor: HTMLElement
+      childRun: ChildNode[]
+      paragraphs: HTMLElement[]
+    }> = []
+    const inlineParagraphsByDirectChild = new Map<ChildNode, HTMLElement[]>()
+    for (const paragraph of inlineParagraphs) {
+      let directChild: Node = paragraph
+      while (directChild.parentNode && directChild.parentNode !== element) {
+        directChild = directChild.parentNode
+      }
+      if (directChild.parentNode !== element) continue
+      const directChildNode = directChild as ChildNode
+      const paragraphs = inlineParagraphsByDirectChild.get(directChildNode) ?? []
+      paragraphs.push(paragraph)
+      inlineParagraphsByDirectChild.set(directChildNode, paragraphs)
+    }
+
+    let childRun: ChildNode[] = []
+    let childRunParagraphs: HTMLElement[] = []
+    let previousBlockChild: HTMLElement | null = null
+
+    const flush = (nextBlockChild: HTMLElement | null) => {
+      if (childRun.length === 0) return
+      const hasDirectText = childRun.some(
+        (node) => node.nodeType === Node.TEXT_NODE && Boolean(node.textContent?.trim()),
+      )
+      if (childRunParagraphs.length > 0 || hasDirectText) {
+        targets.push({
+          anchor:
+            childRunParagraphs[0] ?? nextBlockChild ?? previousBlockChild ?? fallbackBlockAnchor,
+          childRun,
+          paragraphs: childRunParagraphs,
+        })
+      }
+      childRun = []
+      childRunParagraphs = []
+    }
+
+    for (const child of element.childNodes) {
+      if (isHTMLElement(child) && child.hasAttribute(BLOCK_ATTRIBUTE)) {
+        flush(child)
+        previousBlockChild = child
+      } else {
+        childRun.push(child)
+        childRunParagraphs.push(...(inlineParagraphsByDirectChild.get(child) ?? []))
+      }
+    }
+    flush(null)
+
+    return targets
+  }
+
   /**
    * Observe a paragraph as one lazy-translation unit — unless it is so tall
    * that its first intersection would expand into (nearly) the whole page at
    * once. docs.docker.com labels its entire flat 185k-px <article> as ONE
    * paragraph (inline <em> dates are direct children), which defeated
    * viewport gating and enqueued 5k+ paragraphs instantly (#1881). Giant
-   * paragraphs are split: their next-level block paragraph descendants in the
-   * same DOM root are observed individually instead. Inline paragraph
-   * descendants stay attached to the parent unit because direct sibling text
-   * may contain most of the translatable content (for example, SillyTavern
-   * narration around <q> tags; #1951). Paragraphs in nested shadow roots are
-   * always independent units because translating a paragraph host does not
-   * traverse its shadow root.
-   *
-   * Known tradeoff: direct inline children of a giant split across real block
-   * paragraphs (e.g. docs.docker.com date <em>s) are not covered by any
-   * observed unit and stay untranslated. Stray standalone inlines in a
-   * >3-viewport flat container are rare, and numeric-only text is skipped by
-   * the pipeline anyway.
+   * paragraphs are split at their next-level block paragraphs. Inline
+   * paragraphs become viewport anchors for their complete parent-owned child
+   * runs; text-only runs use an adjacent block boundary as their anchor. This
+   * preserves direct text without recursively translating the split block
+   * paragraphs (#1951). Paragraphs in nested shadow roots remain independent
+   * units because a paragraph translation never crosses a shadow boundary.
    */
   private observeParagraphUnit(element: HTMLElement, walkId: string, depth: number): void {
     const observer = this.intersectionObserver
@@ -655,28 +776,25 @@ export class PageTranslationManager implements IPageTranslationManager {
       depth >= GIANT_PARAGRAPH_MAX_SPLIT_DEPTH ||
       element.getBoundingClientRect().height <= maxUnitHeight
     ) {
-      observer.observe(element)
+      this.observeFullParagraphUnit(element)
       return
     }
 
     const paragraphs = this.collectParagraphElementsDeep(element, walkId)
     const elementRoot = element.getRootNode()
     const paragraphSelector = `[data-read-frog-paragraph][data-read-frog-walked="${CSS.escape(walkId)}"]`
-    const blockParagraphSelector = `${paragraphSelector}[${BLOCK_ATTRIBUTE}]`
 
-    const innerTopLevelBlockParagraphs = paragraphs.filter((paragraph) => {
-      if (
-        paragraph === element ||
-        paragraph.getRootNode() !== elementRoot ||
-        !paragraph.hasAttribute(BLOCK_ATTRIBUTE)
-      ) {
-        return false
-      }
-      const ancestor = paragraph.parentElement?.closest(blockParagraphSelector)
-      // Keep only block paragraphs whose nearest block-paragraph ancestor in
-      // this DOM root is the giant itself (or that have none).
+    const localTopLevelParagraphs = paragraphs.filter((paragraph) => {
+      if (paragraph === element || paragraph.getRootNode() !== elementRoot) return false
+      const ancestor = paragraph.parentElement?.closest(paragraphSelector)
       return !ancestor || ancestor === element
     })
+    const localBlockParagraphs = localTopLevelParagraphs.filter((paragraph) =>
+      paragraph.hasAttribute(BLOCK_ATTRIBUTE),
+    )
+    const localInlineParagraphs = localTopLevelParagraphs.filter(
+      (paragraph) => !paragraph.hasAttribute(BLOCK_ATTRIBUTE),
+    )
 
     const nestedRootTopLevelParagraphs = paragraphs.filter((paragraph) => {
       const paragraphRoot = paragraph.getRootNode()
@@ -688,13 +806,29 @@ export class PageTranslationManager implements IPageTranslationManager {
       return !ancestor || ancestor.getRootNode() !== paragraphRoot
     })
 
-    if (innerTopLevelBlockParagraphs.length === 0) {
+    if (localBlockParagraphs.length === 0) {
       // No same-root block split is available — observe the giant whole so its
       // direct text and inline descendants remain in one translation unit.
-      observer.observe(element)
+      this.observeFullParagraphUnit(element)
     } else {
-      for (const paragraph of innerTopLevelBlockParagraphs) {
+      const coveredInlineParagraphs = new Set<HTMLElement>()
+      for (const target of this.collectParagraphChildRunTargets(
+        element,
+        localInlineParagraphs,
+        localBlockParagraphs[0],
+      )) {
+        target.paragraphs.forEach((paragraph) => coveredInlineParagraphs.add(paragraph))
+        this.observeParagraphChildRun(element, target.anchor, target.childRun)
+      }
+      for (const paragraph of localBlockParagraphs) {
         this.observeParagraphUnit(paragraph, walkId, depth + 1)
+      }
+      // Defensive fallback for unusual invalid markup where a top-level inline
+      // paragraph is not reachable from a direct non-block child run.
+      for (const paragraph of localInlineParagraphs) {
+        if (!coveredInlineParagraphs.has(paragraph)) {
+          this.observeParagraphUnit(paragraph, walkId, depth + 1)
+        }
       }
     }
 

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -16,6 +16,7 @@ import {
 import { classifyProviderConfig, UNKNOWN_FEATURE_PROVIDER } from "@/utils/analytics-provider"
 import { getLocalConfig } from "@/utils/config/storage"
 import {
+  BLOCK_ATTRIBUTE,
   CONTENT_WRAPPER_CLASS,
   REACT_SHADOW_HOST_CLASS,
   SPINNER_CLASS,
@@ -629,13 +630,19 @@ export class PageTranslationManager implements IPageTranslationManager {
    * once. docs.docker.com labels its entire flat 185k-px <article> as ONE
    * paragraph (inline <em> dates are direct children), which defeated
    * viewport gating and enqueued 5k+ paragraphs instantly (#1881). Giant
-   * paragraphs are split: their next-level descendant paragraphs are observed
-   * individually instead.
+   * paragraphs are split: their next-level block paragraph descendants in the
+   * same DOM root are observed individually instead. Inline paragraph
+   * descendants stay attached to the parent unit because direct sibling text
+   * may contain most of the translatable content (for example, SillyTavern
+   * narration around <q> tags; #1951). Paragraphs in nested shadow roots are
+   * always independent units because translating a paragraph host does not
+   * traverse its shadow root.
    *
-   * Known tradeoff: direct inline children of a split giant (e.g. those date
-   * <em>s) are not covered by any observed unit and stay untranslated. Stray
-   * standalone inlines in a >3-viewport flat container are rare, and
-   * numeric-only text is skipped by the pipeline anyway.
+   * Known tradeoff: direct inline children of a giant split across real block
+   * paragraphs (e.g. docs.docker.com date <em>s) are not covered by any
+   * observed unit and stay untranslated. Stray standalone inlines in a
+   * >3-viewport flat container are rare, and numeric-only text is skipped by
+   * the pipeline anyway.
    */
   private observeParagraphUnit(element: HTMLElement, walkId: string, depth: number): void {
     const observer = this.intersectionObserver
@@ -652,22 +659,47 @@ export class PageTranslationManager implements IPageTranslationManager {
       return
     }
 
-    const innerTopLevelParagraphs = this.collectParagraphElementsDeep(element, walkId).filter(
-      (paragraph) => {
-        if (paragraph === element) return false
-        const ancestor = paragraph.parentElement?.closest("[data-read-frog-paragraph]")
-        // Keep only paragraphs whose nearest paragraph ancestor is the giant
-        // itself (or that have none inside it, e.g. across shadow roots).
-        return !ancestor || ancestor === element || !element.contains(ancestor)
-      },
-    )
-    if (innerTopLevelParagraphs.length === 0) {
-      // Unsplittable giant (no nested paragraphs) — observe it whole.
+    const paragraphs = this.collectParagraphElementsDeep(element, walkId)
+    const elementRoot = element.getRootNode()
+    const paragraphSelector = `[data-read-frog-paragraph][data-read-frog-walked="${CSS.escape(walkId)}"]`
+    const blockParagraphSelector = `${paragraphSelector}[${BLOCK_ATTRIBUTE}]`
+
+    const innerTopLevelBlockParagraphs = paragraphs.filter((paragraph) => {
+      if (
+        paragraph === element ||
+        paragraph.getRootNode() !== elementRoot ||
+        !paragraph.hasAttribute(BLOCK_ATTRIBUTE)
+      ) {
+        return false
+      }
+      const ancestor = paragraph.parentElement?.closest(blockParagraphSelector)
+      // Keep only block paragraphs whose nearest block-paragraph ancestor in
+      // this DOM root is the giant itself (or that have none).
+      return !ancestor || ancestor === element
+    })
+
+    const nestedRootTopLevelParagraphs = paragraphs.filter((paragraph) => {
+      const paragraphRoot = paragraph.getRootNode()
+      if (paragraph === element || paragraphRoot === elementRoot) return false
+      const ancestor = paragraph.parentElement?.closest(paragraphSelector)
+      // A paragraph translation never crosses a shadow boundary. Observe the
+      // top-level paragraph in every nested root independently; its normal
+      // translation walk will cover paragraph descendants in that same root.
+      return !ancestor || ancestor.getRootNode() !== paragraphRoot
+    })
+
+    if (innerTopLevelBlockParagraphs.length === 0) {
+      // No same-root block split is available — observe the giant whole so its
+      // direct text and inline descendants remain in one translation unit.
       observer.observe(element)
-      return
+    } else {
+      for (const paragraph of innerTopLevelBlockParagraphs) {
+        this.observeParagraphUnit(paragraph, walkId, depth + 1)
+      }
     }
-    for (const paragraph of innerTopLevelParagraphs) {
-      this.observeParagraphUnit(paragraph, walkId, depth + 1)
+
+    for (const paragraph of nestedRootTopLevelParagraphs) {
+      this.observeParagraphUnit(paragraph, walkId, 0)
     }
   }
 

--- a/src/utils/host/translate/core/__tests__/translation-walker-liveness.test.ts
+++ b/src/utils/host/translate/core/__tests__/translation-walker-liveness.test.ts
@@ -2,7 +2,13 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
-import { WALKED_ATTRIBUTE } from "@/utils/constants/dom-labels"
+import {
+  BLOCK_ATTRIBUTE,
+  CONTENT_WRAPPER_CLASS,
+  INLINE_ATTRIBUTE,
+  PARAGRAPH_ATTRIBUTE,
+  WALKED_ATTRIBUTE,
+} from "@/utils/constants/dom-labels"
 import { createWorkPacer } from "@/utils/scheduler"
 import { translateWalkedElement } from "../translation-walker"
 
@@ -23,13 +29,13 @@ vi.mock("../translation-state", () => ({
 function buildParagraphTree(childCount: number): HTMLElement {
   const container = document.createElement("div")
   container.setAttribute(WALKED_ATTRIBUTE, "walk-1")
-  container.setAttribute("data-read-frog-paragraph", "")
-  container.setAttribute("data-read-frog-block-node", "")
+  container.setAttribute(PARAGRAPH_ATTRIBUTE, "")
+  container.setAttribute(BLOCK_ATTRIBUTE, "")
   for (let i = 0; i < childCount; i++) {
     const p = document.createElement("p")
     p.setAttribute(WALKED_ATTRIBUTE, "walk-1")
-    p.setAttribute("data-read-frog-paragraph", "")
-    p.setAttribute("data-read-frog-block-node", "")
+    p.setAttribute(PARAGRAPH_ATTRIBUTE, "")
+    p.setAttribute(BLOCK_ATTRIBUTE, "")
     p.textContent = `paragraph ${i}`
     container.append(p)
   }
@@ -93,5 +99,51 @@ describe("translateWalkedElement liveness", () => {
     await translateWalkedElement(container, "walk-1", DEFAULT_CONFIG, false, pacer, () => true)
 
     expect(new Set(realTranslationTexts()).size).toBe(4)
+  })
+
+  it("translates only an explicit inline child run when a split block is already translated", async () => {
+    const container = document.createElement("p")
+    container.setAttribute(WALKED_ATTRIBUTE, "walk-1")
+    container.setAttribute(PARAGRAPH_ATTRIBUTE, "")
+    container.setAttribute(BLOCK_ATTRIBUTE, "")
+    const before = document.createTextNode("Narration before. ")
+    const dialogue = document.createElement("q")
+    dialogue.setAttribute(WALKED_ATTRIBUTE, "walk-1")
+    dialogue.setAttribute(PARAGRAPH_ATTRIBUTE, "")
+    dialogue.setAttribute(INLINE_ATTRIBUTE, "")
+    dialogue.textContent = '"Dialogue"'
+    const after = document.createTextNode(" Narration after.")
+    const block = document.createElement("p")
+    block.setAttribute(WALKED_ATTRIBUTE, "walk-1")
+    block.setAttribute(PARAGRAPH_ATTRIBUTE, "")
+    block.setAttribute(BLOCK_ATTRIBUTE, "")
+    block.textContent = "Block paragraph"
+    const existingTranslation = document.createElement("span")
+    existingTranslation.className = CONTENT_WRAPPER_CLASS
+    block.append(existingTranslation)
+    container.append(before, dialogue, after, block)
+    document.body.append(container)
+
+    const childRun = [before, dialogue, after]
+    await translateWalkedElement(
+      container,
+      "walk-1",
+      DEFAULT_CONFIG,
+      false,
+      createWorkPacer(),
+      () => true,
+      undefined,
+      { childRuns: [childRun] },
+    )
+
+    expect(mockTranslateNodes).toHaveBeenCalledTimes(1)
+    expect(mockTranslateNodes).toHaveBeenCalledWith(
+      childRun,
+      "walk-1",
+      false,
+      DEFAULT_CONFIG,
+      true,
+      undefined,
+    )
   })
 })

--- a/src/utils/host/translate/core/translation-walker.ts
+++ b/src/utils/host/translate/core/translation-walker.ts
@@ -20,6 +20,21 @@ import {
 import { translateNodes } from "./translation-modes"
 import { getTranslationOnlyAnchorState } from "./translation-state"
 
+export interface TranslateWalkedElementOptions {
+  /** Translate only these current direct-child runs; never recurse into block children. */
+  childRuns?: ChildNode[][]
+}
+
+function isCurrentChildRun(element: HTMLElement, childRun: ChildNode[]): boolean {
+  if (childRun.length === 0) return false
+  const currentChildren = [...element.childNodes]
+  const startIndex = currentChildren.indexOf(childRun[0])
+  return (
+    startIndex >= 0 &&
+    childRun.every((child, offset) => currentChildren[startIndex + offset] === child)
+  )
+}
+
 /**
  * Marker attributes can outlive their WeakMap state (extension reload on a
  * live tab). A ghost marker must not block walks forever — heal it and treat
@@ -51,6 +66,7 @@ export async function translateWalkedElement(
   // the user just cleared (#1881).
   shouldContinue: () => boolean = () => true,
   actionContext?: TranslationActionContext,
+  options: TranslateWalkedElementOptions = {},
 ): Promise<void> {
   // Self-pacing: a giant observed subtree (a flat article can label as ONE
   // huge paragraph unit, #1881) must not expand into thousands of wrapper
@@ -59,9 +75,11 @@ export async function translateWalkedElement(
   await pauseIfBudgetSpent(pacer)
   if (!shouldContinue()) return
 
-  // Translated regions are skipped on non-toggle walks. In-place-swapped
-  // paragraphs leave no wrapper, so also check the anchor marker attribute.
+  // Translated regions are skipped on ordinary non-toggle walks. Explicit
+  // child runs may coexist with independently translated block descendants,
+  // so descendant wrappers/anchors cannot suppress those parent-owned runs.
   if (
+    options.childRuns === undefined &&
     !toggle &&
     (element.querySelector(`.${CONTENT_WRAPPER_CLASS}`) || hasLiveTranslationOnlyAnchor(element))
   ) {
@@ -94,7 +112,21 @@ export async function translateWalkedElement(
     const computedStyle = window.getComputedStyle(element)
     const isFlexParent = computedStyle.display.includes("flex")
 
-    if (!hasBlockNodeChild) {
+    if (options.childRuns !== undefined) {
+      for (const childRun of options.childRuns) {
+        if (!isCurrentChildRun(element, childRun)) continue
+        promises.push(
+          translateNodes(
+            childRun,
+            walkId,
+            toggle,
+            config,
+            !isFlexParent && hasBlockLayoutChild,
+            actionContext,
+          ),
+        )
+      }
+    } else if (!hasBlockNodeChild) {
       promises.push(translateNodes([element], walkId, toggle, config, false, actionContext))
     } else {
       // prevent children change during iteration


### PR DESCRIPTION
1|> **AI model(s) used (required):** OpenAI GPT-5.6 (Codex); delegated independent review agents (model identifiers unavailable in run metadata)
2|
3|## Type of Changes
4|
5|- [ ] ✨ New feature (feat)
6|- [x] 🐛 Bug fix (fix)
7|- [ ] 📝 Documentation change (docs)
8|- [ ] 💄 UI/style change (style)
9|- [ ] ♻️ Code refactoring (refactor)
10|- [ ] ⚡ Performance improvement (perf)
11|- [x] ✅ Test related (test)
12|- [ ] 🔧 Build or dependencies update (build)
13|- [ ] 🔄 CI/CD related (ci)
14|- [ ] 🌐 Internationalization (i18n)
15|- [ ] 🧠 AI model related (ai)
16|- [ ] 🔄 Revert a previous commit (revert)
17|- [ ] 📦 Other changes that do not modify src or test files (chore)
18|
19|## Description
20|
21|Long SillyTavern messages can be labeled as one giant paragraph while quoted dialogue is represented by an inline `<q>` paragraph. The giant-paragraph optimization introduced for #1881 previously split on nested paragraphs in a way that could omit the surrounding narration in direct text nodes.
22|
23|This change:
24|
25|- keeps an inline-only giant paragraph as one translation unit;
26|- splits giant mixed-content paragraphs at same-root block paragraph boundaries while mapping each remaining parent-owned child run to a viewport-local inline or adjacent-block anchor;
27|- translates those exact child runs without recursively translating block descendants, avoiding both dropped narration and duplicate block translation;
28|- keeps #1881 viewport gating effective for giant flat pages instead of observing the whole giant host;
29|- observes top-level paragraphs inside nested shadow roots independently because translating a light-DOM host does not traverse its shadow root;
30|- adds regression coverage for prefix, interstitial, and suffix direct-text runs, mixed narration/dialogue/block content, block-first translation ordering, and nested-shadow-root content;
31|- adds a patch changeset for `@read-frog/extension`.
32|
33|## Related Issue
34|
35|Closes #1951
36|
37|## How Has This Been Tested?
38|
39|- [x] Added unit tests
40|- [ ] Verified through manual testing
41|
42|Validation completed locally with Node 24 and pnpm 11.13.1:
43|
44|- focused page-translation and translation-walker tests: 24/24 passed;
45|- full test suite with `SKIP_FREE_API=true`: 2110 passed, with the 4 free-API tests intentionally skipped;
46|- `pnpm type-check`: 0 warnings and 0 errors;
47|- `pnpm fmt:check`: passed;
48|- Chrome MV3 production build: passed with the repository-supported `WXT_SKIP_ENV_VALIDATION=true` test-build setting;
49|- Edge MV3 production build: passed with the same test-build setting.
50|
51|## Screenshots
52|
53|Not applicable; this is translation-target selection and traversal behavior covered by DOM-level regression tests.
54|
55|## Checklist
56|
57|- [x] I have tested these changes locally
58|- [x] I have updated the documentation accordingly if necessary
59|- [x] My code follows the code style of this project
60|- [x] My changes do not break existing functionality
61|- [x] If my code was generated by AI, I have proofread and improved it as necessary.
62|
63|## Additional Information
64|
65|Independent fail-closed review results will be reflected before the branch is updated.
66|