### PR TITLE
feat(config): default new installs to Google Translate when reachable

### DIFF
--- a/.changeset/olive-frogs-listen.md
+++ b/.changeset/olive-frogs-listen.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(config): default new installs to Google Translate when it is reachable

--- a/src/entrypoints/background/config.ts
+++ b/src/entrypoints/background/config.ts
@@ -1,9 +1,10 @@
 import type { Config } from "@/types/config/config"
+import type { InitializeConfigResult } from "@/utils/config/init"
 import { storage } from "#imports"
 import { initializeConfig } from "@/utils/config/init"
 import { CONFIG_STORAGE_KEY } from "@/utils/constants/config"
 
-let configPromise: Promise<void> | null = null
+let configPromise: Promise<InitializeConfigResult> | null = null
 
 // To avoid background script initialize config simultaneously and avoid race condition
 export async function ensureInitializedConfig() {
@@ -12,4 +13,15 @@ export async function ensureInitializedConfig() {
   }
   await configPromise
   return storage.getItem<Config>(`local:${CONFIG_STORAGE_KEY}`)
+}
+
+/**
+ * Whether the config was created from defaults in this run, rather than loaded from storage.
+ * Shares the memoized initialization above, so it never triggers a second init.
+ */
+export async function isFreshInstalledConfig() {
+  if (!configPromise) {
+    configPromise = initializeConfig()
+  }
+  return (await configPromise).isFreshInstall
 }

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -3,6 +3,7 @@ import type { Config, UiLanguage } from "@/types/config/config"
 import { browser, defineBackground } from "#imports"
 import { env } from "@/env"
 import { storageAdapter } from "@/utils/atoms/storage-adapter"
+import { promoteGoogleTranslateDefaultIfReachable } from "@/utils/config/default-translate-provider"
 import { CONFIG_STORAGE_KEY } from "@/utils/constants/config"
 import { initI18n, setUiLanguage } from "@/utils/i18n"
 import { logger } from "@/utils/logger"
@@ -17,7 +18,7 @@ import {
 } from "./analytics"
 import { dispatchBackgroundStreamPort } from "./background-stream"
 import { initializeActionIcons, registerActionIconListeners } from "./browser-action-icon"
-import { ensureInitializedConfig } from "./config"
+import { ensureInitializedConfig, isFreshInstalledConfig } from "./config"
 import { setUpConfigBackup } from "./config-backup"
 import { initializeContextMenu, registerContextMenuListeners } from "./context-menu"
 import {
@@ -53,6 +54,15 @@ export default defineBackground({
         await browser.tabs.create({
           url: `${env.WXT_WEBSITE_URL}/guide/step-1`,
         })
+
+        // Deliberately last: probing Google Translate can hang for seconds on networks that
+        // block it, and nothing above should wait for that. Awaiting inside the listener
+        // keeps the service worker alive until the probe settles. Guarded by the config
+        // actually being new, because reloading an unpacked extension also reports
+        // "install" while the developer's own provider choice is still in storage.
+        if (await isFreshInstalledConfig()) {
+          await promoteGoogleTranslateDefaultIfReachable()
+        }
       }
 
       // Clear blog cache on extension update to fetch latest blog posts

--- a/src/utils/config/__tests__/default-translate-provider.test.ts
+++ b/src/utils/config/__tests__/default-translate-provider.test.ts
@@ -1,0 +1,114 @@
+import type { Config } from "@/types/config/config"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import {
+  GOOGLE_TRANSLATE_PROVIDER_ID,
+  MICROSOFT_TRANSLATE_PROVIDER_ID,
+} from "@/utils/constants/providers"
+
+const isGoogleTranslateReachableMock = vi.fn<(...args: any[]) => any>()
+const getLocalConfigMock = vi.fn<(...args: any[]) => any>()
+const setLocalConfigMock = vi.fn<(...args: any[]) => any>()
+
+vi.mock("@/utils/host/translate/api/google", () => ({
+  isGoogleTranslateReachable: isGoogleTranslateReachableMock,
+}))
+
+vi.mock("../storage", () => ({
+  getLocalConfig: getLocalConfigMock,
+  setLocalConfig: setLocalConfigMock,
+}))
+
+function translateProviderIdsOf(config: Config) {
+  return [
+    config.translate.providerId,
+    config.selectionToolbar.features.translate.providerId,
+    config.inputTranslation.providerId,
+    config.videoSubtitles.providerId,
+  ]
+}
+
+async function promote() {
+  const { promoteGoogleTranslateDefaultIfReachable } = await import("../default-translate-provider")
+  await promoteGoogleTranslateDefaultIfReachable()
+}
+
+describe("promoteGoogleTranslateDefaultIfReachable", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    getLocalConfigMock.mockResolvedValue(structuredClone(DEFAULT_CONFIG))
+    setLocalConfigMock.mockResolvedValue(undefined)
+  })
+
+  it("promotes Google Translate on every translate feature when the probe reaches it", async () => {
+    isGoogleTranslateReachableMock.mockResolvedValue(true)
+
+    await promote()
+
+    expect(setLocalConfigMock).toHaveBeenCalledTimes(1)
+    const written = setLocalConfigMock.mock.calls[0]?.[0] as Config
+    expect(translateProviderIdsOf(written)).toEqual([
+      GOOGLE_TRANSLATE_PROVIDER_ID,
+      GOOGLE_TRANSLATE_PROVIDER_ID,
+      GOOGLE_TRANSLATE_PROVIDER_ID,
+      GOOGLE_TRANSLATE_PROVIDER_ID,
+    ])
+  })
+
+  it("leaves the config untouched when Google Translate is unreachable", async () => {
+    isGoogleTranslateReachableMock.mockResolvedValue(false)
+
+    await promote()
+
+    expect(getLocalConfigMock).not.toHaveBeenCalled()
+    expect(setLocalConfigMock).not.toHaveBeenCalled()
+  })
+
+  it("keeps a provider the user already chose and only fills the untouched slots", async () => {
+    isGoogleTranslateReachableMock.mockResolvedValue(true)
+    const config = structuredClone(DEFAULT_CONFIG)
+    config.translate.providerId = "openai-default"
+    getLocalConfigMock.mockResolvedValue(config)
+
+    await promote()
+
+    const written = setLocalConfigMock.mock.calls[0]?.[0] as Config
+    expect(translateProviderIdsOf(written)).toEqual([
+      "openai-default",
+      GOOGLE_TRANSLATE_PROVIDER_ID,
+      GOOGLE_TRANSLATE_PROVIDER_ID,
+      GOOGLE_TRANSLATE_PROVIDER_ID,
+    ])
+  })
+
+  it("does not write when no feature is on the Microsoft default any more", async () => {
+    isGoogleTranslateReachableMock.mockResolvedValue(true)
+    const config = structuredClone(DEFAULT_CONFIG)
+    config.translate.providerId = "openai-default"
+    config.selectionToolbar.features.translate.providerId = "openai-default"
+    config.inputTranslation.providerId = "openai-default"
+    config.videoSubtitles.providerId = "openai-default"
+    getLocalConfigMock.mockResolvedValue(config)
+
+    await promote()
+
+    expect(setLocalConfigMock).not.toHaveBeenCalled()
+  })
+
+  it("preserves the rest of the config", async () => {
+    isGoogleTranslateReachableMock.mockResolvedValue(true)
+    const config = structuredClone(DEFAULT_CONFIG)
+    config.language.targetCode = "jpn"
+    config.translate.page.autoTranslatePatterns = ["example.com"]
+    getLocalConfigMock.mockResolvedValue(config)
+
+    await promote()
+
+    const written = setLocalConfigMock.mock.calls[0]?.[0] as Config
+    expect(written.language.targetCode).toBe("jpn")
+    expect(written.translate.page.autoTranslatePatterns).toEqual(["example.com"])
+    expect(written.translate.mode).toBe(DEFAULT_CONFIG.translate.mode)
+    expect(MICROSOFT_TRANSLATE_PROVIDER_ID).not.toBe(written.translate.providerId)
+  })
+})

--- a/src/utils/config/__tests__/init.test.ts
+++ b/src/utils/config/__tests__/init.test.ts
@@ -2,6 +2,7 @@ import type { Config } from "@/types/config/config"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { isAPIProviderConfig } from "@/types/config/provider"
 import { CONFIG_SCHEMA_VERSION, DEFAULT_CONFIG } from "@/utils/constants/config"
+import { MICROSOFT_TRANSLATE_PROVIDER_ID } from "@/utils/constants/providers"
 
 const getItemMock = vi.fn<(...args: any[]) => any>()
 const getMetaMock = vi.fn<(...args: any[]) => any>()
@@ -70,6 +71,15 @@ describe("initializeConfig", () => {
     runMigrationMock.mockImplementation(async (_nextVersion: number, config: Config) => config)
   })
 
+  function translateProviderIdsOf(config: Config) {
+    return [
+      config.translate.providerId,
+      config.selectionToolbar.features.translate.providerId,
+      config.inputTranslation.providerId,
+      config.videoSubtitles.providerId,
+    ]
+  }
+
   it("does not write when config and meta are already up to date", async () => {
     const config = buildStableConfig()
     getItemMock.mockResolvedValueOnce(config)
@@ -109,6 +119,50 @@ describe("initializeConfig", () => {
         lastModifiedAt: expect.any(Number),
       }),
     )
+  })
+
+  it("starts every translate feature on the globally reachable Microsoft default", async () => {
+    getItemMock.mockResolvedValueOnce(null)
+    getMetaMock.mockResolvedValueOnce(null)
+
+    const { initializeConfig } = await import("../init")
+    const { isFreshInstall } = await initializeConfig()
+
+    expect(isFreshInstall).toBe(true)
+    const freshConfig = setItemMock.mock.calls[0]?.[1] as Config
+    expect(translateProviderIdsOf(freshConfig)).toEqual([
+      MICROSOFT_TRANSLATE_PROVIDER_ID,
+      MICROSOFT_TRANSLATE_PROVIDER_ID,
+      MICROSOFT_TRANSLATE_PROVIDER_ID,
+      MICROSOFT_TRANSLATE_PROVIDER_ID,
+    ])
+  })
+
+  it("does not report a fresh install when a stored config is reused", async () => {
+    const config = buildStableConfig()
+    getItemMock.mockResolvedValueOnce(config)
+    getMetaMock.mockResolvedValueOnce({
+      schemaVersion: CONFIG_SCHEMA_VERSION,
+      lastModifiedAt: 123,
+    })
+
+    const { initializeConfig } = await import("../init")
+    const { isFreshInstall } = await initializeConfig()
+
+    expect(isFreshInstall).toBe(false)
+  })
+
+  it("reports a fresh install when an unparseable config is rebuilt", async () => {
+    getItemMock.mockResolvedValueOnce({ not: "a config" })
+    getMetaMock.mockResolvedValueOnce({
+      schemaVersion: CONFIG_SCHEMA_VERSION,
+      lastModifiedAt: 123,
+    })
+
+    const { initializeConfig } = await import("../init")
+    const { isFreshInstall } = await initializeConfig()
+
+    expect(isFreshInstall).toBe(true)
   })
 
   it("runs migration and persists migrated config once", async () => {

--- a/src/utils/config/default-translate-provider.ts
+++ b/src/utils/config/default-translate-provider.ts
@@ -1,0 +1,63 @@
+import type { Config } from "@/types/config/config"
+import type { FeatureKey } from "@/utils/constants/feature-providers"
+import { mergeWithArrayOverwrite } from "@/utils/atoms/config"
+import {
+  buildFeatureProviderPatch,
+  FEATURE_KEYS,
+  FEATURE_PROVIDER_DEFS,
+} from "@/utils/constants/feature-providers"
+import {
+  GOOGLE_TRANSLATE_PROVIDER_ID,
+  MICROSOFT_TRANSLATE_PROVIDER_ID,
+} from "@/utils/constants/providers"
+import { isGoogleTranslateReachable } from "@/utils/host/translate/api/google"
+import { logger } from "@/utils/logger"
+import { getLocalConfig, setLocalConfig } from "./storage"
+
+/**
+ * Move a fresh install onto Google Translate when this network can actually reach it.
+ *
+ * A fresh config ships with Microsoft Translate because it works everywhere, including the
+ * networks where Google is blocked — that keeps install itself off the network, so the first
+ * config write and the guide tab never wait on a probe that, on a blocked network, does not
+ * fail fast but simply hangs. Google is the better default where it works, so once the user
+ * is set up we probe the real endpoint and promote it.
+ *
+ * Only slots still holding the Microsoft default are rewritten, so a user who picked a
+ * provider before the probe answered keeps their choice, and a Microsoft-by-choice install is
+ * never revisited (the caller runs this only for a config that was just created).
+ */
+export async function promoteGoogleTranslateDefaultIfReachable(): Promise<void> {
+  if (!(await isGoogleTranslateReachable())) {
+    logger.info("[Config] Google Translate unreachable, keeping the Microsoft Translate default")
+    return
+  }
+
+  const config = await getLocalConfig()
+  if (!config) {
+    return
+  }
+
+  const assignments = collectDefaultTranslateFeatures(config)
+  if (Object.keys(assignments).length === 0) {
+    return
+  }
+
+  await setLocalConfig(mergeWithArrayOverwrite(config, buildFeatureProviderPatch(assignments)))
+  logger.info("[Config] Google Translate reachable, promoted it to the default translate provider")
+}
+
+/** Translate features still pointing at the Microsoft default, mapped to the Google default. */
+function collectDefaultTranslateFeatures(config: Config): Partial<Record<FeatureKey, string>> {
+  const assignments: Partial<Record<FeatureKey, string>> = {}
+
+  for (const featureKey of FEATURE_KEYS) {
+    if (
+      FEATURE_PROVIDER_DEFS[featureKey].getProviderId(config) === MICROSOFT_TRANSLATE_PROVIDER_ID
+    ) {
+      assignments[featureKey] = GOOGLE_TRANSLATE_PROVIDER_ID
+    }
+  }
+
+  return assignments
+}

--- a/src/utils/config/init.ts
+++ b/src/utils/config/init.ts
@@ -13,11 +13,20 @@ import {
 import { logger } from "../logger"
 import { runMigration } from "./migration"
 
+export interface InitializeConfigResult {
+  /**
+   * The config was built from defaults in this run — a first install, or a rebuild after an
+   * unparseable config. Callers use it to run one-time setup that only makes sense on top of
+   * untouched defaults (see `promoteGoogleTranslateDefaultIfReachable`).
+   */
+  isFreshInstall: boolean
+}
+
 /**
  * Initialize the config, this function should only be called once in the background script
  * @returns The extension config
  */
-export async function initializeConfig() {
+export async function initializeConfig(): Promise<InitializeConfigResult> {
   const [storedConfig, configMeta] = await Promise.all([
     storage.getItem<Config>(`local:${CONFIG_STORAGE_KEY}`),
     storage.getMeta<ConfigMeta>(`local:${CONFIG_STORAGE_KEY}`),
@@ -26,6 +35,7 @@ export async function initializeConfig() {
   let config: Config
   let currentVersion: number
   let didConfigChange = false
+  let isFreshInstall = false
 
   if (!storedConfig) {
     // Fresh install: resolve the default custom-action strings in the browser locale
@@ -34,6 +44,7 @@ export async function initializeConfig() {
     config = buildFreshDefaultConfig()
     currentVersion = CONFIG_SCHEMA_VERSION
     didConfigChange = true
+    isFreshInstall = true
   } else {
     config = storedConfig
     currentVersion = configMeta?.schemaVersion ?? 1
@@ -57,6 +68,7 @@ export async function initializeConfig() {
     config = buildFreshDefaultConfig()
     currentVersion = CONFIG_SCHEMA_VERSION
     didConfigChange = true
+    isFreshInstall = true
   }
 
   if (import.meta.env.DEV) {
@@ -82,6 +94,8 @@ export async function initializeConfig() {
       lastModifiedAt: configMeta?.lastModifiedAt ?? Date.now(),
     })
   }
+
+  return { isFreshInstall }
 }
 
 function applyAPIKeysFromEnv(config: Config): { config: Config; changed: boolean } {

--- a/src/utils/constants/config.ts
+++ b/src/utils/constants/config.ts
@@ -5,7 +5,11 @@ import type { PageTranslateRange } from "@/types/config/translate"
 import { BUILT_IN_AI_PROVIDER_ID } from "@/utils/providers/provider-registry"
 import { CUSTOM_ACTION_TEMPLATES } from "./custom-action-templates"
 import { DEFAULT_TRANSLATE_PROMPTS_CONFIG } from "./prompt"
-import { buildDefaultProviderConfigList, DEFAULT_PROVIDER_CONFIG_LIST } from "./providers"
+import {
+  buildDefaultProviderConfigList,
+  DEFAULT_PROVIDER_CONFIG_LIST,
+  MICROSOFT_TRANSLATE_PROVIDER_ID,
+} from "./providers"
 import { DEFAULT_SELECTION_OVERLAY_OPACITY } from "./selection"
 import { DEFAULT_SIDE_CONTENT_WIDTH } from "./side"
 import {
@@ -88,7 +92,7 @@ export const DEFAULT_CONFIG: Config = {
   },
   providersConfig: DEFAULT_PROVIDER_CONFIG_LIST,
   translate: {
-    providerId: "microsoft-translate-default",
+    providerId: MICROSOFT_TRANSLATE_PROVIDER_ID,
     mode: "bilingual",
     modeShortcut: DEFAULT_TRANSLATION_MODE_SHORTCUT_KEY,
     node: {
@@ -145,7 +149,7 @@ export const DEFAULT_CONFIG: Config = {
     features: {
       translate: {
         enabled: true,
-        providerId: "microsoft-translate-default",
+        providerId: MICROSOFT_TRANSLATE_PROVIDER_ID,
         shortcut: DEFAULT_SELECTION_TRANSLATION_SHORTCUT_KEY,
       },
       speak: {
@@ -168,7 +172,7 @@ export const DEFAULT_CONFIG: Config = {
   },
   inputTranslation: {
     enabled: true,
-    providerId: "microsoft-translate-default",
+    providerId: MICROSOFT_TRANSLATE_PROVIDER_ID,
     fromLang: "targetCode",
     toLang: "sourceCode",
     enableCycle: false,
@@ -177,7 +181,7 @@ export const DEFAULT_CONFIG: Config = {
   videoSubtitles: {
     enabled: true,
     autoStart: false,
-    providerId: "microsoft-translate-default",
+    providerId: MICROSOFT_TRANSLATE_PROVIDER_ID,
     style: {
       displayMode: DEFAULT_DISPLAY_MODE,
       translationPosition: DEFAULT_TRANSLATION_POSITION,
@@ -224,6 +228,10 @@ export const DEFAULT_CONFIG: Config = {
 /**
  * Build a default config whose persisted custom-action strings use the initialized UI locale.
  * Callers must initialize i18n before calling this function.
+ *
+ * Translate features start on Microsoft Translate, which is reachable everywhere; a fresh
+ * install is moved onto Google Translate afterwards where that endpoint answers — see
+ * `promoteGoogleTranslateDefaultIfReachable`.
  */
 export function buildFreshDefaultConfig(): Config {
   return {

--- a/src/utils/constants/providers.ts
+++ b/src/utils/constants/providers.ts
@@ -586,6 +586,9 @@ export const DEFAULT_PROVIDER_CONFIG = {
   },
 } as const satisfies Record<AllProviderTypes, ProviderConfig>
 
+export const GOOGLE_TRANSLATE_PROVIDER_ID = DEFAULT_PROVIDER_CONFIG["google-translate"].id
+export const MICROSOFT_TRANSLATE_PROVIDER_ID = DEFAULT_PROVIDER_CONFIG["microsoft-translate"].id
+
 export const PROVIDER_BASE_URL_PLACEHOLDERS: Partial<Record<APIProviderTypes, string>> = {
   atlascloud: DEFAULT_PROVIDER_CONFIG.atlascloud.baseURL,
   siliconflow: DEFAULT_PROVIDER_CONFIG.siliconflow.baseURL,

--- a/src/utils/host/translate/api/__tests__/google-reachability.test.ts
+++ b/src/utils/host/translate/api/__tests__/google-reachability.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { isGoogleTranslateReachable } from "../google"
+
+const fetchMock = vi.fn<(...args: any[]) => any>()
+
+function okResponse(translated: string) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: vi.fn<(...args: any[]) => any>().mockResolvedValue([[translated]]),
+    text: vi.fn<(...args: any[]) => any>().mockResolvedValue(""),
+  })
+}
+
+describe("isGoogleTranslateReachable", () => {
+  beforeEach(() => {
+    fetchMock.mockReset()
+    vi.stubGlobal("fetch", fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("reports reachable when the endpoint returns a translation", async () => {
+    fetchMock.mockImplementation(() => okResponse("你好"))
+
+    await expect(isGoogleTranslateReachable()).resolves.toBe(true)
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("translate-pa.googleapis.com")
+  })
+
+  it("reports unreachable when the request fails at the network layer", async () => {
+    fetchMock.mockRejectedValue(new Error("Failed to fetch"))
+
+    await expect(isGoogleTranslateReachable()).resolves.toBe(false)
+  })
+
+  it("reports unreachable when the endpoint answers with an error status", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      statusText: "Forbidden",
+      text: vi.fn<(...args: any[]) => any>().mockResolvedValue("blocked"),
+    })
+
+    await expect(isGoogleTranslateReachable()).resolves.toBe(false)
+  })
+
+  it("reports unreachable when the request hangs past the timeout", async () => {
+    // The blocked-network case: no response, no error, just silence until we give up.
+    fetchMock.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () =>
+            reject(new Error("The operation was aborted")),
+          )
+        }),
+    )
+
+    await expect(isGoogleTranslateReachable({ timeoutMs: 10 })).resolves.toBe(false)
+  })
+
+  it("reports unreachable when the response shape is not a translation", async () => {
+    fetchMock.mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: vi.fn<(...args: any[]) => any>().mockResolvedValue({ error: "unexpected" }),
+        text: vi.fn<(...args: any[]) => any>().mockResolvedValue(""),
+      }),
+    )
+
+    await expect(isGoogleTranslateReachable()).resolves.toBe(false)
+  })
+})

--- a/src/utils/host/translate/api/google.ts
+++ b/src/utils/host/translate/api/google.ts
@@ -2,9 +2,42 @@ import type { TranslationTextFormat } from "@/types/config/translate"
 import { escapeText } from "entities"
 import { attachRequestErrorMeta } from "@/utils/request/retry-policy"
 
+/**
+ * Upper bound for the install-time reachability probe. Where Google is blocked the request
+ * usually hangs instead of failing fast, so this is the delay users in those networks pay
+ * once; keep it short enough not to stall extension startup.
+ */
+const GOOGLE_TRANSLATE_PROBE_TIMEOUT_MS = 3000
+
 const GOOGLE_TRANSLATE_HTML_URL = "https://translate-pa.googleapis.com/v1/translateHtml"
 const GOOGLE_TRANSLATE_HTML_API_KEY = "AIzaSyATBXajvzQLTDHEQbcpq0Ihe0vWDHmO520"
 const GOOGLE_TRANSLATE_HTML_CLIENT = "wt_lib"
+
+/**
+ * Probe whether this network can actually reach Google Translate, by running the smallest
+ * possible real translation against the same endpoint the provider uses. Any failure —
+ * DNS, TLS, timeout, non-2xx, unexpected payload — answers `false`; the caller is expected
+ * to fall back to a provider that works everywhere.
+ *
+ * To exercise the blocked-network path locally, add one of these to `chromiumArgs` in
+ * `web-ext.config.ts` (`pnpm dev` uses a fresh profile per run, so every start is an install):
+ *   --host-resolver-rules=MAP translate-pa.googleapis.com ^NOTFOUND   → DNS fails fast
+ *   --host-resolver-rules=MAP translate-pa.googleapis.com 203.0.113.1 → dropped, times out
+ */
+export async function isGoogleTranslateReachable(options?: {
+  timeoutMs?: number
+}): Promise<boolean> {
+  const timeoutMs = options?.timeoutMs ?? GOOGLE_TRANSLATE_PROBE_TIMEOUT_MS
+
+  try {
+    const translated = await googleTranslate("hello", "en", "zh", {
+      signal: AbortSignal.timeout(timeoutMs),
+    })
+    return translated.trim().length > 0
+  } catch {
+    return false
+  }
+}
 
 export async function googleTranslate(
   sourceText: string,


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 5 (Claude Code)

## Type of Changes

- [x] ✨ New feature (feat)

## Description

New installs now start on Google Translate where that endpoint is actually reachable, and stay on Microsoft Translate where it is not.

The default config still ships with `microsoft-translate-default` in all four translate slots (page translation, selection toolbar, input translation, video subtitles), because it is reachable everywhere. Right after the install flow finishes, the background service worker probes the real Google endpoint once and promotes Google when it answers.

**Why the probe runs after install rather than before the first config write:** on networks that block Google, the request does not fail fast — it hangs. Probing inside `initializeConfig()` would stall the first config write and, with it, the guide tab. So `initializeConfig()` stays entirely off the network and now reports `{ isFreshInstall }`; the `onInstalled` listener opens the guide tab first and only then awaits the probe (awaiting inside the listener keeps the MV3 service worker alive until it settles).

Two guards:

- Only slots still holding the Microsoft default are rewritten, so a provider the user picked while the probe was in flight is preserved.
- The promotion is gated on the config actually being new, not just on `details.reason === "install"` — reloading an unpacked extension also reports `install` while the developer's own provider choice is still in storage.

Any probe failure (DNS, TLS, 3s timeout, non-2xx, unexpected payload) is treated as unreachable, so a false negative on a slow network simply leaves the previous default in place.

### Changes

| File | Change |
| --- | --- |
| `src/utils/host/translate/api/google.ts` | `isGoogleTranslateReachable()` — smallest possible real translation against the same endpoint the provider uses, 3s timeout |
| `src/utils/config/default-translate-provider.ts` | `promoteGoogleTranslateDefaultIfReachable()`, reusing the existing `FEATURE_PROVIDER_DEFS` / `buildFeatureProviderPatch` machinery |
| `src/utils/config/init.ts` | Returns `{ isFreshInstall }` (first install, and rebuild after an unparseable config); no other behavior change |
| `src/entrypoints/background/config.ts` | `isFreshInstalledConfig()`, sharing the memoized initialization |
| `src/entrypoints/background/index.ts` | Runs the promotion after the guide tab opens |
| `src/utils/constants/{config,providers}.ts` | Replaced the four hardcoded `"microsoft-translate-default"` literals with a `MICROSOFT_TRANSLATE_PROVIDER_ID` constant |

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

- `google-reachability.test.ts` — reachable, network error, non-2xx, hang past the timeout, unexpected response shape.
- `default-translate-provider.test.ts` — promotes all four slots, no write when unreachable, keeps a provider the user already chose, no write when nothing is on the Microsoft default, rest of the config preserved.
- `init.test.ts` — fresh install starts on Microsoft, stored config does not report a fresh install, unparseable config rebuild does.
- Full suite (2119 passed), `pnpm lint` (with type-check) and `wxt build` all pass.
- Sent one real request to the live endpoint to confirm the probe's call shape: 255ms, `[["你好"]]`.

To simulate a blocked network locally, add one of these to `chromiumArgs` in `web-ext.config.ts` (gitignored, so the recipe also lives in the `isGoogleTranslateReachable` doc comment):

```
--host-resolver-rules=MAP translate-pa.googleapis.com ^NOTFOUND   # DNS fails fast
--host-resolver-rules=MAP translate-pa.googleapis.com 203.0.113.1 # silently dropped, exercises the timeout
```

`pnpm dev` uses a fresh profile per run, so every start is a fresh install. Check the result in the service worker console:

```js
(await chrome.storage.local.get('config')).config.translate.providerId
```

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The probe was not exercised through a full in-browser install run — the repo has no puppeteer/playwright dependency and adding one for verification was out of scope. The `--host-resolver-rules` recipe above covers both branches manually.
