### PR TITLE
feat(ui): morph the thinking glyph and shimmer its label

### DIFF
--- a/.changeset/tidy-glyphs-stop-spinning.md
+++ b/.changeset/tidy-glyphs-stop-spinning.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(ui): morphing thinking glyph with shimmering label, ending at the first output token

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "jotai-family": "^1.0.2",
     "js-sha256": "^0.12.0",
     "lucide-react": "^1.27.0",
+    "motion": "^12.43.0",
     "posthog-js": "^1.407.3",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,9 @@ importers:
       lucide-react:
         specifier: ^1.27.0
         version: 1.27.0(react@19.2.8)
+      motion:
+        specifier: ^12.43.0
+        version: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       posthog-js:
         specifier: ^1.407.3
         version: 1.407.3
@@ -4359,6 +4362,20 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  framer-motion@12.43.0:
+    resolution: {integrity: sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   franc@6.2.0:
     resolution: {integrity: sha512-rcAewP7PSHvjq7Kgd7dhj82zE071kX5B4W1M4ewYMf/P+i6YsDQmj62Xz3VQm9zyUzUXwhIde/wHLGCMrM+yGg==}
 
@@ -5388,6 +5405,26 @@ packages:
       snappy:
         optional: true
       socks:
+        optional: true
+
+  motion-dom@12.43.0:
+    resolution: {integrity: sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==}
+
+  motion-utils@12.39.0:
+    resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
+
+  motion@12.43.0:
+    resolution: {integrity: sha512-BQgQbSa9Hn3/mtbib0MK53y6JSANa+YKUKlaYnWzAVDH424RYQ5LVpV3pNiWH00BA2z4ojsSdMzqT7g2FQwjuQ==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
         optional: true
 
   mri@1.2.0:
@@ -10931,6 +10968,15 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
+  framer-motion@12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      motion-dom: 12.43.0
+      motion-utils: 12.39.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+
   franc@6.2.0:
     dependencies:
       trigram-utils: 2.0.1
@@ -11947,6 +11993,20 @@ snapshots:
       bson: 7.3.1
       mongodb-connection-string-url: 7.0.1
     optional: true
+
+  motion-dom@12.43.0:
+    dependencies:
+      motion-utils: 12.39.0
+
+  motion-utils@12.39.0: {}
+
+  motion@12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      framer-motion: 12.43.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   mri@1.2.0: {}
 

--- a/src/components/icons/thinking-icon.tsx
+++ b/src/components/icons/thinking-icon.tsx
@@ -1,44 +1,63 @@
+import { domAnimation, LazyMotion, m, useReducedMotion } from "motion/react"
 import { cn } from "@/utils/styles/utils"
 
-const THINKING_DOTS = [
-  { cx: 12.5, cy: 12.5, begin: "0s" },
-  { cx: 12.5, cy: 52.5, begin: "100ms", fillOpacity: 0.5 },
-  { cx: 52.5, cy: 12.5, begin: "300ms" },
-  { cx: 52.5, cy: 52.5, begin: "600ms" },
-  { cx: 92.5, cy: 12.5, begin: "800ms" },
-  { cx: 92.5, cy: 52.5, begin: "400ms" },
-  { cx: 12.5, cy: 92.5, begin: "700ms" },
-  { cx: 52.5, cy: 92.5, begin: "500ms" },
-  { cx: 92.5, cy: 92.5, begin: "200ms" },
-] as const
+/* The three shapes share an identical command structure (M + 4×C + Z, 26 numbers
+   each), which is what lets motion interpolate the `d` string between them. Keep
+   them in lockstep if you ever redraw one. */
+const CIRCLE_CLOCKWISE =
+  "M 12 8 C 14.21 8 16 9.79 16 12 C 16 14.21 14.21 16 12 16 C 9.79 16 8 14.21 8 12 C 8 9.79 9.79 8 12 8 Z"
+const INFINITY_LOOP =
+  "M 12 12 C 14 8.5 19 8.5 19 12 C 19 15.5 14 15.5 12 12 C 10 8.5 5 8.5 5 12 C 5 15.5 10 15.5 12 12 Z"
+const CIRCLE_COUNTER_CLOCKWISE =
+  "M 12 16 C 14.21 16 16 14.21 16 12 C 16 9.79 14.21 8 12 8 C 9.79 8 8 9.79 8 12 C 8 14.21 9.79 16 12 16 Z"
+
+const MORPH_KEYFRAMES = [
+  CIRCLE_CLOCKWISE,
+  INFINITY_LOOP,
+  CIRCLE_COUNTER_CLOCKWISE,
+  INFINITY_LOOP,
+  CIRCLE_CLOCKWISE,
+]
 
 interface ThinkingIconProps extends React.ComponentProps<"svg"> {
   animated?: boolean
 }
 
 export function ThinkingIcon({ animated = true, className, ...props }: ThinkingIconProps) {
+  const prefersReducedMotion = useReducedMotion() ?? false
+  const isMorphing = animated && !prefersReducedMotion
+
   return (
-    <svg viewBox="0 0 105 105" fill="currentColor" className={cn("size-2.5", className)} {...props}>
-      {THINKING_DOTS.map((dot) => (
-        <circle
-          key={`${dot.cx}-${dot.cy}`}
-          cx={dot.cx}
-          cy={dot.cy}
-          r="12.5"
-          fillOpacity={animated ? ("fillOpacity" in dot ? dot.fillOpacity : 1) : 1}
-        >
-          {animated && (
-            <animate
-              attributeName="fill-opacity"
-              begin={dot.begin}
-              dur="1s"
-              values="1;.2;1"
-              calcMode="linear"
-              repeatCount="indefinite"
-            />
-          )}
-        </circle>
-      ))}
-    </svg>
+    <LazyMotion features={domAnimation}>
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={cn("size-4", className)}
+        {...props}
+      >
+        <m.path
+          d={CIRCLE_CLOCKWISE}
+          animate={isMorphing ? { d: MORPH_KEYFRAMES } : { d: CIRCLE_CLOCKWISE }}
+          transition={
+            isMorphing
+              ? {
+                  d: {
+                    duration: 6,
+                    ease: "easeInOut",
+                    repeat: Number.POSITIVE_INFINITY,
+                    times: [0, 0.25, 0.5, 0.75, 1],
+                  },
+                }
+              : // Settling from wherever the loop happened to be is the whole point
+                // of animating this at runtime instead of in CSS.
+                { d: { duration: 0.4, ease: "easeInOut" } }
+          }
+        />
+      </svg>
+    </LazyMotion>
   )
 }

--- a/src/components/thinking.tsx
+++ b/src/components/thinking.tsx
@@ -33,9 +33,15 @@ export function Thinking({ status, content, defaultExpanded = false, className }
   )
   const triggerClassName =
     "flex w-full items-center justify-between gap-2 px-2.5 py-1.5 text-left text-xs"
-  const thinkingIconClassName = cn(
-    "shrink-0",
-    isThinking ? "text-primary" : "text-muted-foreground",
+  // The morphing glyph and the shimmering label already carry the "in progress"
+  // signal; tinting the icon on top of them only competes with it.
+  const thinkingIconClassName = "shrink-0 text-muted-foreground"
+  // `shimmer` sweeps a highlight across the glyphs, taking the surrounding
+  // muted-foreground as its base; pointing the highlight at `foreground` is what
+  // makes the sweep visible against it.
+  const statusLabelClassName = cn(
+    "font-medium tracking-[0.01em]",
+    isThinking && "shimmer shimmer-color-foreground shimmer-duration-1500",
   )
 
   useEffect(() => {
@@ -81,7 +87,7 @@ export function Thinking({ status, content, defaultExpanded = false, className }
         <div className={triggerClassName}>
           <span className="flex min-w-0 items-center gap-2">
             <ThinkingIcon animated={isThinking} className={thinkingIconClassName} />
-            <span className="font-medium tracking-[0.01em]">{statusLabel}</span>
+            <span className={statusLabelClassName}>{statusLabel}</span>
           </span>
         </div>
       </div>
@@ -96,7 +102,7 @@ export function Thinking({ status, content, defaultExpanded = false, className }
       >
         <span className="flex min-w-0 items-center gap-2">
           <ThinkingIcon animated={isThinking} className={thinkingIconClassName} />
-          <span className="font-medium tracking-[0.01em]">{statusLabel}</span>
+          <span className={statusLabelClassName}>{statusLabel}</span>
         </span>
         <IconChevronDown
           className={cn(

--- a/src/entrypoints/background/__tests__/background-stream.test.ts
+++ b/src/entrypoints/background/__tests__/background-stream.test.ts
@@ -178,14 +178,14 @@ describe("background-stream", () => {
       {
         output: { score: 97 },
         thinking: {
-          status: "thinking",
+          status: "complete",
           text: "",
         },
       },
       {
         output: { score: 97, summary: "Strong argument structure" },
         thinking: {
-          status: "thinking",
+          status: "complete",
           text: "",
         },
       },
@@ -413,7 +413,7 @@ describe("background-stream", () => {
       data: {
         output: "Hello",
         thinking: {
-          status: "thinking",
+          status: "complete",
           text: "",
         },
       },
@@ -424,7 +424,7 @@ describe("background-stream", () => {
       data: {
         output: "Hello world",
         thinking: {
-          status: "thinking",
+          status: "complete",
           text: "",
         },
       },
@@ -488,6 +488,66 @@ describe("background-stream", () => {
       },
     })
     expect(chunkSnapshots.at(-1)).toEqual(result)
+  })
+
+  it("ends the thinking phase at the first output delta when no reasoning is emitted", async () => {
+    hostedStreamTextMock.mockResolvedValue(
+      (async function* () {
+        yield { type: "start" }
+        yield { type: "text-delta", id: "text-1", text: "Hola" }
+        yield { type: "text-delta", id: "text-1", text: " mundo" }
+        yield { type: "finish", finishReason: "stop" }
+      })(),
+    )
+
+    const chunkSnapshots: BackgroundTextStreamSnapshot[] = []
+    const { runStreamTextInBackground } = await import("../background-stream")
+    await runStreamTextInBackground(
+      {
+        providerId: "read-frog-free-ai",
+        instructions: "Translate text",
+        prompt: "Hello world",
+      },
+      {
+        onChunk: (snapshot) => {
+          chunkSnapshots.push(snapshot)
+        },
+      },
+    )
+
+    expect(chunkSnapshots[0]).toEqual({
+      output: "Hola",
+      thinking: { status: "complete", text: "" },
+    })
+  })
+
+  it("reopens the thinking phase when reasoning arrives after output", async () => {
+    hostedStreamTextMock.mockResolvedValue(
+      (async function* () {
+        yield { type: "start" }
+        yield { type: "text-delta", id: "text-1", text: "Hola" }
+        yield { type: "reasoning-delta", id: "reasoning-1", text: "second guess" }
+        yield { type: "text-delta", id: "text-1", text: " mundo" }
+        yield { type: "finish", finishReason: "stop" }
+      })(),
+    )
+
+    const chunkSnapshots: BackgroundTextStreamSnapshot[] = []
+    const { runStreamTextInBackground } = await import("../background-stream")
+    await runStreamTextInBackground(
+      { providerId: "read-frog-free-ai", instructions: "Translate text", prompt: "Hello world" },
+      {
+        onChunk: (snapshot) => {
+          chunkSnapshots.push(snapshot)
+        },
+      },
+    )
+
+    expect(chunkSnapshots.map((snapshot) => snapshot.thinking)).toEqual([
+      { status: "complete", text: "" },
+      { status: "thinking", text: "second guess" },
+      { status: "complete", text: "second guess" },
+    ])
   })
 
   it("prefers stream onError root cause and posts error once", async () => {

--- a/src/entrypoints/background/background-stream.ts
+++ b/src/entrypoints/background/background-stream.ts
@@ -340,6 +340,17 @@ function getStreamFinishReason(part: Record<string, unknown>): string | undefine
   return typeof part.finishReason === "string" ? part.finishReason : undefined
 }
 
+/**
+ * Reasoning is over once the answer starts coming out, so the first output delta
+ * closes the thinking phase. Models that emit no reasoning at all never send
+ * `reasoning-end`, and without this they would stay "thinking" for the whole
+ * stream while their output is already rendering. Models that interleave need no
+ * special case: a later `reasoning-delta` reopens the phase on its own.
+ */
+function endThinkingOnOutput(thinking: ThinkingSnapshot): ThinkingSnapshot {
+  return thinking.status === "thinking" ? { ...thinking, status: "complete" } : thinking
+}
+
 function validateFinishedStream(hasFinish: boolean, finishReason: string | undefined): void {
   if (!hasFinish) {
     throw new BackgroundStreamError("stream_protocol_error", aiStreamProtocolErrorMessage)
@@ -375,6 +386,7 @@ async function consumeTextPartStream(
     switch (part.type) {
       case "text-delta": {
         cumulativeText += getStringPartField(part, "text")
+        thinking = endThinkingOnOutput(thinking)
         onChunk?.(createStreamSnapshot(cumulativeText, thinking))
         break
       }
@@ -455,6 +467,7 @@ async function consumeStructuredObjectPartStream<TOutput extends Record<string, 
     switch (part.type) {
       case "text-delta": {
         cumulativeText += getStringPartField(part, "text")
+        thinking = endThinkingOnOutput(thinking)
         const partial = await parsePartialJson(cumulativeText)
         if (isRecord(partial.value)) {
           cumulativeValue = { ...cumulativeValue, ...partial.value }


### PR DESCRIPTION
Reworks the selection-toolbar Thinking indicator, borrowing the visual language of [fluidfunctionalism's thinking-indicator](https://www.fluidfunctionalism.com/docs/thinking-indicator) without adopting the component itself.

That component is a pure status indicator — morphing SVG plus cycling shimmer words, no reasoning body. Ours is status *plus* a collapsible reasoning transcript. So this keeps our structure and takes only the visuals.

## What changed

**Glyph.** `ThinkingIcon` swaps its 9-dot SMIL grid for a path that morphs between a circle and an infinity loop, settling back on the circle when reasoning ends.

Settling *from wherever the loop currently is* needs runtime interpolation — CSS `d: path()` snaps instead of easing when the animation is removed. That is what `motion` buys here. `LazyMotion` + `domAnimation` holds the cost to **+25.8 KB gz** on `selection.js`; plain `motion.path` measured **+39.2 KB gz**, so the wrapper earns its keep. `side.js` is untouched.

**Label.** Uses the `shimmer` utility that already ships in `shadcn/tailwind.css` (already imported at `src/assets/styles/theme.css:3`) rather than a hand-rolled gradient — that brings a dark-mode variant and a `prefers-reduced-motion` guard for free. `shimmer-color-foreground` resolves to `var(--rf-foreground)`, so the sweep reads against the surrounding muted text.

**Timing.** The thinking phase now ends at the first output delta. Models that emit no reasoning never send `reasoning-end`, so they stayed "Thinking" for the entire stream while their translation was already rendering below. Now the glyph settles exactly when output begins. Interleaving models need no special case — a later `reasoning-delta` reopens the phase on its own.

The box still appears for every LLM run, including models with no reasoning text: absence of a transcript does not mean the model was not reasoning. It just is not expandable.

## Not adopted

The cycling words (`Thinking / Moonwalking / Planning / Refining`). At a 4s period, a 1–3s selection translation only ever shows the first word — while costing 8 locales of translation and a `words.reduce(longest)` width reservation that jitters under CJK.

## Verification

- Full suite green: 235 files, 2236 tests. Two pre-existing background-stream expectations updated to the new timing, plus new coverage for the no-reasoning and reasoning-after-output paths.
- `type-check`, `lint`, `fmt:check` clean.
- Path interpolation confirmed numerically — all three shapes are `M` + 4×`C` + `Z` with 26 numbers, and `mix()` returns a real blend at t=0.5 rather than a hard cut.
- Rendered light and dark in a browser: the morph animates, the glyph settles to a clean circle on completion, and the shimmer reads in both themes. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)