### PR TITLE
feat(providers): add Codex OAuth support

### DIFF
--- a/.changeset/add-codex-oauth-provider.md
+++ b/.changeset/add-codex-oauth-provider.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(providers): add ChatGPT Codex OAuth provider

--- a/src/components/llm-providers/__tests__/feature-provider-selector-list.test.tsx
+++ b/src/components/llm-providers/__tests__/feature-provider-selector-list.test.tsx
@@ -3,7 +3,10 @@ import type { Config } from "@/types/config/config"
 import { render, screen } from "@testing-library/react"
 import { createStore, Provider } from "jotai"
 import { describe, expect, it, vi } from "vitest"
-import { FeatureProviderSelectorList } from "@/components/llm-providers/feature-provider-selector-list"
+import {
+  FeatureProviderSelectorList,
+  needsApiKeyWarning,
+} from "@/components/llm-providers/feature-provider-selector-list"
 import { configAtom } from "@/utils/atoms/config"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 
@@ -42,6 +45,22 @@ function renderWithConfig(config: Config) {
 }
 
 describe("featureProviderSelectorList custom action filtering", () => {
+  it("does not show an API key warning for Codex OAuth", () => {
+    expect(
+      needsApiKeyWarning({
+        id: "codex",
+        name: "Codex OAuth",
+        enabled: true,
+        provider: "openai-codex",
+        model: {
+          model: "gpt-5.4-mini",
+          isCustomModel: false,
+          customModel: null,
+        },
+      }),
+    ).toBe(false)
+  })
+
   it("only renders provider rows for enabled custom actions", () => {
     const config = cloneConfig(DEFAULT_CONFIG)
     const providerId = config.providersConfig[0]!.id

--- a/src/components/llm-providers/feature-provider-selector-list.tsx
+++ b/src/components/llm-providers/feature-provider-selector-list.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/utils/constants/feature-providers"
 import { getSelectionToolbarActions, patchSelectionToolbarAction } from "@/utils/custom-actions"
 import { i18n } from "@/utils/i18n"
+import { providerRequiresApiKey } from "@/utils/providers/api-key"
 import { getSelectableProvidersForCapability } from "@/utils/providers/provider-registry"
 import { cn } from "@/utils/styles/utils"
 
@@ -34,6 +35,7 @@ export function needsApiKeyWarning(providerConfig: ProviderConfig | null): boole
     !!providerConfig &&
     isAPIProviderConfig(providerConfig) &&
     !isPureAPIProvider(providerConfig.provider) &&
+    providerRequiresApiKey(providerConfig.provider) &&
     !providerConfig.apiKey
   )
 }

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/api-key-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/api-key-field.tsx
@@ -14,7 +14,7 @@ export const APIKeyField = withForm({
     const providerConfig = useSelector(form.store, (state) => state.values)
 
     const providerType = providerConfig.provider
-    if (providerType === "ollama") {
+    if (providerType === "ollama" || providerType === "openai-codex") {
       return <></>
     }
 

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/base-url-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/base-url-field.tsx
@@ -12,7 +12,7 @@ export const BaseURLField = withForm({
     const providerConfig = useSelector(form.store, (state) => state.values)
     const providerType = providerConfig.provider
 
-    if (providerType === "deepl") {
+    if (providerType === "deepl" || providerType === "openai-codex") {
       return null
     }
 

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/codex-oauth-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/codex-oauth-field.tsx
@@ -1,0 +1,99 @@
+import type { APIProviderConfig } from "@/types/config/provider"
+import { useEffect, useRef, useState } from "react"
+import { browser } from "#imports"
+import { Button } from "@/components/ui/base-ui/button"
+import {
+  clearCodexOAuthAuth,
+  CODEX_OAUTH_DEVICE_URL,
+  completeCodexDeviceAuthorization,
+  getCodexOAuthAuth,
+  startCodexDeviceAuthorization,
+  type CodexOAuthAuth,
+} from "@/utils/auth/codex-oauth"
+import { i18n } from "@/utils/i18n"
+import { ConnectionTestButton } from "./components/connection-button"
+
+export function CodexOAuthField({ providerConfig }: { providerConfig: APIProviderConfig }) {
+  const [auth, setAuth] = useState<CodexOAuthAuth | null>(null)
+  const [userCode, setUserCode] = useState<string>()
+  const [error, setError] = useState<string>()
+  const [isPending, setIsPending] = useState(false)
+  const abortControllerRef = useRef<AbortController | undefined>(undefined)
+
+  useEffect(() => {
+    void getCodexOAuthAuth().then(setAuth)
+    return () => abortControllerRef.current?.abort()
+  }, [])
+
+  const signIn = async () => {
+    abortControllerRef.current?.abort()
+    const abortController = new AbortController()
+    abortControllerRef.current = abortController
+    setError(undefined)
+    setUserCode(undefined)
+    setIsPending(true)
+
+    try {
+      const device = await startCodexDeviceAuthorization()
+      setUserCode(device.userCode)
+      await browser.tabs.create({ url: CODEX_OAUTH_DEVICE_URL })
+      const nextAuth = await completeCodexDeviceAuthorization(device, {
+        signal: abortController.signal,
+      })
+      setAuth(nextAuth)
+      setUserCode(undefined)
+    } catch (cause) {
+      if (!abortController.signal.aborted) {
+        setError(cause instanceof Error ? cause.message : String(cause))
+      }
+    } finally {
+      if (abortControllerRef.current === abortController) {
+        abortControllerRef.current = undefined
+        setIsPending(false)
+      }
+    }
+  }
+
+  const signOut = async () => {
+    abortControllerRef.current?.abort()
+    await clearCodexOAuthAuth()
+    setAuth(null)
+    setUserCode(undefined)
+    setError(undefined)
+  }
+
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-border p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        {auth ? (
+          <>
+            <Button type="button" size="sm" variant="outline" onClick={signOut}>
+              {i18n.t("options.apiProviders.codexOAuth.signOut")}
+            </Button>
+            <ConnectionTestButton providerConfig={providerConfig} />
+          </>
+        ) : (
+          <Button type="button" size="sm" onClick={signIn} disabled={isPending}>
+            {isPending
+              ? i18n.t("options.apiProviders.codexOAuth.waiting")
+              : i18n.t("options.apiProviders.codexOAuth.signIn")}
+          </Button>
+        )}
+      </div>
+      {auth && (
+        <p className="text-sm text-muted-foreground">
+          {auth.email
+            ? i18n.t("options.apiProviders.codexOAuth.connectedAs", [auth.email])
+            : i18n.t("options.apiProviders.codexOAuth.connected")}
+        </p>
+      )}
+      {userCode && (
+        <p className="text-sm text-muted-foreground">
+          {i18n.t("options.apiProviders.codexOAuth.enterCode")}{" "}
+          <code className="rounded bg-muted px-1.5 py-0.5 font-mono font-semibold">{userCode}</code>
+        </p>
+      )}
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  )
+}

--- a/src/entrypoints/options/pages/api-providers/provider-config-form/components/connection-button.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-config-form/components/connection-button.tsx
@@ -9,6 +9,7 @@ import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { executeTranslate } from "@/utils/host/translate/execute-translate"
 import { i18n } from "@/utils/i18n"
 import { getTranslatePrompt } from "@/utils/prompts/translate"
+import { providerRequiresApiKey } from "@/utils/providers/api-key"
 
 const SLOW_CONNECTION_THRESHOLD_MS = 3_000
 const CONNECTION_TEST_FEEDBACK_DURATION_MS = 5_000
@@ -190,7 +191,7 @@ export function ConnectionTestButton({ providerConfig }: { providerConfig: APIPr
       variant="outline"
       className="gap-2"
       onClick={handleTestConnection}
-      disabled={mutation.isPending || (!apiKey && provider !== "deeplx" && provider !== "ollama")}
+      disabled={mutation.isPending || (!apiKey && providerRequiresApiKey(provider))}
     >
       {mutation.isPending ? (
         <>

--- a/src/entrypoints/options/pages/api-providers/provider-editor.tsx
+++ b/src/entrypoints/options/pages/api-providers/provider-editor.tsx
@@ -42,6 +42,7 @@ import {
 import { cn } from "@/utils/styles/utils"
 import { APIKeyField } from "./provider-config-form/api-key-field"
 import { BaseURLField } from "./provider-config-form/base-url-field"
+import { CodexOAuthField } from "./provider-config-form/codex-oauth-field"
 import { AdvancedOptionsSection } from "./provider-config-form/components/advanced-options-section"
 import { ConfigHeader as ProviderConfigHeader } from "./provider-config-form/config-header"
 import { formOpts, useAppForm } from "./provider-config-form/form"
@@ -313,6 +314,12 @@ function DescriptionField() {
 
 function ConnectionFields() {
   const form = useApiProviderForm()
+  const providerConfig = useSelector(form.store, (state) => state.values)
+
+  if (providerConfig.provider === "openai-codex") {
+    return <CodexOAuthField providerConfig={providerConfig} />
+  }
+
   return (
     <>
       <APIKeyField form={form} />

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -184,6 +184,7 @@ options:
       attribution:
         builtInAi: Provided by Atlas Cloud. Currently only available for Custom AI Actions. To unlock an unrestricted experience, purchase highly cost-effective credits on the official website.
       description:
+        openaiCodex: Use a ChatGPT subscription through Codex OAuth without an API key
         openai: Provides models like GPT-4o
         azure: Azure-hosted OpenAI models through your deployments
         deepseek: Recommend to use in China
@@ -216,6 +217,13 @@ options:
         huggingface: Hugging Face Inference API providing access to thousands of open-source models
     apiKey:
       showAPIKey: Show API Key
+    codexOAuth:
+      signIn: Sign in with ChatGPT
+      signOut: Sign out
+      waiting: Waiting for authorization...
+      enterCode: "Enter this code on the page that opened:"
+      connected: Connected to ChatGPT
+      connectedAs: Connected as $1
     howToConfigure: How to configure?
     testConnection:
       button: Test Connection

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -184,6 +184,7 @@ options:
       attribution:
         builtInAi: Provided by Atlas Cloud. 目前仅对自定义 AI 指令开放。若要解锁无限制体验，可以前往官网购买超高性价比额度。
       description:
+        openaiCodex: 通过 Codex OAuth 使用 ChatGPT 订阅，无需 API Key
         openai: 提供 GPT-4o 等模型
         azure: 通过 Azure 部署使用 OpenAI 模型
         deepseek: 推荐在中国使用
@@ -216,6 +217,13 @@ options:
         huggingface: Hugging Face推理API，提供数千种开源模型访问
     apiKey:
       showAPIKey: 显示 API Key
+    codexOAuth:
+      signIn: 使用 ChatGPT 登录
+      signOut: 退出登录
+      waiting: 等待授权...
+      enterCode: 请在已打开的页面中输入此代码：
+      connected: 已连接 ChatGPT
+      connectedAs: 已连接为 $1
     howToConfigure: 如何配置?
     testConnection:
       button: 测试连接

--- a/src/types/config/provider/constants.ts
+++ b/src/types/config/provider/constants.ts
@@ -23,6 +23,7 @@ export const TRANSLATE_PROVIDER_TYPES = [
   "microsoft-translate",
   "deeplx",
   "deepl",
+  "openai-codex",
   "openai",
   "deepseek",
   "google",
@@ -60,6 +61,7 @@ export function isTranslateProvider(provider: string): provider is TranslateProv
 }
 
 export const LLM_PROVIDER_TYPES = [
+  "openai-codex",
   "openai",
   "deepseek",
   "google",
@@ -109,6 +111,7 @@ export function isCustomLLMProvider(provider: string): provider is CustomLLMProv
 }
 
 export const NON_CUSTOM_LLM_PROVIDER_TYPES = [
+  "openai-codex",
   "openai",
   "deepseek",
   "google",
@@ -144,6 +147,7 @@ export const API_PROVIDER_TYPES = [
   "siliconflow",
   "tensdaq",
   "volcengine",
+  "openai-codex",
   "openai",
   "deepseek",
   "google",
@@ -199,6 +203,7 @@ export const ALL_PROVIDER_TYPES = [
   "siliconflow",
   "tensdaq",
   "volcengine",
+  "openai-codex",
   "openai",
   "deepseek",
   "google",
@@ -235,6 +240,7 @@ export const AI_SDK_REASONING_VALUES = [
 export type AISDKReasoning = (typeof AI_SDK_REASONING_VALUES)[number]
 
 export const TOP_LEVEL_REASONING_PROVIDER_TYPES = [
+  "openai-codex",
   "openai",
   "anthropic",
   "google",

--- a/src/types/config/provider/schemas.ts
+++ b/src/types/config/provider/schemas.ts
@@ -89,6 +89,11 @@ const llmProviderConfigSchemaList = [
     model: createProviderModelSchema<"minimax">("minimax"),
   }),
   baseAPIProviderConfigSchema.extend({
+    provider: z.literal("openai-codex"),
+    model: createProviderModelSchema<"openai-codex">("openai-codex"),
+    ...topLevelReasoningConfigSchema,
+  }),
+  baseAPIProviderConfigSchema.extend({
     provider: z.literal("openai"),
     model: createProviderModelSchema<"openai">("openai"),
     ...topLevelReasoningConfigSchema,

--- a/src/utils/auth/__tests__/codex-oauth.test.ts
+++ b/src/utils/auth/__tests__/codex-oauth.test.ts
@@ -187,7 +187,104 @@ describe("Codex OAuth", () => {
     expect(networkFetch).toHaveBeenCalledOnce()
   })
 
-  it("limits streaming Codex requests to two active response bodies", async () => {
+  it("returns a completed response without waiting for transport cancellation", async () => {
+    getItemMock.mockResolvedValue({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 3_600_000,
+      accountId: "account-id",
+    })
+    const completedResponse = { id: "response-id", output: [], status: "completed" }
+    const encoder = new TextEncoder()
+    let cancellationStarted = false
+    const neverCompletes = new Promise<void>(() => {})
+    const networkFetch = vi.fn<() => Promise<Response>>(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  `event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response: completedResponse })}\n\n`,
+                ),
+              )
+            },
+            cancel() {
+              cancellationStarted = true
+              return neverCompletes
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          },
+        ),
+    )
+    vi.stubGlobal("fetch", networkFetch)
+
+    const response = await Promise.race([
+      codexOAuthFetch(`${CODEX_API_BASE_URL}/responses`, {
+        method: "POST",
+        body: JSON.stringify({ model: "gpt-5.4-mini" }),
+      }),
+      new Promise<never>((_, reject) => {
+        setTimeout(() => reject(new Error("Timed out waiting for the completed response")), 250)
+      }),
+    ])
+
+    await expect(response.json()).resolves.toEqual(completedResponse)
+    expect(cancellationStarted).toBe(true)
+  })
+
+  it("assembles response output from completed SSE output items", async () => {
+    getItemMock.mockResolvedValue({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 3_600_000,
+      accountId: "account-id",
+    })
+    const outputItem = {
+      id: "message-id",
+      type: "message",
+      role: "assistant",
+      status: "completed",
+      content: [{ type: "output_text", text: "Translated text", annotations: [] }],
+    }
+    const completedResponse = { id: "response-id", output: [], status: "completed" }
+    const encoder = new TextEncoder()
+    const networkFetch = vi.fn<() => Promise<Response>>(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  `event: response.output_item.done\ndata: ${JSON.stringify({ type: "response.output_item.done", output_index: 0, item: outputItem })}\n\n` +
+                    `event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response: completedResponse })}\n\n`,
+                ),
+              )
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          },
+        ),
+    )
+    vi.stubGlobal("fetch", networkFetch)
+
+    const response = await codexOAuthFetch(`${CODEX_API_BASE_URL}/responses`, {
+      method: "POST",
+      body: JSON.stringify({ model: "gpt-5.4-mini" }),
+    })
+
+    await expect(response.json()).resolves.toEqual({
+      ...completedResponse,
+      output: [outputItem],
+    })
+  })
+
+  it("does not add provider-specific request concurrency limits", async () => {
     getItemMock.mockResolvedValue({
       accessToken: "access-token",
       refreshToken: "refresh-token",
@@ -213,21 +310,12 @@ describe("Codex OAuth", () => {
         method: "POST",
         body: JSON.stringify({ model: "gpt-5.4-mini", stream: true }),
       })
-    const firstPromise = createRequest()
-    const secondPromise = createRequest()
-    const thirdPromise = createRequest()
-    const [firstResponse, secondResponse] = await Promise.all([firstPromise, secondPromise])
+    const responses = await Promise.all([createRequest(), createRequest(), createRequest()])
 
-    expect(networkFetch).toHaveBeenCalledTimes(2)
-
-    controllers[0]!.close()
-    await firstResponse.text()
-    const thirdResponse = await thirdPromise
     expect(networkFetch).toHaveBeenCalledTimes(3)
 
-    controllers[1]!.close()
-    controllers[2]!.close()
-    await Promise.all([secondResponse.text(), thirdResponse.text()])
+    for (const controller of controllers) controller.close()
+    await Promise.all(responses.map((response) => response.text()))
   })
 
   it("closes streaming responses when Codex sends a terminal event", async () => {

--- a/src/utils/auth/__tests__/codex-oauth.test.ts
+++ b/src/utils/auth/__tests__/codex-oauth.test.ts
@@ -75,6 +75,54 @@ describe("Codex OAuth", () => {
     expect(setItemMock).toHaveBeenCalledWith("local:codexOAuthAuth", auth)
   })
 
+  it("does not store credentials when sign-in is cancelled during token exchange", async () => {
+    const abortController = new AbortController()
+    let resolveExchange!: (response: Response) => void
+    let exchangeStarted!: () => void
+    const exchangeStartedPromise = new Promise<void>((resolve) => {
+      exchangeStarted = resolve
+    })
+    const exchangeResponsePromise = new Promise<Response>((resolve) => {
+      resolveExchange = resolve
+    })
+    const fetchMock = vi
+      .fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ authorization_code: "authorization-code", code_verifier: "verifier" }),
+          { status: 200 },
+        ),
+      )
+      .mockImplementationOnce(async (_input, init) => {
+        expect(init?.signal).toBe(abortController.signal)
+        exchangeStarted()
+        return exchangeResponsePromise
+      }) as unknown as typeof fetch
+
+    const authorizationPromise = completeCodexDeviceAuthorization(
+      { deviceAuthId: "device-id", userCode: "ABCD-EFGH", intervalMs: 5000 },
+      { fetchFn: fetchMock, signal: abortController.signal },
+    )
+    await exchangeStartedPromise
+    abortController.abort()
+    resolveExchange(
+      new Response(
+        JSON.stringify({
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_in: 3600,
+          id_token: createJwt({
+            "https://api.openai.com/auth": { chatgpt_account_id: "account-id" },
+          }),
+        }),
+        { status: 200 },
+      ),
+    )
+
+    await expect(authorizationPromise).rejects.toMatchObject({ name: "AbortError" })
+    expect(setItemMock).not.toHaveBeenCalled()
+  })
+
   it("refreshes an expired token without falling back to the old token", async () => {
     getItemMock.mockResolvedValue({
       accessToken: "expired-access-token",

--- a/src/utils/auth/__tests__/codex-oauth.test.ts
+++ b/src/utils/auth/__tests__/codex-oauth.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { storage } from "#imports"
+
+const { getItemMock, removeItemMock, setItemMock } = vi.hoisted(() => ({
+  getItemMock: vi.fn<(...args: any[]) => any>(),
+  removeItemMock: vi.fn<(...args: any[]) => any>(),
+  setItemMock: vi.fn<(...args: any[]) => any>(),
+}))
+
+import {
+  clearCodexOAuthAuth,
+  CODEX_API_BASE_URL,
+  codexOAuthFetch,
+  completeCodexDeviceAuthorization,
+  getValidCodexOAuthAuth,
+  startCodexDeviceAuthorization,
+} from "../codex-oauth"
+
+function createJwt(payload: Record<string, unknown>): string {
+  const encoded = btoa(JSON.stringify(payload)).replaceAll("+", "-").replaceAll("/", "_")
+  return `e30.${encoded.replace(/=+$/, "")}.signature`
+}
+
+describe("Codex OAuth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+    getItemMock.mockResolvedValue(null)
+    ;(storage.getItem as unknown as typeof getItemMock) = getItemMock
+    ;(storage.removeItem as unknown as typeof removeItemMock) = removeItemMock
+    ;(storage.setItem as unknown as typeof setItemMock) = setItemMock
+  })
+
+  it("completes device authorization and stores the ChatGPT account", async () => {
+    const fetchMock = vi.fn<(input: RequestInfo | URL) => Promise<Response>>(async (input) => {
+      const url = input instanceof URL ? input.href : typeof input === "string" ? input : input.url
+      if (url.endsWith("/api/accounts/deviceauth/usercode")) {
+        return new Response(
+          JSON.stringify({ device_auth_id: "device-id", user_code: "ABCD-EFGH", interval: "5" }),
+          { status: 200 },
+        )
+      }
+      if (url.endsWith("/api/accounts/deviceauth/token")) {
+        return new Response(
+          JSON.stringify({ authorization_code: "authorization-code", code_verifier: "verifier" }),
+          { status: 200 },
+        )
+      }
+      return new Response(
+        JSON.stringify({
+          access_token: "access-token",
+          refresh_token: "refresh-token",
+          expires_in: 3600,
+          id_token: createJwt({
+            email: "frog@example.com",
+            "https://api.openai.com/auth": { chatgpt_account_id: "account-id" },
+          }),
+        }),
+        { status: 200 },
+      )
+    }) as unknown as typeof fetch
+
+    const device = await startCodexDeviceAuthorization(fetchMock)
+    const auth = await completeCodexDeviceAuthorization(device, { fetchFn: fetchMock })
+
+    expect(device).toEqual({ deviceAuthId: "device-id", userCode: "ABCD-EFGH", intervalMs: 5000 })
+    expect(auth).toEqual(
+      expect.objectContaining({
+        accessToken: "access-token",
+        refreshToken: "refresh-token",
+        accountId: "account-id",
+        email: "frog@example.com",
+      }),
+    )
+    expect(setItemMock).toHaveBeenCalledWith("local:codexOAuthAuth", auth)
+  })
+
+  it("refreshes an expired token without falling back to the old token", async () => {
+    getItemMock.mockResolvedValue({
+      accessToken: "expired-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: 0,
+      accountId: "account-id",
+    })
+    const fetchMock = vi.fn<() => Promise<Response>>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: "new-access-token",
+            refresh_token: "new-refresh-token",
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch
+
+    const auth = await getValidCodexOAuthAuth(fetchMock)
+
+    expect(auth.accessToken).toBe("new-access-token")
+    expect(auth.refreshToken).toBe("new-refresh-token")
+    expect(setItemMock).toHaveBeenCalledWith("local:codexOAuthAuth", auth)
+  })
+
+  it("does not restore credentials when the user signs out during refresh", async () => {
+    const expiredAuth = {
+      accessToken: "expired-access-token",
+      refreshToken: "refresh-token",
+      expiresAt: 0,
+      accountId: "account-id",
+    }
+    getItemMock.mockResolvedValueOnce(expiredAuth).mockResolvedValueOnce(null)
+    const fetchMock = vi.fn<() => Promise<Response>>(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: "new-access-token",
+            refresh_token: "new-refresh-token",
+            expires_in: 3600,
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch
+
+    await expect(getValidCodexOAuthAuth(fetchMock)).rejects.toThrow(
+      "Codex OAuth session changed during token refresh",
+    )
+    expect(setItemMock).not.toHaveBeenCalled()
+  })
+
+  it("injects OAuth headers only for the Codex backend", async () => {
+    getItemMock.mockResolvedValue({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 3_600_000,
+      accountId: "account-id",
+    })
+    const completedResponse = { id: "response-id", output: [], status: "completed" }
+    let streamCancelled = false
+    const encoder = new TextEncoder()
+    const networkFetch = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+      async () =>
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(
+                encoder.encode(
+                  `event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response: completedResponse })}\n\n`,
+                ),
+              )
+            },
+            cancel() {
+              streamCancelled = true
+            },
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          },
+        ),
+    )
+    vi.stubGlobal("fetch", networkFetch)
+
+    const response = await codexOAuthFetch(`${CODEX_API_BASE_URL}/responses`, {
+      method: "POST",
+      headers: { "X-Test": "value" },
+      body: JSON.stringify({ model: "gpt-5.4-mini", store: true }),
+    })
+
+    const [request] = networkFetch.mock.calls[0]!
+    const forwardedRequest = request as Request
+    const headers = new Headers(forwardedRequest.headers)
+    expect(headers.get("Authorization")).toBe("Bearer access-token")
+    expect(headers.get("ChatGPT-Account-Id")).toBe("account-id")
+    expect(headers.get("originator")).toBe("read-frog")
+    expect(headers.get("X-Test")).toBe("value")
+    await expect(forwardedRequest.clone().json()).resolves.toEqual({
+      model: "gpt-5.4-mini",
+      store: false,
+      stream: true,
+    })
+    await expect(response.json()).resolves.toEqual(completedResponse)
+    expect(streamCancelled).toBe(true)
+
+    await expect(codexOAuthFetch("https://example.com/responses")).rejects.toThrow(
+      "Refusing to send Codex OAuth credentials",
+    )
+    expect(networkFetch).toHaveBeenCalledOnce()
+  })
+
+  it("limits streaming Codex requests to two active response bodies", async () => {
+    getItemMock.mockResolvedValue({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 3_600_000,
+      accountId: "account-id",
+    })
+    const controllers: ReadableStreamDefaultController<Uint8Array>[] = []
+    const networkFetch = vi.fn<() => Promise<Response>>(async () => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controllers.push(controller)
+        },
+      })
+      return new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    })
+    vi.stubGlobal("fetch", networkFetch)
+
+    const createRequest = () =>
+      codexOAuthFetch(`${CODEX_API_BASE_URL}/responses`, {
+        method: "POST",
+        body: JSON.stringify({ model: "gpt-5.4-mini", stream: true }),
+      })
+    const firstPromise = createRequest()
+    const secondPromise = createRequest()
+    const thirdPromise = createRequest()
+    const [firstResponse, secondResponse] = await Promise.all([firstPromise, secondPromise])
+
+    expect(networkFetch).toHaveBeenCalledTimes(2)
+
+    controllers[0]!.close()
+    await firstResponse.text()
+    const thirdResponse = await thirdPromise
+    expect(networkFetch).toHaveBeenCalledTimes(3)
+
+    controllers[1]!.close()
+    controllers[2]!.close()
+    await Promise.all([secondResponse.text(), thirdResponse.text()])
+  })
+
+  it("closes streaming responses when Codex sends a terminal event", async () => {
+    getItemMock.mockResolvedValue({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      expiresAt: Date.now() + 3_600_000,
+      accountId: "account-id",
+    })
+    let streamCancelled = false
+    const encoder = new TextEncoder()
+    const networkFetch = vi.fn<() => Promise<Response>>(async () => {
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(
+            encoder.encode(
+              `event: response.created\ndata: ${JSON.stringify({ type: "response.created" })}\n\n` +
+                `event: response.completed\ndata: ${JSON.stringify({ type: "response.completed", response: { id: "response-id" } })}\n\n`,
+            ),
+          )
+        },
+        cancel() {
+          streamCancelled = true
+        },
+      })
+      return new Response(body, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      })
+    })
+    vi.stubGlobal("fetch", networkFetch)
+
+    const response = await codexOAuthFetch(`${CODEX_API_BASE_URL}/responses`, {
+      method: "POST",
+      body: JSON.stringify({ model: "gpt-5.4-mini", stream: true }),
+    })
+
+    await expect(response.text()).resolves.toContain("response.completed")
+    expect(streamCancelled).toBe(true)
+  })
+
+  it("clears locally stored credentials on sign out", async () => {
+    await clearCodexOAuthAuth()
+    expect(removeItemMock).toHaveBeenCalledWith("local:codexOAuthAuth")
+  })
+})

--- a/src/utils/auth/codex-oauth.ts
+++ b/src/utils/auth/codex-oauth.ts
@@ -1,0 +1,576 @@
+import { storage } from "#imports"
+
+export const CODEX_OAUTH_CLIENT_ID = "app_EMoamEEZ73f0CkXaXp7hrann"
+export const CODEX_OAUTH_ISSUER = "https://auth.openai.com"
+export const CODEX_OAUTH_DEVICE_URL = `${CODEX_OAUTH_ISSUER}/codex/device`
+export const CODEX_API_BASE_URL = "https://chatgpt.com/backend-api/codex"
+
+const CODEX_OAUTH_STORAGE_KEY = "local:codexOAuthAuth"
+const CODEX_DEVICE_CODE_ENDPOINT = `${CODEX_OAUTH_ISSUER}/api/accounts/deviceauth/usercode`
+const CODEX_DEVICE_TOKEN_ENDPOINT = `${CODEX_OAUTH_ISSUER}/api/accounts/deviceauth/token`
+const CODEX_TOKEN_ENDPOINT = `${CODEX_OAUTH_ISSUER}/oauth/token`
+const CODEX_DEVICE_REDIRECT_URI = `${CODEX_OAUTH_ISSUER}/deviceauth/callback`
+const CODEX_DEVICE_TIMEOUT_MS = 10 * 60 * 1000
+const CODEX_DEVICE_POLL_MARGIN_MS = 3_000
+const CODEX_TOKEN_REFRESH_MARGIN_MS = 60_000
+const CODEX_MAX_CONCURRENT_REQUESTS = 2
+
+type ReleaseCodexRequestSlot = () => void
+
+interface CodexRequestWaiter {
+  resolve: (release: ReleaseCodexRequestSlot) => void
+  reject: (reason: unknown) => void
+  signal?: AbortSignal
+  handleAbort?: () => void
+}
+
+let activeCodexRequests = 0
+const codexRequestWaiters: CodexRequestWaiter[] = []
+
+function createCodexRequestRelease(): ReleaseCodexRequestSlot {
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    activeCodexRequests--
+    dispatchNextCodexRequest()
+  }
+}
+
+function dispatchNextCodexRequest(): void {
+  while (activeCodexRequests < CODEX_MAX_CONCURRENT_REQUESTS && codexRequestWaiters.length > 0) {
+    const waiter = codexRequestWaiters.shift()!
+    if (waiter.signal?.aborted) continue
+
+    waiter.signal?.removeEventListener("abort", waiter.handleAbort!)
+    activeCodexRequests++
+    waiter.resolve(createCodexRequestRelease())
+  }
+}
+
+function acquireCodexRequestSlot(signal?: AbortSignal): Promise<ReleaseCodexRequestSlot> {
+  if (signal?.aborted) {
+    return Promise.reject(
+      signal.reason ?? new DOMException("Codex request cancelled", "AbortError"),
+    )
+  }
+
+  if (activeCodexRequests < CODEX_MAX_CONCURRENT_REQUESTS) {
+    activeCodexRequests++
+    return Promise.resolve(createCodexRequestRelease())
+  }
+
+  return new Promise((resolve, reject) => {
+    const waiter: CodexRequestWaiter = { resolve, reject, signal }
+    waiter.handleAbort = () => {
+      const index = codexRequestWaiters.indexOf(waiter)
+      if (index >= 0) codexRequestWaiters.splice(index, 1)
+      reject(signal?.reason ?? new DOMException("Codex request cancelled", "AbortError"))
+    }
+    signal?.addEventListener("abort", waiter.handleAbort, { once: true })
+    codexRequestWaiters.push(waiter)
+  })
+}
+
+export interface CodexOAuthAuth {
+  accessToken: string
+  refreshToken: string
+  expiresAt: number
+  accountId: string
+  email?: string
+}
+
+export interface CodexDeviceAuthorization {
+  deviceAuthId: string
+  userCode: string
+  intervalMs: number
+}
+
+interface DeviceCodeResponse {
+  device_auth_id: string
+  user_code: string
+  interval: string
+}
+
+interface DeviceTokenResponse {
+  authorization_code: string
+  code_verifier: string
+}
+
+interface TokenResponse {
+  access_token: string
+  refresh_token?: string
+  id_token?: string
+  expires_in?: number
+}
+
+interface IdTokenClaims {
+  email?: string
+  chatgpt_account_id?: string
+  organizations?: Array<{ id?: string }>
+  "https://api.openai.com/auth"?: {
+    chatgpt_account_id?: string
+  }
+}
+
+interface CompleteDeviceAuthorizationOptions {
+  fetchFn?: typeof fetch
+  signal?: AbortSignal
+  timeoutMs?: number
+}
+
+function getErrorStatusMessage(action: string, response: Response): string {
+  return `${action} failed: HTTP ${response.status}`
+}
+
+function decodeBase64Url(value: string): Uint8Array {
+  const base64 = value.replace(/-/g, "+").replace(/_/g, "/")
+  const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, "=")
+  const binary = atob(padded)
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0))
+}
+
+export function parseCodexJwtClaims(token: string): IdTokenClaims | undefined {
+  const parts = token.split(".")
+  if (parts.length !== 3 || !parts[1]) return undefined
+
+  try {
+    return JSON.parse(new TextDecoder().decode(decodeBase64Url(parts[1]))) as IdTokenClaims
+  } catch {
+    return undefined
+  }
+}
+
+function extractAccountId(claims: IdTokenClaims): string | undefined {
+  return (
+    claims.chatgpt_account_id ||
+    claims["https://api.openai.com/auth"]?.chatgpt_account_id ||
+    claims.organizations?.[0]?.id
+  )
+}
+
+function parseInitialTokenResponse(tokens: TokenResponse): CodexOAuthAuth {
+  if (!tokens.access_token || !tokens.refresh_token || !tokens.id_token || !tokens.expires_in) {
+    throw new Error("Codex OAuth response is missing required tokens")
+  }
+
+  const claims = parseCodexJwtClaims(tokens.id_token)
+  const accountId = claims && extractAccountId(claims)
+  if (!accountId) {
+    throw new Error("Codex OAuth response has no ChatGPT account id")
+  }
+
+  return {
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    expiresAt: Date.now() + tokens.expires_in * 1000,
+    accountId,
+    ...(claims.email ? { email: claims.email } : {}),
+  }
+}
+
+async function exchangeAuthorizationCode(
+  authorization: DeviceTokenResponse,
+  fetchFn: typeof fetch,
+): Promise<CodexOAuthAuth> {
+  const response = await fetchFn(CODEX_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code: authorization.authorization_code,
+      redirect_uri: CODEX_DEVICE_REDIRECT_URI,
+      client_id: CODEX_OAUTH_CLIENT_ID,
+      code_verifier: authorization.code_verifier,
+    }).toString(),
+  })
+
+  if (!response.ok) {
+    throw new Error(getErrorStatusMessage("Codex token exchange", response))
+  }
+
+  return parseInitialTokenResponse((await response.json()) as TokenResponse)
+}
+
+export async function startCodexDeviceAuthorization(
+  fetchFn: typeof fetch = fetch,
+): Promise<CodexDeviceAuthorization> {
+  const response = await fetchFn(CODEX_DEVICE_CODE_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ client_id: CODEX_OAUTH_CLIENT_ID }),
+  })
+
+  if (!response.ok) {
+    throw new Error(getErrorStatusMessage("Codex device authorization", response))
+  }
+
+  const device = (await response.json()) as DeviceCodeResponse
+  const intervalSeconds = Number.parseInt(device.interval, 10)
+  if (!device.device_auth_id || !device.user_code || !Number.isFinite(intervalSeconds)) {
+    throw new Error("Codex device authorization response is invalid")
+  }
+
+  return {
+    deviceAuthId: device.device_auth_id,
+    userCode: device.user_code,
+    intervalMs: Math.max(intervalSeconds, 1) * 1000,
+  }
+}
+
+function waitForNextPoll(delayMs: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(signal.reason ?? new DOMException("Codex sign-in cancelled", "AbortError"))
+      return
+    }
+
+    const handleAbort = () => {
+      clearTimeout(timeout)
+      reject(signal?.reason ?? new DOMException("Codex sign-in cancelled", "AbortError"))
+    }
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", handleAbort)
+      resolve()
+    }, delayMs)
+    signal?.addEventListener("abort", handleAbort, { once: true })
+  })
+}
+
+export async function completeCodexDeviceAuthorization(
+  device: CodexDeviceAuthorization,
+  options: CompleteDeviceAuthorizationOptions = {},
+): Promise<CodexOAuthAuth> {
+  const fetchFn = options.fetchFn ?? fetch
+  const timeoutMs = options.timeoutMs ?? CODEX_DEVICE_TIMEOUT_MS
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const response = await fetchFn(CODEX_DEVICE_TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        device_auth_id: device.deviceAuthId,
+        user_code: device.userCode,
+      }),
+      signal: options.signal,
+    })
+
+    if (response.ok) {
+      const auth = await exchangeAuthorizationCode(
+        (await response.json()) as DeviceTokenResponse,
+        fetchFn,
+      )
+      await storage.setItem(CODEX_OAUTH_STORAGE_KEY, auth)
+      return auth
+    }
+
+    if (response.status !== 403 && response.status !== 404) {
+      throw new Error(getErrorStatusMessage("Codex device authorization", response))
+    }
+
+    await waitForNextPoll(device.intervalMs + CODEX_DEVICE_POLL_MARGIN_MS, options.signal)
+  }
+
+  throw new Error("Codex device authorization timed out")
+}
+
+export async function getCodexOAuthAuth(): Promise<CodexOAuthAuth | null> {
+  return (await storage.getItem<CodexOAuthAuth>(CODEX_OAUTH_STORAGE_KEY)) ?? null
+}
+
+export async function clearCodexOAuthAuth(): Promise<void> {
+  await storage.removeItem(CODEX_OAUTH_STORAGE_KEY)
+}
+
+async function refreshCodexOAuthAuth(
+  current: CodexOAuthAuth,
+  fetchFn: typeof fetch,
+): Promise<CodexOAuthAuth> {
+  const response = await fetchFn(CODEX_TOKEN_ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: current.refreshToken,
+      client_id: CODEX_OAUTH_CLIENT_ID,
+    }).toString(),
+  })
+
+  if (!response.ok) {
+    throw new Error(getErrorStatusMessage("Codex token refresh", response))
+  }
+
+  const tokens = (await response.json()) as TokenResponse
+  if (!tokens.access_token || !tokens.refresh_token || !tokens.expires_in) {
+    throw new Error("Codex token refresh response is missing required tokens")
+  }
+
+  const next: CodexOAuthAuth = {
+    ...current,
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+    expiresAt: Date.now() + tokens.expires_in * 1000,
+  }
+  const latest = await getCodexOAuthAuth()
+  if (!latest || latest.refreshToken !== current.refreshToken) {
+    throw new Error("Codex OAuth session changed during token refresh")
+  }
+  await storage.setItem(CODEX_OAUTH_STORAGE_KEY, next)
+  return next
+}
+
+let refreshPromise: Promise<CodexOAuthAuth> | undefined
+
+interface CodexResponseCompletedEvent {
+  type: "response.completed" | "response.incomplete"
+  response: Record<string, unknown>
+}
+
+function getCodexEventData(block: string): string | undefined {
+  const data = block
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trimStart())
+    .join("\n")
+  return data || undefined
+}
+
+function parseCodexCompletedResponseBlock(block: string): Record<string, unknown> | undefined {
+  const data = getCodexEventData(block)
+  if (!data || data === "[DONE]") return undefined
+
+  const event = JSON.parse(data) as Partial<CodexResponseCompletedEvent>
+  if (
+    (event.type === "response.completed" || event.type === "response.incomplete") &&
+    event.response &&
+    typeof event.response === "object" &&
+    !Array.isArray(event.response)
+  ) {
+    return event.response
+  }
+
+  return undefined
+}
+
+function isCodexTerminalEventBlock(block: string): boolean {
+  const data = getCodexEventData(block)
+  if (!data) return false
+  if (data === "[DONE]") return true
+
+  const event = JSON.parse(data) as { type?: unknown }
+  return (
+    event.type === "response.completed" ||
+    event.type === "response.incomplete" ||
+    event.type === "response.failed" ||
+    event.type === "error"
+  )
+}
+
+async function readCodexCompletedResponse(response: Response): Promise<Record<string, unknown>> {
+  if (!response.body) {
+    throw new Error("Codex streaming response has no body")
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ""
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      buffer += done ? decoder.decode() : decoder.decode(value, { stream: true })
+
+      while (true) {
+        const separator = /\r?\n\r?\n/.exec(buffer)
+        if (!separator) break
+
+        const block = buffer.slice(0, separator.index)
+        buffer = buffer.slice(separator.index + separator[0].length)
+        const completedResponse = parseCodexCompletedResponseBlock(block)
+        if (completedResponse) return completedResponse
+      }
+
+      if (done) {
+        const completedResponse = parseCodexCompletedResponseBlock(buffer)
+        if (completedResponse) return completedResponse
+        throw new Error("Codex stream ended without a completed response")
+      }
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined)
+    reader.releaseLock()
+  }
+}
+
+async function convertCodexStreamToJson(response: Response): Promise<Response> {
+  if (!response.ok) return response
+
+  const completedResponse = await readCodexCompletedResponse(response)
+  const headers = new Headers(response.headers)
+  headers.set("Content-Type", "application/json")
+  headers.delete("Content-Length")
+  headers.delete("Content-Encoding")
+  return new Response(JSON.stringify(completedResponse), {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
+function releaseCodexSlotWhenBodyEnds(
+  response: Response,
+  release: ReleaseCodexRequestSlot,
+): Response {
+  if (!response.body) {
+    release()
+    return response
+  }
+
+  const reader = response.body.getReader()
+  const isEventStream = response.headers.get("Content-Type")?.includes("text/event-stream")
+  if (!isEventStream) {
+    const body = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        try {
+          const result = await reader.read()
+          if (result.done) {
+            release()
+            controller.close()
+          } else {
+            controller.enqueue(result.value)
+          }
+        } catch (error) {
+          release()
+          controller.error(error)
+        }
+      },
+      async cancel(reason) {
+        release()
+        await reader.cancel(reason)
+      },
+    })
+
+    return new Response(body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    })
+  }
+
+  const decoder = new TextDecoder()
+  const encoder = new TextEncoder()
+  let buffer = ""
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        while (true) {
+          const separator = /\r?\n\r?\n/.exec(buffer)
+          if (separator) {
+            const eventEnd = separator.index + separator[0].length
+            const block = buffer.slice(0, separator.index)
+            const eventBytes = encoder.encode(buffer.slice(0, eventEnd))
+            buffer = buffer.slice(eventEnd)
+            controller.enqueue(eventBytes)
+
+            if (isCodexTerminalEventBlock(block)) {
+              await reader.cancel().catch(() => undefined)
+              release()
+              controller.close()
+            }
+            return
+          }
+
+          const result = await reader.read()
+          if (result.done) {
+            buffer += decoder.decode()
+            if (buffer) controller.enqueue(encoder.encode(buffer))
+            release()
+            controller.close()
+            return
+          }
+          buffer += decoder.decode(result.value, { stream: true })
+        }
+      } catch (error) {
+        release()
+        controller.error(error)
+      }
+    },
+    async cancel(reason) {
+      release()
+      await reader.cancel(reason)
+    },
+  })
+
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  })
+}
+
+export async function getValidCodexOAuthAuth(
+  fetchFn: typeof fetch = fetch,
+): Promise<CodexOAuthAuth> {
+  const current = await getCodexOAuthAuth()
+  if (!current) {
+    throw new Error("Not signed in to Codex")
+  }
+
+  if (current.expiresAt > Date.now() + CODEX_TOKEN_REFRESH_MARGIN_MS) {
+    return current
+  }
+
+  refreshPromise ??= refreshCodexOAuthAuth(current, fetchFn).finally(() => {
+    refreshPromise = undefined
+  })
+  return refreshPromise
+}
+
+export async function codexOAuthFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  let request = new Request(input, init)
+  const requestUrl = new URL(request.url)
+  const allowedBase = new URL(CODEX_API_BASE_URL)
+  if (
+    requestUrl.origin !== allowedBase.origin ||
+    !requestUrl.pathname.startsWith(`${allowedBase.pathname}/`)
+  ) {
+    throw new Error("Refusing to send Codex OAuth credentials to an unexpected endpoint")
+  }
+
+  let convertStreamingResponseToJson = false
+  if (requestUrl.pathname === `${allowedBase.pathname}/responses`) {
+    const payload = (await request.clone().json()) as unknown
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+      throw new Error("Codex Responses request body must be a JSON object")
+    }
+    convertStreamingResponseToJson = (payload as Record<string, unknown>).stream !== true
+    request = new Request(request, {
+      body: JSON.stringify({ ...payload, store: false, stream: true }),
+    })
+  }
+
+  const auth = await getValidCodexOAuthAuth()
+  const headers = new Headers(request.headers)
+  headers.set("Authorization", `Bearer ${auth.accessToken}`)
+  headers.set("ChatGPT-Account-Id", auth.accountId)
+  headers.set("originator", "read-frog")
+
+  const authenticatedRequest = new Request(request, { headers })
+  const release = await acquireCodexRequestSlot(authenticatedRequest.signal)
+  try {
+    const response = await fetch(authenticatedRequest)
+    if (convertStreamingResponseToJson && response.ok) {
+      const convertedResponse = await convertCodexStreamToJson(response)
+      release()
+      return convertedResponse
+    }
+    return releaseCodexSlotWhenBodyEnds(response, release)
+  } catch (error) {
+    release()
+    throw error
+  }
+}

--- a/src/utils/auth/codex-oauth.ts
+++ b/src/utils/auth/codex-oauth.ts
@@ -13,64 +13,6 @@ const CODEX_DEVICE_REDIRECT_URI = `${CODEX_OAUTH_ISSUER}/deviceauth/callback`
 const CODEX_DEVICE_TIMEOUT_MS = 10 * 60 * 1000
 const CODEX_DEVICE_POLL_MARGIN_MS = 3_000
 const CODEX_TOKEN_REFRESH_MARGIN_MS = 60_000
-const CODEX_MAX_CONCURRENT_REQUESTS = 2
-
-type ReleaseCodexRequestSlot = () => void
-
-interface CodexRequestWaiter {
-  resolve: (release: ReleaseCodexRequestSlot) => void
-  reject: (reason: unknown) => void
-  signal?: AbortSignal
-  handleAbort?: () => void
-}
-
-let activeCodexRequests = 0
-const codexRequestWaiters: CodexRequestWaiter[] = []
-
-function createCodexRequestRelease(): ReleaseCodexRequestSlot {
-  let released = false
-  return () => {
-    if (released) return
-    released = true
-    activeCodexRequests--
-    dispatchNextCodexRequest()
-  }
-}
-
-function dispatchNextCodexRequest(): void {
-  while (activeCodexRequests < CODEX_MAX_CONCURRENT_REQUESTS && codexRequestWaiters.length > 0) {
-    const waiter = codexRequestWaiters.shift()!
-    if (waiter.signal?.aborted) continue
-
-    waiter.signal?.removeEventListener("abort", waiter.handleAbort!)
-    activeCodexRequests++
-    waiter.resolve(createCodexRequestRelease())
-  }
-}
-
-function acquireCodexRequestSlot(signal?: AbortSignal): Promise<ReleaseCodexRequestSlot> {
-  if (signal?.aborted) {
-    return Promise.reject(
-      signal.reason ?? new DOMException("Codex request cancelled", "AbortError"),
-    )
-  }
-
-  if (activeCodexRequests < CODEX_MAX_CONCURRENT_REQUESTS) {
-    activeCodexRequests++
-    return Promise.resolve(createCodexRequestRelease())
-  }
-
-  return new Promise((resolve, reject) => {
-    const waiter: CodexRequestWaiter = { resolve, reject, signal }
-    waiter.handleAbort = () => {
-      const index = codexRequestWaiters.indexOf(waiter)
-      if (index >= 0) codexRequestWaiters.splice(index, 1)
-      reject(signal?.reason ?? new DOMException("Codex request cancelled", "AbortError"))
-    }
-    signal?.addEventListener("abort", waiter.handleAbort, { once: true })
-    codexRequestWaiters.push(waiter)
-  })
-}
 
 export interface CodexOAuthAuth {
   accessToken: string
@@ -322,9 +264,10 @@ async function refreshCodexOAuthAuth(
 
 let refreshPromise: Promise<CodexOAuthAuth> | undefined
 
-interface CodexResponseCompletedEvent {
-  type: "response.completed" | "response.incomplete"
-  response: Record<string, unknown>
+interface CodexOutputItemDoneEvent {
+  type: "response.output_item.done"
+  item: Record<string, unknown>
+  output_index?: number
 }
 
 function getCodexEventData(block: string): string | undefined {
@@ -336,18 +279,27 @@ function getCodexEventData(block: string): string | undefined {
   return data || undefined
 }
 
-function parseCodexCompletedResponseBlock(block: string): Record<string, unknown> | undefined {
+function parseCodexEventBlock(block: string): Record<string, unknown> | undefined {
   const data = getCodexEventData(block)
   if (!data || data === "[DONE]") return undefined
 
-  const event = JSON.parse(data) as Partial<CodexResponseCompletedEvent>
+  const event = JSON.parse(data) as unknown
+  return event && typeof event === "object" && !Array.isArray(event)
+    ? (event as Record<string, unknown>)
+    : undefined
+}
+
+function getCodexCompletedResponse(
+  event: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
   if (
-    (event.type === "response.completed" || event.type === "response.incomplete") &&
+    (event?.type === "response.completed" || event?.type === "response.incomplete") &&
+    "response" in event &&
     event.response &&
     typeof event.response === "object" &&
     !Array.isArray(event.response)
   ) {
-    return event.response
+    return event.response as Record<string, unknown>
   }
 
   return undefined
@@ -375,6 +327,33 @@ async function readCodexCompletedResponse(response: Response): Promise<Record<st
   const reader = response.body.getReader()
   const decoder = new TextDecoder()
   let buffer = ""
+  const outputItems: Array<Record<string, unknown> | undefined> = []
+
+  const collectOutputItem = (event: Record<string, unknown> | undefined) => {
+    if (event?.type !== "response.output_item.done") return
+    const { item, output_index: outputIndex } = event as Partial<CodexOutputItemDoneEvent>
+    if (!item || typeof item !== "object" || Array.isArray(item)) return
+
+    if (Number.isInteger(outputIndex) && outputIndex! >= 0) {
+      outputItems[outputIndex!] = item
+    } else {
+      outputItems.push(item)
+    }
+  }
+
+  const completeResponse = (
+    event: Record<string, unknown> | undefined,
+  ): Record<string, unknown> | undefined => {
+    const completedResponse = getCodexCompletedResponse(event)
+    if (!completedResponse) return undefined
+
+    const streamedOutput = outputItems.filter(
+      (item): item is Record<string, unknown> => item !== undefined,
+    )
+    return streamedOutput.length > 0
+      ? { ...completedResponse, output: streamedOutput }
+      : completedResponse
+  }
 
   try {
     while (true) {
@@ -387,18 +366,26 @@ async function readCodexCompletedResponse(response: Response): Promise<Record<st
 
         const block = buffer.slice(0, separator.index)
         buffer = buffer.slice(separator.index + separator[0].length)
-        const completedResponse = parseCodexCompletedResponseBlock(block)
+        const event = parseCodexEventBlock(block)
+        collectOutputItem(event)
+        const completedResponse = completeResponse(event)
         if (completedResponse) return completedResponse
       }
 
       if (done) {
-        const completedResponse = parseCodexCompletedResponseBlock(buffer)
+        const event = parseCodexEventBlock(buffer)
+        collectOutputItem(event)
+        const completedResponse = completeResponse(event)
         if (completedResponse) return completedResponse
         throw new Error("Codex stream ended without a completed response")
       }
     }
   } finally {
-    await reader.cancel().catch(() => undefined)
+    // The terminal SSE event already contains the complete response. Browser
+    // fetch streams may keep the cancellation promise pending while the
+    // underlying HTTP connection is being torn down, so waiting here can
+    // prevent the completed response from ever reaching the AI SDK.
+    void reader.cancel().catch(() => undefined)
     reader.releaseLock()
   }
 }
@@ -418,45 +405,11 @@ async function convertCodexStreamToJson(response: Response): Promise<Response> {
   })
 }
 
-function releaseCodexSlotWhenBodyEnds(
-  response: Response,
-  release: ReleaseCodexRequestSlot,
-): Response {
-  if (!response.body) {
-    release()
-    return response
-  }
-
-  const reader = response.body.getReader()
+function closeCodexStreamAtTerminalEvent(response: Response): Response {
+  if (!response.body) return response
   const isEventStream = response.headers.get("Content-Type")?.includes("text/event-stream")
-  if (!isEventStream) {
-    const body = new ReadableStream<Uint8Array>({
-      async pull(controller) {
-        try {
-          const result = await reader.read()
-          if (result.done) {
-            release()
-            controller.close()
-          } else {
-            controller.enqueue(result.value)
-          }
-        } catch (error) {
-          release()
-          controller.error(error)
-        }
-      },
-      async cancel(reason) {
-        release()
-        await reader.cancel(reason)
-      },
-    })
-
-    return new Response(body, {
-      status: response.status,
-      statusText: response.statusText,
-      headers: response.headers,
-    })
-  }
+  if (!isEventStream) return response
+  const reader = response.body.getReader()
 
   const decoder = new TextDecoder()
   const encoder = new TextEncoder()
@@ -474,8 +427,9 @@ function releaseCodexSlotWhenBodyEnds(
             controller.enqueue(eventBytes)
 
             if (isCodexTerminalEventBlock(block)) {
-              await reader.cancel().catch(() => undefined)
-              release()
+              // Close the consumer-facing stream immediately on a terminal
+              // event; do not couple completion to transport teardown.
+              void reader.cancel().catch(() => undefined)
               controller.close()
             }
             return
@@ -485,19 +439,16 @@ function releaseCodexSlotWhenBodyEnds(
           if (result.done) {
             buffer += decoder.decode()
             if (buffer) controller.enqueue(encoder.encode(buffer))
-            release()
             controller.close()
             return
           }
           buffer += decoder.decode(result.value, { stream: true })
         }
       } catch (error) {
-        release()
         controller.error(error)
       }
     },
     async cancel(reason) {
-      release()
       await reader.cancel(reason)
     },
   })
@@ -560,17 +511,8 @@ export async function codexOAuthFetch(
   headers.set("originator", "read-frog")
 
   const authenticatedRequest = new Request(request, { headers })
-  const release = await acquireCodexRequestSlot(authenticatedRequest.signal)
-  try {
-    const response = await fetch(authenticatedRequest)
-    if (convertStreamingResponseToJson && response.ok) {
-      const convertedResponse = await convertCodexStreamToJson(response)
-      release()
-      return convertedResponse
-    }
-    return releaseCodexSlotWhenBodyEnds(response, release)
-  } catch (error) {
-    release()
-    throw error
-  }
+  const response = await fetch(authenticatedRequest)
+  return convertStreamingResponseToJson && response.ok
+    ? convertCodexStreamToJson(response)
+    : closeCodexStreamAtTerminalEvent(response)
 }

--- a/src/utils/auth/codex-oauth.ts
+++ b/src/utils/auth/codex-oauth.ts
@@ -114,6 +114,7 @@ function parseInitialTokenResponse(tokens: TokenResponse): CodexOAuthAuth {
 async function exchangeAuthorizationCode(
   authorization: DeviceTokenResponse,
   fetchFn: typeof fetch,
+  signal?: AbortSignal,
 ): Promise<CodexOAuthAuth> {
   const response = await fetchFn(CODEX_TOKEN_ENDPOINT, {
     method: "POST",
@@ -125,6 +126,7 @@ async function exchangeAuthorizationCode(
       client_id: CODEX_OAUTH_CLIENT_ID,
       code_verifier: authorization.code_verifier,
     }).toString(),
+    signal,
   })
 
   if (!response.ok) {
@@ -202,7 +204,11 @@ export async function completeCodexDeviceAuthorization(
       const auth = await exchangeAuthorizationCode(
         (await response.json()) as DeviceTokenResponse,
         fetchFn,
+        options.signal,
       )
+      if (options.signal?.aborted) {
+        throw options.signal.reason ?? new DOMException("Codex sign-in cancelled", "AbortError")
+      }
       await storage.setItem(CODEX_OAUTH_STORAGE_KEY, auth)
       return auth
     }

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -7,6 +7,15 @@ import {
 import { LLM_PROVIDER_MODELS } from "../models"
 
 describe("getProviderOptions", () => {
+  it("maps Codex OAuth provider options to the OpenAI SDK namespace", () => {
+    expect(getProviderOptions("gpt-5.4", "openai-codex")).toEqual({
+      openai: expect.any(Object),
+    })
+    expect(
+      getProviderOptionsWithOverride("gpt-5.4", "openai-codex", { reasoningEffort: "high" }),
+    ).toEqual({ openai: { reasoningEffort: "high" } })
+  })
+
   describe("model pattern matching", () => {
     it("should return options for gemini models", () => {
       const options = getProviderOptions("gemini-2.5-pro", "google")

--- a/src/utils/constants/__tests__/providers.test.ts
+++ b/src/utils/constants/__tests__/providers.test.ts
@@ -13,6 +13,26 @@ import {
 } from "../providers"
 
 describe("provider constants", () => {
+  it("defines Codex OAuth as a non-custom provider without an API key", () => {
+    expect(DEFAULT_PROVIDER_CONFIG["openai-codex"]).toEqual(
+      expect.objectContaining({
+        id: "openai-codex-default",
+        provider: "openai-codex",
+        model: {
+          model: "gpt-5.4-mini",
+          isCustomModel: false,
+          customModel: null,
+        },
+        reasoning: "none",
+      }),
+    )
+    expect(DEFAULT_PROVIDER_CONFIG["openai-codex"]).not.toHaveProperty("apiKey")
+    expect(NON_CUSTOM_LLM_PROVIDER_TYPES).toContain("openai-codex")
+    expect(apiProviderConfigItemSchema.parse(DEFAULT_PROVIDER_CONFIG["openai-codex"])).toEqual(
+      DEFAULT_PROVIDER_CONFIG["openai-codex"],
+    )
+  })
+
   it("defines Azure with the LobeHub color icon and GPT shortcut defaults", () => {
     expect(PROVIDER_ITEMS.azure.logo("light")).toContain("/light/azure-color.webp")
     expect(PROVIDER_ITEMS.azure.logo("dark")).toContain("/dark/azure-color.webp")

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -10,6 +10,7 @@ interface OpenAIGPT5ReasoningEffortPolicy {
 }
 
 export const LLM_PROVIDER_MODELS = {
+  "openai-codex": ["gpt-5.4-mini", "gpt-5.4", "gpt-5.5", "gpt-5.3-codex-spark"],
   openai: [
     "gpt-5.5",
     "gpt-5.4-pro",

--- a/src/utils/constants/providers.ts
+++ b/src/utils/constants/providers.ts
@@ -29,6 +29,11 @@ import { i18n } from "@/utils/i18n"
 import { getLobeIconsCDNUrlFn } from "../logo"
 
 export const DEFAULT_LLM_PROVIDER_MODELS: LLMProviderModels = {
+  "openai-codex": {
+    model: "gpt-5.4-mini",
+    isCustomModel: false,
+    customModel: null,
+  },
   openrouter: {
     model: "x-ai/grok-4-fast:free",
     isCustomModel: false,
@@ -194,6 +199,11 @@ export const PROVIDER_ITEMS: Record<
     logo: (theme: Theme) => (theme === "light" ? deeplxLogoLight : deeplxLogoDark),
     name: "DeepL",
     website: "https://www.deepl.com/pro-api",
+  },
+  "openai-codex": {
+    logo: getLobeIconsCDNUrlFn("openai"),
+    name: "Codex OAuth",
+    website: "https://chatgpt.com/codex",
   },
   atlascloud: {
     logo: getLobeIconsCDNUrlFn("atlascloud"),
@@ -385,6 +395,14 @@ export const DEFAULT_PROVIDER_CONFIG = {
     provider: "openai-compatible",
     baseURL: "https://api.example.com/v1",
     model: DEFAULT_LLM_PROVIDER_MODELS["openai-compatible"],
+  },
+  "openai-codex": {
+    id: "openai-codex-default",
+    name: PROVIDER_ITEMS["openai-codex"].name,
+    enabled: true,
+    provider: "openai-codex",
+    model: DEFAULT_LLM_PROVIDER_MODELS["openai-codex"],
+    reasoning: "none",
   },
   openai: {
     id: "openai-default",
@@ -594,6 +612,7 @@ export const PROVIDER_BASE_URL_PLACEHOLDERS: Partial<Record<APIProviderTypes, st
   siliconflow: DEFAULT_PROVIDER_CONFIG.siliconflow.baseURL,
   tensdaq: DEFAULT_PROVIDER_CONFIG.tensdaq.baseURL,
   "openai-compatible": DEFAULT_PROVIDER_CONFIG["openai-compatible"].baseURL,
+  "openai-codex": "https://chatgpt.com/backend-api/codex",
   openai: "https://api.openai.com/v1",
   azure: "https://<resource>.services.ai.azure.com/openai",
   deepseek: "https://api.deepseek.com",

--- a/src/utils/host/translate/translate-text.ts
+++ b/src/utils/host/translate/translate-text.ts
@@ -17,6 +17,7 @@ import { detectLanguage } from "@/utils/content/language"
 import { i18n } from "@/utils/i18n"
 import { logger } from "@/utils/logger"
 import { getTranslatePrompt } from "@/utils/prompts/translate"
+import { providerRequiresApiKey } from "@/utils/providers/api-key"
 import { TranslationCancelledError } from "@/utils/request/cancellation"
 import { Sha256Hex } from "../../hash"
 import { sendMessage } from "../../message"
@@ -221,12 +222,13 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     throw new TranslationCancelledError(sessionId)
   }
 
+  const requestHash = Sha256Hex(...hashComponents)
   const result = await sendMessage("enqueueTranslateRequest", {
     text: preparedText,
     langConfig,
     providerConfig,
     scheduleAt: Date.now(),
-    hash: Sha256Hex(...hashComponents),
+    hash: requestHash,
     textFormat,
     webTitle: normalizedWebPageContext?.webTitle,
     webDescription: normalizedWebPageContext?.webDescription,
@@ -281,7 +283,7 @@ export function validateTranslationConfigAndToast(
   if (
     isAPIProviderConfig(providerConfig) &&
     !providerConfig.apiKey?.trim() &&
-    !["deeplx", "ollama"].includes(providerConfig.provider)
+    providerRequiresApiKey(providerConfig.provider)
   ) {
     toastManager.add({ type: "error", title: i18n.t("noAPIKeyConfig.warning") })
     logger.info("validateTranslationConfig: returning false (no API key)")

--- a/src/utils/providers/__tests__/api-key.test.ts
+++ b/src/utils/providers/__tests__/api-key.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest"
+import { providerRequiresApiKey } from "../api-key"
+
+describe("providerRequiresApiKey", () => {
+  it("does not require an API key for Codex OAuth", () => {
+    expect(providerRequiresApiKey("openai-codex")).toBe(false)
+  })
+
+  it("keeps API keys required for ordinary hosted providers", () => {
+    expect(providerRequiresApiKey("openai")).toBe(true)
+  })
+})

--- a/src/utils/providers/__tests__/model.test.ts
+++ b/src/utils/providers/__tests__/model.test.ts
@@ -9,16 +9,19 @@ const {
   azureChatModelMock,
   azureLanguageModelMock,
   openAICompatibleLanguageModelMock,
+  openAIResponsesModelMock,
   ollamaLanguageModelMock,
   createAnthropicMock,
   createAzureMock,
   createOllamaMock,
+  createOpenAIMock,
   createOpenAICompatibleMock,
 } = vi.hoisted(() => {
   const innerAnthropicLanguageModelMock = vi.fn<(...args: any[]) => any>()
   const innerAzureChatModelMock = vi.fn<(...args: any[]) => any>()
   const innerAzureLanguageModelMock = vi.fn<(...args: any[]) => any>()
   const innerOpenAICompatibleLanguageModelMock = vi.fn<(...args: any[]) => any>()
+  const innerOpenAIResponsesModelMock = vi.fn<(...args: any[]) => any>()
   const innerOllamaLanguageModelMock = vi.fn<(...args: any[]) => any>()
   const innerCreateAnthropicMock = vi.fn<(...args: any[]) => any>(
     (_options?: Record<string, unknown>) => ({
@@ -41,16 +44,21 @@ const {
       languageModel: innerOllamaLanguageModelMock,
     }),
   )
+  const innerCreateOpenAIMock = vi.fn<(...args: any[]) => any>(() => ({
+    responses: innerOpenAIResponsesModelMock,
+  }))
 
   return {
     anthropicLanguageModelMock: innerAnthropicLanguageModelMock,
     azureChatModelMock: innerAzureChatModelMock,
     azureLanguageModelMock: innerAzureLanguageModelMock,
     openAICompatibleLanguageModelMock: innerOpenAICompatibleLanguageModelMock,
+    openAIResponsesModelMock: innerOpenAIResponsesModelMock,
     ollamaLanguageModelMock: innerOllamaLanguageModelMock,
     createAnthropicMock: innerCreateAnthropicMock,
     createAzureMock: innerCreateAzureMock,
     createOllamaMock: innerCreateOllamaMock,
+    createOpenAIMock: innerCreateOpenAIMock,
     createOpenAICompatibleMock: innerCreateOpenAICompatibleMock,
   }
 })
@@ -65,6 +73,10 @@ vi.mock("@ai-sdk/azure", () => ({
 
 vi.mock("@ai-sdk/openai-compatible", () => ({
   createOpenAICompatible: createOpenAICompatibleMock,
+}))
+
+vi.mock("@ai-sdk/openai", () => ({
+  createOpenAI: createOpenAIMock,
 }))
 
 vi.mock("ai-sdk-ollama", () => ({
@@ -127,6 +139,7 @@ describe("getModelById", () => {
     azureChatModelMock.mockReturnValue("azure-chat-model")
     azureLanguageModelMock.mockReturnValue("azure-model")
     openAICompatibleLanguageModelMock.mockReturnValue("custom-model")
+    openAIResponsesModelMock.mockReturnValue("codex-model")
     ollamaLanguageModelMock.mockReturnValue("ollama-model")
     getStorageItemMock = vi.fn<(...args: any[]) => any>()
     ;(storage.getItem as unknown as ReturnType<typeof vi.fn>) = getStorageItemMock
@@ -148,6 +161,36 @@ describe("getModelById", () => {
       }),
     )
     expect(anthropicLanguageModelMock).toHaveBeenCalledWith("claude-haiku-4-5")
+  })
+
+  it("uses the Responses API with the Codex OAuth transport", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [
+        {
+          id: "openai-codex-default",
+          name: "Codex OAuth",
+          enabled: true,
+          provider: "openai-codex",
+          model: {
+            model: "gpt-5.4-mini",
+            isCustomModel: false,
+            customModel: null,
+          },
+        },
+      ],
+    })
+
+    const { CODEX_API_BASE_URL, codexOAuthFetch } = await import("../../auth/codex-oauth")
+    const { getModelById } = await import("../model")
+    const result = await getModelById("openai-codex-default")
+
+    expect(result).toBe("codex-model")
+    expect(createOpenAIMock).toHaveBeenCalledWith({
+      apiKey: "codex-oauth",
+      baseURL: CODEX_API_BASE_URL,
+      fetch: codexOAuthFetch,
+    })
+    expect(openAIResponsesModelMock).toHaveBeenCalledWith("gpt-5.4-mini")
   })
 
   it("passes attribution headers for OpenRouter when user headers are undefined", async () => {

--- a/src/utils/providers/api-key.ts
+++ b/src/utils/providers/api-key.ts
@@ -1,0 +1,11 @@
+import type { APIProviderTypes } from "@/types/config/provider"
+
+const API_KEY_OPTIONAL_PROVIDER_TYPES = new Set<APIProviderTypes>([
+  "deeplx",
+  "ollama",
+  "openai-codex",
+])
+
+export function providerRequiresApiKey(provider: APIProviderTypes): boolean {
+  return !API_KEY_OPTIONAL_PROVIDER_TYPES.has(provider)
+}

--- a/src/utils/providers/model.ts
+++ b/src/utils/providers/model.ts
@@ -25,6 +25,7 @@ import { createOllama } from "ai-sdk-ollama"
 import { storage } from "#imports"
 import { DEFAULT_AZURE_API_MODE, isCustomLLMProvider } from "@/types/config/provider"
 import { compactObject } from "@/types/utils"
+import { CODEX_API_BASE_URL, codexOAuthFetch } from "../auth/codex-oauth"
 import { getLLMProvidersConfig, getProviderConfigById } from "../config/helpers"
 import { CONFIG_STORAGE_KEY } from "../constants/config"
 import { getProviderHeadersWithOverride } from "./headers"
@@ -99,6 +100,21 @@ async function getLanguageModelById(providerId: string) {
 
   const headers = getProviderHeadersWithOverride(providerConfig.provider, providerConfig.headers)
   const providerSpecificSettings = getProviderSpecificSettings(providerConfig)
+  const modelId = resolveModelId(providerConfig.model)
+
+  if (!modelId) {
+    throw new Error("Model is undefined")
+  }
+
+  if (providerConfig.provider === "openai-codex") {
+    const provider = createOpenAI({
+      apiKey: "codex-oauth",
+      baseURL: CODEX_API_BASE_URL,
+      fetch: codexOAuthFetch,
+      ...(headers && { headers }),
+    })
+    return provider.responses(modelId)
+  }
 
   const provider = isCustomLLMProvider(providerConfig.provider)
     ? CREATE_AI_MAPPER[providerConfig.provider]({
@@ -115,12 +131,6 @@ async function getLanguageModelById(providerId: string) {
         ...(providerConfig.apiKey && { apiKey: providerConfig.apiKey }),
         ...(headers && { headers }),
       })
-
-  const modelId = resolveModelId(providerConfig.model)
-
-  if (!modelId) {
-    throw new Error("Model is undefined")
-  }
 
   if (providerConfig.provider === "azure" && getAzureApiMode(providerConfig) === "chat") {
     return (provider as ReturnType<typeof createAzure>).chat(modelId)

--- a/src/utils/providers/options.ts
+++ b/src/utils/providers/options.ts
@@ -92,7 +92,8 @@ export function getProviderOptions(
     return {}
   }
 
-  return { [provider]: options }
+  const runtimeProvider = provider === "openai-codex" ? "openai" : provider
+  return { [runtimeProvider]: options }
 }
 
 /**
@@ -106,8 +107,10 @@ export function getProviderOptionsWithOverride(
   userOptions?: Record<string, JSONValue>,
   reasoning?: string,
 ): Record<string, Record<string, JSONValue>> | undefined {
+  const runtimeProvider = provider === "openai-codex" ? "openai" : provider
+
   if (userOptions !== undefined) {
-    return { [provider]: normalizeUserProviderOptions(provider, userOptions) }
+    return { [runtimeProvider]: normalizeUserProviderOptions(provider, userOptions) }
   }
 
   const recommendedOptions = getRecommendedProviderOptions(model)
@@ -123,5 +126,5 @@ export function getProviderOptionsWithOverride(
     return undefined
   }
 
-  return { [provider]: recommendedOptions }
+  return { [runtimeProvider]: recommendedOptions }
 }


### PR DESCRIPTION
> **AI model(s) used (required):** OpenAI Codex

## Type of Changes

- [x] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [x] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [x] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Adds a dedicated Codex OAuth provider that uses a ChatGPT subscription session instead of an API key.

The implementation includes:

- Device authorization, token refresh, sign-in status, and sign-out controls.
- Account-scoped Codex requests with endpoint validation to prevent credential forwarding.
- Responses API compatibility for the Codex backend, including `store: false`, required streaming transport, SSE completion handling, and non-stream response conversion for the AI SDK.
- Reconstruction of completed response output from `response.output_item.done` events when the terminal response contains an empty output array.
- Immediate consumer completion on terminal SSE events without waiting for transport cancellation.
- Provider registration, model selection, localized UI copy, and API-key validation exemptions specific to OAuth providers.
- Unit coverage for authorization parsing, request shaping, stream handling, response reconstruction, provider registration, and configuration behavior.

OAuth credentials remain outside exported configuration data, and the provider does not fall back to API-key authentication. Codex requests use the extension's existing request and batch queues without an additional provider-specific concurrency limiter.

## Related Issue

No linked issue.

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation performed on the latest changes:

- 44 focused unit tests passed.
- Type-aware lint and type checking passed.
- Chrome MV3 production build completed successfully.
- Device sign-in and webpage translation were verified in Microsoft Edge.

## Screenshots

Not included; the provider follows the existing provider editor layout.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The transport accepts OAuth credentials only for the configured Codex backend origin and path. It forces non-persistent Responses API requests and preserves completed streaming output for non-streaming AI SDK consumers.
