### PR TITLE
feat(floating-button): add contextual feedback and directional tooltips

### DIFF
--- a/.changeset/calm-frogs-share-feedback.md
+++ b/.changeset/calm-frogs-share-feedback.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(floating-button): add contextual feedback and directional tooltips

--- a/src/entrypoints/options/app-sidebar/product-nav.tsx
+++ b/src/entrypoints/options/app-sidebar/product-nav.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@iconify/react"
+import { useAtomValue } from "jotai"
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -7,37 +8,51 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/base-ui/sidebar"
+import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { buildFeaturebasePortalUrl, type FeaturebasePortalDestination } from "@/utils/featurebase"
 import { i18n } from "@/utils/i18n"
+import { resolveUiLocale } from "@/utils/i18n/locale-map"
 
 const PRODUCT_LINKS = [
   {
-    href: "https://feedback.readfrog.app/roadmap",
+    destination: "roadmap",
     icon: "tabler:route",
     labelKey: "options.product.roadmap",
   },
   {
-    href: "https://feedback.readfrog.app/",
+    destination: "feedback",
     icon: "tabler:message-circle",
     labelKey: "options.product.feedback",
   },
-] as const
+] as const satisfies ReadonlyArray<{
+  destination: FeaturebasePortalDestination
+  icon: string
+  labelKey: "options.product.feedback" | "options.product.roadmap"
+}>
 
 export function ProductNav() {
+  const uiLanguage = useAtomValue(configFieldsAtomMap.uiLanguage)
+  const locale = resolveUiLocale(uiLanguage)
+
   return (
     <SidebarGroup>
       <SidebarGroupLabel>{i18n.t("options.sidebar.product")}</SidebarGroupLabel>
       <SidebarGroupContent>
         <SidebarMenu>
-          {PRODUCT_LINKS.map(({ href, icon, labelKey }) => (
-            <SidebarMenuItem key={href}>
-              <SidebarMenuButton
-                render={<a href={href} target="_blank" rel="noopener noreferrer" />}
-              >
-                <Icon icon={icon} />
-                <span>{i18n.t(labelKey)}</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          ))}
+          {PRODUCT_LINKS.map(({ destination, icon, labelKey }) => {
+            const href = buildFeaturebasePortalUrl({ destination, locale })
+
+            return (
+              <SidebarMenuItem key={href}>
+                <SidebarMenuButton
+                  render={<a href={href} target="_blank" rel="noopener noreferrer" />}
+                >
+                  <Icon icon={icon} />
+                  <span>{i18n.t(labelKey)}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            )
+          })}
         </SidebarMenu>
       </SidebarGroupContent>
     </SidebarGroup>

--- a/src/entrypoints/side.content/components/floating-button/__tests__/index.test.tsx
+++ b/src/entrypoints/side.content/components/floating-button/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import type { FloatingButtonConfig } from "@/types/config/floating-button"
-import { act, fireEvent, render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { atom, createStore, Provider } from "jotai"
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
@@ -13,6 +13,7 @@ vi.mock("#imports", () => ({
   browser: {
     runtime: {
       getURL: (path = "") => `chrome-extension://test-extension${path}`,
+      getManifest: () => ({ version: "1.43.3" }),
     },
   },
   i18n: {
@@ -43,6 +44,7 @@ vi.mock("@/utils/atoms/config", () => {
     configFieldsAtomMap: {
       floatingButton: floatingButtonAtom,
       sideContent: atom({ width: 360 }),
+      uiLanguage: atom("en"),
     },
   }
 })
@@ -61,6 +63,10 @@ vi.mock("@/utils/message", () => ({
   sendMessage: vi.fn<(...args: any[]) => any>(),
 }))
 
+vi.mock("@/utils/i18n/locale-map", () => ({
+  resolveUiLocale: (uiLanguage: string) => (uiLanguage === "auto" ? "en" : uiLanguage),
+}))
+
 vi.mock("@/components/ui/base-ui/toast", () => ({
   anchoredToastManager: {
     add: (...args: unknown[]) => toastAddMock(...args),
@@ -68,6 +74,8 @@ vi.mock("@/components/ui/base-ui/toast", () => ({
 }))
 
 beforeAll(() => {
+  vi.stubEnv("BROWSER", "chrome")
+
   class ResizeObserverMock {
     observe() {}
     unobserve() {}
@@ -82,6 +90,7 @@ afterEach(() => {
   vi.restoreAllMocks()
   vi.mocked(sendMessage).mockReset()
   toastAddMock.mockReset()
+  window.history.replaceState({}, "", "/")
   setViewport(1024, 768)
 })
 
@@ -136,11 +145,37 @@ function mockRect(element: Element, rect: Partial<DOMRect>) {
   })
 }
 
+const TOOLTIP_CONTROL_LABELS = [
+  "options.floatingButtonAndToolbar.floatingButton.tooltips.togglePageTranslation",
+  "options.floatingButtonAndToolbar.floatingButton.tooltips.settings",
+  "options.floatingButtonAndToolbar.floatingButton.tooltips.feedback",
+] as const
+
+async function expectTooltipSide(label: string, side: "left" | "right") {
+  const trigger = screen.getByRole("button", { name: label })
+  fireEvent.focus(trigger)
+
+  await waitFor(() => {
+    const popup = document.querySelector<HTMLElement>('[data-slot="tooltip-content"][data-open]')
+    expect(popup).toHaveTextContent(label)
+    expect(popup).toHaveAttribute("data-side", side)
+    expect(popup).toHaveClass("pointer-events-none")
+    expect(popup?.parentElement).toHaveClass("pointer-events-none")
+  })
+
+  fireEvent.blur(trigger)
+  await waitFor(() => {
+    expect(document.querySelector('[data-slot="tooltip-content"][data-open]')).toBeNull()
+  })
+}
+
 describe("floatingButton controls", () => {
   it("shows the close trigger only after entering the main floating button", () => {
     renderFloatingButton()
 
-    const closeTrigger = screen.getByRole("button", { name: "Close floating button" })
+    const closeTrigger = screen.getByRole("button", {
+      name: "options.floatingButtonAndToolbar.floatingButton.tooltips.floatingButtonOptions",
+    })
     const mainButton = getMainButton()
 
     expect(mainButton).toHaveClass("transition-transform")
@@ -165,7 +200,9 @@ describe("floatingButton controls", () => {
   it("renders a lock trigger at the lower-left corner and keeps controls expanded after entering the main button", () => {
     renderFloatingButton()
 
-    const lockTrigger = screen.getByRole("button", { name: "Lock floating button" })
+    const lockTrigger = screen.getByRole("button", {
+      name: "options.floatingButtonAndToolbar.floatingButton.tooltips.lockPosition",
+    })
     const mainButton = getMainButton()
     const floatingButtonContainer = screen.getByTestId("floating-button-container")
 
@@ -189,7 +226,9 @@ describe("floatingButton controls", () => {
 
     fireEvent.click(lockTrigger)
 
-    const unlockTrigger = screen.getByRole("button", { name: "Unlock floating button" })
+    const unlockTrigger = screen.getByRole("button", {
+      name: "options.floatingButtonAndToolbar.floatingButton.tooltips.unlockPosition",
+    })
 
     expect(unlockTrigger).toHaveClass("text-neutral-300")
     expect(unlockTrigger).toHaveClass("-left-6")
@@ -207,21 +246,54 @@ describe("floatingButton controls", () => {
     expect(mainButton).toHaveClass("opacity-100")
   })
 
-  it("forces the close trigger visible while the dropdown is open", () => {
+  it("does not show a tooltip for options and keeps its trigger visible while the dropdown is open", () => {
     renderFloatingButton()
 
-    const closeTrigger = screen.getByRole("button", { name: "Close floating button" })
+    const closeTrigger = screen.getByRole("button", {
+      name: "options.floatingButtonAndToolbar.floatingButton.tooltips.floatingButtonOptions",
+    })
     const mainButton = getMainButton()
 
     fireEvent.mouseEnter(mainButton)
+    fireEvent.focus(closeTrigger)
+    expect(document.querySelector('[data-slot="tooltip-content"][data-open]')).toBeNull()
     fireEvent.click(closeTrigger)
 
     expect(closeTrigger).toHaveClass("visible")
     expect(closeTrigger).toHaveClass("pointer-events-auto")
+    expect(document.querySelector('[data-slot="tooltip-content"][data-open]')).toBeNull()
     expect(
       screen.getByText("options.floatingButtonAndToolbar.floatingButton.closeMenu.disableForSite"),
     ).toBeInTheDocument()
   })
+
+  it("does not show a tooltip for the lock control", () => {
+    renderFloatingButton()
+    fireEvent.mouseEnter(getMainButton())
+
+    const lockTrigger = screen.getByRole("button", {
+      name: "options.floatingButtonAndToolbar.floatingButton.tooltips.lockPosition",
+    })
+    fireEvent.focus(lockTrigger)
+
+    expect(document.querySelector('[data-slot="tooltip-content"][data-open]')).toBeNull()
+  })
+
+  it.each([
+    { floatingSide: "right", tooltipSide: "left" },
+    { floatingSide: "left", tooltipSide: "right" },
+  ] as const)(
+    "opens each directional tooltip on the $tooltipSide when docked to the $floatingSide",
+    async ({ floatingSide, tooltipSide }) => {
+      renderFloatingButton({ side: floatingSide })
+      fireEvent.mouseEnter(getMainButton())
+      expect(TOOLTIP_CONTROL_LABELS).toHaveLength(3)
+
+      for (const label of TOOLTIP_CONTROL_LABELS) {
+        await expectTooltipSide(label, tooltipSide)
+      }
+    },
+  )
 
   it("toggles the browser side panel on a normal panel click", () => {
     vi.useFakeTimers()
@@ -246,6 +318,43 @@ describe("floatingButton controls", () => {
     })
 
     expect(sendMessage).toHaveBeenCalledWith("toggleSidePanel", undefined)
+  })
+
+  it("places feedback after settings and opens a localized Featurebase URL with safe metadata", () => {
+    window.history.replaceState({}, "", "/private/path?token=secret#section")
+    renderFloatingButton()
+
+    const settingsButton = screen.getByRole("button", {
+      name: "options.floatingButtonAndToolbar.floatingButton.tooltips.settings",
+    })
+    const feedbackButton = screen.getByRole("button", {
+      name: "options.floatingButtonAndToolbar.floatingButton.tooltips.feedback",
+    })
+
+    expect(
+      settingsButton.compareDocumentPosition(feedbackButton) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+
+    fireEvent.click(feedbackButton)
+
+    const openPageCall = vi
+      .mocked(sendMessage)
+      .mock.calls.find(([message]) => message === "openPage")
+    const openPagePayload = openPageCall?.[1] as { active: boolean; url: string } | undefined
+    expect(openPagePayload).toBeDefined()
+    const openedUrl = new URL(openPagePayload!.url)
+
+    expect(openedUrl.origin).toBe("https://feedback.readfrog.app")
+    expect(openedUrl.pathname).toBe("/en")
+    expect(JSON.parse(openedUrl.searchParams.get("metaData")!)).toEqual({
+      browser: "chrome",
+      extension_version: "1.0.0",
+      page_url: "http://localhost:3000/private/path",
+    })
+    expect(openPagePayload).toEqual({
+      url: openedUrl.toString(),
+      active: true,
+    })
   })
 
   it("shows a Firefox sidebar help link when the browser requires an extension user action", async () => {
@@ -374,7 +483,7 @@ describe("floatingButton controls", () => {
     renderFloatingButton()
 
     const mainButton = getMainButton()
-    expect(screen.getAllByRole("button")).toHaveLength(4)
+    expect(screen.getAllByRole("button")).toHaveLength(5)
 
     fireEvent.pointerDown(mainButton, {
       pointerId: 1,
@@ -515,8 +624,12 @@ describe("floatingButton controls", () => {
   it("mirrors the controls when attached to the left edge", () => {
     renderFloatingButton({ side: "left" })
 
-    const closeTrigger = screen.getByRole("button", { name: "Close floating button" })
-    const lockTrigger = screen.getByRole("button", { name: "Lock floating button" })
+    const closeTrigger = screen.getByRole("button", {
+      name: "options.floatingButtonAndToolbar.floatingButton.tooltips.floatingButtonOptions",
+    })
+    const lockTrigger = screen.getByRole("button", {
+      name: "options.floatingButtonAndToolbar.floatingButton.tooltips.lockPosition",
+    })
     const mainButton = getMainButton()
     const hiddenButtons = screen
       .getAllByRole("button")

--- a/src/entrypoints/side.content/components/floating-button/components/floating-button-tooltip.tsx
+++ b/src/entrypoints/side.content/components/floating-button/components/floating-button-tooltip.tsx
@@ -1,0 +1,38 @@
+import type { ReactElement, ReactNode } from "react"
+import type { FloatingButtonSide } from "@/types/config/floating-button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/base-ui/tooltip"
+import { shadowWrapper } from "../../.."
+
+interface FloatingButtonTooltipProps extends Pick<
+  React.ComponentProps<typeof Tooltip>,
+  "onOpenChange" | "open"
+> {
+  children?: ReactNode
+  content: ReactNode
+  render: ReactElement
+  side: FloatingButtonSide
+}
+
+export function FloatingButtonTooltip({
+  children,
+  content,
+  onOpenChange,
+  open,
+  render,
+  side,
+}: FloatingButtonTooltipProps) {
+  return (
+    <Tooltip open={open} onOpenChange={onOpenChange}>
+      <TooltipTrigger render={render}>{children}</TooltipTrigger>
+      <TooltipContent
+        container={shadowWrapper ?? document.body}
+        side={side === "right" ? "left" : "right"}
+        sideOffset={8}
+        className="notranslate pointer-events-none whitespace-nowrap"
+        positionerClassName="pointer-events-none"
+      >
+        {content}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/entrypoints/side.content/components/floating-button/components/hidden-button.tsx
+++ b/src/entrypoints/side.content/components/floating-button/components/hidden-button.tsx
@@ -1,8 +1,10 @@
 import type { FloatingButtonSide } from "@/types/config/floating-button"
 import { cn } from "@/utils/styles/utils"
+import { FloatingButtonTooltip } from "./floating-button-tooltip"
 
 export default function HiddenButton({
   icon,
+  label,
   onClick,
   children,
   className,
@@ -10,6 +12,7 @@ export default function HiddenButton({
   expanded = false,
 }: {
   icon: React.ReactNode
+  label: string
   onClick: () => void
   children?: React.ReactNode
   className?: string
@@ -17,18 +20,25 @@ export default function HiddenButton({
   expanded?: boolean
 }) {
   return (
-    <button
-      type="button"
-      className={cn(
-        "cursor-pointer rounded-full border border-border bg-white p-1.5 text-neutral-600 shadow-lg transition-transform duration-300 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-400 dark:hover:bg-neutral-800",
-        side === "right" ? "mr-2" : "ml-2",
-        expanded ? "translate-x-0" : side === "right" ? "translate-x-12" : "-translate-x-12",
-        className,
-      )}
-      onClick={onClick}
+    <FloatingButtonTooltip
+      content={label}
+      side={side}
+      render={
+        <button
+          type="button"
+          aria-label={label}
+          className={cn(
+            "cursor-pointer rounded-full border border-border bg-white p-1.5 text-neutral-600 shadow-lg transition-transform duration-300 hover:bg-neutral-100 dark:bg-neutral-900 dark:text-neutral-400 dark:hover:bg-neutral-800",
+            side === "right" ? "mr-2" : "ml-2",
+            expanded ? "translate-x-0" : side === "right" ? "translate-x-12" : "-translate-x-12",
+            className,
+          )}
+          onClick={onClick}
+        />
+      }
     >
       {icon}
       {children}
-    </button>
+    </FloatingButtonTooltip>
   )
 }

--- a/src/entrypoints/side.content/components/floating-button/index.tsx
+++ b/src/entrypoints/side.content/components/floating-button/index.tsx
@@ -1,5 +1,5 @@
 import type { FloatingButtonSide } from "@/types/config/floating-button"
-import { IconLock, IconLockOpen, IconSettings, IconX } from "@tabler/icons-react"
+import { IconLock, IconLockOpen, IconMessageCircle, IconSettings, IconX } from "@tabler/icons-react"
 import { useAtom, useAtomValue } from "jotai"
 import { useEffect, useRef, useState } from "react"
 import { browser } from "#imports"
@@ -15,7 +15,9 @@ import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext } from "@/utils/analytics"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { APP_NAME } from "@/utils/constants/app"
+import { buildFeaturebaseFeedbackMetadata, buildFeaturebasePortalUrl } from "@/utils/featurebase"
 import { i18n } from "@/utils/i18n"
+import { resolveUiLocale } from "@/utils/i18n/locale-map"
 import { sendMessage } from "@/utils/message"
 import { cn } from "@/utils/styles/utils"
 import { matchDomainPattern } from "@/utils/url"
@@ -122,6 +124,7 @@ function getNormalizedFloatingContainerTop(mainButtonTop: number, mainOffsetY: n
 
 export default function FloatingButton() {
   const [floatingButton, setFloatingButton] = useAtom(configFieldsAtomMap.floatingButton)
+  const uiLanguage = useAtomValue(configFieldsAtomMap.uiLanguage)
   const translationState = useAtomValue(enablePageTranslationAtom)
   const [isDraggingButton, setIsDraggingButton] = useAtom(isDraggingButtonAtom)
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
@@ -135,6 +138,7 @@ export default function FloatingButton() {
   const floatingButtonSide = getFloatingButtonSide(floatingButton.side)
   const isFloatingButtonExpanded = isHitAreaExpanded || isDropdownOpen
   const isMainButtonAttached = isFloatingButtonLocked || isFloatingButtonExpanded
+  const locale = resolveUiLocale(uiLanguage)
 
   useEffect(() => {
     if (!isDraggingButton) return undefined
@@ -190,6 +194,20 @@ export default function FloatingButton() {
         })
       }
     })
+  }
+
+  const handleFeedbackClick = () => {
+    const url = buildFeaturebasePortalUrl({
+      destination: "feedback",
+      locale,
+      metadata: buildFeaturebaseFeedbackMetadata({
+        browserName: import.meta.env.BROWSER,
+        extensionVersion: browser.runtime.getManifest().version,
+        pageUrl: window.location.href,
+      }),
+    })
+
+    void sendMessage("openPage", { url, active: true })
   }
 
   const startActiveDrag = () => {
@@ -418,9 +436,19 @@ export default function FloatingButton() {
           side={floatingButtonSide}
           expanded={isFloatingButtonExpanded}
           icon={<IconSettings className="h-5 w-5" />}
+          label={i18n.t("options.floatingButtonAndToolbar.floatingButton.tooltips.settings")}
           onClick={() => {
             void sendMessage("openOptionsPage", undefined)
           }}
+        />
+      )}
+      {!isDraggingButton && (
+        <HiddenButton
+          side={floatingButtonSide}
+          expanded={isFloatingButtonExpanded}
+          icon={<IconMessageCircle className="h-5 w-5" />}
+          label={i18n.t("options.floatingButtonAndToolbar.floatingButton.tooltips.feedback")}
+          onClick={handleFeedbackClick}
         />
       )}
     </div>
@@ -470,7 +498,9 @@ function FloatingButtonCloseMenu({
         render={
           <button
             type="button"
-            aria-label="Close floating button"
+            aria-label={i18n.t(
+              "options.floatingButtonAndToolbar.floatingButton.tooltips.floatingButtonOptions",
+            )}
             className={cn(
               floatingButtonControlClassName,
               "-top-1",
@@ -516,11 +546,14 @@ function FloatingButtonLockControl({ expanded, side }: FloatingButtonLockControl
   const handleToggleLocked = () => {
     void setFloatingButton({ ...floatingButton, locked: !locked })
   }
+  const label = locked
+    ? i18n.t("options.floatingButtonAndToolbar.floatingButton.tooltips.unlockPosition")
+    : i18n.t("options.floatingButtonAndToolbar.floatingButton.tooltips.lockPosition")
 
   return (
     <button
       type="button"
-      aria-label={locked ? "Unlock floating button" : "Lock floating button"}
+      aria-label={label}
       className={cn(
         floatingButtonControlClassName,
         "-bottom-1",

--- a/src/entrypoints/side.content/components/floating-button/translate-button.tsx
+++ b/src/entrypoints/side.content/components/floating-button/translate-button.tsx
@@ -2,6 +2,7 @@ import type { FloatingButtonSide } from "@/types/config/floating-button"
 import { RiTranslate } from "@remixicon/react"
 import { IconCheck } from "@tabler/icons-react"
 import { useAtomValue } from "jotai"
+import { i18n } from "@/utils/i18n"
 import { sendMessage } from "@/utils/message"
 import { cn } from "@/utils/styles/utils"
 import { enablePageTranslationAtom } from "../../atoms"
@@ -22,6 +23,9 @@ export default function TranslateButton({
   return (
     <HiddenButton
       icon={<RiTranslate className="h-5 w-5" />}
+      label={i18n.t(
+        "options.floatingButtonAndToolbar.floatingButton.tooltips.togglePageTranslation",
+      )}
       className={className}
       side={side}
       expanded={expanded}

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -323,6 +323,13 @@ options:
       closeMenu:
         disableForSite: Disable for this site
         disableGlobally: Disable globally
+      tooltips:
+        togglePageTranslation: Toggle page translation
+        floatingButtonOptions: Floating button options
+        lockPosition: Lock position
+        unlockPosition: Unlock position
+        settings: Settings
+        feedback: Send feedback
       disabledSites:
         title: Floating Button Disabled Sites
         description: Configure websites where the floating button should be disabled

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -323,6 +323,13 @@ options:
       closeMenu:
         disableForSite: Desactivar para este sitio
         disableGlobally: Desactivar globalmente
+      tooltips:
+        togglePageTranslation: Alternar traducción de página
+        floatingButtonOptions: Opciones del botón flotante
+        lockPosition: Bloquear posición
+        unlockPosition: Desbloquear posición
+        settings: Ajustes
+        feedback: Enviar comentarios
       disabledSites:
         title: Sitios con botón flotante desactivado
         description: Configura los sitios web donde se debe desactivar el botón flotante

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -322,6 +322,13 @@ options:
       closeMenu:
         disableForSite: このサイトで無効化
         disableGlobally: グローバルで無効化
+      tooltips:
+        togglePageTranslation: ページ翻訳を切り替え
+        floatingButtonOptions: フローティングボタンのオプション
+        lockPosition: 位置を固定
+        unlockPosition: 位置の固定を解除
+        settings: 設定
+        feedback: フィードバックを送信
       disabledSites:
         title: フローティングボタン無効化サイト
         description: フローティングボタンを無効化するウェブサイトを設定します

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -322,6 +322,13 @@ options:
       closeMenu:
         disableForSite: 이 사이트에서 비활성화
         disableGlobally: 전역 비활성화
+      tooltips:
+        togglePageTranslation: 페이지 번역 전환
+        floatingButtonOptions: 플로팅 버튼 옵션
+        lockPosition: 위치 잠금
+        unlockPosition: 위치 잠금 해제
+        settings: 설정
+        feedback: 피드백 보내기
       disabledSites:
         title: 플로팅 버튼 비활성화 사이트
         description: 플로팅 버튼을 비활성화할 웹사이트를 설정합니다

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -322,6 +322,13 @@ options:
       closeMenu:
         disableForSite: Отключить для этого сайта
         disableGlobally: Отключить глобально
+      tooltips:
+        togglePageTranslation: Переключить перевод страницы
+        floatingButtonOptions: Настройки плавающей кнопки
+        lockPosition: Закрепить положение
+        unlockPosition: Открепить положение
+        settings: Настройки
+        feedback: Отправить отзыв
       disabledSites:
         title: Сайты с отключённой плавающей кнопкой
         description: Настройте веб-сайты, где плавающая кнопка должна быть отключена

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -322,6 +322,13 @@ options:
       closeMenu:
         disableForSite: Bu site için devre dışı bırak
         disableGlobally: Genel olarak devre dışı bırak
+      tooltips:
+        togglePageTranslation: Sayfa çevirisini aç/kapat
+        floatingButtonOptions: Kayan düğme seçenekleri
+        lockPosition: Konumu kilitle
+        unlockPosition: Konum kilidini aç
+        settings: Ayarlar
+        feedback: Geri bildirim gönder
       disabledSites:
         title: Yüzen Buton Devre Dışı Siteler
         description: Yüzen butonun devre dışı bırakılması gereken web sitelerini yapılandırın

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -322,6 +322,13 @@ options:
       closeMenu:
         disableForSite: Tắt cho trang web này
         disableGlobally: Tắt toàn cục
+      tooltips:
+        togglePageTranslation: Bật/tắt dịch trang
+        floatingButtonOptions: Tùy chọn nút nổi
+        lockPosition: Khóa vị trí
+        unlockPosition: Mở khóa vị trí
+        settings: Cài đặt
+        feedback: Gửi phản hồi
       disabledSites:
         title: Các trang web đã tắt nút nổi
         description: Cấu hình các trang web mà nút nổi nên bị tắt

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -323,6 +323,13 @@ options:
       closeMenu:
         disableForSite: 当前网站禁用
         disableGlobally: 全局禁用
+      tooltips:
+        togglePageTranslation: 切换页面翻译
+        floatingButtonOptions: 悬浮按钮选项
+        lockPosition: 锁定位置
+        unlockPosition: 解锁位置
+        settings: 设置
+        feedback: 发送反馈
       disabledSites:
         title: 悬浮按钮禁用网站
         description: 配置需要禁用悬浮按钮的网站

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -323,6 +323,13 @@ options:
       closeMenu:
         disableForSite: 停用此網站
         disableGlobally: 全域停用
+      tooltips:
+        togglePageTranslation: 切換頁面翻譯
+        floatingButtonOptions: 懸浮按鈕選項
+        lockPosition: 鎖定位置
+        unlockPosition: 解鎖位置
+        settings: 設定
+        feedback: 傳送意見回饋
       disabledSites:
         title: 懸浮按鈕停用網站
         description: 設定需要停用懸浮按鈕的網站

--- a/src/utils/__tests__/featurebase.test.ts
+++ b/src/utils/__tests__/featurebase.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest"
+import { buildFeaturebaseFeedbackMetadata, buildFeaturebasePortalUrl } from "@/utils/featurebase"
+
+const SUPPORTED_UI_LOCALES = ["en", "es", "ja", "ko", "ru", "tr", "vi", "zh-CN", "zh-TW"] as const
+
+describe("buildFeaturebasePortalUrl", () => {
+  it.each(SUPPORTED_UI_LOCALES)("builds locale-prefixed portal URLs for %s", (locale) => {
+    expect(buildFeaturebasePortalUrl({ destination: "feedback", locale })).toBe(
+      `https://feedback.readfrog.app/${locale}`,
+    )
+    expect(buildFeaturebasePortalUrl({ destination: "roadmap", locale })).toBe(
+      `https://feedback.readfrog.app/${locale}/roadmap`,
+    )
+  })
+
+  it("serializes metadata with Featurebase's metaData query parameter", () => {
+    const result = buildFeaturebasePortalUrl({
+      destination: "feedback",
+      locale: "zh-CN",
+      metadata: {
+        browser: "edge",
+        extension_version: "1.43.3",
+        page_url: "https://example.com/private/path",
+      },
+    })
+    const url = new URL(result)
+
+    expect(url.pathname).toBe("/zh-CN")
+    expect(JSON.parse(url.searchParams.get("metaData")!)).toEqual({
+      browser: "edge",
+      extension_version: "1.43.3",
+      page_url: "https://example.com/private/path",
+    })
+  })
+})
+
+describe("buildFeaturebaseFeedbackMetadata", () => {
+  it("keeps only the origin and pathname for HTTP(S) pages", () => {
+    expect(
+      buildFeaturebaseFeedbackMetadata({
+        browserName: "edge",
+        extensionVersion: "1.43.3",
+        pageUrl: "https://user:password@example.com/private/path?token=secret#section",
+      }),
+    ).toEqual({
+      browser: "edge",
+      extension_version: "1.43.3",
+      page_url: "https://example.com/private/path",
+    })
+  })
+
+  it.each(["file:///Users/example/private.html", "about:blank", "not a URL"])(
+    "omits page_url for unsupported or invalid URL %s",
+    (pageUrl) => {
+      expect(
+        buildFeaturebaseFeedbackMetadata({
+          browserName: "firefox",
+          extensionVersion: "1.43.3",
+          pageUrl,
+        }),
+      ).toEqual({
+        browser: "firefox",
+        extension_version: "1.43.3",
+      })
+    },
+  )
+})

--- a/src/utils/featurebase.ts
+++ b/src/utils/featurebase.ts
@@ -1,0 +1,65 @@
+import type { SupportedUiLocale } from "@/utils/i18n/resources"
+
+const FEATUREBASE_PORTAL_ORIGIN = "https://feedback.readfrog.app"
+
+export type FeaturebasePortalDestination = "feedback" | "roadmap"
+
+export interface FeaturebaseFeedbackMetadata {
+  [key: string]: string | undefined
+  browser: string
+  extension_version: string
+  page_url?: string
+}
+
+export function buildFeaturebasePortalUrl({
+  destination,
+  locale,
+  metadata,
+}: {
+  destination: FeaturebasePortalDestination
+  locale: SupportedUiLocale
+  metadata?: Record<string, string | undefined>
+}) {
+  const pathname = destination === "roadmap" ? `/${locale}/roadmap` : `/${locale}`
+  const url = new URL(pathname, FEATUREBASE_PORTAL_ORIGIN)
+
+  const definedMetadata = metadata
+    ? Object.fromEntries(
+        Object.entries(metadata).filter(
+          (entry): entry is [string, string] => entry[1] !== undefined,
+        ),
+      )
+    : undefined
+
+  if (definedMetadata && Object.keys(definedMetadata).length > 0) {
+    url.searchParams.set("metaData", JSON.stringify(definedMetadata))
+  }
+
+  return url.toString()
+}
+
+export function buildFeaturebaseFeedbackMetadata({
+  browserName,
+  extensionVersion,
+  pageUrl,
+}: {
+  browserName: string
+  extensionVersion: string
+  pageUrl: string
+}): FeaturebaseFeedbackMetadata {
+  const metadata: FeaturebaseFeedbackMetadata = {
+    browser: browserName,
+    extension_version: extensionVersion,
+  }
+
+  try {
+    const url = new URL(pageUrl)
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      metadata.page_url = `${url.origin}${url.pathname}`
+    }
+  } catch {
+    // Keep the extension version even when the current page URL is not parseable.
+  }
+
+  return metadata
+}


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-5 (Codex)

## Type of Changes

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

- Add a Feedback action below Settings in the expanded floating button.
- Open the locale-aware Featurebase portal with privacy-safe metadata for browser, extension version, and the current HTTP(S) origin plus pathname.
- Reuse a shared Featurebase URL helper for the options-page Feedback and Roadmap links.
- Add Shadow DOM-aware directional tooltips for Translate, Settings, and Feedback; tooltips open away from the docked page edge.
- Keep the X/options and lock/unlock controls tooltip-free while preserving localized ARIA labels.
- Add localized strings for all supported UI locales and a patch changeset.

## Related Issue

None.

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Automated validation:

- `pnpm type-check`
- `pnpm fmt:check`
- Focused Vitest suite: 30 tests passed
- Full Vitest suite: 223 files and 2161 tests passed in the pre-push hook
- `pnpm build`
- `pnpm build:edge`
- `pnpm build:firefox`

Built-artifact verification:

- Loaded the Edge MV3 artifact in a fresh profile and verified right/left tooltip direction, hover/focus open state, pointer-events behavior, menu behavior, drag hiding, and feedback metadata privacy.
- Loaded the Firefox MV3 artifact through WebDriver BiDi and verified the Shadow DOM tooltip and feedback link metadata.
- Confirmed browser metadata resolves to `edge` and `firefox` in their respective artifacts.

## Screenshots

Not included. The behavior was validated against the built Edge and Firefox artifacts.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The page URL metadata deliberately removes credentials, query parameters, and hashes. Non-HTTP(S) pages omit `page_url` entirely.
