### PR TITLE
feat(options): add roadmap and feedback sidebar links

### DIFF
--- a/.changeset/tidy-frogs-share.md
+++ b/.changeset/tidy-frogs-share.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(options): add roadmap and feedback sidebar links

--- a/src/entrypoints/options/app-sidebar/index.tsx
+++ b/src/entrypoints/options/app-sidebar/index.tsx
@@ -12,6 +12,7 @@ import { UserAccountMenuSidebar } from "@/components/user-account-menu"
 import { i18n } from "@/utils/i18n"
 import { getCommandPaletteShortcutHint } from "@/utils/os"
 import { commandPaletteOpenAtom } from "../command-palette/atoms"
+import { ProductNav } from "./product-nav"
 import { SettingsNav } from "./settings-nav"
 import { ToolsNav } from "./tools-nav"
 import { WhatsNewFooter } from "./whats-new-footer"
@@ -41,6 +42,7 @@ export function AppSidebar() {
       <SidebarContent className="transition-all group-data-[state=expanded]:px-2">
         <SettingsNav />
         <ToolsNav />
+        <ProductNav />
       </SidebarContent>
       <SidebarFooter className="transition-all group-data-[state=expanded]:px-2">
         <WhatsNewFooter />

--- a/src/entrypoints/options/app-sidebar/product-nav.tsx
+++ b/src/entrypoints/options/app-sidebar/product-nav.tsx
@@ -1,0 +1,45 @@
+import { Icon } from "@iconify/react"
+import {
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/base-ui/sidebar"
+import { i18n } from "@/utils/i18n"
+
+const PRODUCT_LINKS = [
+  {
+    href: "https://feedback.readfrog.app/roadmap",
+    icon: "tabler:route",
+    labelKey: "options.product.roadmap",
+  },
+  {
+    href: "https://feedback.readfrog.app/",
+    icon: "tabler:message-circle",
+    labelKey: "options.product.feedback",
+  },
+] as const
+
+export function ProductNav() {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>{i18n.t("options.sidebar.product")}</SidebarGroupLabel>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {PRODUCT_LINKS.map(({ href, icon, labelKey }) => (
+            <SidebarMenuItem key={href}>
+              <SidebarMenuButton
+                render={<a href={href} target="_blank" rel="noopener noreferrer" />}
+              >
+                <Icon icon={icon} />
+                <span>{i18n.t(labelKey)}</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  )
+}

--- a/src/entrypoints/options/main.tsx
+++ b/src/entrypoints/options/main.tsx
@@ -6,7 +6,6 @@ import { Provider as JotaiProvider } from "jotai"
 import { useHydrateAtoms } from "jotai/utils"
 import * as React from "react"
 import { HashRouter } from "react-router"
-import { HelpButton } from "@/components/help-button"
 import { ThemeProvider } from "@/components/providers/theme-provider"
 import { RecoveryBoundary } from "@/components/recovery/recovery-boundary"
 import { SidebarProvider } from "@/components/ui/base-ui/sidebar"
@@ -71,7 +70,6 @@ async function initApp() {
                           <RecoveryBoundary>
                             <AppSidebar />
                             <App />
-                            <HelpButton />
                             <SettingsSearch />
                           </RecoveryBoundary>
                         </AnchoredToastProvider>

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -90,6 +90,9 @@ options:
     product: Product
   tools:
     translationHub: Translation Hub
+  product:
+    roadmap: Roadmap
+    feedback: Feedback
   setAPIKeyWarning:
     please: Please set API Key on
     page: page

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -90,6 +90,9 @@ options:
     product: Producto
   tools:
     translationHub: Centro de traducción
+  product:
+    roadmap: Hoja de ruta
+    feedback: Comentarios
   setAPIKeyWarning:
     please: Configura la clave API en
     page: página

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -90,6 +90,9 @@ options:
     product: 製品
   tools:
     translationHub: 翻訳ハブ
+  product:
+    roadmap: ロードマップ
+    feedback: フィードバック
   setAPIKeyWarning:
     please: 設定ページで
     page: APIキーを設定してください

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -90,6 +90,9 @@ options:
     product: 제품
   tools:
     translationHub: 번역 허브
+  product:
+    roadmap: 로드맵
+    feedback: 피드백
   setAPIKeyWarning:
     please: API Key를 설정해 주세요
     page: 페이지에서

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -90,6 +90,9 @@ options:
     product: Продукт
   tools:
     translationHub: Центр переводов
+  product:
+    roadmap: Дорожная карта
+    feedback: Обратная связь
   setAPIKeyWarning:
     please: Пожалуйста, установите API-ключ на странице
     page: настроек

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -90,6 +90,9 @@ options:
     product: Ürün
   tools:
     translationHub: Çeviri Merkezi
+  product:
+    roadmap: Yol Haritası
+    feedback: Geri Bildirim
   setAPIKeyWarning:
     please: Lütfen API Anahtarını
     page: sayfasında ayarlayın

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -90,6 +90,9 @@ options:
     product: Sản phẩm
   tools:
     translationHub: Trung tâm Dịch thuật
+  product:
+    roadmap: Lộ trình
+    feedback: Phản hồi
   setAPIKeyWarning:
     please: Vui lòng đặt API Key trên trang
     page: cài đặt

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -90,6 +90,9 @@ options:
     product: 产品
   tools:
     translationHub: 翻译中心
+  product:
+    roadmap: 路线图
+    feedback: 反馈
   setAPIKeyWarning:
     please: 请在
     page: 页设置 API Key

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -90,6 +90,9 @@ options:
     product: 產品
   tools:
     translationHub: 翻譯中心
+  product:
+    roadmap: 產品路線圖
+    feedback: 意見回饋
   setAPIKeyWarning:
     please: 請在
     page: 頁面設定 API 金鑰


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-5

## Type of Changes

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

- Add Roadmap and Feedback external links under the Options sidebar Product group.
- Localize both labels across all nine supported UI languages.
- Remove the redundant floating help button from the Options page while leaving the Translation Hub button unchanged.
- Add a patch changeset for `@read-frog/extension`.

## Related Issue

None.

## How Has This Been Tested?

- [ ] Added unit tests
- [ ] Verified through manual testing
- [x] `pnpm type-check`
- [x] `pnpm build`
- [x] Pre-push formatting, lint, and full Vitest suite (218 files, 2110 tests)

No dedicated UI test was added for this presentation-only change.

## Screenshots

Not included.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The Roadmap and Feedback links open in a new tab with `noopener noreferrer`.