### PR TITLE
fix(translation-hub): wrap long provider error messages inside the card

### DIFF
--- a/.changeset/translation-hub-error-overflow.md
+++ b/.changeset/translation-hub-error-overflow.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation-hub): wrap long provider error messages so they stay inside the card

--- a/src/entrypoints/translation-hub/components/__tests__/translation-card.test.tsx
+++ b/src/entrypoints/translation-hub/components/__tests__/translation-card.test.tsx
@@ -20,13 +20,27 @@ const {
   selectedProviderIdsAtom: {},
 }))
 
-vi.mock("@tanstack/react-query", () => ({
-  useMutation: () => ({
+interface UseMutationMockShape {
+  data: string | undefined
+  isError: boolean
+  isPending: boolean
+  mutate: (request: unknown) => void
+  error: Error | undefined
+}
+
+const useMutationMock = vi.hoisted(() => {
+  const initial: UseMutationMockShape = {
     data: "Translated text",
     isError: false,
     isPending: false,
     mutate: vi.fn<(request: unknown) => void>(),
-  }),
+    error: undefined,
+  }
+  return { current: initial }
+})
+
+vi.mock("@tanstack/react-query", () => ({
+  useMutation: () => useMutationMock.current,
 }))
 
 vi.mock("jotai", () => ({
@@ -81,6 +95,13 @@ describe("TranslationCard copy feedback", () => {
       configurable: true,
       value: { writeText: clipboardWriteMock },
     })
+    useMutationMock.current = {
+      data: "Translated text",
+      isError: false,
+      isPending: false,
+      mutate: vi.fn<(request: unknown) => void>(),
+      error: undefined,
+    }
   })
 
   it("anchors provider-specific copy feedback to the copy button", () => {
@@ -102,5 +123,37 @@ describe("TranslationCard copy feedback", () => {
       positionerProps: { anchor: copyButton, sideOffset: 6 },
       title: "translationHub.copiedToClipboard",
     })
+  })
+})
+
+describe("TranslationCard error display", () => {
+  beforeEach(() => {
+    useMutationMock.current = {
+      data: undefined,
+      isError: true,
+      isPending: false,
+      mutate: vi.fn<(request: unknown) => void>(),
+      error: new Error(
+        "upstream_429_rate_limit_exceeded_for_provider_openai_completions_with_a_very_long_unbroken_token_stream_that_overflows_the_card_boundary",
+      ),
+    }
+  })
+
+  it("renders long unbroken error messages with overflow-wrap so they stay inside the card", () => {
+    render(
+      <TranslationCard
+        providerId="provider-1"
+        isExpanded
+        onExpandedChange={vi.fn<(expanded: boolean) => void>()}
+      />,
+    )
+
+    const errorParagraph = screen.getByText(
+      "upstream_429_rate_limit_exceeded_for_provider_openai_completions_with_a_very_long_unbroken_token_stream_that_overflows_the_card_boundary",
+    )
+    // break-words forces long unbreakable runs to wrap instead of overflowing
+    expect(errorParagraph.className).toContain("break-words")
+    // whitespace-pre-wrap preserves newlines in multi-line provider errors
+    expect(errorParagraph.className).toContain("whitespace-pre-wrap")
   })
 })

--- a/src/entrypoints/translation-hub/components/translation-card.tsx
+++ b/src/entrypoints/translation-hub/components/translation-card.tsx
@@ -216,7 +216,7 @@ export function TranslationCard({
                   {i18n.t("translationHub.translationFailed")}
                 </span>
               </div>
-              <p className="text-sm text-muted-foreground">
+              <p className="text-sm break-words whitespace-pre-wrap text-muted-foreground">
                 {mutation.error instanceof Error
                   ? mutation.error.message
                   : i18n.t("translationHub.translationFailedFallback")}


### PR DESCRIPTION
> **AI model(s) used (required):** GLM-5.2 High (Cognition Devin CLI)

## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

In the Translation Hub, when an API provider returns an error, the error message could overflow the card boundary. Long unbreakable strings (e.g. rate-limit responses with underscore-joined tokens, or full HTTP response bodies some providers return) had no wrap handling, so they spilled outside the card.

The error `<p>` in `TranslationCard` only had `text-sm text-muted-foreground` — no `break-words`, no `whitespace-pre-wrap`. This adds both so:
- long unbreakable runs wrap at the card edge (`break-words`)
- multi-line provider errors preserve their newlines (`whitespace-pre-wrap`)

## Related Issue

Closes #1746

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Added a regression test (`TranslationCard error display`) that renders a long unbreakable error string and asserts the error `<p>` has `break-words` and `whitespace-pre-wrap` classes.

## Screenshots

Before:
<img width="2784" height="1360" alt="image" src="https://github.com/user-attachments/assets/e7407be8-4f88-4b8e-a4cf-c34f79021e48" />
After:
<img width="1863" height="880" alt="image" src="https://github.com/user-attachments/assets/dcdaf2f8-2e3d-4c8d-8afa-38edff3b13fc" />

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- `pnpm type-check` and `pnpm lint` pass clean.
- `pnpm test src/entrypoints/translation-hub/components/__tests__/translation-card.test.tsx` passes (2/2).
- The pre-push hook runs the full suite without `SKIP_FREE_API=true`; 6 pre-existing failures are unrelated to this change (2 are Microsoft free-API 429 rate-limit tests that AGENTS.md notes should be skipped via `SKIP_FREE_API=true`, 4 are 5000ms timeouts on flaky tests: `context-menu`, `config v051`, `crypto.randomUUID`, `translator`). The changed file's tests pass.
- Added a `.changeset/translation-hub-error-overflow.md` (patch) per AGENTS.md.