### PR TITLE
fix(network): preserve proxied request headers and bodies on Firefox

### DIFF
--- a/.changeset/firefox-normalize-headers.md
+++ b/.changeset/firefox-normalize-headers.md
@@ -2,15 +2,15 @@
 "@read-frog/extension": patch
 ---
 
-fix(subtitles): make "Request AI subtitles" work on Firefox
+fix(network): preserve proxied request headers and bodies on Firefox
 
-Two Firefox-only issues in the extension's request path blocked AI subtitle
-requests:
+Two Firefox-only issues in the extension's shared request path blocked AI
+subtitle requests and Notebase loading:
 
 - `normalizeHeaders` spread `Headers.entries()`, whose iterator is not iterable
   across the Firefox extension realm ("headersInit.entries() is not iterable").
   Collect entries with `Headers.forEach` instead.
 - The proxy-fetch dropped the POST body because `Request.body` is null for
-  content-script requests on Firefox. Read the body with `request.text()`
-  directly so the payload is forwarded (fixed the `create` 400 "expected object,
-  received undefined").
+  some extension requests on Firefox. Read the body with `request.text()`
+  directly so the payload is forwarded instead of producing 400 "expected
+  object, received undefined" responses.

--- a/.changeset/firefox-normalize-headers.md
+++ b/.changeset/firefox-normalize-headers.md
@@ -1,0 +1,16 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(subtitles): make "Request AI subtitles" work on Firefox
+
+Two Firefox-only issues in the extension's request path blocked AI subtitle
+requests:
+
+- `normalizeHeaders` spread `Headers.entries()`, whose iterator is not iterable
+  across the Firefox extension realm ("headersInit.entries() is not iterable").
+  Collect entries with `Headers.forEach` instead.
+- The proxy-fetch dropped the POST body because `Request.body` is null for
+  content-script requests on Firefox. Read the body with `request.text()`
+  directly so the payload is forwarded (fixed the `create` 400 "expected object,
+  received undefined").

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,6 +1,10 @@
 export function normalizeHeaders(headersInit?: HeadersInit): [string, string][] {
   if (!headersInit) return []
-  if (headersInit instanceof Headers) return [...headersInit.entries()]
+  if (headersInit instanceof Headers) {
+    const entries: [string, string][] = []
+    headersInit.forEach((value, key) => entries.push([key, value]))
+    return entries
+  }
   if (Array.isArray(headersInit)) return headersInit.map(([k, v]) => [k, v])
   // plain object shape
   const entries: [string, string][] = []

--- a/src/utils/orpc/__tests__/client.test.ts
+++ b/src/utils/orpc/__tests__/client.test.ts
@@ -1,0 +1,108 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { linkOptions, sendMessageMock } = vi.hoisted(() => ({
+  linkOptions: {
+    fetch: undefined as typeof fetch | undefined,
+  },
+  sendMessageMock: vi.fn<(...args: any[]) => any>(),
+}))
+
+vi.mock("@orpc/client", () => ({
+  createORPCClient: vi.fn<(link: unknown) => Record<string, never>>(() => ({})),
+}))
+
+vi.mock("@orpc/client/fetch", () => {
+  const RPCLink = vi.fn<(options: { fetch: typeof fetch }) => void>(
+    function captureLinkOptions(options) {
+      linkOptions.fetch = options.fetch
+    },
+  )
+  return { RPCLink }
+})
+
+vi.mock("@orpc/tanstack-query", () => ({
+  createTanstackQueryUtils: vi.fn<(client: unknown) => Record<string, never>>(() => ({})),
+}))
+
+vi.mock("@/env", () => ({
+  env: {
+    WXT_API_URL: "https://api.example.com",
+  },
+}))
+
+vi.mock("@/utils/message", () => ({
+  sendMessage: sendMessageMock,
+}))
+
+describe("oRPC background fetch", () => {
+  beforeAll(async () => {
+    await import("../client")
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sendMessageMock.mockResolvedValue({
+      status: 200,
+      statusText: "OK",
+      headers: [["content-type", "application/json"]],
+      body: JSON.stringify({ json: { ok: true } }),
+    })
+  })
+
+  it("forwards Firefox request headers and body when body is null", async () => {
+    const headers = new Headers({
+      "content-type": "application/json",
+      "x-orpc-source": "extension",
+    })
+    Object.defineProperty(headers, "entries", {
+      value: () => {
+        throw new TypeError("headers.entries() is not iterable")
+      },
+    })
+
+    const text = vi.fn<() => Promise<string>>().mockResolvedValue(JSON.stringify({ json: {} }))
+    const request = {
+      url: "https://api.example.com/api/rpc/notebase/list",
+      method: "POST",
+      headers,
+      body: null,
+      text,
+    } as unknown as Request
+
+    await linkOptions.fetch!(request, {
+      redirect: "manual",
+    })
+
+    expect(text).toHaveBeenCalledOnce()
+    expect(sendMessageMock).toHaveBeenCalledWith("backgroundFetch", {
+      url: "https://api.example.com/api/rpc/notebase/list",
+      method: "POST",
+      headers: [
+        ["content-type", "application/json"],
+        ["x-orpc-source", "extension"],
+      ],
+      body: JSON.stringify({ json: {} }),
+      credentials: "include",
+      redirect: "manual",
+    })
+  })
+
+  it("keeps an empty request body undefined", async () => {
+    const request = {
+      url: "https://api.example.com/api/rpc/notebase/list",
+      method: "GET",
+      headers: new Headers(),
+      body: null,
+      text: vi.fn<() => Promise<string>>().mockResolvedValue(""),
+    } as unknown as Request
+
+    await linkOptions.fetch!(request, {})
+
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      "backgroundFetch",
+      expect.objectContaining({
+        body: undefined,
+      }),
+    )
+  })
+})

--- a/src/utils/orpc/client.ts
+++ b/src/utils/orpc/client.ts
@@ -17,7 +17,8 @@ const link = new RPCLink({
     const url = request.url
     const method = request.method
     const headerEntries = normalizeHeaders(request.headers)
-    const body = request.body ? await request.text() : undefined
+    const text = await request.text()
+    const body = text.length > 0 ? text : undefined
 
     const resp = await sendMessage("backgroundFetch", {
       url,


### PR DESCRIPTION
## Summary

- Serialize `Headers` with `forEach` so Firefox extension contexts do not depend on a cross-realm iterator.
- Read the request text before deciding whether a body exists, preserving JSON payloads when Firefox exposes `Request.body` as `null`.
- Add regression coverage for both Firefox behaviors and for bodyless requests.

This shared proxy fix addresses both Firefox AI subtitle requests and the Notebase loading failure reported as the first problem in #1969. The separate Notebase mapping problem in that issue is not part of this PR.

## Root cause

The extension's oRPC client prepares plain request data and sends it to the background fetch proxy.

1. Spreading `Headers.entries()` can fail in Firefox extension contexts because the returned iterator is not iterable across the relevant realm boundary.
2. The client previously gated `request.text()` on `request.body`. Firefox can expose `request.body` as `null` even when `request.text()` contains the serialized JSON payload, so the background proxy received `body: undefined` and the server returned HTTP 400 (`expected object, received undefined`).

The fix collects headers through `Headers.forEach` and always reads `request.text()`, treating only an empty string as a bodyless request.

## Validation

- Added an oRPC transport regression test that simulates `Headers.entries()` throwing and `Request.body === null` while `request.text()` returns JSON.
- Added coverage that an empty request body remains `undefined`.
- `SKIP_FREE_API=true pnpm test` — 221 test files / 2142 tests passed.
- `pnpm lint`
- `pnpm build:firefox`
