### PR TITLE
fix(selection-toolbar): ignore native video player clicks

### DIFF
--- a/.changeset/quiet-videos-rest.md
+++ b/.changeset/quiet-videos-rest.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(selection-toolbar): ignore clicks on native video players

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx
@@ -360,6 +360,33 @@ describe("selectionToolbar - isInputOrTextarea logic", () => {
     expectToolbarHidden()
   })
 
+  it("should not show toolbar when a preserved selection does not contain the clicked video player", async () => {
+    render(
+      <div>
+        <SelectionToolbar />
+        <div data-testid="selected-element">{MOCK_SELECTED_TEXT}</div>
+        <video data-testid="video-player" />
+      </div>,
+    )
+
+    await clearToolbarState()
+
+    const videoPlayer = screen.getByTestId("video-player")
+    window.getSelection = vi.fn<(...args: any[]) => any>(() => ({
+      toString: vi.fn<(...args: any[]) => any>(() => MOCK_SELECTED_TEXT),
+      getRangeAt: () => ({
+        startContainer: document.body,
+        startOffset: 0,
+        endContainer: document.body,
+        endOffset: 1,
+      }),
+      containsNode: vi.fn<(...args: any[]) => any>((node: Node) => node !== videoPlayer),
+    }))
+
+    await triggerMouseUpWithSelection(videoPlayer)
+    expectToolbarHidden()
+  })
+
   it("should not show toolbar when shadow DOM retargets button clicks to the host element", async () => {
     render(
       <div>

--- a/src/entrypoints/selection.content/selection-toolbar/index.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/index.tsx
@@ -57,6 +57,7 @@ const SELECTION_GUARD_INTERACTIVE_SELECTOR = [
   "textarea",
   "select",
   "summary",
+  "video",
 ].join(", ")
 
 const SELECTION_OVERLAY_ROOT_SELECTOR = `[${SELECTION_CONTENT_OVERLAY_ROOT_ATTRIBUTE}]`


### PR DESCRIPTION
> **AI model(s) used (required):** OpenAI GPT-5.6 (Hermes Agent)

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Firefox can preserve the previous page selection when a user clicks a native video player. The selection toolbar's `mouseup` handler then treated that preserved range as a new selection and reopened the toolbar at the video click coordinates.

This change:

- treats native `<video>` elements as interactive selection-guard targets;
- keeps the toolbar hidden instead of re-anchoring it to a video click;
- adds regression coverage for a preserved selection outside the clicked video;
- includes a patch changeset for `@read-frog/extension`.

## Related Issue

Closes #1973

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation performed on current `origin/main`:

- `SKIP_FREE_API=true pnpm exec vitest run src/entrypoints/selection.content/selection-toolbar/__tests__/selection-toolbar.test.tsx` — 40 passed
- `SKIP_FREE_API=true pnpm test` — 2,233 passed; 4 intentionally skipped free-API tests
- `pnpm lint` — 0 warnings and 0 errors
- `pnpm fmt:check` — passed
- `WXT_SKIP_ENV_VALIDATION=true pnpm build:firefox` — passed
- Built Firefox MV3 artifact exercised in Firefox 140 through a closed-shadow-root harness: toolbar visible before the video click, hidden afterward, and the original selected text remained unchanged
- Independent pre-commit review — passed with no security concerns, logic errors, or suggestions

## Screenshots

Not applicable; the real-browser harness asserted the production toolbar's visible/hidden state and preserved selection directly.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The change intentionally targets native video elements only. It does not broaden the guard to arbitrary custom-player overlay `<div>` elements without evidence that they share the same event path.
