### PR TITLE
fix(translate): skip icon-font ligatures during page translation

### DIFF
--- a/.changeset/quiet-icons-stay-icons.md
+++ b/.changeset/quiet-icons-stay-icons.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): skip common icon-font ligatures during page translation

--- a/src/utils/host/dom/__tests__/traversal.test.ts
+++ b/src/utils/host/dom/__tests__/traversal.test.ts
@@ -146,6 +146,63 @@ describe("extractTextContent", () => {
     })
   })
 
+  describe("icon font exclusion", () => {
+    it("should exclude Google Symbols ligatures from surrounding page text", () => {
+      const div = document.createElement("div")
+      div.innerHTML = `
+        <span id="icon" style="font-family: 'Google Symbols'">keyboard_return</span>
+        <span>Readable text</span>
+      `
+      document.body.append(div)
+
+      walkAndLabelElement(div, "icon-font", DEFAULT_CONFIG)
+
+      const icon = div.querySelector<HTMLElement>("#icon")!
+      expect(icon).not.toHaveAttribute(WALKED_ATTRIBUTE)
+      expect(extractTextContent(div, DEFAULT_CONFIG)).not.toContain("keyboard_return")
+      expect(extractTextContent(div, DEFAULT_CONFIG)).toContain("Readable text")
+      div.remove()
+    })
+
+    it("should exclude common icon-font ligatures", () => {
+      const iconFonts = [
+        ["Material Icons", "expand_more"],
+        ["Material Icons Outlined", "settings"],
+        ["Material Symbols Rounded", "keyboard_return"],
+        ["FontAwesome", "house"],
+        ["Font Awesome 6 Free", "user"],
+      ]
+
+      for (const [fontFamily, ligature] of iconFonts) {
+        const div = document.createElement("div")
+        div.innerHTML = `<span id="icon">${ligature}</span>`
+        document.body.append(div)
+
+        const icon = div.querySelector<HTMLElement>("#icon")!
+        icon.style.fontFamily = `"${fontFamily}"`
+        walkAndLabelElement(div, "icon-font", DEFAULT_CONFIG)
+
+        expect(icon).not.toHaveAttribute(WALKED_ATTRIBUTE)
+        expect(extractTextContent(div, DEFAULT_CONFIG)).not.toContain(ligature)
+        div.remove()
+      }
+    })
+
+    it("should keep ordinary text when an icon font is only a fallback", () => {
+      const div = document.createElement("div")
+      div.innerHTML = '<span id="text">Readable text</span>'
+      document.body.append(div)
+
+      const text = div.querySelector<HTMLElement>("#text")!
+      text.style.fontFamily = 'Arial, "Google Symbols", sans-serif'
+      walkAndLabelElement(div, "icon-font", DEFAULT_CONFIG)
+
+      expect(text).toHaveAttribute(WALKED_ATTRIBUTE)
+      expect(extractTextContent(div, DEFAULT_CONFIG)).toContain("Readable text")
+      div.remove()
+    })
+  })
+
   describe("extension wrapper exclusion", () => {
     it("should exclude translated wrapper text but keep host notranslate children (issues #1831, #249)", () => {
       const p = document.createElement("p")

--- a/src/utils/host/dom/filter.ts
+++ b/src/utils/host/dom/filter.ts
@@ -16,6 +16,27 @@ import {
 } from "@/utils/constants/dom-rules"
 import { getEffectiveSiteRule } from "@/utils/site-rules/effective"
 
+const ICON_FONT_FAMILY_NAMES = ["material icons", "material symbols", "font awesome"]
+
+// Ligature icon fonts store glyph names such as `keyboard_return` in text nodes.
+// Translating those names breaks the glyph lookup and exposes the translated text.
+function usesIconFont(fontFamily: string): boolean {
+  // Only the primary family indicates how the element is intended to render;
+  // an icon font appearing later as a fallback is not enough to exclude real text.
+  const [primaryFamily = ""] = fontFamily.split(",")
+  const normalizedFamily = primaryFamily
+    .trim()
+    .replace(/^(["'])(.*)\1$/, "$2")
+    .toLowerCase()
+  return (
+    normalizedFamily === "google symbols" ||
+    normalizedFamily === "fontawesome" ||
+    ICON_FONT_FAMILY_NAMES.some(
+      (name) => normalizedFamily === name || normalizedFamily.startsWith(`${name} `),
+    )
+  )
+}
+
 export function isEditable(element: HTMLElement): boolean {
   const tag = element.tagName
   if (tag === "INPUT" || tag === "TEXTAREA") return true
@@ -229,7 +250,11 @@ export function isDontWalkIntoAndDontTranslateAsChildElement(
   if (dontWalkCustomElement) return true
 
   const computedStyle = window.getComputedStyle(element)
-  return computedStyle.display === "none" || computedStyle.visibility === "hidden"
+  return (
+    usesIconFont(computedStyle.fontFamily) ||
+    computedStyle.display === "none" ||
+    computedStyle.visibility === "hidden"
+  )
 }
 
 /**


### PR DESCRIPTION
> **AI model(s) used (required):** OpenAI `gpt-5.6-sol` via Hermes Agent

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Page translation treated icon-font ligature names such as `keyboard_return` as ordinary text. Translating those strings breaks the font's glyph lookup and exposes translated text in place of the icon.

This change:

- skips elements whose primary computed font family is Google Symbols, Material Icons/Symbols, or Font Awesome;
- keeps ordinary text translatable when an icon font appears only as a fallback family;
- adds traversal and text-extraction regression coverage for the reported behavior;
- adds a patch changeset for the extension.

## Related Issue

Closes #1966

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Commands and results:

- `SKIP_FREE_API=true pnpm exec vitest run src/utils/host/dom/__tests__/traversal.test.ts -t 'icon font exclusion'` — 3 passed
- `SKIP_FREE_API=true pnpm test` — 2230 passed, 4 intentionally skipped free-API tests
- `pnpm lint` — 0 warnings, 0 errors
- `pnpm fmt:check` — passed
- `WXT_SKIP_ENV_VALIDATION=true pnpm build` — Chrome MV3 build passed; manifest artifact verified
- Built-extension Puppeteer test in headed Chromium — ordinary and fallback text translated; Google Symbols, Material Symbols, and Font Awesome ligatures stayed unchanged and unwalked; no page errors

## Screenshots

The screenshots below were captured from the same deterministic fixture, Chromium viewport, target language (`cmn`), and bilingual translation mode using built Chrome MV3 artifacts.

| Before — `origin/main` (`b6ff2d83`) | After — PR #1986 (`950a3a61`) |
|---|---|
| The icon ligature is walked and translated, stretching the control and exposing translated text. | The ligature is skipped; the Material Symbols glyph remains intact while ordinary and fallback text still translate. |
| ![Before: translated icon-font ligature breaks and stretches the Material Symbols control](https://f004.backblazeb2.com/file/mengxi-public/hermes-assets/58/588f28fc057bb386c445.png) | ![After: Material Symbols icon remains intact while surrounding text is translated](https://f004.backblazeb2.com/file/mengxi-public/hermes-assets/d8/d8fc4c817315ad4357f8.png) |

> The red outline is fixture instrumentation: it appears only when the built extension labels the icon node as walked and exposes it to translation.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The regression test was also run without the source fix on current `origin/main` and reproduced the reported failure before the implementation was restored.
