### PR TITLE
fix(translate): stop page-translation flicker on same-origin navigation

### DIFF
--- a/.changeset/spa-translation-flicker.md
+++ b/.changeset/spa-translation-flicker.md
@@ -4,8 +4,18 @@
 
 fix(translate): stop page-translation flicker on same-origin navigation
 
-Same-origin route changes no longer tear down and rebuild every translation
-wrapper. The live MutationObserver keeps translating newly inserted content,
-and Navigation API listening waits for `currententrychange` (URL committed)
-instead of the pre-commit `navigate` event that flashed original text on the
-still-visible previous page.
+Fixes two independent bugs that each caused translations to disappear and
+reappear around SPA route changes:
+
+1. The same-origin URL-change handler tore down every translation wrapper and
+   rebuilt the session. Both Navigation API events fire synchronously inside
+   `pushState` — before the router swaps the DOM — so the teardown always hit
+   the still-visible previous page. The handler now keeps the session and
+   wrappers mounted (the live MutationObserver walks the new route's DOM) and
+   only swaps path-scoped site CSS, in place.
+
+2. URL-change detection listened to the Navigation API `navigate` event, which
+   also fires for cross-document navigations and pre-commit (cancellable)
+   ones — running a full translation restart on pages about to unload and
+   desyncing the tracked URL on cancelled navigations. Detection now uses
+   `currententrychange`, which only fires for committed same-document changes.

--- a/.changeset/spa-translation-flicker.md
+++ b/.changeset/spa-translation-flicker.md
@@ -1,0 +1,11 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): stop page-translation flicker on same-origin navigation
+
+Same-origin route changes no longer tear down and rebuild every translation
+wrapper. The live MutationObserver keeps translating newly inserted content,
+and Navigation API listening waits for `currententrychange` (URL committed)
+instead of the pre-commit `navigate` event that flashed original text on the
+still-visible previous page.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs/
+logs
 *.log
 npm-debug.log*
 yarn-debug.log*
@@ -7,51 +7,43 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-# Dependencies
-node_modules/
-.pnpm-store/
-
-# Build / tooling outputs
-.output/
-.wxt/
-.turbo/
-.nx/
-coverage/
+node_modules
+.output
 stats.html
 stats-*.html
 stats-*.json
-tsconfig.local.json
+.wxt
 web-ext.config.ts
-web-ext-artifacts/
 
-# Packed extension artifacts
-*.crx
-*.xpi
-*.pem
-
-# Environment
-.env
-.env.*
-!.env.example
-!.env.local.example
-
-# Editor / OS
+# Editor directories and files
 .vscode/*
 !.vscode/extensions.json
 !.vscode/settings.json
-.idea/
+.idea
 .DS_Store
-Thumbs.db
 *.suo
 *.ntvs*
 *.njsproj
 *.sln
 *.sw?
 
-# Local / scratch directories
+.env
+.env.*
+!.env.example
+!.env.local.example
+
+coverage/
+.turbo/
+.nx/
 .claude/worktrees/
+
+tsconfig.local.json
+
 docs/
+
 /repos
+
 scripts/output/
+
 reference/
 .gstack/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Logs
-logs
+logs/
 *.log
 npm-debug.log*
 yarn-debug.log*
@@ -7,43 +7,51 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-node_modules
-.output
+# Dependencies
+node_modules/
+.pnpm-store/
+
+# Build / tooling outputs
+.output/
+.wxt/
+.turbo/
+.nx/
+coverage/
 stats.html
 stats-*.html
 stats-*.json
-.wxt
+tsconfig.local.json
 web-ext.config.ts
+web-ext-artifacts/
 
-# Editor directories and files
+# Packed extension artifacts
+*.crx
+*.xpi
+*.pem
+
+# Environment
+.env
+.env.*
+!.env.example
+!.env.local.example
+
+# Editor / OS
 .vscode/*
 !.vscode/extensions.json
 !.vscode/settings.json
-.idea
+.idea/
 .DS_Store
+Thumbs.db
 *.suo
 *.ntvs*
 *.njsproj
 *.sln
 *.sw?
 
-.env
-.env.*
-!.env.example
-!.env.local.example
-
-coverage/
-.turbo/
-.nx/
+# Local / scratch directories
 .claude/worktrees/
-
-tsconfig.local.json
-
 docs/
-
 /repos
-
 scripts/output/
-
 reference/
 .gstack/

--- a/src/entrypoints/host.content/__tests__/listen.test.ts
+++ b/src/entrypoints/host.content/__tests__/listen.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { setupUrlChangeListener } from "../listen"
+
+type NavigationListener = (event?: Event) => void
+
+function installNavigationMock(initialUrl: string) {
+  const listeners = new Map<string, Set<NavigationListener>>()
+  const navigation = {
+    currentEntry: { url: initialUrl },
+    addEventListener: vi.fn<(type: string, listener: NavigationListener) => void>(
+      (type, listener) => {
+        const set = listeners.get(type) ?? new Set()
+        set.add(listener)
+        listeners.set(type, set)
+      },
+    ),
+    removeEventListener: vi.fn<(type: string, listener: NavigationListener) => void>(
+      (type, listener) => {
+        listeners.get(type)?.delete(listener)
+      },
+    ),
+    dispatch(type: string) {
+      for (const listener of listeners.get(type) ?? []) {
+        listener()
+      }
+    },
+  }
+
+  Object.defineProperty(window, "navigation", {
+    configurable: true,
+    value: navigation,
+    writable: true,
+  })
+
+  return navigation
+}
+
+describe("setupUrlChangeListener", () => {
+  let cleanup: (() => void) | undefined
+  let events: Array<{ from: string; to: string; reason: string }>
+  let origin: string
+  let onUrlChange: EventListener
+
+  beforeEach(() => {
+    events = []
+    origin = window.location.origin
+    // Ensure a clean, same-origin path before any history monkeypatch is installed.
+    window.history.replaceState({}, "", `${origin}/a`)
+    onUrlChange = ((e: CustomEvent) => {
+      events.push(e.detail)
+    }) as EventListener
+    window.addEventListener("extension:URLChange", onUrlChange)
+  })
+
+  afterEach(() => {
+    cleanup?.()
+    cleanup = undefined
+    window.removeEventListener("extension:URLChange", onUrlChange)
+    Reflect.deleteProperty(window, "navigation")
+  })
+
+  it("does not fire on Navigation API navigate (pre-commit) events", () => {
+    const navigation = installNavigationMock(`${origin}/a`)
+    cleanup = setupUrlChangeListener()
+
+    navigation.currentEntry.url = `${origin}/a`
+    navigation.dispatch("navigate")
+
+    expect(events).toEqual([])
+  })
+
+  it("fires after Navigation API currententrychange when the URL commits", () => {
+    const navigation = installNavigationMock(`${origin}/a`)
+    cleanup = setupUrlChangeListener()
+
+    // Update only the Navigation API entry — avoid history.replaceState here,
+    // which would also emit via the pushState/replaceState monkeypatch.
+    navigation.currentEntry.url = `${origin}/b`
+    navigation.dispatch("currententrychange")
+
+    expect(events).toEqual([
+      {
+        from: `${origin}/a`,
+        to: `${origin}/b`,
+        reason: "currententrychange",
+      },
+    ])
+  })
+
+  it("fires on pushState pathname changes and ignores hash-only updates", () => {
+    cleanup = setupUrlChangeListener()
+
+    window.history.pushState({}, "", `${origin}/a#section`)
+    expect(events).toEqual([])
+
+    window.history.pushState({}, "", `${origin}/b`)
+    expect(events).toEqual([
+      {
+        from: `${origin}/a#section`,
+        to: `${origin}/b`,
+        reason: "pushState",
+      },
+    ])
+  })
+})

--- a/src/entrypoints/host.content/__tests__/listen.test.ts
+++ b/src/entrypoints/host.content/__tests__/listen.test.ts
@@ -89,7 +89,10 @@ describe("setupUrlChangeListener", () => {
     ])
   })
 
-  it("fires on pushState pathname changes and ignores hash-only updates", () => {
+  // jsdom has no `window.navigation`, so this exercises the monkeypatch-only
+  // path (Firefox/Safari). In Chrome the same pushState is reported via
+  // `currententrychange` instead — see the ordering test below.
+  it("fires on pushState pathname changes and ignores hash-only updates (no Navigation API)", () => {
     cleanup = setupUrlChangeListener()
 
     window.history.pushState({}, "", `${origin}/a#section`)
@@ -103,5 +106,42 @@ describe("setupUrlChangeListener", () => {
         reason: "pushState",
       },
     ])
+  })
+
+  it("dispatches exactly one event when currententrychange fires inside pushState (Chrome ordering)", () => {
+    const navigation = installNavigationMock(`${origin}/a`)
+
+    // In real Chrome (verified on 145), `currententrychange` fires
+    // SYNCHRONOUSLY inside `history.pushState()` — before the monkeypatched
+    // wrapper resumes and runs its own fire(). Simulate that ordering with a
+    // fake "native" pushState that commits the URL and dispatches
+    // currententrychange, installed BEFORE the listener monkeypatches over
+    // it. The guard under test: the wrapper's fire() must see `prev` already
+    // advanced by the currententrychange handler and stay silent, so both
+    // detection paths together dispatch exactly one URLChange event.
+    const realPushState = window.history.pushState.bind(window.history)
+    window.history.pushState = ((data: unknown, unused: string, url?: string | URL | null) => {
+      realPushState(data, unused, url)
+      navigation.currentEntry.url = window.location.href
+      navigation.dispatch("currententrychange")
+    }) as typeof window.history.pushState
+
+    try {
+      cleanup = setupUrlChangeListener()
+
+      window.history.pushState({}, "", `${origin}/b`)
+      expect(events).toEqual([
+        {
+          from: `${origin}/a`,
+          to: `${origin}/b`,
+          reason: "currententrychange",
+        },
+      ])
+    } finally {
+      // Listener cleanup restores our fake native; then restore the real one.
+      cleanup?.()
+      cleanup = undefined
+      window.history.pushState = realPushState
+    }
   })
 })

--- a/src/entrypoints/host.content/__tests__/runtime.test.ts
+++ b/src/entrypoints/host.content/__tests__/runtime.test.ts
@@ -22,7 +22,7 @@ const {
     isActive: boolean
     start: ReturnType<typeof vi.fn>
     stop: ReturnType<typeof vi.fn>
-    restart: ReturnType<typeof vi.fn>
+    refreshSiteRuleCSS: ReturnType<typeof vi.fn>
     registerPageTranslationTriggers: ReturnType<typeof vi.fn>
   }>,
   mockBindTranslationShortcutKey: vi.fn<(...args: any[]) => any>(),
@@ -88,9 +88,7 @@ vi.mock("../translation-control/page-translation", () => ({
       this.isActive = false
     })
 
-    restart = vi.fn<(...args: any[]) => any>(async () => {
-      this.isActive = true
-    })
+    refreshSiteRuleCSS = vi.fn<(...args: any[]) => any>(async () => {})
 
     registerPageTranslationTriggers = vi.fn<(...args: any[]) => any>(() =>
       vi.fn<(...args: any[]) => any>(),
@@ -147,7 +145,7 @@ describe("bootstrapHostContent URL changes", () => {
     })
   })
 
-  it("soft-refreshes active page translation on same-origin SPA navigation without disabling the session", async () => {
+  it("only refreshes site CSS on same-origin SPA navigation, keeping the session active", async () => {
     mockSendMessage.mockImplementation((name: string) => {
       if (name === "getEnablePageTranslationFromContentScript") return Promise.resolve(true)
 
@@ -169,7 +167,7 @@ describe("bootstrapHostContent URL changes", () => {
     await flushAsyncWork()
 
     expect(manager!.start).toHaveBeenCalledTimes(1)
-    expect(manager!.restart).toHaveBeenCalledTimes(1)
+    expect(manager!.refreshSiteRuleCSS).toHaveBeenCalledTimes(1)
     expect(manager!.stop).not.toHaveBeenCalled()
     expect(mockSendMessage).toHaveBeenCalledWith("reportDetectedPageLanguage", {
       url: "https://example.com/articles/2?ref=nav#comments",
@@ -195,7 +193,7 @@ describe("bootstrapHostContent URL changes", () => {
     await flushAsyncWork()
 
     expect(manager!.start).not.toHaveBeenCalled()
-    expect(manager!.restart).not.toHaveBeenCalled()
+    expect(manager!.refreshSiteRuleCSS).not.toHaveBeenCalled()
     expect(manager!.stop).not.toHaveBeenCalled()
     expect(mockSendMessage).toHaveBeenCalledWith("reportDetectedPageLanguage", {
       url: "https://example.com/articles/2",

--- a/src/entrypoints/host.content/__tests__/runtime.test.ts
+++ b/src/entrypoints/host.content/__tests__/runtime.test.ts
@@ -147,7 +147,7 @@ describe("bootstrapHostContent URL changes", () => {
     })
   })
 
-  it("refreshes active page translation on same-origin SPA navigation without disabling the session", async () => {
+  it("soft-refreshes active page translation on same-origin SPA navigation without disabling the session", async () => {
     mockSendMessage.mockImplementation((name: string) => {
       if (name === "getEnablePageTranslationFromContentScript") return Promise.resolve(true)
 

--- a/src/entrypoints/host.content/listen.ts
+++ b/src/entrypoints/host.content/listen.ts
@@ -55,11 +55,18 @@ export function setupUrlChangeListener(signal?: AbortSignal): () => void {
   window.addEventListener("hashchange", onHashChange, { signal })
 
   /* ---------- 3. Modern Navigation API (only Chrome/Edge) ---------- */
-  // Prefer `currententrychange` over `navigate`. The `navigate` event fires
-  // when navigation is *initiated* — before the URL commits and before SPA
-  // routers swap the DOM. Listening there made page translation tear down
-  // wrappers on the still-visible previous page (visible flicker) and could
-  // desync `prev` when a navigation was cancelled or redirected.
+  // Prefer `currententrychange` over `navigate`, for two reasons:
+  //  • `navigate` also fires for CROSS-document navigations (clicking a plain
+  //    link), so we ran a full same-origin URL-change cycle on a page that was
+  //    about to unload. `currententrychange` only fires for committed
+  //    same-document entry changes.
+  //  • `navigate` fires when navigation is *initiated*, so a cancelled or
+  //    redirected navigation desynced `prev` from the real URL.
+  // Note this is NOT a "wait until the DOM is ready" fix: currententrychange
+  // still fires synchronously inside pushState, before SPA routers swap the
+  // DOM. URL-change consumers must not touch route content — that is why the
+  // page-translation handler only swaps site CSS and leaves new-DOM work to
+  // its MutationObserver.
   let removeNavigateListener: (() => void) | null = null
   if ("navigation" in window) {
     const onCurrentEntryChange = () => {

--- a/src/entrypoints/host.content/listen.ts
+++ b/src/entrypoints/host.content/listen.ts
@@ -55,16 +55,25 @@ export function setupUrlChangeListener(signal?: AbortSignal): () => void {
   window.addEventListener("hashchange", onHashChange, { signal })
 
   /* ---------- 3. Modern Navigation API (only Chrome/Edge) ---------- */
+  // Prefer `currententrychange` over `navigate`. The `navigate` event fires
+  // when navigation is *initiated* — before the URL commits and before SPA
+  // routers swap the DOM. Listening there made page translation tear down
+  // wrappers on the still-visible previous page (visible flicker) and could
+  // desync `prev` when a navigation was cancelled or redirected.
   let removeNavigateListener: (() => void) | null = null
   if ("navigation" in window) {
-    const onNavigate = (e: any) => {
-      const now = e.destination?.url ?? location.href
-      fire(prev, now, "navigate")
+    const onCurrentEntryChange = () => {
+      const navigation = (window as Window & { navigation?: { currentEntry?: { url?: string } } })
+        .navigation
+      const now = navigation?.currentEntry?.url ?? location.href
+      fire(prev, now, "currententrychange")
       prev = now
     }
-    ;(window as any).navigation.addEventListener("navigate", onNavigate, { signal })
+    ;(window as any).navigation.addEventListener("currententrychange", onCurrentEntryChange, {
+      signal,
+    })
     removeNavigateListener = () => {
-      ;(window as any).navigation.removeEventListener("navigate", onNavigate)
+      ;(window as any).navigation.removeEventListener("currententrychange", onCurrentEntryChange)
     }
   }
 

--- a/src/entrypoints/host.content/runtime.ts
+++ b/src/entrypoints/host.content/runtime.ts
@@ -64,7 +64,9 @@ export async function bootstrapHostContent(
         if (areSamePageTranslationOrigin(from, to)) {
           // Same-document route change: keep the session and wrappers
           // mounted — the MutationObserver walks the new route's DOM as the
-          // router inserts it. Only path-scoped site CSS may need swapping.
+          // router inserts it. Site CSS is swapped for the new path;
+          // persistent DOM keeps its old walk decisions (accepted tradeoff,
+          // see refreshSiteRuleCSS).
           await manager.refreshSiteRuleCSS()
         } else {
           manager.stop()

--- a/src/entrypoints/host.content/runtime.ts
+++ b/src/entrypoints/host.content/runtime.ts
@@ -62,8 +62,10 @@ export async function bootstrapHostContent(
       logger.info("URL changed from", from, "to", to)
       if (manager.isActive) {
         if (areSamePageTranslationOrigin(from, to)) {
-          // Keep wrappers mounted; MutationObserver handles the new DOM.
-          await manager.restart()
+          // Same-document route change: keep the session and wrappers
+          // mounted — the MutationObserver walks the new route's DOM as the
+          // router inserts it. Only path-scoped site CSS may need swapping.
+          await manager.refreshSiteRuleCSS()
         } else {
           manager.stop()
         }

--- a/src/entrypoints/host.content/runtime.ts
+++ b/src/entrypoints/host.content/runtime.ts
@@ -62,6 +62,7 @@ export async function bootstrapHostContent(
       logger.info("URL changed from", from, "to", to)
       if (manager.isActive) {
         if (areSamePageTranslationOrigin(from, to)) {
+          // Keep wrappers mounted; MutationObserver handles the new DOM.
           await manager.restart()
         } else {
           manager.stop()

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-observer-root.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-observer-root.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { PageTranslationManager } from "../page-translation"
+
+const {
+  mockDeepQueryTopLevelSelector,
+  mockGetLocalConfig,
+  mockSendMessage,
+  mockTranslateWalkedElement,
+  mockValidateTranslationConfigAndToast,
+  mockWalkAndLabelElement,
+} = vi.hoisted(() => ({
+  mockGetLocalConfig: vi.fn<(...args: any[]) => any>(),
+  mockDeepQueryTopLevelSelector: vi.fn<(...args: any[]) => any>(),
+  mockWalkAndLabelElement: vi.fn<(...args: any[]) => any>(),
+  mockTranslateWalkedElement: vi.fn<(...args: any[]) => any>(),
+  mockValidateTranslationConfigAndToast: vi.fn<(...args: any[]) => any>(),
+  mockSendMessage: vi.fn<(...args: any[]) => any>(),
+}))
+
+vi.mock("@/utils/config/storage", () => ({
+  getLocalConfig: mockGetLocalConfig,
+}))
+
+vi.mock("@/utils/host/dom/filter", () => ({
+  hasNoWalkAncestor: vi.fn<(...args: any[]) => any>().mockReturnValue(false),
+  isWalkBlockedElement: vi.fn<(...args: any[]) => any>().mockReturnValue(false),
+  isHTMLElement: (node: unknown) => node instanceof HTMLElement,
+}))
+
+vi.mock("@/utils/host/dom/find", () => ({
+  deepQueryTopLevelSelector: mockDeepQueryTopLevelSelector,
+}))
+
+vi.mock("@/utils/host/dom/traversal", () => ({
+  walkAndLabelElement: mockWalkAndLabelElement,
+  walkAndLabelElementChunked: vi
+    .fn<(...args: any[]) => any>()
+    .mockResolvedValue({ forceBlock: false, isInlineNode: false }),
+}))
+
+vi.mock("@/utils/host/translate/node-manipulation", () => ({
+  removeAllTranslatedWrapperNodes: vi.fn<(...args: any[]) => any>(),
+  translateWalkedElement: mockTranslateWalkedElement,
+}))
+
+vi.mock("@/utils/host/translate/translate-variants", () => ({
+  translateTextForPageTitle: vi.fn<(...args: any[]) => any>().mockResolvedValue(null),
+}))
+
+vi.mock("@/utils/host/translate/webpage-context", () => ({
+  getOrCreateWebPageContext: vi.fn<(...args: any[]) => any>().mockResolvedValue(null),
+}))
+
+vi.mock("@/utils/host/translate/translate-text", () => ({
+  validateTranslationConfigAndToast: mockValidateTranslationConfigAndToast,
+}))
+
+vi.mock("@/utils/logger", () => ({
+  logger: {
+    error: vi.fn<(...args: any[]) => any>(),
+    info: vi.fn<(...args: any[]) => any>(),
+    warn: vi.fn<(...args: any[]) => any>(),
+  },
+}))
+
+vi.mock("@/utils/message", () => ({
+  sendMessage: mockSendMessage,
+}))
+
+class MockIntersectionObserver {
+  observe = vi.fn<(...args: any[]) => any>()
+  unobserve = vi.fn<(...args: any[]) => any>()
+  disconnect = vi.fn<(...args: any[]) => any>()
+}
+
+async function flushDomUpdates(): Promise<void> {
+  await Promise.resolve()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await Promise.resolve()
+}
+
+describe("pageTranslationManager mutation observer root", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    document.head.innerHTML = ""
+    document.body.innerHTML = "<main>Route A body</main>"
+
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver)
+
+    mockGetLocalConfig.mockResolvedValue(DEFAULT_CONFIG)
+    mockDeepQueryTopLevelSelector.mockReturnValue([])
+    mockValidateTranslationConfigAndToast.mockReturnValue(true)
+    mockSendMessage.mockResolvedValue(undefined)
+  })
+
+  it("keeps observing after a router replaces the body node (Turbo Drive)", async () => {
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+    mockWalkAndLabelElement.mockClear()
+
+    // Body-replacing SPA visit: the soft URL-change path deliberately keeps
+    // observers attached instead of restarting, so the mutation observer must
+    // be rooted where it survives the swap (documentElement, not the body
+    // node captured at start()).
+    const newBody = document.createElement("body")
+    newBody.innerHTML = "<main>Route B body</main>"
+    document.documentElement.replaceChild(newBody, document.body)
+    await flushDomUpdates()
+
+    // The swap itself must be walked like any inserted subtree...
+    expect(mockWalkAndLabelElement).toHaveBeenCalledWith(
+      newBody,
+      expect.any(String),
+      DEFAULT_CONFIG,
+      expect.anything(),
+    )
+
+    // ...and content inserted into the NEW body afterwards must still be seen.
+    mockWalkAndLabelElement.mockClear()
+    const lateParagraph = document.createElement("p")
+    lateParagraph.textContent = "Late route B content"
+    newBody.appendChild(lateParagraph)
+    await flushDomUpdates()
+
+    expect(mockWalkAndLabelElement).toHaveBeenCalledWith(
+      lateParagraph,
+      expect.any(String),
+      DEFAULT_CONFIG,
+      expect.anything(),
+    )
+
+    manager.stop()
+  })
+})

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -96,11 +96,12 @@ interface IPageTranslationManager {
   stop: () => void
 
   /**
-   * Soft-refresh after a same-origin in-document route change: keep the live
-   * translation session and wrappers (MutationObserver picks up new DOM), and
-   * only re-apply path-scoped site CSS for the new URL.
+   * Re-resolves the site rule for the current URL and swaps injected CSS in
+   * place. Called on same-origin in-document route changes, where the live
+   * session and wrappers stay mounted (MutationObserver walks the new route's
+   * DOM) and only path-scoped site CSS may differ.
    */
-  restart: () => Promise<void>
+  refreshSiteRuleCSS: () => Promise<void>
 
   /**
    * Registers page translation triggers
@@ -329,23 +330,25 @@ export class PageTranslationManager implements IPageTranslationManager {
     this.stopInternal({ notify: true })
   }
 
-  async restart(): Promise<void> {
-    if (!this.isPageTranslating) {
-      await this.start()
-      return
-    }
-
-    // Do not tear down wrappers / observers here. A full stop→start flash is
-    // what users see as "translations disappear then reappear" on SPA clicks.
-    // New route content is walked via the existing MutationObserver; we only
-    // refresh path-scoped injected CSS that may differ by URL.
+  async refreshSiteRuleCSS(): Promise<void> {
+    // Never tear down wrappers / observers on a route change. A full
+    // stop→start flash is what users see as "translations disappear then
+    // reappear" on SPA clicks — and both Navigation API events fire
+    // synchronously inside pushState, BEFORE the router swaps the DOM, so a
+    // teardown here always hits the still-visible previous page. New route
+    // content is walked via the existing MutationObserver instead.
+    if (!this.isPageTranslating) return
     const config = await getLocalConfig()
     if (!config || !this.isPageTranslating) return
 
-    removeSiteRuleCSS(document)
     const siteRule = getEffectiveSiteRule(config, window.location.href)
     if (siteRule.injectedCss) {
+      // ensureSiteRuleCSS replaces the existing sheet's contents in place —
+      // no remove-first, which would leave a gap with no site CSS applied
+      // and flash layout on rules that exist to pin it (e.g. cnbc.com).
       void ensureSiteRuleCSS(document, siteRule.injectedCss)
+    } else {
+      removeSiteRuleCSS(document)
     }
   }
 

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -98,8 +98,13 @@ interface IPageTranslationManager {
   /**
    * Re-resolves the site rule for the current URL and swaps injected CSS in
    * place. Called on same-origin in-document route changes, where the live
-   * session and wrappers stay mounted (MutationObserver walks the new route's
-   * DOM) and only path-scoped site CSS may differ.
+   * session and wrappers stay mounted and the MutationObserver walks the new
+   * route's DOM under the new URL's rule.
+   *
+   * Known tradeoff: site rules are path-scoped in more than CSS (selectors,
+   * thresholds), and DOM that persists unchanged across the route keeps the
+   * walk decisions made under the previous URL's rule. Accepted — the
+   * alternative is the tear-down/re-walk flash this method exists to avoid.
    */
   refreshSiteRuleCSS: () => Promise<void>
 
@@ -292,7 +297,15 @@ export class PageTranslationManager implements IPageTranslationManager {
       // slices, and records emitted meanwhile must not be lost. The walk only
       // writes data-read-frog-* attributes, which this observer's
       // attributeFilter never reports, so this creates no feedback loop.
-      this.observeMutations(document.body)
+      //
+      // Root the observer at documentElement, NOT body: routers like Turbo
+      // Drive replace the body NODE itself on every visit, and an observer
+      // bound to the old body goes permanently blind — the soft URL-change
+      // path (refreshSiteRuleCSS) intentionally never re-attaches observers.
+      // On documentElement the swap itself surfaces as a childList record
+      // with addedNodes=[newBody], which walks the new body like any other
+      // inserted subtree.
+      this.observeMutations(document.documentElement)
 
       // Label existing elements in time-sliced chunks (walkability caching is
       // handled by the walk's onBlockedElement callback).

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -96,8 +96,9 @@ interface IPageTranslationManager {
   stop: () => void
 
   /**
-   * Refreshes translation after an in-document route change without disabling
-   * the tab-level page translation session.
+   * Soft-refresh after a same-origin in-document route change: keep the live
+   * translation session and wrappers (MutationObserver picks up new DOM), and
+   * only re-apply path-scoped site CSS for the new URL.
    */
   restart: () => Promise<void>
 
@@ -299,7 +300,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       try {
         await initialWalk
       } finally {
-        // restart() may already have installed a newer walk's promise.
+        // A newer start() may already have installed a newer walk's promise.
         if (this.initialWalkDone === initialWalk) {
           this.initialWalkDone = null
         }
@@ -334,8 +335,18 @@ export class PageTranslationManager implements IPageTranslationManager {
       return
     }
 
-    this.stopInternal({ notify: false })
-    await this.start()
+    // Do not tear down wrappers / observers here. A full stop→start flash is
+    // what users see as "translations disappear then reappear" on SPA clicks.
+    // New route content is walked via the existing MutationObserver; we only
+    // refresh path-scoped injected CSS that may differ by URL.
+    const config = await getLocalConfig()
+    if (!config || !this.isPageTranslating) return
+
+    removeSiteRuleCSS(document)
+    const siteRule = getEffectiveSiteRule(config, window.location.href)
+    if (siteRule.injectedCss) {
+      void ensureSiteRuleCSS(document, siteRule.injectedCss)
+    }
   }
 
   private stopInternal({ notify }: { notify: boolean }): void {


### PR DESCRIPTION
> **AI model(s) used (required):** Cursor Grok 4.5; maintainer amendments by Claude Opus 5

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fixes three related bugs around same-origin SPA navigation. Note the first two are **independent** — the event-timing change alone does not fix the flicker, because (verified in Chrome 145) `currententrychange` also fires synchronously inside `pushState`, *before* the router swaps the DOM.

1. **No teardown on same-origin route changes** — the URL-change handler used to stop→start the whole translation session, tearing every wrapper off the still-visible previous page (the flicker users see). It now keeps the session and wrappers mounted and only swaps path-scoped site CSS in place (`PageTranslationManager.refreshSiteRuleCSS`); the live MutationObserver walks the new route's DOM as the router inserts it.

2. **`navigate` → `currententrychange`** — `navigate` also fires for cross-document navigations (running a full restart on a page about to unload) and fires pre-commit (desyncing the tracked URL on cancelled/redirected navigations). `currententrychange` only fires for committed same-document changes.

3. **Mutation observer rooted at `documentElement`** — body-replacing routers (Turbo Drive etc.) swap the body *node* per visit; with observers bound to the old body node and the soft path never re-attaching them, the session went permanently blind after the first in-site navigation. On `documentElement`, the body swap surfaces as a normal childList record and the new body is walked like any inserted subtree.

Known tradeoff (documented in code): site rules are path-scoped in more than CSS; DOM persisting unchanged across a route change keeps the walk decisions made under the previous URL's rule.

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

- `listen.test.ts` — pre-commit `navigate` does not fire; `currententrychange` / `pushState` do; **Chrome event ordering**: when `currententrychange` fires inside `pushState` (real-browser behavior), exactly one URLChange event is dispatched
- `page-translation-observer-root.test.ts` — translation keeps observing after a router replaces the body node (fails when the observer is rooted at `document.body`)
- `runtime.test.ts` — same-origin navigation only refreshes site CSS, session stays active
- Manual: built local Chrome MV3 under `.output/chrome-mv3` and loaded unpacked for SPA navigation checks; Navigation API event ordering verified against an instrumented page in Chrome 145

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Changeset included for `@read-frog/extension` (patch).

Maintainer amendments (commits `6c2d66e` and `20fd2fc` on top of the original):
- renamed `restart()` → `refreshSiteRuleCSS()` and removed its unreachable inactive→start branch
- site CSS now replaced in place (no remove-then-ensure gap that flashed layout on rules like cnbc.com)
- observer root moved to `documentElement` (fix 3 above) + regression test
- the unrelated `.gitignore` reorganization was split out of this PR (will land as its own chore PR, credited to @YoungLee-coder)

Made with [Cursor](https://cursor.com)