### PR TITLE
i18n(subtitles): show estimated time while AI subtitles load

### DIFF
--- a/.changeset/ai-subtitles-loading-estimate.md
+++ b/.changeset/ai-subtitles-loading-estimate.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+i18n(subtitles): show an estimated time (~3 min) while AI subtitles are loading

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1139,7 +1139,7 @@ thinking:
 shortcutKeySelector:
   placeholder: Please enter the shortcut
 subtitles:
-  loadingAiSubtitles: Loading AI subtitles…
+  loadingAiSubtitles: Loading AI subtitles… (estimated 3 min)
   requestAiSubtitles: Request AI subtitles (Beta)
   usingAiSubtitles: Using AI subtitles
   actions:

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -1139,7 +1139,7 @@ thinking:
 shortcutKeySelector:
   placeholder: Introduce el atajo
 subtitles:
-  loadingAiSubtitles: Cargando subtítulos con IA…
+  loadingAiSubtitles: Cargando subtítulos con IA… (estimado 3 min)
   requestAiSubtitles: Solicitar subtítulos con IA (Beta)
   usingAiSubtitles: Usando subtítulos con IA
   actions:

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -1024,7 +1024,7 @@ thinking:
 shortcutKeySelector:
   placeholder: ショートカットを入力してください
 subtitles:
-  loadingAiSubtitles: AI字幕を読み込み中…
+  loadingAiSubtitles: AI字幕を読み込み中…（推定3分）
   requestAiSubtitles: AI字幕をリクエスト（Beta）
   usingAiSubtitles: AI字幕を使用中
   actions:

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -1024,7 +1024,7 @@ thinking:
 shortcutKeySelector:
   placeholder: 단축키를 입력해 주세요
 subtitles:
-  loadingAiSubtitles: AI 자막 불러오는 중…
+  loadingAiSubtitles: AI 자막 불러오는 중… (예상 3분)
   requestAiSubtitles: AI 자막 요청 (Beta)
   usingAiSubtitles: AI 자막 사용 중
   actions:

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -1024,7 +1024,7 @@ thinking:
 shortcutKeySelector:
   placeholder: Пожалуйста, введите горячую клавишу
 subtitles:
-  loadingAiSubtitles: Загрузка ИИ-субтитров…
+  loadingAiSubtitles: Загрузка ИИ-субтитров… (ожидается 3 мин)
   requestAiSubtitles: Запросить ИИ-субтитры (Beta)
   usingAiSubtitles: Используются ИИ-субтитры
   actions:

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -1024,7 +1024,7 @@ thinking:
 shortcutKeySelector:
   placeholder: Lütfen kısayolu girin
 subtitles:
-  loadingAiSubtitles: Yapay zeka altyazıları yükleniyor…
+  loadingAiSubtitles: Yapay zeka altyazıları yükleniyor… (tahmini 3 dk)
   requestAiSubtitles: Yapay zeka altyazısı iste (Beta)
   usingAiSubtitles: Yapay zeka altyazısı kullanılıyor
   actions:

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -1024,7 +1024,7 @@ thinking:
 shortcutKeySelector:
   placeholder: Vui lòng nhập phím tắt
 subtitles:
-  loadingAiSubtitles: Đang tải phụ đề AI…
+  loadingAiSubtitles: Đang tải phụ đề AI… (dự kiến 3 phút)
   requestAiSubtitles: Yêu cầu phụ đề AI (Beta)
   usingAiSubtitles: Đang dùng phụ đề AI
   actions:

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -1139,7 +1139,7 @@ thinking:
 shortcutKeySelector:
   placeholder: 请输入快捷键
 subtitles:
-  loadingAiSubtitles: 正在加载 AI 字幕中
+  loadingAiSubtitles: 正在加载 AI 字幕中（预计 3 分钟）
   requestAiSubtitles: 请求 AI 字幕（Beta）
   usingAiSubtitles: 正在使用 AI 字幕中
   actions:

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -1139,7 +1139,7 @@ thinking:
 shortcutKeySelector:
   placeholder: 請輸入快速鍵
 subtitles:
-  loadingAiSubtitles: 正在載入 AI 字幕
+  loadingAiSubtitles: 正在載入 AI 字幕（預計 3 分鐘）
   requestAiSubtitles: 請求 AI 字幕（Beta）
   usingAiSubtitles: 正在使用 AI 字幕
   actions:


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 4.8

## Type of Changes

- [x] 🌐 Internationalization (i18n)

## Description

While AI subtitles are being generated, the on-video loading overlay only showed "Loading AI subtitles…", giving no sense of how long to wait (generation typically takes a couple of minutes). This appends an estimated-duration hint to that overlay so users don't think it has stalled.

The overlay text comes from the `subtitles.loadingAiSubtitles` i18n key (rendered by `state-message.tsx`, supplied via `LOADING_MESSAGE[AI]` in `universal-adapter.ts`). Updated that string in every locale:

| Locale | Text |
| --- | --- |
| en | `Loading AI subtitles… (estimated 3 min)` |
| zh-CN | `正在加载 AI 字幕中（预计 3 分钟）` |
| zh-TW | `正在載入 AI 字幕（預計 3 分鐘）` |
| es | `Cargando subtítulos con IA… (estimado 3 min)` |
| ja | `AI字幕を読み込み中…（推定3分）` |
| ko | `AI 자막 불러오는 중… (예상 3분)` |
| ru | `Загрузка ИИ-субтитров… (ожидается 3 мин)` |
| tr | `Yapay zeka altyazıları yükleniyor… (tahmini 3 dk)` |
| vi | `Đang tải phụ đề AI… (dự kiến 3 phút)` |

Only the string values change — no keys, code, or types are touched, so the loading overlay picks up the new text automatically. The estimate is a fixed ~3 min hint.

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Verified through manual testing

`pnpm type-check` (oxlint --type-aware) passes and `wxt prepare` regenerates i18n cleanly; confirmed `loadingAiSubtitles` is the string shown by the AI-subtitles loading overlay.

## Screenshots

N/A — text-only change to the existing loading overlay.