### PR TITLE
Claude/wechat qr code copy 5d7db5

### DIFF
--- a/.changeset/website-patterns-full-height.md
+++ b/.changeset/website-patterns-full-height.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+style(options): let the website pattern lists run full height on their own pages

--- a/.changeset/wechat-discussion-group-copy.md
+++ b/.changeset/wechat-discussion-group-copy.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+i18n(contact-us): point the WeChat card at the discussion group

--- a/src/entrypoints/options/components/patterns-table.tsx
+++ b/src/entrypoints/options/components/patterns-table.tsx
@@ -26,6 +26,12 @@ interface PatternsTableProps {
   placeholderText: string
   tableHeaderText: string
   className?: string
+  /**
+   * The box the rows sit in. Capped and scrolling by default, so a list inside a settings
+   * row can't grow until it pushes the section off screen; pass `max-h-none` where the list
+   * has the room to run its full length.
+   */
+  rowsClassName?: string
 }
 
 export function PatternsTable({
@@ -35,6 +41,7 @@ export function PatternsTable({
   placeholderText,
   tableHeaderText,
   className,
+  rowsClassName,
 }: PatternsTableProps) {
   const [inputValue, setInputValue] = useState("")
 
@@ -87,7 +94,7 @@ export function PatternsTable({
               </TableRow>
             </TableHeader>
           </Table>
-          <div className="max-h-42 overflow-y-auto">
+          <div className={cn("max-h-42 overflow-y-auto", rowsClassName)}>
             <Table>
               <TableBody>
                 {patterns.map((pattern, index) => (

--- a/src/entrypoints/options/pages/translation/translation-control/website-patterns-page.tsx
+++ b/src/entrypoints/options/pages/translation/translation-control/website-patterns-page.tsx
@@ -41,6 +41,7 @@ function WebsitePatternsPage({
           onRemovePattern={removePattern}
           placeholderText={placeholderText}
           tableHeaderText={tableHeaderText}
+          rowsClassName="max-h-none"
         />
       </ConfigDetailSection>
     </PageLayout>

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -108,7 +108,7 @@ options:
       description: Reach the team directly at contact@readfrog.app
     wechat:
       title: WeChat
-      description: Scan the QR code to add the maintainer on WeChat
+      description: Scan the QR code to join the WeChat discussion group
       qrCodeAlt: WeChat QR code
   apiProviders:
     title: API Providers

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -108,7 +108,7 @@ options:
       description: Contacta directamente con el equipo en contact@readfrog.app
     wechat:
       title: WeChat
-      description: Escanea el código QR para añadir al desarrollador en WeChat
+      description: Escanea el código QR para unirte al grupo de discusión de WeChat
       qrCodeAlt: Código QR de WeChat
   apiProviders:
     title: Proveedores de API

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -108,7 +108,7 @@ options:
       description: contact@readfrog.app からチームに直接連絡できます
     wechat:
       title: WeChat
-      description: QR コードをスキャンして開発者を WeChat に追加
+      description: QR コードをスキャンして WeChat のディスカッショングループに参加
       qrCodeAlt: WeChat QR コード
   apiProviders:
     title: APIプロバイダー

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -108,7 +108,7 @@ options:
       description: contact@readfrog.app 으로 팀에 직접 연락하세요
     wechat:
       title: WeChat
-      description: QR 코드를 스캔해 개발자를 WeChat에 추가하세요
+      description: QR 코드를 스캔해 WeChat 토론 그룹에 참여하세요
       qrCodeAlt: WeChat QR 코드
   apiProviders:
     title: API 제공업체

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -108,7 +108,7 @@ options:
       description: Свяжитесь с командой напрямую по адресу contact@readfrog.app
     wechat:
       title: WeChat
-      description: Отсканируйте QR-код, чтобы добавить разработчика в WeChat
+      description: Отсканируйте QR-код, чтобы вступить в группу обсуждения в WeChat
       qrCodeAlt: QR-код WeChat
   apiProviders:
     title: API-провайдеры

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -108,7 +108,7 @@ options:
       description: Ekibe doğrudan contact@readfrog.app adresinden ulaşın
     wechat:
       title: WeChat
-      description: Geliştiriciyi WeChat üzerinde eklemek için QR kodu tarayın
+      description: WeChat tartışma grubuna katılmak için QR kodu tarayın
       qrCodeAlt: WeChat QR kodu
   apiProviders:
     title: API Sağlayıcıları

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -108,7 +108,7 @@ options:
       description: Liên hệ trực tiếp với nhóm qua contact@readfrog.app
     wechat:
       title: WeChat
-      description: Quét mã QR để thêm nhà phát triển trên WeChat
+      description: Quét mã QR để tham gia nhóm thảo luận trên WeChat
       qrCodeAlt: Mã QR WeChat
   apiProviders:
     title: Nhà cung cấp API

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -108,7 +108,7 @@ options:
       description: 通过 contact@readfrog.app 直接联系团队
     wechat:
       title: 微信
-      description: 扫描二维码添加开发者微信
+      description: 扫描二维码进入微信讨论群
       qrCodeAlt: 微信二维码
   apiProviders:
     title: API 提供商

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -108,7 +108,7 @@ options:
       description: 透過 contact@readfrog.app 直接聯絡團隊
     wechat:
       title: 微信
-      description: 掃描 QR code 加開發者微信
+      description: 掃描 QR code 進入微信討論群
       qrCodeAlt: 微信 QR code
   apiProviders:
     title: API 提供者


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 5

## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [x] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [x] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Two small options-page changes.

**1. WeChat contact card points at the discussion group**

`options.contactUs.wechat.description` said "scan the QR code to add the developer on WeChat". It now says the code leads into the WeChat discussion group, updated across all nine locales:

| Locale | New copy |
| --- | --- |
| zh-CN | 扫描二维码进入微信讨论群 |
| zh-TW | 掃描 QR code 進入微信討論群 |
| en | Scan the QR code to join the WeChat discussion group |
| es | Escanea el código QR para unirte al grupo de discusión de WeChat |
| ja | QR コードをスキャンして WeChat のディスカッショングループに参加 |
| ko | QR 코드를 스캔해 WeChat 토론 그룹에 참여하세요 |
| ru | Отсканируйте QR-код, чтобы вступить в группу обсуждения в WeChat |
| tr | WeChat tartışma grubuna katılmak için QR kodu tarayın |
| vi | Quét mã QR để tham gia nhóm thảo luận trên WeChat |

`title` and `qrCodeAlt` are untouched.

**2. Website pattern lists run full height on their own pages**

`PatternsTable` hard-coded `max-h-42 overflow-y-auto` on the box holding its rows, so every list scrolled inside a short window. That cap is right for the tables embedded in a settings row, but wrong on the two drill-in pages where the list *is* the page.

The cap moves behind a `rowsClassName` prop that keeps `max-h-42 overflow-y-auto` as its default, following the `<part>ClassName` convention already used across the codebase (`contentClassName`, `trackClassName`, `positionerClassName`). Because `cn` is built on tailwind-merge, a caller passing `max-h-none` replaces the cap in the same class group rather than fighting it, and a future caller can pick a different cap instead of being limited to on/off.

Only **基于网站自动翻译** and **基于网站永不自动翻译** opt out — both go through the shared `WebsitePatternsPage`, so one call site covers them. The three embedded tables are untouched and still capped:

- Preference → Extension activation
- Selection toolbar → Display
- Floating button → Display

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

- `tsc --noEmit` clean
- `oxfmt --check` clean on both changed components
- `vitest run src/hooks/__tests__/use-pattern-list.test.ts` — 4 passed
- Full suite green via the pre-push hook

Header and rows are deliberately two separate `<table>` elements so only the rows scroll; the `w-16` action-column hint that keeps the two aligned is independent of the cap, so removing it does not disturb the alignment. Without a scrollbar taking width, the two tables line up marginally better than before.

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

⚠️ **The QR image still needs swapping.** `src/assets/wechat-account.jpg` is a personal add-a-friend code — it shows "MengXi" and the caption "Scan the QR code to add me as a friend." With the new copy the card promises a group but the code still adds the maintainer personally. Worth replacing the asset before this ships, keeping in mind WeChat group codes expire after about 7 days, which is presumably why a personal code was used in the first place.

Two changesets, both `patch`: an i18n copy change and a UI tweak.