### PR TITLE
fix(dictionary): return the selected term's sentence from paragraph c…

### DIFF
--- a/.changeset/dictionary-sentence-fields.md
+++ b/.changeset/dictionary-sentence-fields.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(dictionary): return the selected term's sentence from paragraph context

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -519,25 +519,26 @@ options:
               1. Focus on the meaning that best matches the provided paragraphs.
               2. Normalize Term to its base/canonical form.
               3. Keep Definition precise and learner-friendly.
-              4. Keep Paragraphs exactly as provided in the prompt.
-              5. Phonetic must use the standard notation for the term's language (e.g., IPA for English, pinyin for Mandarin, romaji for Japanese).
-              6. Part of Speech in English (noun, verb, adjective, etc.).
-              7. Difficulty must be a CEFR level (A1, A2, B1, B2, C1, or C2).
-              8. If a field is unknown, return an empty string instead of guessing.
-              9. Respond in {{targetLanguage}} for all textual fields unless source-form text is required for clarity.
+              4. For Sentence, extract only the complete sentence from the provided paragraphs that contains the selected term. Do not include surrounding sentences.
+              5. Sentence Translation must translate only the extracted Sentence.
+              6. Phonetic must use the standard notation for the term's language (e.g., IPA for English, pinyin for Mandarin, romaji for Japanese).
+              7. Part of Speech in English (noun, verb, adjective, etc.).
+              8. Difficulty must be a CEFR level (A1, A2, B1, B2, C1, or C2).
+              9. If a field is unknown, return an empty string instead of guessing.
+              10. Respond in {{targetLanguage}} for all textual fields unless source-form text is required for clarity.
 
               ## Examples
 
               ### Example 1
-              Input: Selection="blossoms", Paragraphs="The ephemeral beauty of cherry blossoms reminds us to cherish each moment.", Target language=Chinese
+              Input: Selection="blossoms", Paragraphs="Spring arrives quietly in the park. The ephemeral beauty of cherry blossoms reminds us to cherish each moment. Families and friends gather beneath the trees.", Target language=Chinese
 
               Output:
               - Term: blossom
               - Phonetic: /ˈblɒs.əm/
               - Part of Speech: noun
-              - Paragraphs: The ephemeral beauty of cherry blossoms reminds us to cherish each moment.
+              - Sentence: The ephemeral beauty of cherry blossoms reminds us to cherish each moment.
               - Definition: 花；花朵（尤指果树的花）
-              - Paragraphs Translation: 樱花短暂的美丽提醒我们珍惜每一刻。
+              - Sentence Translation: 樱花短暂的美丽提醒我们珍惜每一刻。
               - Difficulty: B2
 
               ### Example 2
@@ -547,9 +548,9 @@ options:
               - Term: 感動
               - Phonetic: kandou
               - Part of Speech: noun
-              - Paragraphs: この映画はつまらないと思ったけど、最後は感動した。
+              - Sentence: この映画はつまらないと思ったけど、最後は感動した。
               - Definition: Being deeply moved; emotional touch
-              - Paragraphs Translation: I thought this movie was boring, but the ending was moving.
+              - Sentence Translation: I thought this movie was boring, but the ending was moving.
               - Difficulty: B1
             prompt: |-
               ## Input
@@ -562,12 +563,12 @@ options:
             fieldPhoneticDescription: Standard phonetic transcription for the term's language (e.g., IPA for English, pinyin for Mandarin, romaji for Japanese).
             fieldPartOfSpeech: Part of Speech
             fieldPartOfSpeechDescription: Grammatical category (e.g., noun, verb, adjective).
-            fieldParagraphs: Paragraphs
-            fieldParagraphsDescription: The paragraphs from the prompt above. Do not rewrite them.
+            fieldSentence: Sentence
+            fieldSentenceDescription: The complete sentence from the paragraphs above that contains the selected term. Do not include surrounding sentences.
             fieldDefinition: Definition
             fieldDefinitionDescription: One concise definition for the contextual sense.
-            fieldParagraphsTranslation: Paragraphs Translation
-            fieldParagraphsTranslationDescription: The translation of the paragraphs.
+            fieldSentenceTranslation: Sentence Translation
+            fieldSentenceTranslationDescription: The translation of Sentence only.
             fieldDifficulty: Difficulty
             fieldDifficultyDescription: Estimated CEFR difficulty level A1, A2, B1, B2, C1, or C2.
           improveWriting:

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -519,25 +519,26 @@ options:
               1. Céntrate en el significado que mejor coincida con los párrafos proporcionados.
               2. Normaliza Término a su forma base/canónica.
               3. Mantén Definición precisa y fácil para estudiantes.
-              4. Mantén Párrafos exactamente como se proporcionan en el prompt.
-              5. Fonética debe usar la notación estándar del idioma del término (p. ej., IPA para inglés, pinyin para mandarín, romaji para japonés).
-              6. Categoría gramatical en inglés (noun, verb, adjective, etc.).
-              7. Dificultad debe ser un nivel CEFR (A1, A2, B1, B2, C1 o C2).
-              8. Si un campo es desconocido, devuelve una cadena vacía en lugar de adivinar.
-              9. Responde en {{targetLanguage}} para todos los campos textuales, salvo que se requiera texto en la forma de origen para mayor claridad.
+              4. Para Oración, extrae únicamente la oración completa de los párrafos proporcionados que contenga el término seleccionado. No incluyas las oraciones anteriores ni posteriores.
+              5. Traducción de la oración debe traducir únicamente la Oración extraída.
+              6. Fonética debe usar la notación estándar del idioma del término (p. ej., IPA para inglés, pinyin para mandarín, romaji para japonés).
+              7. Categoría gramatical en inglés (noun, verb, adjective, etc.).
+              8. Dificultad debe ser un nivel CEFR (A1, A2, B1, B2, C1 o C2).
+              9. Si un campo es desconocido, devuelve una cadena vacía en lugar de adivinar.
+              10. Responde en {{targetLanguage}} para todos los campos textuales, salvo que se requiera texto en la forma de origen para mayor claridad.
 
               ## Ejemplos
 
               ### Ejemplo 1
-              Entrada: Selección="blossoms", Párrafos="The ephemeral beauty of cherry blossoms reminds us to cherish each moment.", Idioma de destino=chino
+              Entrada: Selección="blossoms", Párrafos="Spring arrives quietly in the park. The ephemeral beauty of cherry blossoms reminds us to cherish each moment. Families and friends gather beneath the trees.", Idioma de destino=chino
 
               Salida:
               - Término: blossom
               - Fonética: /ˈblɒs.əm/
               - Categoría gramatical: noun
-              - Párrafos: The ephemeral beauty of cherry blossoms reminds us to cherish each moment.
+              - Oración: The ephemeral beauty of cherry blossoms reminds us to cherish each moment.
               - Definición: 花；花朵（尤指果树的花）
-              - Traducción de párrafos: 樱花短暂的美丽提醒我们珍惜每一刻。
+              - Traducción de la oración: 樱花短暂的美丽提醒我们珍惜每一刻。
               - Dificultad: B2
 
               ### Ejemplo 2
@@ -547,9 +548,9 @@ options:
               - Término: 感動
               - Fonética: kandou
               - Categoría gramatical: noun
-              - Párrafos: この映画はつまらないと思ったけど、最後は感動した。
+              - Oración: この映画はつまらないと思ったけど、最後は感動した。
               - Definición: Being deeply moved; emotional touch
-              - Traducción de párrafos: I thought this movie was boring, but the ending was moving.
+              - Traducción de la oración: I thought this movie was boring, but the ending was moving.
               - Dificultad: B1
             prompt: |-
               ## Entrada
@@ -562,12 +563,12 @@ options:
             fieldPhoneticDescription: Transcripción fonética estándar para el idioma del término (p. ej., IPA para inglés, pinyin para mandarín, romaji para japonés).
             fieldPartOfSpeech: Categoría gramatical
             fieldPartOfSpeechDescription: Categoría gramatical (p. ej., noun, verb, adjective).
-            fieldParagraphs: Párrafos
-            fieldParagraphsDescription: Los párrafos del prompt anterior. No los reescribas.
+            fieldSentence: Oración
+            fieldSentenceDescription: La oración completa de los párrafos anteriores que contiene el término seleccionado. No incluyas las oraciones anteriores ni posteriores.
             fieldDefinition: Definición
             fieldDefinitionDescription: Una definición concisa para el sentido contextual.
-            fieldParagraphsTranslation: Traducción de párrafos
-            fieldParagraphsTranslationDescription: La traducción de los párrafos.
+            fieldSentenceTranslation: Traducción de la oración
+            fieldSentenceTranslationDescription: La traducción únicamente de la Oración.
             fieldDifficulty: Dificultad
             fieldDifficultyDescription: Nivel de dificultad CEFR estimado A1, A2, B1, B2, C1 o C2.
           improveWriting:

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -519,25 +519,26 @@ options:
               1. 聚焦于最匹配所提供段落内容的含义。
               2. 将词条规范化为其基本/标准形式。
               3. 保持释义精确且适合学习者。
-              4. 保持段落内容与提示词一致，不要改写。
-              5. 音标必须使用该语言的标准标注（如英语用 IPA，中文用拼音，日语用罗马字）。
-              6. 词性使用英文（noun, verb, adjective 等）。
-              7. 难度必须是 CEFR 等级（A1, A2, B1, B2, C1, 或 C2）。
-              8. 如果某个字段未知，返回空字符串而非猜测。
-              9. 除非需要保留原文形式，所有文本字段均使用 {{targetLanguage}} 作答。
+              4. “句子”字段只提取所提供段落中包含选中词语的完整句子，不要包含前后句。
+              5. “句子翻译”字段只翻译所提取的句子。
+              6. 音标必须使用该语言的标准标注（如英语用 IPA，中文用拼音，日语用罗马字）。
+              7. 词性使用英文（noun, verb, adjective 等）。
+              8. 难度必须是 CEFR 等级（A1, A2, B1, B2, C1, 或 C2）。
+              9. 如果某个字段未知，返回空字符串而非猜测。
+              10. 除非需要保留原文形式，所有文本字段均使用 {{targetLanguage}} 作答。
 
               ## 示例
 
               ### 示例 1
-              输入：Selection="blossoms", Paragraphs="The ephemeral beauty of cherry blossoms reminds us to cherish each moment.", 目标语言=中文
+              输入：Selection="blossoms", Paragraphs="Spring arrives quietly in the park. The ephemeral beauty of cherry blossoms reminds us to cherish each moment. Families and friends gather beneath the trees.", 目标语言=中文
 
               输出：
               - 词条：blossom
               - 音标：/ˈblɒs.əm/
               - 词性：noun
-              - 段落内容：The ephemeral beauty of cherry blossoms reminds us to cherish each moment.
+              - 句子：The ephemeral beauty of cherry blossoms reminds us to cherish each moment.
               - 释义：花；花朵（尤指果树的花）
-              - 段落翻译：樱花短暂的美丽提醒我们珍惜每一刻。
+              - 句子翻译：樱花短暂的美丽提醒我们珍惜每一刻。
               - 难度：B2
 
               ### 示例 2
@@ -547,9 +548,9 @@ options:
               - 词条：感動
               - 音标：kandou
               - 词性：noun
-              - 段落内容：この映画はつまらないと思ったけど、最後は感動した。
+              - 句子：この映画はつまらないと思ったけど、最後は感動した。
               - 释义：Being deeply moved; emotional touch
-              - 段落翻译：I thought this movie was boring, but the ending was moving.
+              - 句子翻译：I thought this movie was boring, but the ending was moving.
               - 难度：B1
             prompt: |-
               ## 输入
@@ -562,12 +563,12 @@ options:
             fieldPhoneticDescription: 该语言的标准音标（如英语用 IPA，中文用拼音，日语用罗马字）。
             fieldPartOfSpeech: 词性
             fieldPartOfSpeechDescription: 语法类别（如 noun、verb、adjective）。
-            fieldParagraphs: 段落内容
-            fieldParagraphsDescription: 使用上方提示词中的原始段落内容，不要改写。
+            fieldSentence: 句子
+            fieldSentenceDescription: 提取上方段落中包含选中词语的完整句子，不要包含前后句。
             fieldDefinition: 释义
             fieldDefinitionDescription: 针对语境含义的一条简洁释义。
-            fieldParagraphsTranslation: 段落翻译
-            fieldParagraphsTranslationDescription: 段落内容的翻译。
+            fieldSentenceTranslation: 句子翻译
+            fieldSentenceTranslationDescription: 只翻译提取出的句子。
             fieldDifficulty: 难度
             fieldDifficultyDescription: 预估 CEFR 难度等级：A1、A2、B1、B2、C1 或 C2。
           improveWriting:

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -519,25 +519,26 @@ options:
               1. 專注於最符合所提供段落的語意。
               2. 將詞條標準化為基本／標準形式。
               3. 定義要精確且適合學習者理解。
-              4. 段落必須與提示詞中提供的內容完全一致。
-              5. 音標必須使用該詞條語言的標準標記（例如英文使用 IPA、中文使用拼音、日文使用羅馬字）。
-              6. 詞性請使用英文（noun、verb、adjective 等）。
-              7. 難度必須是 CEFR 等級（A1、A2、B1、B2、C1 或 C2）。
-              8. 如果某個欄位無法判斷，請回傳空字串，不要猜測。
-              9. 除非必須使用來源形式才能保持清楚，所有文字欄位都請使用 {{targetLanguage}} 回答。
+              4. 「句子」欄位只提取所提供段落中包含所選字詞的完整句子，不要包含前後句。
+              5. 「句子翻譯」欄位只翻譯所提取的句子。
+              6. 音標必須使用該詞條語言的標準標記（例如英文使用 IPA、中文使用拼音、日文使用羅馬字）。
+              7. 詞性請使用英文（noun、verb、adjective 等）。
+              8. 難度必須是 CEFR 等級（A1、A2、B1、B2、C1 或 C2）。
+              9. 如果某個欄位無法判斷，請回傳空字串，不要猜測。
+              10. 除非必須使用來源形式才能保持清楚，所有文字欄位都請使用 {{targetLanguage}} 回答。
 
               ## 範例
 
               ### 範例 1
-              輸入：Selection=blossoms；Paragraphs=The ephemeral beauty of cherry blossoms reminds us to cherish each moment.；Target language=Chinese
+              輸入：Selection=blossoms；Paragraphs=Spring arrives quietly in the park. The ephemeral beauty of cherry blossoms reminds us to cherish each moment. Families and friends gather beneath the trees.；Target language=Chinese
 
               輸出：
               - 詞條：blossom
               - 音標：/ˈblɒs.əm/
               - 詞性：noun
-              - 段落：The ephemeral beauty of cherry blossoms reminds us to cherish each moment.
+              - 句子：The ephemeral beauty of cherry blossoms reminds us to cherish each moment.
               - 定義：花；花朵（尤指果樹的花）
-              - 段落翻譯：櫻花短暫的美麗提醒我們珍惜每一刻。
+              - 句子翻譯：櫻花短暫的美麗提醒我們珍惜每一刻。
               - 難度：B2
 
               ### 範例 2
@@ -547,9 +548,9 @@ options:
               - 詞條：感動
               - 音標：kandou
               - 詞性：noun
-              - 段落：この映画はつまらないと思ったけど、最後は感動した。
+              - 句子：この映画はつまらないと思ったけど、最後は感動した。
               - 定義：Being deeply moved; emotional touch
-              - 段落翻譯：I thought this movie was boring, but the ending was moving.
+              - 句子翻譯：I thought this movie was boring, but the ending was moving.
               - 難度：B1
             prompt: |-
               ## 輸入
@@ -562,12 +563,12 @@ options:
             fieldPhoneticDescription: 詞條語言的標準音標標記（例如英文使用 IPA、中文使用拼音、日文使用羅馬字）。
             fieldPartOfSpeech: 詞性
             fieldPartOfSpeechDescription: 文法類別（例如 noun、verb、adjective）。
-            fieldParagraphs: 段落
-            fieldParagraphsDescription: 上方提示詞中的段落。請勿重寫。
+            fieldSentence: 句子
+            fieldSentenceDescription: 提取上方段落中包含所選字詞的完整句子，不要包含前後句。
             fieldDefinition: 定義
             fieldDefinitionDescription: 針對脈絡語意提供一則精簡定義。
-            fieldParagraphsTranslation: 段落翻譯
-            fieldParagraphsTranslationDescription: 段落的翻譯。
+            fieldSentenceTranslation: 句子翻譯
+            fieldSentenceTranslationDescription: 只翻譯提取出的句子。
             fieldDifficulty: 難度
             fieldDifficultyDescription: 預估 CEFR 難度等級 A1、A2、B1、B2、C1 或 C2。
           improveWriting:

--- a/src/utils/__tests__/notebase.test.ts
+++ b/src/utils/__tests__/notebase.test.ts
@@ -1,6 +1,8 @@
 import type { NotebaseRowCreateInput } from "@read-frog/api-contract"
 import type { SelectionToolbarCustomAction } from "@/types/config/selection-toolbar"
 import { describe, expect, it } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { getBuiltInDictionaryAction } from "@/utils/custom-actions"
 import { sanitizeSelectionToolbarCustomAction } from "../notebase/connection"
 import {
   buildNotebaseRowCells,
@@ -171,6 +173,77 @@ describe("notebase utils", () => {
     })
     expect(typedCells).toEqual({
       "column-summary": "A short summary",
+    })
+  })
+
+  it("keeps existing Dictionary context ids mapped to the original Notebase columns", () => {
+    const action = getBuiltInDictionaryAction(DEFAULT_CONFIG.selectionToolbar)
+    const connectedAction: SelectionToolbarCustomAction = {
+      ...action,
+      outputSchema: action.outputSchema.map((field) => {
+        if (field.id === "default-dictionary-context") {
+          return { ...field, name: "Sentence" }
+        }
+        if (field.id === "default-dictionary-context-translation") {
+          return { ...field, name: "Sentence Translation" }
+        }
+        return field
+      }),
+      notebaseConnection: {
+        notebaseId: "notebase-1",
+        notebaseNameSnapshot: "Words",
+        connectedAccount,
+        mappings: [
+          createNotebaseMapping("default-dictionary-context", "column-paragraphs", "Paragraphs"),
+          createNotebaseMapping(
+            "default-dictionary-context-translation",
+            "column-paragraphs-translation",
+            "Paragraphs Translation",
+          ),
+        ],
+      },
+    }
+    const schema = {
+      id: "notebase-1",
+      name: "Words",
+      updatedAt: new Date(),
+      notebaseColumns: [
+        {
+          id: "column-paragraphs",
+          notebaseId: "notebase-1",
+          name: "Paragraphs",
+          config: { type: "string" as const },
+          position: 0,
+          isPrimary: false,
+          width: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        {
+          id: "column-paragraphs-translation",
+          notebaseId: "notebase-1",
+          name: "Paragraphs Translation",
+          config: { type: "string" as const },
+          position: 1,
+          isPrimary: false,
+          width: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+    }
+
+    expect(
+      resolveNotebaseMappings(connectedAction, schema).map((mapping) => mapping.status),
+    ).toEqual(["valid", "valid"])
+    expect(
+      buildNotebaseRowCells(connectedAction, schema, {
+        Sentence: "The selected term appears in this sentence.",
+        "Sentence Translation": "所选词语出现在这个句子中。",
+      }).cells,
+    ).toEqual({
+      "column-paragraphs": "The selected term appears in this sentence.",
+      "column-paragraphs-translation": "所选词语出现在这个句子中。",
     })
   })
 

--- a/src/utils/constants/custom-action-templates.ts
+++ b/src/utils/constants/custom-action-templates.ts
@@ -61,16 +61,16 @@ export const CUSTOM_ACTION_TEMPLATES: CustomActionTemplate[] = [
           "dictionary-definition",
         ),
         createOutputSchemaField(
-          i18n.t(`${T_PREFIX}.dictionary.fieldParagraphs`),
+          i18n.t(`${T_PREFIX}.dictionary.fieldSentence`),
           "string",
-          i18n.t(`${T_PREFIX}.dictionary.fieldParagraphsDescription`),
+          i18n.t(`${T_PREFIX}.dictionary.fieldSentenceDescription`),
           "dictionary-context",
           true,
         ),
         createOutputSchemaField(
-          i18n.t(`${T_PREFIX}.dictionary.fieldParagraphsTranslation`),
+          i18n.t(`${T_PREFIX}.dictionary.fieldSentenceTranslation`),
           "string",
-          i18n.t(`${T_PREFIX}.dictionary.fieldParagraphsTranslationDescription`),
+          i18n.t(`${T_PREFIX}.dictionary.fieldSentenceTranslationDescription`),
           "dictionary-context-translation",
         ),
         createOutputSchemaField(


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-5 (Codex)

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

- Rename the built-in Dictionary output fields from Paragraphs to Sentence and from Paragraphs Translation to Sentence Translation.
- Update the default prompt to extract only the complete sentence containing the selected term and translate only that sentence.
- Expand an existing example with surrounding sentences to demonstrate the new output behavior.
- Keep the stable Dictionary context field IDs unchanged so existing Notebase connections continue writing to their mapped columns.
- Update the English, Spanish, Simplified Chinese, and Traditional Chinese Dictionary templates.

## Related Issue

None.

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Validated with:

- `pnpm exec nx fmt:check`
- `pnpm exec nx lint`
- `SKIP_FREE_API=true pnpm exec nx test -- --exclude="**/free-api.test.ts"` — 232 test files and 2,222 tests passed

## Screenshots

Not applicable.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- Existing Notebase columns are not renamed; their stable field and column mappings remain valid.
- New Notebases use the Sentence and Sentence Translation column names.
- The change includes a patch changeset for `@read-frog/extension`.