### PR TITLE
feat(providers): add Responses API mode to custom providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@ai-sdk/huggingface": "^2.0.14",
     "@ai-sdk/mistral": "^4.0.14",
     "@ai-sdk/moonshotai": "^3.0.17",
+    "@ai-sdk/open-responses": "^2.0.16",
     "@ai-sdk/openai": "^4.0.20",
     "@ai-sdk/openai-compatible": "^3.0.14",
     "@ai-sdk/perplexity": "^4.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@ai-sdk/moonshotai':
         specifier: ^3.0.17
         version: 3.0.17(zod@4.4.3)
+      '@ai-sdk/open-responses':
+        specifier: ^2.0.16
+        version: 2.0.16(zod@4.4.3)
       '@ai-sdk/openai':
         specifier: ^4.0.20
         version: 4.0.20(zod@4.4.3)
@@ -510,6 +513,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/open-responses@2.0.16':
+    resolution: {integrity: sha512-zViEZlRMU4XBMBRP3Az2AcpLDwDemQ1NTNO6uGyQ8oE7dulgr1IthQleZL+h8YgYrWRDa5TiSYkSGYJTHLlXfg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai-compatible@3.0.14':
     resolution: {integrity: sha512-nUl7dBHUDTqcnuWGnEbKMwDDqL94BxRfibLwYv8uWp+kZn8Zqdxy7tUBt4sv2hpHQi+S2P6bUyqW18xmbykErw==}
     engines: {node: '>=22'}
@@ -534,8 +543,18 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@5.0.16':
+    resolution: {integrity: sha512-LWDrmYWkZoAJwMbToUglpR6AmgvtnNtCCGeU9MKlXiSV3Yiu4u73/pVA18sQAAe3kZtCRBY9P31lAfnPekWWyg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@4.0.3':
     resolution: {integrity: sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/provider@4.0.4':
+    resolution: {integrity: sha512-tbHKNLirllUNF3ZlkCsXnwab2ZV1Sl4b1H/Cp9ruCce15IBmskE8Gwkk0yo9xDWY+jho2of7lVXtwSsyrq7cwQ==}
     engines: {node: '>=22'}
 
   '@ai-sdk/react@4.0.40':
@@ -7169,6 +7188,12 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/open-responses@2.0.16(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@ai-sdk/provider-utils': 5.0.16(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/openai-compatible@3.0.14(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.3
@@ -7195,7 +7220,20 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@5.0.16(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.4
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.28.0
+      zod: 4.4.3
+
   '@ai-sdk/provider@4.0.3':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.4':
     dependencies:
       json-schema: 0.4.0
 

--- a/src/entrypoints/options/pages/api-providers/providers-config/provider-config-form/__tests__/provider-specific-settings-field.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/providers-config/provider-config-form/__tests__/provider-specific-settings-field.test.tsx
@@ -106,6 +106,50 @@ describe("providerSpecificSettingsField", () => {
     )
   })
 
+  it("renders Chat Completions by default for Custom Provider and persists Responses API", async () => {
+    render(
+      <ProviderSpecificSettingsFieldHarness
+        initialConfig={DEFAULT_PROVIDER_CONFIG["openai-compatible"]}
+      />,
+    )
+
+    const apiModeSelect = screen.getByLabelText(
+      "options.apiProviders.form.providerSettingLabels.apiMode",
+    )
+    expect(apiModeSelect).toHaveTextContent(
+      "options.apiProviders.form.providerSettingOptionLabels.chatCompletions",
+    )
+
+    fireEvent.click(apiModeSelect)
+    const responsesOption = screen.getByRole("option", {
+      name: "options.apiProviders.form.providerSettingOptionLabels.responses",
+    })
+    fireEvent.pointerDown(responsesOption, { pointerType: "mouse" })
+    fireEvent.click(responsesOption)
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+      await Promise.resolve()
+    })
+
+    expect(screen.getByLabelText("persisted-provider-specific-settings")).toHaveTextContent(
+      '{"apiMode":"responses"}',
+    )
+  })
+
+  it.each(["openrouter", "siliconflow", "atlascloud", "minimax", "tensdaq", "volcengine"] as const)(
+    "does not render API mode for %s",
+    (provider) => {
+      render(
+        <ProviderSpecificSettingsFieldHarness initialConfig={DEFAULT_PROVIDER_CONFIG[provider]} />,
+      )
+
+      expect(
+        screen.queryByLabelText("options.apiProviders.form.providerSettingLabels.apiMode"),
+      ).not.toBeInTheDocument()
+    },
+  )
+
   it("does not render or write settings for providers without provider-specific schemas", async () => {
     render(<ProviderSpecificSettingsFieldHarness initialConfig={DEFAULT_PROVIDER_CONFIG.openai} />)
 

--- a/src/types/config/__tests__/provider-specific-settings.test.ts
+++ b/src/types/config/__tests__/provider-specific-settings.test.ts
@@ -1,10 +1,30 @@
+import type { CustomLLMProviderTypes } from "../provider"
 import { describe, expect, it } from "vitest"
 import { z } from "zod"
 import {
   azureProviderSpecificSettingsSchema,
   bedrockProviderSpecificSettingsSchema,
+  customProviderSpecificSettingsSchema,
+  CUSTOM_LLM_PROVIDER_TYPES,
   getProviderSpecificSettingFields,
+  LLM_PROVIDER_MODELS,
+  providerConfigItemSchema,
 } from "../provider"
+
+function createCustomProviderConfig(provider: CustomLLMProviderTypes) {
+  return {
+    id: `${provider}-default`,
+    name: provider,
+    enabled: true,
+    provider,
+    baseURL: "https://api.example.com/v1",
+    model: {
+      model: LLM_PROVIDER_MODELS[provider][0],
+      isCustomModel: provider === "openai-compatible",
+      customModel: null,
+    },
+  }
+}
 
 describe("provider-specific settings metadata", () => {
   it("returns the Bedrock region field from Zod metadata", () => {
@@ -45,6 +65,21 @@ describe("provider-specific settings metadata", () => {
     ])
   })
 
+  it("returns the Custom Provider API mode field from Zod metadata", () => {
+    expect(getProviderSpecificSettingFields(customProviderSpecificSettingsSchema)).toEqual([
+      {
+        key: "apiMode",
+        labelKey: "apiMode",
+        type: "select",
+        defaultValue: "chat",
+        options: [
+          { value: "responses", labelKey: "responses" },
+          { value: "chat", labelKey: "chatCompletions" },
+        ],
+      },
+    ])
+  })
+
   it("throws when a provider-specific setting lacks providerSettingUi metadata", () => {
     const schema = z.strictObject({
       region: z.string(),
@@ -69,4 +104,39 @@ describe("provider-specific settings metadata", () => {
       "Unsupported providerSpecificSettings.region field type: password",
     )
   })
+})
+
+describe("Custom Provider config schema", () => {
+  it("accepts Responses API mode", () => {
+    const result = providerConfigItemSchema.safeParse({
+      ...createCustomProviderConfig("openai-compatible"),
+      providerSpecificSettings: {
+        apiMode: "responses",
+      },
+    })
+
+    expect(result.success).toBe(true)
+  })
+
+  it("accepts an existing config without provider-specific settings", () => {
+    const result = providerConfigItemSchema.safeParse(
+      createCustomProviderConfig("openai-compatible"),
+    )
+
+    expect(result.success).toBe(true)
+  })
+
+  it.each(CUSTOM_LLM_PROVIDER_TYPES.filter((provider) => provider !== "openai-compatible"))(
+    "rejects provider-specific settings for %s",
+    (provider) => {
+      const result = providerConfigItemSchema.safeParse({
+        ...createCustomProviderConfig(provider),
+        providerSpecificSettings: {
+          apiMode: "responses",
+        },
+      })
+
+      expect(result.success).toBe(false)
+    },
+  )
 })

--- a/src/types/config/provider/provider-specific-settings.ts
+++ b/src/types/config/provider/provider-specific-settings.ts
@@ -1,9 +1,13 @@
 import type { LLMProviderTypes } from "./constants"
 import { z } from "zod"
 
-export const AZURE_API_MODES = ["responses", "chat"] as const
-export type AzureApiMode = (typeof AZURE_API_MODES)[number]
+export const API_MODES = ["responses", "chat"] as const
+export type ApiMode = (typeof API_MODES)[number]
+
+export const AZURE_API_MODES = API_MODES
+export type AzureApiMode = ApiMode
 export const DEFAULT_AZURE_API_MODE: AzureApiMode = "responses"
+export const DEFAULT_CUSTOM_API_MODE: ApiMode = "chat"
 
 interface ProviderSettingBaseUiMeta {
   labelKey: string
@@ -47,6 +51,23 @@ export const bedrockProviderSpecificSettingsSchema = z.strictObject({
         labelKey: "region",
         type: "text",
         placeholder: "us-east-1",
+      },
+    }),
+})
+
+export const customProviderSpecificSettingsSchema = z.strictObject({
+  apiMode: z
+    .enum(API_MODES)
+    .optional()
+    .meta({
+      providerSettingUi: {
+        labelKey: "apiMode",
+        type: "select",
+        defaultValue: DEFAULT_CUSTOM_API_MODE,
+        options: [
+          { value: "responses", labelKey: "responses" },
+          { value: "chat", labelKey: "chatCompletions" },
+        ],
       },
     }),
 })
@@ -95,6 +116,7 @@ export const PROVIDER_SPECIFIC_SETTINGS_SCHEMAS: Partial<
 > = {
   azure: azureProviderSpecificSettingsSchema,
   bedrock: bedrockProviderSpecificSettingsSchema,
+  "openai-compatible": customProviderSpecificSettingsSchema,
 }
 
 export function getProviderSpecificSettingFields(

--- a/src/types/config/provider/schemas.ts
+++ b/src/types/config/provider/schemas.ts
@@ -13,6 +13,7 @@ import { AI_SDK_REASONING_VALUES, LLM_PROVIDER_MODELS } from "./constants"
 import {
   azureProviderSpecificSettingsSchema,
   bedrockProviderSpecificSettingsSchema,
+  customProviderSpecificSettingsSchema,
 } from "./provider-specific-settings"
 
 export const providerSponsorConfigSchema = z.object({
@@ -79,6 +80,7 @@ const llmProviderConfigSchemaList = [
   baseCustomLLMProviderConfigSchema.extend({
     provider: z.literal("openai-compatible"),
     model: createProviderModelSchema<"openai-compatible">("openai-compatible"),
+    providerSpecificSettings: customProviderSpecificSettingsSchema.optional(),
   }),
   baseCustomLLMProviderConfigSchema.extend({
     provider: z.literal("openrouter"),

--- a/src/utils/providers/__tests__/model.test.ts
+++ b/src/utils/providers/__tests__/model.test.ts
@@ -9,16 +9,19 @@ const {
   azureChatModelMock,
   azureLanguageModelMock,
   openAICompatibleLanguageModelMock,
+  openResponsesLanguageModelMock,
   ollamaLanguageModelMock,
   createAnthropicMock,
   createAzureMock,
   createOllamaMock,
   createOpenAICompatibleMock,
+  createOpenResponsesMock,
 } = vi.hoisted(() => {
   const innerAnthropicLanguageModelMock = vi.fn<(...args: any[]) => any>()
   const innerAzureChatModelMock = vi.fn<(...args: any[]) => any>()
   const innerAzureLanguageModelMock = vi.fn<(...args: any[]) => any>()
   const innerOpenAICompatibleLanguageModelMock = vi.fn<(...args: any[]) => any>()
+  const innerOpenResponsesLanguageModelMock = vi.fn<(...args: any[]) => any>()
   const innerOllamaLanguageModelMock = vi.fn<(...args: any[]) => any>()
   const innerCreateAnthropicMock = vi.fn<(...args: any[]) => any>(
     (_options?: Record<string, unknown>) => ({
@@ -36,6 +39,11 @@ const {
       languageModel: innerOpenAICompatibleLanguageModelMock,
     }),
   )
+  const innerCreateOpenResponsesMock = vi.fn<(...args: any[]) => any>(
+    (_options?: Record<string, unknown>) => ({
+      languageModel: innerOpenResponsesLanguageModelMock,
+    }),
+  )
   const innerCreateOllamaMock = vi.fn<(...args: any[]) => any>(
     (_options?: Record<string, unknown>) => ({
       languageModel: innerOllamaLanguageModelMock,
@@ -47,11 +55,13 @@ const {
     azureChatModelMock: innerAzureChatModelMock,
     azureLanguageModelMock: innerAzureLanguageModelMock,
     openAICompatibleLanguageModelMock: innerOpenAICompatibleLanguageModelMock,
+    openResponsesLanguageModelMock: innerOpenResponsesLanguageModelMock,
     ollamaLanguageModelMock: innerOllamaLanguageModelMock,
     createAnthropicMock: innerCreateAnthropicMock,
     createAzureMock: innerCreateAzureMock,
     createOllamaMock: innerCreateOllamaMock,
     createOpenAICompatibleMock: innerCreateOpenAICompatibleMock,
+    createOpenResponsesMock: innerCreateOpenResponsesMock,
   }
 })
 
@@ -65,6 +75,10 @@ vi.mock("@ai-sdk/azure", () => ({
 
 vi.mock("@ai-sdk/openai-compatible", () => ({
   createOpenAICompatible: createOpenAICompatibleMock,
+}))
+
+vi.mock("@ai-sdk/open-responses", () => ({
+  createOpenResponses: createOpenResponsesMock,
 }))
 
 vi.mock("ai-sdk-ollama", () => ({
@@ -127,6 +141,7 @@ describe("getModelById", () => {
     azureChatModelMock.mockReturnValue("azure-chat-model")
     azureLanguageModelMock.mockReturnValue("azure-model")
     openAICompatibleLanguageModelMock.mockReturnValue("custom-model")
+    openResponsesLanguageModelMock.mockReturnValue("custom-responses-model")
     ollamaLanguageModelMock.mockReturnValue("ollama-model")
     getStorageItemMock = vi.fn<(...args: any[]) => any>()
     ;(storage.getItem as unknown as ReturnType<typeof vi.fn>) = getStorageItemMock
@@ -232,6 +247,7 @@ describe("getModelById", () => {
     expect(createAzureMock.mock.calls[0]?.[0]).not.toHaveProperty("region")
     expect(azureLanguageModelMock).toHaveBeenCalledWith("read-frog-gpt-4o")
     expect(azureChatModelMock).not.toHaveBeenCalled()
+    expect(createOpenResponsesMock).not.toHaveBeenCalled()
   })
 
   it("uses Azure chat completions when API mode is chat", async () => {
@@ -274,6 +290,7 @@ describe("getModelById", () => {
     expect(createAzureMock.mock.calls[0]?.[0]).not.toHaveProperty("region")
     expect(azureChatModelMock).toHaveBeenCalledWith("read-frog-gpt-4o")
     expect(azureLanguageModelMock).not.toHaveBeenCalled()
+    expect(createOpenResponsesMock).not.toHaveBeenCalled()
   })
 
   it("uses user headers as a full override for Anthropic", async () => {
@@ -304,7 +321,119 @@ describe("getModelById", () => {
     expect(createAnthropicMock.mock.calls[0]?.[0]).not.toHaveProperty("headers")
   })
 
-  it("passes custom headers for OpenAI-compatible providers", async () => {
+  it("uses the Responses API for an OpenAI-compatible provider in responses mode", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [
+        {
+          id: "custom-openai",
+          name: "Custom Provider",
+          enabled: true,
+          provider: "openai-compatible",
+          apiKey: "custom-key",
+          baseURL: " https://api.example.com/v1/ ",
+          model: {
+            model: "use-custom-model",
+            isCustomModel: true,
+            customModel: "custom-responses-model-id",
+          },
+          providerSpecificSettings: {
+            apiMode: "responses",
+          },
+          headers: {
+            "HTTP-Referer": "https://example.com",
+            "X-Title": "Read Frog",
+          },
+        },
+      ],
+    })
+
+    const { getModelById } = await import("../model")
+    const result = await getModelById("custom-openai")
+
+    expect(result).toBe("custom-responses-model")
+    expect(createOpenResponsesMock).toHaveBeenCalledWith({
+      name: "openai-compatible",
+      url: "https://api.example.com/v1/responses",
+      apiKey: "custom-key",
+      headers: {
+        "HTTP-Referer": "https://example.com",
+        "X-Title": "Read Frog",
+      },
+    })
+    expect(openResponsesLanguageModelMock).toHaveBeenCalledWith("custom-responses-model-id")
+    expect(createOpenAICompatibleMock).not.toHaveBeenCalled()
+  })
+
+  it("uses Chat Completions for an OpenAI-compatible provider in chat mode", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [
+        {
+          id: "custom-openai",
+          name: "Custom Provider",
+          enabled: true,
+          provider: "openai-compatible",
+          apiKey: "custom-key",
+          baseURL: "https://api.example.com/v1",
+          model: {
+            model: "use-custom-model",
+            isCustomModel: true,
+            customModel: "custom-chat-model-id",
+          },
+          providerSpecificSettings: {
+            apiMode: "chat",
+          },
+        },
+      ],
+    })
+
+    const { getModelById } = await import("../model")
+    const result = await getModelById("custom-openai")
+
+    expect(result).toBe("custom-model")
+    expect(createOpenAICompatibleMock).toHaveBeenCalledWith({
+      name: "openai-compatible",
+      baseURL: "https://api.example.com/v1",
+      supportsStructuredOutputs: true,
+      apiKey: "custom-key",
+    })
+    expect(createOpenAICompatibleMock.mock.calls[0]?.[0]).not.toHaveProperty("apiMode")
+    expect(openAICompatibleLanguageModelMock).toHaveBeenCalledWith("custom-chat-model-id")
+    expect(createOpenResponsesMock).not.toHaveBeenCalled()
+  })
+
+  it("falls back to Chat Completions for an unknown OpenAI-compatible API mode", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [
+        {
+          id: "custom-openai",
+          name: "Custom Provider",
+          enabled: true,
+          provider: "openai-compatible",
+          baseURL: "https://api.example.com/v1",
+          model: {
+            model: "use-custom-model",
+            isCustomModel: true,
+            customModel: "custom-chat-model-id",
+          },
+          providerSpecificSettings: {
+            apiMode: "unknown",
+          },
+        },
+      ],
+    })
+
+    const { getModelById } = await import("../model")
+    await getModelById("custom-openai")
+
+    expect(createOpenAICompatibleMock).toHaveBeenCalledWith({
+      name: "openai-compatible",
+      baseURL: "https://api.example.com/v1",
+      supportsStructuredOutputs: true,
+    })
+    expect(createOpenResponsesMock).not.toHaveBeenCalled()
+  })
+
+  it("keeps legacy OpenAI-compatible configs on Chat Completions", async () => {
     getStorageItemMock.mockResolvedValue({
       providersConfig: [
         {
@@ -331,19 +460,19 @@ describe("getModelById", () => {
     const result = await getModelById("custom-openai")
 
     expect(result).toBe("custom-model")
-    expect(createOpenAICompatibleMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "openai-compatible",
-        baseURL: "http://127.0.0.1:1234/v1",
-        apiKey: "custom-key",
-        headers: {
-          "HTTP-Referer": "https://example.com",
-          "X-Title": "Read Frog",
-        },
-      }),
-    )
+    expect(createOpenAICompatibleMock).toHaveBeenCalledWith({
+      name: "openai-compatible",
+      baseURL: "http://127.0.0.1:1234/v1",
+      supportsStructuredOutputs: true,
+      apiKey: "custom-key",
+      headers: {
+        "HTTP-Referer": "https://example.com",
+        "X-Title": "Read Frog",
+      },
+    })
     expect(openAICompatibleLanguageModelMock).toHaveBeenCalledWith(
       "huihui-hy-mt1.5-1.8b-abliterated",
     )
+    expect(createOpenResponsesMock).not.toHaveBeenCalled()
   })
 })

--- a/src/utils/providers/__tests__/responses-url.test.ts
+++ b/src/utils/providers/__tests__/responses-url.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import { resolveResponsesUrl } from "../responses-url"
+
+describe("resolveResponsesUrl", () => {
+  it.each([
+    ["https://api.example.com/v1", "https://api.example.com/v1/responses"],
+    [" https://api.example.com/v1/ ", "https://api.example.com/v1/responses"],
+    [
+      "https://gateway.example.com/openai/responses",
+      "https://gateway.example.com/openai/responses",
+    ],
+    [
+      "https://gateway.example.com/openai/responses?api-version=preview",
+      "https://gateway.example.com/openai/responses?api-version=preview",
+    ],
+    ["https://api.example.com", "https://api.example.com/responses"],
+    [
+      "https://api.example.com/v1/?api-version=preview",
+      "https://api.example.com/v1/responses?api-version=preview",
+    ],
+  ])("resolves %s to %s", (baseURL, expected) => {
+    expect(resolveResponsesUrl(baseURL)).toBe(expected)
+  })
+})

--- a/src/utils/providers/model.ts
+++ b/src/utils/providers/model.ts
@@ -1,5 +1,5 @@
 import type { Config } from "@/types/config/config"
-import type { AzureApiMode, LLMProviderConfig } from "@/types/config/provider"
+import type { ApiMode, LLMProviderConfig } from "@/types/config/provider"
 import { createAlibaba } from "@ai-sdk/alibaba"
 import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock"
 import { createAnthropic } from "@ai-sdk/anthropic"
@@ -14,6 +14,7 @@ import { createGroq } from "@ai-sdk/groq"
 import { createHuggingFace } from "@ai-sdk/huggingface"
 import { createMistral } from "@ai-sdk/mistral"
 import { createMoonshotAI } from "@ai-sdk/moonshotai"
+import { createOpenResponses } from "@ai-sdk/open-responses"
 import { createOpenAI } from "@ai-sdk/openai"
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible"
 import { createPerplexity } from "@ai-sdk/perplexity"
@@ -23,12 +24,17 @@ import { createVercel } from "@ai-sdk/vercel"
 import { createXai } from "@ai-sdk/xai"
 import { createOllama } from "ai-sdk-ollama"
 import { storage } from "#imports"
-import { DEFAULT_AZURE_API_MODE, isCustomLLMProvider } from "@/types/config/provider"
+import {
+  DEFAULT_AZURE_API_MODE,
+  DEFAULT_CUSTOM_API_MODE,
+  isCustomLLMProvider,
+} from "@/types/config/provider"
 import { compactObject } from "@/types/utils"
 import { getLLMProvidersConfig, getProviderConfigById } from "../config/helpers"
 import { CONFIG_STORAGE_KEY } from "../constants/config"
 import { getProviderHeadersWithOverride } from "./headers"
 import { resolveModelId } from "./model-id"
+import { resolveResponsesUrl } from "./responses-url"
 
 const CREATE_AI_MAPPER = {
   atlascloud: createOpenAICompatible,
@@ -67,22 +73,22 @@ function getProviderSpecificSettings(providerConfig: LLMProviderConfig) {
       ? compactObject(providerConfig.providerSpecificSettings ?? {})
       : {}
 
-  if (providerConfig.provider !== "azure") {
+  if (providerConfig.provider !== "azure" && providerConfig.provider !== "openai-compatible") {
     return settings
   }
 
-  const { apiMode: _apiMode, ...azureSettings } = settings as Record<string, unknown>
-  return azureSettings
+  const { apiMode: _apiMode, ...providerSettings } = settings as Record<string, unknown>
+  return providerSettings
 }
 
-function getAzureApiMode(providerConfig: LLMProviderConfig): AzureApiMode {
-  if (providerConfig.provider !== "azure") {
-    return DEFAULT_AZURE_API_MODE
-  }
-
+function getApiMode(
+  providerConfig: Extract<LLMProviderConfig, { provider: "azure" | "openai-compatible" }>,
+): ApiMode {
+  const defaultApiMode =
+    providerConfig.provider === "azure" ? DEFAULT_AZURE_API_MODE : DEFAULT_CUSTOM_API_MODE
   const apiMode = (providerConfig.providerSpecificSettings as { apiMode?: unknown } | undefined)
     ?.apiMode
-  return apiMode === "chat" ? "chat" : DEFAULT_AZURE_API_MODE
+  return apiMode === "chat" || apiMode === "responses" ? apiMode : defaultApiMode
 }
 
 async function getLanguageModelById(providerId: string) {
@@ -100,21 +106,29 @@ async function getLanguageModelById(providerId: string) {
   const headers = getProviderHeadersWithOverride(providerConfig.provider, providerConfig.headers)
   const providerSpecificSettings = getProviderSpecificSettings(providerConfig)
 
-  const provider = isCustomLLMProvider(providerConfig.provider)
-    ? CREATE_AI_MAPPER[providerConfig.provider]({
-        ...providerSpecificSettings,
-        name: providerConfig.provider,
-        baseURL: providerConfig.baseURL ?? "",
-        supportsStructuredOutputs: true,
-        ...(providerConfig.apiKey && { apiKey: providerConfig.apiKey }),
-        ...(headers && { headers }),
-      })
-    : CREATE_AI_MAPPER[providerConfig.provider]({
-        ...providerSpecificSettings,
-        ...(providerConfig.baseURL && { baseURL: providerConfig.baseURL }),
-        ...(providerConfig.apiKey && { apiKey: providerConfig.apiKey }),
-        ...(headers && { headers }),
-      })
+  const provider =
+    providerConfig.provider === "openai-compatible" && getApiMode(providerConfig) === "responses"
+      ? createOpenResponses({
+          name: providerConfig.provider,
+          url: resolveResponsesUrl(providerConfig.baseURL),
+          ...(providerConfig.apiKey && { apiKey: providerConfig.apiKey }),
+          ...(headers && { headers }),
+        })
+      : isCustomLLMProvider(providerConfig.provider)
+        ? CREATE_AI_MAPPER[providerConfig.provider]({
+            ...providerSpecificSettings,
+            name: providerConfig.provider,
+            baseURL: providerConfig.baseURL ?? "",
+            supportsStructuredOutputs: true,
+            ...(providerConfig.apiKey && { apiKey: providerConfig.apiKey }),
+            ...(headers && { headers }),
+          })
+        : CREATE_AI_MAPPER[providerConfig.provider]({
+            ...providerSpecificSettings,
+            ...(providerConfig.baseURL && { baseURL: providerConfig.baseURL }),
+            ...(providerConfig.apiKey && { apiKey: providerConfig.apiKey }),
+            ...(headers && { headers }),
+          })
 
   const modelId = resolveModelId(providerConfig.model)
 
@@ -122,7 +136,7 @@ async function getLanguageModelById(providerId: string) {
     throw new Error("Model is undefined")
   }
 
-  if (providerConfig.provider === "azure" && getAzureApiMode(providerConfig) === "chat") {
+  if (providerConfig.provider === "azure" && getApiMode(providerConfig) === "chat") {
     return (provider as ReturnType<typeof createAzure>).chat(modelId)
   }
 

--- a/src/utils/providers/responses-url.ts
+++ b/src/utils/providers/responses-url.ts
@@ -1,0 +1,9 @@
+export function resolveResponsesUrl(baseURL: string): string {
+  const trimmedBaseURL = baseURL.trim()
+  const suffixIndex = trimmedBaseURL.search(/[?#]/)
+  const path = suffixIndex === -1 ? trimmedBaseURL : trimmedBaseURL.slice(0, suffixIndex)
+  const suffix = suffixIndex === -1 ? "" : trimmedBaseURL.slice(suffixIndex)
+  const normalizedPath = path.replace(/\/+$/, "")
+
+  return `${normalizedPath}${normalizedPath.endsWith("/responses") ? "" : "/responses"}${suffix}`
+}


### PR DESCRIPTION
> **AI model(s) used (required): 

- GPT 5.6 Sol
- Fable 5

## Type of Changes

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Added a Responses API option using `@ai-sdk/open-responses` for Custom Provider to be compatible with more third-party APIs.

The design references the previous API Mode changes from the Azure provider.

## Related Issue

Closes #2007 

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

## Screenshots

<img width="1732" height="1810" alt="image" src="https://github.com/user-attachments/assets/b3186104-5f56-45be-9dd4-ad801df54a90" />

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information
