### PR TITLE
feat(selection): reuse a pinned selection popover in place for new se…

### DIFF
--- a/.changeset/pinned-selection-popover-reuse.md
+++ b/.changeset/pinned-selection-popover-reuse.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(selection): reuse a pinned selection popover in place — translating or running a custom action on a new selection keeps the pinned window's position, size, and pin state and streams the new result into it instead of reopening at a new anchor

--- a/src/components/ui/selection-popover/__tests__/selection-popover.test.tsx
+++ b/src/components/ui/selection-popover/__tests__/selection-popover.test.tsx
@@ -315,7 +315,11 @@ function PortalledBoundary() {
   return createPortal(<div data-testid="portalled-boundary">Portalled boundary</div>, document.body)
 }
 
-function ReopenablePopoverHarness() {
+function ReopenablePopoverHarness({
+  onReuseRequestSpy,
+}: {
+  onReuseRequestSpy?: (details: { anchor: { x: number; y: number } | null }) => void
+} = {}) {
   const [open, setOpen] = React.useState(false)
   const [sourceSelection, setSourceSelection] = React.useState("First selection")
   const [snapshotSelection, setSnapshotSelection] = React.useState<string | null>(null)
@@ -336,13 +340,25 @@ function ReopenablePopoverHarness() {
     [sourceSelection],
   )
 
+  const handleReuseRequest = React.useCallback(
+    (details: { anchor: { x: number; y: number } | null }) => {
+      onReuseRequestSpy?.(details)
+      setSnapshotSelection(sourceSelection)
+    },
+    [onReuseRequestSpy, sourceSelection],
+  )
+
   return (
     <div>
       <button type="button" onClick={() => setSourceSelection("Second selection")}>
         Switch selection
       </button>
 
-      <SelectionPopover.Root open={open} onOpenChange={handleOpenChange}>
+      <SelectionPopover.Root
+        open={open}
+        onOpenChange={handleOpenChange}
+        onReuseRequest={handleReuseRequest}
+      >
         <SelectionPopover.Trigger>Open popover</SelectionPopover.Trigger>
         <SelectionPopover.Content key={sessionKey}>
           <SelectionPopover.Header className="border-b">
@@ -358,6 +374,71 @@ function ReopenablePopoverHarness() {
         </SelectionPopover.Content>
       </SelectionPopover.Root>
     </div>
+  )
+}
+
+function ControlledPinHarness({ onPinnedChange }: { onPinnedChange: (pinned: boolean) => void }) {
+  const [pinned, setPinned] = React.useState(false)
+
+  const handlePinnedChange = React.useCallback(
+    (nextPinned: boolean) => {
+      onPinnedChange(nextPinned)
+      setPinned(nextPinned)
+    },
+    [onPinnedChange],
+  )
+
+  return (
+    <SelectionPopover.Root
+      pinned={pinned}
+      onPinnedChange={handlePinnedChange}
+      onOpenChange={onOpenChangeSpy}
+    >
+      <SelectionPopover.Trigger>Open popover</SelectionPopover.Trigger>
+      <SelectionPopover.Content>
+        <SelectionPopover.Header className="border-b">
+          <SelectionPopover.Title>Controlled Pin Popover</SelectionPopover.Title>
+          <div className="flex items-center gap-1">
+            <SelectionPopover.Pin />
+            <SelectionPopover.Close />
+          </div>
+        </SelectionPopover.Header>
+        <SelectionPopover.Body>
+          <div>Popover content</div>
+        </SelectionPopover.Body>
+      </SelectionPopover.Content>
+    </SelectionPopover.Root>
+  )
+}
+
+function ActionsPopoverHarness({
+  actionsRef,
+  onReuseRequest,
+}: {
+  actionsRef: React.RefObject<{
+    requestOpen: (anchor?: { x: number; y: number } | null) => void
+  } | null>
+  onReuseRequest?: (details: { anchor: { x: number; y: number } | null }) => void
+}) {
+  return (
+    <SelectionPopover.Root
+      actionsRef={actionsRef}
+      onReuseRequest={onReuseRequest}
+      onOpenChange={onOpenChangeSpy}
+    >
+      <SelectionPopover.Content>
+        <SelectionPopover.Header className="border-b">
+          <SelectionPopover.Title>Actions Popover</SelectionPopover.Title>
+          <div className="flex items-center gap-1">
+            <SelectionPopover.Pin />
+            <SelectionPopover.Close />
+          </div>
+        </SelectionPopover.Header>
+        <SelectionPopover.Body>
+          <div>Popover content</div>
+        </SelectionPopover.Body>
+      </SelectionPopover.Content>
+    </SelectionPopover.Root>
   )
 }
 
@@ -700,8 +781,29 @@ describe("selectionPopover", () => {
     expect(screen.getByText("Second content")).toBeInTheDocument()
   })
 
-  it("restarts the same popover session when clicking the same trigger again", () => {
+  it("restarts the same popover session when clicking the same trigger again while unpinned", () => {
     render(<ReopenablePopoverHarness />)
+
+    const trigger = screen.getByRole("button", { name: "Open popover" })
+    vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue(buildTriggerRect())
+
+    fireEvent.click(trigger)
+    flushRaf()
+
+    expect(screen.getByText("First selection")).toBeInTheDocument()
+
+    const firstElement = screen.getByTestId("mock-rnd")
+
+    fireEvent.click(trigger)
+    flushRaf()
+
+    expect(screen.getByText("First selection")).toBeInTheDocument()
+    expect(screen.getByTestId("mock-rnd")).not.toBe(firstElement)
+  })
+
+  it("reuses a pinned popover in place when clicking the same trigger again", () => {
+    const onReuseRequestSpy = vi.fn<(...args: any[]) => any>()
+    render(<ReopenablePopoverHarness onReuseRequestSpy={onReuseRequestSpy} />)
 
     const trigger = screen.getByRole("button", { name: "Open popover" })
     vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue(buildTriggerRect())
@@ -718,19 +820,121 @@ describe("selectionPopover", () => {
     )
 
     const firstElement = screen.getByTestId("mock-rnd")
+    const positionBeforeReuse = latestRndProps?.position
+    updatePositionSpy.mockReset()
+    updateSizeSpy.mockReset()
 
     fireEvent.click(screen.getByRole("button", { name: "Switch selection" }))
-    expect(screen.getByText("First selection")).toBeInTheDocument()
-
     fireEvent.click(trigger)
     flushRaf()
 
     expect(screen.getByText("Second selection")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Pin popover" })).toHaveAttribute(
+    expect(onReuseRequestSpy).toHaveBeenCalledWith({ anchor: { x: 120, y: 140 } })
+    expect(screen.getByRole("button", { name: "Unpin popover" })).toHaveAttribute(
       "aria-pressed",
-      "false",
+      "true",
     )
-    expect(screen.getByTestId("mock-rnd")).not.toBe(firstElement)
+    expect(screen.getByTestId("mock-rnd")).toBe(firstElement)
+    expect(latestRndProps?.position).toEqual(positionBeforeReuse)
+    expect(updatePositionSpy).not.toHaveBeenCalled()
+    expect(updateSizeSpy).not.toHaveBeenCalled()
+  })
+
+  it("notifies pinned-state changes through onPinnedChange", () => {
+    const onPinnedChangeSpy = vi.fn<(...args: any[]) => any>()
+    render(<ControlledPinHarness onPinnedChange={onPinnedChangeSpy} />)
+
+    const trigger = screen.getByRole("button", { name: "Open popover" })
+    vi.spyOn(trigger, "getBoundingClientRect").mockReturnValue(buildTriggerRect())
+
+    fireEvent.click(trigger)
+    flushRaf()
+
+    fireEvent.click(screen.getByRole("button", { name: "Pin popover" }))
+    expect(onPinnedChangeSpy).toHaveBeenLastCalledWith(true)
+    expect(screen.getByRole("button", { name: "Unpin popover" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+    expect(onPinnedChangeSpy).toHaveBeenLastCalledWith(false)
+  })
+
+  it("opens at the requested anchor through actionsRef.requestOpen", () => {
+    const actionsRef = React.createRef<{
+      requestOpen: (anchor?: { x: number; y: number } | null) => void
+    }>()
+    render(<ActionsPopoverHarness actionsRef={actionsRef} />)
+
+    expect(screen.queryByTestId("mock-rnd")).not.toBeInTheDocument()
+
+    act(() => {
+      actionsRef.current?.requestOpen({ x: 200, y: 160 })
+    })
+
+    expect(onOpenChangeSpy).toHaveBeenLastCalledWith(true)
+    expect(screen.getByTestId("mock-rnd")).toBeInTheDocument()
+  })
+
+  it("restarts an unpinned popover through actionsRef.requestOpen", () => {
+    const actionsRef = React.createRef<{
+      requestOpen: (anchor?: { x: number; y: number } | null) => void
+    }>()
+    const onReuseRequestSpy = vi.fn<(...args: any[]) => any>()
+    render(<ActionsPopoverHarness actionsRef={actionsRef} onReuseRequest={onReuseRequestSpy} />)
+
+    act(() => {
+      actionsRef.current?.requestOpen({ x: 200, y: 160 })
+    })
+    flushRaf()
+
+    onOpenChangeSpy.mockReset()
+
+    act(() => {
+      actionsRef.current?.requestOpen({ x: 400, y: 320 })
+    })
+
+    expect(onOpenChangeSpy).toHaveBeenLastCalledWith(false)
+
+    flushRaf()
+
+    expect(onOpenChangeSpy).toHaveBeenLastCalledWith(true)
+    expect(onReuseRequestSpy).not.toHaveBeenCalled()
+    expect(screen.getByTestId("mock-rnd")).toBeInTheDocument()
+  })
+
+  it("reuses a pinned popover through actionsRef.requestOpen without moving it", () => {
+    const actionsRef = React.createRef<{
+      requestOpen: (anchor?: { x: number; y: number } | null) => void
+    }>()
+    const onReuseRequestSpy = vi.fn<(...args: any[]) => any>()
+    render(<ActionsPopoverHarness actionsRef={actionsRef} onReuseRequest={onReuseRequestSpy} />)
+
+    act(() => {
+      actionsRef.current?.requestOpen({ x: 200, y: 160 })
+    })
+    flushRaf()
+
+    fireEvent.click(screen.getByRole("button", { name: "Pin popover" }))
+
+    const firstElement = screen.getByTestId("mock-rnd")
+    const positionBeforeReuse = latestRndProps?.position
+    onOpenChangeSpy.mockReset()
+
+    act(() => {
+      actionsRef.current?.requestOpen({ x: 400, y: 320 })
+    })
+    flushRaf()
+
+    expect(onReuseRequestSpy).toHaveBeenCalledWith({ anchor: { x: 400, y: 320 } })
+    expect(onOpenChangeSpy).not.toHaveBeenCalled()
+    expect(screen.getByTestId("mock-rnd")).toBe(firstElement)
+    expect(latestRndProps?.position).toEqual(positionBeforeReuse)
+    expect(screen.getByRole("button", { name: "Unpin popover" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
   })
 
   it("keeps growing downward until streamed content reaches the viewport bottom", async () => {

--- a/src/components/ui/selection-popover/index.tsx
+++ b/src/components/ui/selection-popover/index.tsx
@@ -27,6 +27,10 @@ interface SelectionPopoverPosition {
   y: number
 }
 
+interface SelectionPopoverActions {
+  requestOpen: (anchor?: SelectionPopoverPosition | null) => void
+}
+
 type SelectionPopoverPortalContainer =
   | HTMLElement
   | ShadowRoot
@@ -39,7 +43,8 @@ interface SelectionPopoverRootContextValue {
   anchor: SelectionPopoverPosition | null
   setAnchor: (value: SelectionPopoverPosition | null) => void
   pinned: boolean
-  setPinned: React.Dispatch<React.SetStateAction<boolean>>
+  setPinned: (value: boolean | ((value: boolean) => boolean)) => void
+  requestOpen: (anchor?: SelectionPopoverPosition | null) => void
   triggerElement: HTMLElement | null
   setTriggerElement: React.Dispatch<React.SetStateAction<HTMLElement | null>>
 }
@@ -89,33 +94,58 @@ function SelectionPopoverRoot({
   anchor: anchorProp,
   children,
   defaultOpen = false,
+  defaultPinned = false,
   disablePointerDismissal = false,
   open: openProp,
+  pinned: pinnedProp,
+  actionsRef,
   onAnchorChange,
   onOpenChange,
+  onPinnedChange,
+  onReuseRequest,
 }: {
   anchor?: SelectionPopoverPosition | null
   children: React.ReactNode
   defaultOpen?: boolean
+  defaultPinned?: boolean
   disablePointerDismissal?: boolean
   open?: boolean
+  pinned?: boolean
+  actionsRef?: React.RefObject<SelectionPopoverActions | null>
   onAnchorChange?: (anchor: SelectionPopoverPosition | null) => void
   onOpenChange?: (open: boolean) => void
+  onPinnedChange?: (pinned: boolean) => void
+  onReuseRequest?: (details: { anchor: SelectionPopoverPosition | null }) => void
 }) {
   const instanceId = React.useId()
   const [uncontrolledOpen, setUncontrolledOpen] = React.useState(defaultOpen)
   const [uncontrolledAnchor, setUncontrolledAnchor] =
     React.useState<SelectionPopoverPosition | null>(null)
-  const [pinned, setPinned] = React.useState(false)
+  const [uncontrolledPinned, setUncontrolledPinned] = React.useState(defaultPinned)
   const [triggerElement, setTriggerElement] = React.useState<HTMLElement | null>(null)
+  const reopenFrameRef = React.useRef<number | null>(null)
   const open = openProp ?? uncontrolledOpen
   const anchor = anchorProp ?? uncontrolledAnchor
+  const pinned = pinnedProp ?? uncontrolledPinned
+
+  const setPinned = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const nextPinned = typeof value === "function" ? value(pinned) : value
+
+      if (pinnedProp === undefined) {
+        setUncontrolledPinned(nextPinned)
+      }
+
+      onPinnedChange?.(nextPinned)
+    },
+    [onPinnedChange, pinned, pinnedProp],
+  )
 
   const setOpen = React.useCallback(
     (value: boolean | ((value: boolean) => boolean)) => {
       const nextOpen = typeof value === "function" ? value(open) : value
 
-      if (!nextOpen) {
+      if (!nextOpen && pinned) {
         setPinned(false)
       }
 
@@ -125,7 +155,7 @@ function SelectionPopoverRoot({
 
       onOpenChange?.(nextOpen)
     },
-    [onOpenChange, open, openProp],
+    [onOpenChange, open, openProp, pinned, setPinned],
   )
 
   const setAnchor = React.useCallback(
@@ -138,6 +168,57 @@ function SelectionPopoverRoot({
     },
     [anchorProp, onAnchorChange],
   )
+
+  const requestOpen = React.useCallback(
+    (nextAnchor: SelectionPopoverPosition | null = null) => {
+      if (open && pinned) {
+        // A pinned popover is reused in place: keep its anchor, layout, and
+        // pin state, and let the consumer swap session-scoped content via
+        // onReuseRequest. Re-dispatch the open event to re-assert exclusivity.
+        window.dispatchEvent(
+          new CustomEvent(SELECTION_POPOVER_OPEN_EVENT, {
+            detail: { instanceId },
+          }),
+        )
+        onReuseRequest?.({ anchor: nextAnchor })
+        return
+      }
+
+      if (open) {
+        // Reopen on the next frame so controlled consumers observe a full
+        // close/open cycle and can refresh session-scoped state from the
+        // current selection.
+        if (reopenFrameRef.current !== null) {
+          cancelAnimationFrame(reopenFrameRef.current)
+        }
+        setOpen(false)
+        reopenFrameRef.current = requestAnimationFrame(() => {
+          reopenFrameRef.current = null
+          if (nextAnchor) {
+            setAnchor(nextAnchor)
+          }
+          setOpen(true)
+        })
+        return
+      }
+
+      if (nextAnchor) {
+        setAnchor(nextAnchor)
+      }
+      setOpen(true)
+    },
+    [instanceId, onReuseRequest, open, pinned, setAnchor, setOpen],
+  )
+
+  React.useImperativeHandle(actionsRef, () => ({ requestOpen }), [requestOpen])
+
+  React.useEffect(() => {
+    return () => {
+      if (reopenFrameRef.current !== null) {
+        cancelAnimationFrame(reopenFrameRef.current)
+      }
+    }
+  }, [])
 
   React.useEffect(() => {
     if (!open) {
@@ -171,10 +252,11 @@ function SelectionPopoverRoot({
       setAnchor,
       pinned,
       setPinned,
+      requestOpen,
       triggerElement,
       setTriggerElement,
     }),
-    [anchor, open, pinned, setAnchor, setOpen, triggerElement],
+    [anchor, open, pinned, requestOpen, setAnchor, setOpen, setPinned, triggerElement],
   )
 
   return (
@@ -199,33 +281,15 @@ function SelectionPopoverTrigger({
   render,
   ...props
 }: useRender.ComponentProps<"button"> & React.ComponentProps<"button">) {
-  const { open, setAnchor, setOpen, setPinned, setTriggerElement } =
-    useSelectionPopoverRootContext()
-
-  const restartPopoverSession = React.useCallback(() => {
-    // Reopen on the next frame so controlled consumers observe a full close/open
-    // cycle and can refresh session-scoped state from the current selection.
-    // Example: a pinned popover keeps showing the original selection until the
-    // user clicks the same trigger again after selecting different text.
-    setOpen(false)
-    requestAnimationFrame(() => {
-      setOpen(true)
-    })
-  }, [setOpen])
+  const { open, requestOpen, setTriggerElement } = useSelectionPopoverRootContext()
 
   const handleClick = React.useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       const rect = event.currentTarget.getBoundingClientRect()
-      setPinned(false)
       setTriggerElement(event.currentTarget)
-      setAnchor({ x: rect.left, y: rect.top })
-      if (open) {
-        restartPopoverSession()
-      } else {
-        setOpen(true)
-      }
+      requestOpen({ x: rect.left, y: rect.top })
     },
-    [open, restartPopoverSession, setAnchor, setOpen, setPinned, setTriggerElement],
+    [requestOpen, setTriggerElement],
   )
 
   return useRender({
@@ -362,10 +426,10 @@ function SelectionPopoverContent({
     finalFocus?: DialogPrimitive.Popup.Props["finalFocus"]
   }) {
   const { open, setOpen, anchor, triggerElement } = useSelectionPopoverRootContext()
-  const bodyElementRef = React.useRef<HTMLDivElement | null>(null)
-  const setBodyElement = React.useCallback((node: HTMLDivElement | null) => {
-    bodyElementRef.current = node
-  }, [])
+  // Tracked as state (not a ref) so listeners re-attach when Body remounts
+  // while the popover stays open, e.g. a pinned popover reused for a new
+  // selection session.
+  const [bodyElement, setBodyElement] = React.useState<HTMLDivElement | null>(null)
 
   const {
     rndRef,
@@ -390,7 +454,7 @@ function SelectionPopoverContent({
 
   usePreventScrollThrough({
     isEnabled: open,
-    elementRef: bodyElementRef,
+    element: bodyElement,
   })
 
   const contentContextValue = React.useMemo(
@@ -610,6 +674,8 @@ const SelectionPopover = {
   Pin: SelectionPopoverPin,
   Close: SelectionPopoverClose,
 } as const
+
+export type { SelectionPopoverActions, SelectionPopoverPosition }
 
 export {
   SelectionPopover,

--- a/src/components/ui/selection-popover/use-prevent-scroll-through.ts
+++ b/src/components/ui/selection-popover/use-prevent-scroll-through.ts
@@ -1,14 +1,12 @@
-import type { RefObject } from "react"
 import { useEffect, useEffectEvent } from "react"
 
 interface UsePreventScrollThroughOptions {
   isEnabled: boolean
-  elementRef: RefObject<HTMLElement | null>
+  element: HTMLElement | null
 }
 
-export function usePreventScrollThrough({ isEnabled, elementRef }: UsePreventScrollThroughOptions) {
+export function usePreventScrollThrough({ isEnabled, element }: UsePreventScrollThroughOptions) {
   const handleWheel = useEffectEvent((event: WheelEvent) => {
-    const element = elementRef.current
     if (!element) {
       return
     }
@@ -24,12 +22,7 @@ export function usePreventScrollThrough({ isEnabled, elementRef }: UsePreventScr
   })
 
   useEffect(() => {
-    if (!isEnabled) {
-      return undefined
-    }
-
-    const element = elementRef.current
-    if (!element) {
+    if (!isEnabled || !element) {
       return undefined
     }
 
@@ -37,5 +30,5 @@ export function usePreventScrollThrough({ isEnabled, elementRef }: UsePreventScr
     return () => {
       element.removeEventListener("wheel", handleWheel)
     }
-  }, [elementRef, isEnabled])
+  }, [element, isEnabled])
 }

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
@@ -62,6 +62,9 @@ vi.mock("@/components/ui/selection-popover", async () => {
   interface PopoverContextValue {
     anchor?: { x: number; y: number } | null
     open: boolean
+    pinned: boolean
+    setPinned: (value: boolean | ((value: boolean) => boolean)) => void
+    requestOpen: (anchor?: { x: number; y: number } | null) => void
     onOpenChange?: (open: boolean) => void
   }
 
@@ -79,16 +82,71 @@ vi.mock("@/components/ui/selection-popover", async () => {
     anchor,
     children,
     open,
+    actionsRef,
+    onAnchorChange,
     onOpenChange,
+    onReuseRequest,
   }: {
     anchor?: { x: number; y: number } | null
     children: React.ReactNode
     open: boolean
+    actionsRef?: React.RefObject<{
+      requestOpen: (anchor?: { x: number; y: number } | null) => void
+    } | null>
+    onAnchorChange?: (anchor: { x: number; y: number } | null) => void
     onOpenChange?: (open: boolean) => void
+    onReuseRequest?: (details: { anchor: { x: number; y: number } | null }) => void
   }) {
+    const [pinned, setUncontrolledPinned] = React.useState(false)
+
+    const setPinned = React.useCallback((value: boolean | ((value: boolean) => boolean)) => {
+      setUncontrolledPinned(value)
+    }, [])
+
+    // Mirrors the real Root: closing always resets the pin.
+    const handleOpenChange = React.useCallback(
+      (nextOpen: boolean) => {
+        if (!nextOpen) {
+          setUncontrolledPinned(false)
+        }
+        onOpenChange?.(nextOpen)
+      },
+      [onOpenChange],
+    )
+
+    // Mirrors the real Root's requestOpen decision: pinned popovers are
+    // reused in place, open ones restart on the next frame.
+    const requestOpen = React.useCallback(
+      (nextAnchor: { x: number; y: number } | null = null) => {
+        if (open && pinned) {
+          onReuseRequest?.({ anchor: nextAnchor ?? null })
+          return
+        }
+
+        if (open) {
+          handleOpenChange(false)
+          requestAnimationFrame(() => {
+            if (nextAnchor) {
+              onAnchorChange?.(nextAnchor)
+            }
+            handleOpenChange(true)
+          })
+          return
+        }
+
+        if (nextAnchor) {
+          onAnchorChange?.(nextAnchor)
+        }
+        handleOpenChange(true)
+      },
+      [handleOpenChange, onAnchorChange, onReuseRequest, open, pinned],
+    )
+
+    React.useImperativeHandle(actionsRef, () => ({ requestOpen }), [requestOpen])
+
     const contextValue = React.useMemo(
-      () => ({ anchor, open, onOpenChange }),
-      [anchor, open, onOpenChange],
+      () => ({ anchor, open, pinned, setPinned, requestOpen, onOpenChange: handleOpenChange }),
+      [anchor, open, pinned, setPinned, requestOpen, handleOpenChange],
     )
     return <PopoverContext value={contextValue}>{children}</PopoverContext>
   }
@@ -100,14 +158,15 @@ vi.mock("@/components/ui/selection-popover", async () => {
   }: React.ComponentProps<"button"> & {
     children: React.ReactNode
   }) {
-    const { onOpenChange } = usePopoverContext()
+    const { requestOpen } = usePopoverContext()
     return (
       <button
         {...props}
         type="button"
         onClick={(event) => {
           onClick?.(event)
-          onOpenChange?.(true)
+          const rect = event.currentTarget.getBoundingClientRect()
+          requestOpen({ x: rect.left, y: rect.top })
         }}
       >
         {children}
@@ -152,7 +211,18 @@ vi.mock("@/components/ui/selection-popover", async () => {
   }
 
   function Pin() {
-    return <button type="button">Pin</button>
+    const { pinned, setPinned } = usePopoverContext()
+    const label = pinned ? "Unpin popover" : "Pin popover"
+    return (
+      <button
+        type="button"
+        aria-label={label}
+        aria-pressed={pinned}
+        onClick={() => setPinned((prev) => !prev)}
+      >
+        Pin
+      </button>
+    )
   }
 
   function Footer({ children }: { children: React.ReactNode }) {
@@ -365,7 +435,9 @@ function mockWindowSelection(range: Range | null) {
 }
 
 function getRegisteredMessageHandler(name: string): (message: { data: unknown }) => void {
-  const registration = onMessageMock.mock.calls.find((call) => call[0] === name)
+  // The provider re-registers when the selection session changes, so the last
+  // registration is the only live one.
+  const registration = onMessageMock.mock.calls.findLast((call) => call[0] === name)
   if (!registration) {
     throw new Error(`Message handler not registered: ${name}`)
   }
@@ -378,7 +450,7 @@ async function getRegisteredShortcutCallback(shortcut = "Alt+T") {
     expect(hotkeyRegisterMock.mock.calls.some((call) => call[0] === shortcut)).toBe(true)
   })
 
-  const registration = hotkeyRegisterMock.mock.calls.find((call) => call[0] === shortcut)
+  const registration = hotkeyRegisterMock.mock.calls.findLast((call) => call[0] === shortcut)
   if (!registration) {
     throw new Error(`Shortcut not registered: ${shortcut}`)
   }
@@ -1258,6 +1330,365 @@ describe("selection toolbar requests", () => {
     const content = screen.getByTestId("selection-popover-content")
     expect(content).toHaveAttribute("data-anchor-x", String(window.innerWidth / 2))
     expect(content).toHaveAttribute("data-anchor-y", String(window.innerHeight / 2))
+  })
+
+  it("reuses a pinned translation popover in place when translating a new selection from the toolbar", async () => {
+    const firstRun = createDeferredPromise<string>()
+    const secondRun = createDeferredPromise<string>()
+    translateTextCoreMock
+      .mockReturnValueOnce(firstRun.promise)
+      .mockReturnValueOnce(secondRun.promise)
+    getOrCreateWebPageContextMock.mockResolvedValue(null)
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    setSelectionState(store, { text: "First selection" })
+    renderWithProviders(<TranslateButton />, store)
+
+    fireEvent.click(screen.getByRole("button", { name: "action.translation" }))
+
+    await waitFor(() => {
+      expect(translateTextCoreMock).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      firstRun.resolve("first translation")
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("translation-result").textContent).toBe("first translation")
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Pin popover" }))
+
+    const content = screen.getByTestId("selection-popover-content")
+
+    act(() => {
+      setSelectionState(store, { text: "Second selection" })
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "action.translation" }))
+
+    expect(screen.getByTestId("selection-popover-content")).toBe(content)
+    expect(screen.getByRole("button", { name: "Unpin popover" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
+    expect(screen.getByTestId("translation-selection").textContent).toBe("Second selection")
+    expect(screen.getByTestId("translation-result").textContent).toBe("")
+
+    await waitFor(() => {
+      expect(translateTextCoreMock).toHaveBeenCalledTimes(2)
+    })
+    expect(translateTextCoreMock.mock.calls[1]?.[0]).toMatchObject({
+      text: "Second selection",
+    })
+
+    await act(async () => {
+      secondRun.resolve("second translation")
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("translation-result").textContent).toBe("second translation")
+    })
+  })
+
+  it("reuses a pinned translation popover in place from the context menu without moving it", async () => {
+    const firstRun = createDeferredPromise<string>()
+    const secondRun = createDeferredPromise<string>()
+    translateTextCoreMock
+      .mockReturnValueOnce(firstRun.promise)
+      .mockReturnValueOnce(secondRun.promise)
+    getOrCreateWebPageContextMock.mockResolvedValue(null)
+
+    const paragraph = document.createElement("p")
+    paragraph.textContent = "Selected text inside a paragraph."
+    document.body.appendChild(paragraph)
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    setSelectionState(store, { text: "Selected text", range: createRangeFor(paragraph) })
+    renderWithProviders(<TranslateButton />, store)
+
+    act(() => {
+      paragraph.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          button: 2,
+          clientX: 140,
+          clientY: 180,
+        }),
+      )
+    })
+
+    await act(async () => {
+      getRegisteredMessageHandler("openSelectionTranslationFromContextMenu")({
+        data: { selectionText: "Selected text" },
+      })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(translateTextCoreMock).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      firstRun.resolve("first translation")
+      await Promise.resolve()
+    })
+
+    const content = screen.getByTestId("selection-popover-content")
+    const anchorX = content.getAttribute("data-anchor-x")
+    const anchorY = content.getAttribute("data-anchor-y")
+
+    fireEvent.click(screen.getByRole("button", { name: "Pin popover" }))
+
+    act(() => {
+      setSelectionState(store, {
+        text: "inside a paragraph",
+        range: createRangeFor(paragraph),
+      })
+    })
+
+    act(() => {
+      paragraph.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          button: 2,
+          clientX: 400,
+          clientY: 320,
+        }),
+      )
+    })
+
+    await act(async () => {
+      getRegisteredMessageHandler("openSelectionTranslationFromContextMenu")({
+        data: { selectionText: "inside a paragraph" },
+      })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(translateTextCoreMock).toHaveBeenCalledTimes(2)
+    })
+
+    expect(screen.getByTestId("selection-popover-content")).toBe(content)
+    expect(content.getAttribute("data-anchor-x")).toBe(anchorX)
+    expect(content.getAttribute("data-anchor-y")).toBe(anchorY)
+    expect(screen.getByRole("button", { name: "Unpin popover" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
+    expect(screen.getByTestId("translation-selection").textContent).toBe("inside a paragraph")
+
+    await act(async () => {
+      secondRun.resolve("second translation")
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("translation-result").textContent).toBe("second translation")
+    })
+  })
+
+  it("reuses a pinned translation popover in place from the shortcut", async () => {
+    const firstRun = createDeferredPromise<string>()
+    const secondRun = createDeferredPromise<string>()
+    translateTextCoreMock
+      .mockReturnValueOnce(firstRun.promise)
+      .mockReturnValueOnce(secondRun.promise)
+    getOrCreateWebPageContextMock.mockResolvedValue(null)
+
+    const paragraph = document.createElement("p")
+    paragraph.textContent = "Selected text inside a paragraph."
+    document.body.appendChild(paragraph)
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    setSelectionState(store, { text: "Selected text", range: createRangeFor(paragraph) })
+    renderWithProviders(<TranslateButton />, store)
+
+    await act(async () => {
+      ;(await getRegisteredShortcutCallback())()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(translateTextCoreMock).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      firstRun.resolve("first translation")
+      await Promise.resolve()
+    })
+
+    const content = screen.getByTestId("selection-popover-content")
+
+    fireEvent.click(screen.getByRole("button", { name: "Pin popover" }))
+
+    act(() => {
+      setSelectionState(store, {
+        text: "inside a paragraph",
+        range: createRangeFor(paragraph),
+      })
+    })
+
+    await act(async () => {
+      ;(await getRegisteredShortcutCallback())()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(translateTextCoreMock).toHaveBeenCalledTimes(2)
+    })
+
+    expect(screen.getByTestId("selection-popover-content")).toBe(content)
+    expect(screen.getByRole("button", { name: "Unpin popover" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
+    expect(screen.getByTestId("translation-selection").textContent).toBe("inside a paragraph")
+
+    await act(async () => {
+      secondRun.resolve("second translation")
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("translation-result").textContent).toBe("second translation")
+    })
+  })
+
+  it("reruns the translation when a pinned popover is retriggered with the same selection", async () => {
+    translateTextCoreMock.mockResolvedValue("same selection translation")
+    getOrCreateWebPageContextMock.mockResolvedValue(null)
+
+    const paragraph = document.createElement("p")
+    paragraph.textContent = "Selected text inside a paragraph."
+    document.body.appendChild(paragraph)
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    setSelectionState(store, { text: "Selected text", range: createRangeFor(paragraph) })
+    renderWithProviders(<TranslateButton />, store)
+
+    const shortcutCallback = await getRegisteredShortcutCallback()
+
+    await act(async () => {
+      shortcutCallback()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(translateTextCoreMock).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Pin popover" }))
+
+    await act(async () => {
+      shortcutCallback()
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(translateTextCoreMock).toHaveBeenCalledTimes(2)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("translation-result").textContent).toBe(
+        "same selection translation",
+      )
+    })
+  })
+
+  it("reuses a pinned custom action popover in place for a new selection", async () => {
+    const firstRun = createDeferredPromise<BackgroundStructuredObjectStreamSnapshot>()
+    const secondRun = createDeferredPromise<BackgroundStructuredObjectStreamSnapshot>()
+    streamBackgroundStructuredObjectMock
+      .mockReturnValueOnce(firstRun.promise)
+      .mockReturnValueOnce(secondRun.promise)
+
+    const paragraph = document.createElement("p")
+    paragraph.textContent = "Selected text inside a paragraph."
+    document.body.appendChild(paragraph)
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    setSelectionState(store, { text: "Selected text", range: createRangeFor(paragraph) })
+    renderWithProviders(<SelectionToolbarCustomActionButtons />, store)
+
+    const action = DEFAULT_DICTIONARY_ACTION
+
+    act(() => {
+      paragraph.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          button: 2,
+          clientX: 140,
+          clientY: 180,
+        }),
+      )
+    })
+
+    await act(async () => {
+      getRegisteredMessageHandler("openSelectionCustomActionFromContextMenu")({
+        data: { actionId: action.id, selectionText: "Selected text" },
+      })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(streamBackgroundStructuredObjectMock).toHaveBeenCalledTimes(1)
+    })
+
+    await act(async () => {
+      firstRun.resolve(createStructuredObjectSnapshot({ summary: "First result" }))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('{"summary":"First result"}')).toBeInTheDocument()
+    })
+
+    const content = screen.getByTestId("selection-popover-content")
+
+    fireEvent.click(screen.getByRole("button", { name: "Pin popover" }))
+
+    act(() => {
+      setSelectionState(store, {
+        text: "inside a paragraph",
+        range: createRangeFor(paragraph),
+      })
+    })
+
+    await act(async () => {
+      getRegisteredMessageHandler("openSelectionCustomActionFromContextMenu")({
+        data: { actionId: action.id, selectionText: "inside a paragraph" },
+      })
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(streamBackgroundStructuredObjectMock).toHaveBeenCalledTimes(2)
+    })
+
+    expect(screen.getByTestId("selection-popover-content")).toBe(content)
+    expect(screen.getByRole("button", { name: "Unpin popover" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
+    expect(screen.queryByText('{"summary":"First result"}')).not.toBeInTheDocument()
+
+    await act(async () => {
+      secondRun.resolve(createStructuredObjectSnapshot({ summary: "Second result" }))
+      await Promise.resolve()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('{"summary":"Second result"}')).toBeInTheDocument()
+    })
   })
 
   it("opens a custom action from the context menu with the captured selection session", async () => {

--- a/src/entrypoints/selection.content/selection-toolbar/custom-action-button/provider.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/custom-action-button/provider.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react"
 import type { SelectionSession } from "../atoms"
+import type { SelectionPopoverActions } from "@/components/ui/selection-popover"
 import { useAtomValue, useSetAtom } from "jotai"
 import { createContext, use, useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { toastManager } from "@/components/ui/base-ui/toast"
@@ -87,7 +88,7 @@ export function SelectionCustomActionProvider({ children }: { children: ReactNod
   const isSaveToNotebaseDialogOpen = useAtomValue(isSaveToNotebaseDialogOpenAtom)
   const bodyRef = useRef<HTMLDivElement>(null)
   const pendingOpenRequestRef = useRef<SelectionCustomActionPendingOpenRequest | null>(null)
-  const reopenFrameRef = useRef<number | null>(null)
+  const popoverActionsRef = useRef<SelectionPopoverActions | null>(null)
   const nextEphemeralSessionIdRef = useRef(0)
   const trackedPrecheckErrorKeyRef = useRef<string | null>(null)
   const { resolveContextMenuOpenRequest } = useSelectionOpenRequestResolver(selectionSession)
@@ -159,30 +160,29 @@ export function SelectionCustomActionProvider({ children }: { children: ReactNod
     }
   }, [])
 
+  // Anchor application is owned by SelectionPopover.Root (via requestOpen) so
+  // a pinned popover reused in place never moves.
   const commitOpenRequest = useCallback((request: SelectionCustomActionPendingOpenRequest) => {
     pendingOpenRequestRef.current = request
-    if (request.anchor) {
-      setAnchor(request.anchor)
-    }
   }, [])
+
+  const applyPendingSession = useCallback(() => {
+    const pendingRequest = pendingOpenRequestRef.current
+
+    setActiveSession(pendingRequest?.session ?? selectionSession)
+    setActiveActionId(pendingRequest?.actionId ?? null)
+    setSourceSurface(pendingRequest?.surface ?? ANALYTICS_SURFACE.SELECTION_TOOLBAR)
+    setIsSelectionToolbarVisible(false)
+    pendingOpenRequestRef.current = null
+  }, [selectionSession, setIsSelectionToolbarVisible])
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
       resetSessionState()
 
       if (nextOpen) {
-        const pendingRequest = pendingOpenRequestRef.current
-        const nextSession = pendingRequest?.session ?? selectionSession
-
-        setActiveSession(nextSession)
-        setActiveActionId(pendingRequest?.actionId ?? null)
-        setSourceSurface(pendingRequest?.surface ?? ANALYTICS_SURFACE.SELECTION_TOOLBAR)
         setPopoverSessionKey((prev) => prev + 1)
-        if (pendingRequest?.anchor) {
-          setAnchor(pendingRequest.anchor)
-        }
-        setIsSelectionToolbarVisible(false)
-        pendingOpenRequestRef.current = null
+        applyPendingSession()
       } else {
         resetPopoverSession({
           clearAnchor: pendingOpenRequestRef.current === null,
@@ -191,30 +191,25 @@ export function SelectionCustomActionProvider({ children }: { children: ReactNod
 
       setIsOpen(nextOpen)
     },
-    [resetPopoverSession, resetSessionState, selectionSession, setIsSelectionToolbarVisible],
+    [applyPendingSession, resetPopoverSession, resetSessionState],
   )
+
+  // Pinned popovers are reused in place for a new selection or action: the
+  // window keeps its position, size, and pin state while the action reruns.
+  const handleReuseRequest = useCallback(() => {
+    resetSessionState()
+    applyPendingSession()
+    // Forces a rerun even when the retriggered request resolves to an
+    // identical execution key.
+    setRerunNonce((prev) => prev + 1)
+  }, [applyPendingSession, resetSessionState])
 
   const openActionRequest = useCallback(
     (request: SelectionCustomActionPendingOpenRequest) => {
-      if (isOpen) {
-        handleOpenChange(false)
-
-        if (reopenFrameRef.current !== null) {
-          cancelAnimationFrame(reopenFrameRef.current)
-        }
-
-        reopenFrameRef.current = requestAnimationFrame(() => {
-          reopenFrameRef.current = null
-          commitOpenRequest(request)
-          handleOpenChange(true)
-        })
-        return
-      }
-
       commitOpenRequest(request)
-      handleOpenChange(true)
+      popoverActionsRef.current?.requestOpen(request.anchor ?? null)
     },
-    [commitOpenRequest, handleOpenChange, isOpen],
+    [commitOpenRequest],
   )
 
   const openToolbarCustomAction = useCallback(
@@ -329,14 +324,6 @@ export function SelectionCustomActionProvider({ children }: { children: ReactNod
   }, [openContextMenuCustomAction])
 
   useEffect(() => {
-    return () => {
-      if (reopenFrameRef.current !== null) {
-        cancelAnimationFrame(reopenFrameRef.current)
-      }
-    }
-  }, [])
-
-  useEffect(() => {
     if (!isOpen || !executionPlan.error || executionPlan.executionContext) {
       return
     }
@@ -393,6 +380,8 @@ export function SelectionCustomActionProvider({ children }: { children: ReactNod
         onOpenChange={handleOpenChange}
         anchor={anchor}
         onAnchorChange={setAnchor}
+        actionsRef={popoverActionsRef}
+        onReuseRequest={handleReuseRequest}
         disablePointerDismissal={isSaveToNotebaseDialogOpen}
       >
         <SelectionPopover.Content
@@ -410,7 +399,10 @@ export function SelectionCustomActionProvider({ children }: { children: ReactNod
             </div>
           </SelectionPopover.Header>
 
-          <SelectionPopover.Body ref={bodyRef}>
+          <SelectionPopover.Body
+            key={`${popoverSessionKey}:${activeSession?.id ?? 0}`}
+            ref={bodyRef}
+          >
             <CustomActionContent
               isRunning={displayedIsRunning}
               outputSchema={activeAction?.outputSchema ?? []}

--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx
@@ -2,6 +2,7 @@ import type { Hotkey } from "@tanstack/hotkeys"
 import type { ReactNode } from "react"
 import type { SelectionSession, SelectionToolbarTranslateRequestSlice } from "../atoms"
 import type { SelectionToolbarInlineError } from "../inline-error"
+import type { SelectionPopoverActions } from "@/components/ui/selection-popover"
 import type { TranslationActionContext } from "@/types/analytics"
 import type { BackgroundTextStreamSnapshot, ThinkingSnapshot } from "@/types/background-stream"
 import type { LLMProviderConfig, ProviderConfig } from "@/types/config/provider"
@@ -280,7 +281,7 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
   const setConfig = useSetAtom(writeConfigAtom)
   const abortControllerRef = useRef<AbortController | null>(null)
   const pendingOpenRequestRef = useRef<SelectionTranslatePendingOpenRequest | null>(null)
-  const reopenFrameRef = useRef<number | null>(null)
+  const popoverActionsRef = useRef<SelectionPopoverActions | null>(null)
   const lastTranslationRunKeyRef = useRef<string | null>(null)
   const runIdRef = useRef(0)
   const { resolveContextMenuOpenRequest, resolveShortcutOpenRequest } =
@@ -350,12 +351,20 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
     [cancelSaveSuggestion],
   )
 
+  // Anchor application is owned by SelectionPopover.Root (via requestOpen) so
+  // a pinned popover reused in place never moves.
   const commitOpenRequest = useCallback((request: SelectionTranslatePendingOpenRequest) => {
     pendingOpenRequestRef.current = request
-    if (request.anchor) {
-      setAnchor(request.anchor)
-    }
   }, [])
+
+  const applyPendingSession = useCallback(() => {
+    const pendingRequest = pendingOpenRequestRef.current
+
+    setActiveSession(pendingRequest?.session ?? selectionSession)
+    setSourceSurface(pendingRequest?.surface ?? ANALYTICS_SURFACE.SELECTION_TOOLBAR)
+    setIsSelectionToolbarVisible(false)
+    pendingOpenRequestRef.current = null
+  }, [selectionSession, setIsSelectionToolbarVisible])
 
   const handleProviderChange = useCallback(
     (providerId: string) => {
@@ -597,17 +606,8 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
       resetTranslationState()
 
       if (nextOpen) {
-        const pendingRequest = pendingOpenRequestRef.current
-        const nextSession = pendingRequest?.session ?? selectionSession
-
-        setActiveSession(nextSession)
-        setSourceSurface(pendingRequest?.surface ?? ANALYTICS_SURFACE.SELECTION_TOOLBAR)
         setPopoverSessionKey((prev) => prev + 1)
-        if (pendingRequest?.anchor) {
-          setAnchor(pendingRequest.anchor)
-        }
-        setIsSelectionToolbarVisible(false)
-        pendingOpenRequestRef.current = null
+        applyPendingSession()
       } else {
         resetPopoverSession({
           clearAnchor: pendingOpenRequestRef.current === null,
@@ -619,14 +619,32 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
       setIsOpen(nextOpen)
     },
     [
+      applyPendingSession,
       cancelCurrentTranslation,
       resetPopoverSession,
       resetSaveSuggestionSession,
       resetTranslationState,
-      selectionSession,
-      setIsSelectionToolbarVisible,
     ],
   )
+
+  // Pinned popovers are reused in place for a new selection: the window keeps
+  // its position, size, and pin state while the translation restreams. All
+  // state writes stay in one handler so the translation run-key effect
+  // observes exactly one key change.
+  const handleReuseRequest = useCallback(() => {
+    cancelCurrentTranslation()
+    resetTranslationState()
+    resetSaveSuggestionSession()
+    applyPendingSession()
+    // Forces a rerun even when the same selection session is retriggered, and
+    // rotates the save-suggestion session key (which has no session id).
+    setRerunNonce((prev) => prev + 1)
+  }, [
+    applyPendingSession,
+    cancelCurrentTranslation,
+    resetSaveSuggestionSession,
+    resetTranslationState,
+  ])
 
   const prepareToolbarOpen = useCallback(() => {
     if (!selectionSession) {
@@ -678,25 +696,10 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
         return
       }
 
-      if (reopenFrameRef.current !== null) {
-        cancelAnimationFrame(reopenFrameRef.current)
-        reopenFrameRef.current = null
-      }
-
-      if (isOpen) {
-        handleOpenChange(false)
-        reopenFrameRef.current = requestAnimationFrame(() => {
-          reopenFrameRef.current = null
-          commitOpenRequest(request)
-          handleOpenChange(true)
-        })
-        return
-      }
-
       commitOpenRequest(request)
-      handleOpenChange(true)
+      popoverActionsRef.current?.requestOpen(request.anchor ?? null)
     },
-    [commitOpenRequest, handleOpenChange, isOpen],
+    [commitOpenRequest],
   )
 
   const openFromContextMenu = useCallback(() => {
@@ -741,14 +744,6 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
     })
   }, [openFromContextMenu])
 
-  useEffect(() => {
-    return () => {
-      if (reopenFrameRef.current !== null) {
-        cancelAnimationFrame(reopenFrameRef.current)
-      }
-    }
-  }, [])
-
   const contextValue = useMemo<SelectionTranslationContextValue>(
     () => ({
       prepareToolbarOpen,
@@ -763,6 +758,8 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
         onOpenChange={handleOpenChange}
         anchor={anchor}
         onAnchorChange={setAnchor}
+        actionsRef={popoverActionsRef}
+        onReuseRequest={handleReuseRequest}
         disablePointerDismissal={isSaveToNotebaseDialogOpen}
       >
         {children}
@@ -780,7 +777,7 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
             </div>
           </SelectionPopover.Header>
 
-          <SelectionPopover.Body>
+          <SelectionPopover.Body key={`${popoverSessionKey}:${activeSession?.id ?? 0}`}>
             <TranslationContent
               selectionContent={selectionText}
               translatedText={translatedText}


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Fable 5 (claude-fable-5)

## Type of Changes

- [x] ✨ New feature (feat)

## Description

Pinning the selection popover now actually pins it. Previously the Pin button only prevented outside-click dismissal: triggering another selection translation (toolbar button, context menu, or shortcut) always closed the popover, reset the pin, and reopened a fresh window anchored to the new selection — often covering the text the user wanted to read (#2008, same request as #1642).

With this change, when the popover is pinned, a new selection translation (or custom action) **reuses the window in place**: position, size, and pin state are preserved — including any manual drag/resize — and the new result streams into the existing window. Unpinned behavior is byte-for-byte unchanged.

The reuse decision lives in the shared `SelectionPopover` component, so both consumers (translate popup, custom action popup) get it coherently and future consumers inherit it automatically:

- **`SelectionPopover.Root`** gains a single decision point `requestOpen(anchor)`, exposed through context (used by `Trigger`) and a new `actionsRef` (used by the providers' imperative open paths): `open && pinned` → fire the new `onReuseRequest` callback and leave open/anchor/layout untouched; `open` (unpinned) → the existing close → next-frame reopen cycle (moved from `Trigger` into `Root`); closed → set anchor and open. `pinned` is now a controllable prop (`pinned`/`defaultPinned`/`onPinnedChange`), mirroring the existing `open`/`anchor` pattern.
- **Both providers** implement a small `onReuseRequest` handler: cancel the in-flight run, synchronously reset the displayed content (no stale-translation frame), swap the active session, and bump `rerunNonce` — which both forces a rerun when the same selection is retriggered and rotates the save-suggestion session key. `popoverSessionKey` (the window's mount key) and the anchor are deliberately untouched, so `react-rnd` layout memory survives. Anchor application moved from `commitOpenRequest` into `Root` so a pinned window can never be moved by a new request.
- **`SelectionPopover.Body`** is now keyed by session, resetting scroll and per-session UI state on reuse; the scroll-through-prevention wheel listener tracks the body element as state so it re-attaches when `Body` remounts while the popover stays open (a latent bug before this change).

Deliberately unchanged: opening the other popover type still closes a pinned popover (peer exclusivity), and Close/unpin fully reset as before.

## Related Issue

Closes #2008

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

**Unit tests** (full suite: 245 files / 2287 tests green):

- `selection-popover.test.tsx`: rewrote the test that locked the old restart-on-retrigger behavior into two cases (unpinned restart preserved; pinned in-place reuse with same element instance, pin kept, position untouched), plus new coverage for `actionsRef.requestOpen`'s three branches and the controlled `pinned` round trip. Existing pin semantics tests (outside-click survival, pin reset on close/reopen, peer-close of a pinned popover) pass unchanged.
- `request-rerun.test.tsx`: upgraded the in-file `SelectionPopover` mock to model the new contract, and added five provider-level cases: toolbar reuse (no remount, stale text cleared before the new stream), context-menu reuse (anchor unchanged), shortcut reuse, same-selection retrigger reruns, and custom-action pinned reuse.

**E2E** (Puppeteer driving the built extension in headed Chrome, Google translate provider, real streaming):

- Unpinned: outside click closes the popup; retriggering opens at the new selection's anchor. ✅
- Pinned: dragged the window to (390, 511), selected different text, retriggered → window stayed at exactly (390, 511), pin stayed pressed, the content element was not remounted (marker attribute intact), and the new Chinese translation streamed into the reused window. ✅
- Close button fully resets; no React/DOM errors in the console. ✅

## Screenshots

N/A (behavioral change; see E2E description above).

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- Changeset: `patch` (enhancement of an existing feature).
- Possible follow-ups, intentionally out of scope: letting a pinned popover survive the *other* popover type opening (peer-close semantics), and aborting the standard-provider translation path mid-flight (pre-existing limitation).