### PR TITLE
fix(translate): translate SillyTavern <code> narration via site-rule tag-set overrides (#1951)

### DIFF
--- a/.changeset/site-rule-tag-set-overrides.md
+++ b/.changeset/site-rule-tag-set-overrides.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(site-rules): allow per-site `.add`/`.remove` overrides of the built-in DOM tag sets (dontWalkTags, dontWalkButTranslateTags, mainContentIgnoreTags, forceBlockTags, forceInlineTranslationTags), and ship a localhost rule that lets SillyTavern's `<p><code>` narration translate (#1951)

--- a/src/entrypoints/options/pages/translation/translation-control/site-rules/__tests__/validate-user-rules.test.ts
+++ b/src/entrypoints/options/pages/translation/translation-control/site-rules/__tests__/validate-user-rules.test.ts
@@ -123,6 +123,34 @@ describe("validateUserRulesDocument", () => {
     ])
   })
 
+  it("accepts the tag-set delta fields", () => {
+    const rules = [
+      {
+        id: "tag-sets",
+        matches: "example.com",
+        "dontWalkButTranslateTags.remove": ["CODE"],
+        "dontWalkTags.add": ["X-WIDGET"],
+      },
+    ]
+
+    expect(validateUserRulesDocument(JSON.stringify(rules))).toEqual({ ok: true, rules })
+  })
+
+  it("rejects a bare tag-set key to keep the fields delta-only", () => {
+    const result = validateUserRulesDocument(
+      JSON.stringify([{ id: "bare", matches: "example.com", dontWalkTags: ["CODE"] }]),
+    )
+
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+    expect(result.kind).toBe("schema")
+    expect(result.issues).toEqual([
+      { path: "rules[0].dontWalkTags", message: 'Unrecognized field "dontWalkTags"' },
+    ])
+  })
+
   it("reports invalid legacy selector values at their legacy field paths", () => {
     const result = validateUserRulesDocument(
       JSON.stringify([

--- a/src/entrypoints/side.content/components/floating-button/__tests__/index.test.tsx
+++ b/src/entrypoints/side.content/components/floating-button/__tests__/index.test.tsx
@@ -347,7 +347,8 @@ describe("floatingButton controls", () => {
     expect(JSON.parse(openedUrl.searchParams.get("metaData")!)).toEqual({
       browser: "chrome",
       extension_version: "1.0.0",
-      page_url: "http://localhost:3000/private/path",
+      // The intent is query/hash stripping, not the origin itself.
+      page_url: `${window.location.origin}/private/path`,
     })
     expect(openPagePayload).toEqual({
       url: openedUrl.toString(),

--- a/src/types/config/site-rules.ts
+++ b/src/types/config/site-rules.ts
@@ -44,6 +44,21 @@ export const siteRuleSchema = z.object({
   preserveTextSelectors: z.array(z.string()).optional(),
   "preserveTextSelectors.add": z.array(z.string()).optional(),
   "preserveTextSelectors.remove": z.array(z.string()).optional(),
+  // Tag-NAME lists (not CSS selectors) that patch the built-in DOM tag sets
+  // (see DEFAULT_TAG_SETS in utils/constants/dom-rules). Delta-only by design:
+  // there is deliberately no bare base key, so a rule can never be misread as
+  // replacing the defaults. Entries are validated at resolve time; invalid tag
+  // names are dropped with a warning.
+  "dontWalkTags.add": z.array(z.string()).optional(),
+  "dontWalkTags.remove": z.array(z.string()).optional(),
+  "dontWalkButTranslateTags.add": z.array(z.string()).optional(),
+  "dontWalkButTranslateTags.remove": z.array(z.string()).optional(),
+  "mainContentIgnoreTags.add": z.array(z.string()).optional(),
+  "mainContentIgnoreTags.remove": z.array(z.string()).optional(),
+  "forceBlockTags.add": z.array(z.string()).optional(),
+  "forceBlockTags.remove": z.array(z.string()).optional(),
+  "forceInlineTranslationTags.add": z.array(z.string()).optional(),
+  "forceInlineTranslationTags.remove": z.array(z.string()).optional(),
   minCharacters: z.number().int().min(0).optional(),
   minWords: z.number().int().min(0).optional(),
   injectedCss: z.string().max(MAX_CUSTOM_CSS_LENGTH).optional(),

--- a/src/utils/constants/dom-rules.ts
+++ b/src/utils/constants/dom-rules.ts
@@ -92,3 +92,25 @@ export const DONT_WALK_BUT_TRANSLATE_TAGS = new Set(["CODE", "TIME"])
 export const FORCE_INLINE_TRANSLATION_TAGS = new Set(["A", "BUTTON", "SELECT", "OPTION", "SPAN"])
 
 export const MAIN_CONTENT_IGNORE_TAGS = new Set(["HEADER", "FOOTER", "NAV", "NOSCRIPT"])
+
+/**
+ * Site-rule override families for the tag sets above. Each family name is
+ * simultaneously the schema key prefix (`<family>.add` / `<family>.remove`),
+ * the `ResolvedSiteRule` field name, and the consumer lookup key, so
+ * `resolved[family] ?? DEFAULT_TAG_SETS[family]` typechecks without a mapping
+ * table.
+ */
+export type TagSetFamily =
+  | "dontWalkTags"
+  | "dontWalkButTranslateTags"
+  | "mainContentIgnoreTags"
+  | "forceBlockTags"
+  | "forceInlineTranslationTags"
+
+export const DEFAULT_TAG_SETS: Record<TagSetFamily, ReadonlySet<string>> = {
+  dontWalkTags: DONT_WALK_AND_TRANSLATE_TAGS,
+  dontWalkButTranslateTags: DONT_WALK_BUT_TRANSLATE_TAGS,
+  mainContentIgnoreTags: MAIN_CONTENT_IGNORE_TAGS,
+  forceBlockTags: FORCE_BLOCK_TAGS,
+  forceInlineTranslationTags: FORCE_INLINE_TRANSLATION_TAGS,
+}

--- a/src/utils/host/dom/__tests__/custom-tag-sets.test.ts
+++ b/src/utils/host/dom/__tests__/custom-tag-sets.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import type { Config } from "@/types/config/config"
+import { describe, expect, it } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { PARAGRAPH_ATTRIBUTE } from "@/utils/constants/dom-labels"
+import { extractTextContent, walkAndLabelElement } from "../traversal"
+
+function setUrl(url: string) {
+  // jsdom exposes location as read-only; override via defineProperty
+  Object.defineProperty(window, "location", {
+    value: new URL(url),
+    writable: true,
+  })
+}
+
+function configWithDisabledBuiltInRules(ids: string[]): Config {
+  const config = structuredClone(DEFAULT_CONFIG)
+  config.siteRules = { userRules: [], disabledBuiltInRules: ids }
+  return config
+}
+
+// End-to-end coverage for the sillytavern built-in rule (issue #1951):
+// `dontWalkButTranslateTags.remove: ["CODE"]` turns <code> into a normally
+// walked inline element on localhost, so a code-only <p> gets labeled and
+// its narration text reaches extraction.
+describe("sillytavern tag-set rule (#1951)", () => {
+  it("labels a code-only paragraph on localhost", () => {
+    setUrl("http://localhost:8000/")
+    document.body.innerHTML = `<div class="mes_text"><p><code>The wind howled through the pass.</code></p></div>`
+    const container = document.body.firstElementChild as HTMLElement
+    const p = container.querySelector("p")!
+
+    walkAndLabelElement(container, "walk-1", DEFAULT_CONFIG)
+
+    expect(p.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(true)
+    expect(extractTextContent(p, DEFAULT_CONFIG)).toBe("The wind howled through the pass.")
+  })
+
+  it("keeps mixed paragraphs intact, code text included", () => {
+    setUrl("http://localhost:8000/")
+    document.body.innerHTML = `<div class="mes_text"><p>before <code>mid</code> after</p></div>`
+    const container = document.body.firstElementChild as HTMLElement
+    const p = container.querySelector("p")!
+
+    walkAndLabelElement(container, "walk-2", DEFAULT_CONFIG)
+
+    expect(p.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(true)
+    expect(extractTextContent(p, DEFAULT_CONFIG)).toBe("before mid after")
+  })
+
+  it("still blocks fenced code blocks at the PRE level", () => {
+    setUrl("http://localhost:8000/")
+    document.body.innerHTML = `<div class="mes_text"><pre><code>const fenced = true</code></pre></div>`
+    const container = document.body.firstElementChild as HTMLElement
+    const pre = container.querySelector("pre")!
+    const blocked: HTMLElement[] = []
+
+    walkAndLabelElement(container, "walk-3", DEFAULT_CONFIG, {
+      onBlockedElement: (element) => blocked.push(element),
+    })
+
+    expect(blocked).toContain(pre)
+    expect(pre.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(false)
+    expect(container.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(false)
+  })
+
+  it("keeps the default CODE behavior on other hosts", () => {
+    setUrl("https://example.org/article")
+    document.body.innerHTML = `<div class="mes_text"><p><code>The wind howled through the pass.</code></p></div>`
+    const container = document.body.firstElementChild as HTMLElement
+    const p = container.querySelector("p")!
+
+    walkAndLabelElement(container, "walk-4", DEFAULT_CONFIG)
+
+    expect(p.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(false)
+  })
+
+  it("restores the default behavior when the built-in rule is disabled", () => {
+    setUrl("http://localhost:8000/")
+    document.body.innerHTML = `<div class="mes_text"><p><code>The wind howled through the pass.</code></p></div>`
+    const container = document.body.firstElementChild as HTMLElement
+    const p = container.querySelector("p")!
+
+    walkAndLabelElement(container, "walk-5", configWithDisabledBuiltInRules(["sillytavern"]))
+
+    expect(p.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(false)
+  })
+})

--- a/src/utils/host/dom/__tests__/filter.test.ts
+++ b/src/utils/host/dom/__tests__/filter.test.ts
@@ -273,3 +273,71 @@ describe("isDontWalkIntoAndDontTranslateAsChildElement", () => {
     document.body.removeChild(nav)
   })
 })
+
+describe("site-rule tag-set overrides", () => {
+  it("unblocks CODE via dontWalkButTranslateTags.remove while config-less calls keep the default", () => {
+    setHost("tagset-example.org")
+    const config = configWithSiteRule({
+      id: "tagset",
+      matches: "tagset-example.org",
+      "dontWalkButTranslateTags.remove": ["CODE"],
+    })
+    const code = document.createElement("code")
+
+    expect(isDontWalkIntoButTranslateAsChildElement(code, config)).toBe(false)
+    expect(isDontWalkIntoButTranslateAsChildElement(code)).toBe(true)
+  })
+
+  it("keeps notranslate blocking even when CODE is removed", () => {
+    setHost("tagset-example.org")
+    const config = configWithSiteRule({
+      id: "tagset",
+      matches: "tagset-example.org",
+      "dontWalkButTranslateTags.remove": ["CODE"],
+    })
+    const code = document.createElement("code")
+    code.classList.add(NOTRANSLATE_CLASS)
+
+    expect(isDontWalkIntoButTranslateAsChildElement(code, config)).toBe(true)
+  })
+
+  it("blocks extra tags via dontWalkTags.add", () => {
+    setHost("tagset-example.org")
+    const config = configWithSiteRule({
+      id: "tagset",
+      matches: "tagset-example.org",
+      "dontWalkTags.add": ["ASIDE"],
+    })
+    const aside = document.createElement("aside")
+
+    expect(isDontWalkIntoAndDontTranslateAsChildElement(aside, config)).toBe(true)
+    expect(isDontWalkIntoAndDontTranslateAsChildElement(aside, DEFAULT_CONFIG)).toBe(false)
+  })
+
+  it("keeps SCRIPT blocked despite a protected removal attempt", () => {
+    setHost("tagset-example.org")
+    const config = configWithSiteRule({
+      id: "tagset",
+      matches: "tagset-example.org",
+      "dontWalkTags.remove": ["SCRIPT"],
+    })
+    const script = document.createElement("script")
+
+    expect(isDontWalkIntoAndDontTranslateAsChildElement(script, config)).toBe(true)
+  })
+
+  it("forces SPAN to block classification via forceBlockTags.add", () => {
+    setHost("tagset-example.org")
+    const config = configWithSiteRule({
+      id: "tagset",
+      matches: "tagset-example.org",
+      "forceBlockTags.add": ["SPAN"],
+    })
+    const span = document.createElement("span")
+    span.textContent = "text"
+
+    expect(isShallowBlockHTMLElement(span, undefined, config)).toBe(true)
+    expect(isShallowInlineHTMLElement(span, undefined, config)).toBe(false)
+    expect(isShallowBlockHTMLElement(span)).toBe(false)
+  })
+})

--- a/src/utils/host/dom/__tests__/filter.test.ts
+++ b/src/utils/host/dom/__tests__/filter.test.ts
@@ -326,6 +326,22 @@ describe("site-rule tag-set overrides", () => {
     expect(isDontWalkIntoAndDontTranslateAsChildElement(script, config)).toBe(true)
   })
 
+  it("honors mainContentIgnoreTags.remove in main-content mode", () => {
+    setHost("tagset-example.org")
+    const config = configWithSiteRule({
+      id: "tagset",
+      matches: "tagset-example.org",
+      "mainContentIgnoreTags.remove": ["NAV"],
+    })
+    config.translate.page.range = "main"
+    const nav = document.createElement("nav")
+    document.body.appendChild(nav)
+
+    expect(isDontWalkIntoAndDontTranslateAsChildElement(nav, config)).toBe(false)
+    expect(isDontWalkIntoAndDontTranslateAsChildElement(nav, createConfig("main"))).toBe(true)
+    document.body.removeChild(nav)
+  })
+
   it("forces SPAN to block classification via forceBlockTags.add", () => {
     setHost("tagset-example.org")
     const config = configWithSiteRule({

--- a/src/utils/host/dom/filter.ts
+++ b/src/utils/host/dom/filter.ts
@@ -1,5 +1,6 @@
 import type { Config } from "@/types/config/config"
 import type { TransNode } from "@/types/dom"
+import type { TagSetFamily } from "@/utils/constants/dom-rules"
 import {
   BLOCK_ATTRIBUTE,
   BLOCK_CONTENT_CLASS,
@@ -8,12 +9,7 @@ import {
   INLINE_CONTENT_CLASS,
   NOTRANSLATE_CLASS,
 } from "@/utils/constants/dom-labels"
-import {
-  DONT_WALK_AND_TRANSLATE_TAGS,
-  DONT_WALK_BUT_TRANSLATE_TAGS,
-  FORCE_BLOCK_TAGS,
-  MAIN_CONTENT_IGNORE_TAGS,
-} from "@/utils/constants/dom-rules"
+import { DEFAULT_TAG_SETS } from "@/utils/constants/dom-rules"
 import { getEffectiveSiteRule } from "@/utils/site-rules/effective"
 
 const ICON_FONT_FAMILY_NAMES = ["material icons", "material symbols", "font awesome"]
@@ -46,11 +42,11 @@ export function isEditable(element: HTMLElement): boolean {
 
 // shallow means only check the node itself, not the children
 // if a shallow inline node has children are block node, then it's block node rather than inline node
-export function isShallowInlineTransNode(node: Node): boolean {
+export function isShallowInlineTransNode(node: Node, config?: Config): boolean {
   if (isTextNode(node) && node.textContent?.trim()) {
     return true
   } else if (isHTMLElement(node)) {
-    return isShallowInlineHTMLElement(node)
+    return isShallowInlineHTMLElement(node, undefined, config)
   }
   return false
 }
@@ -60,11 +56,12 @@ export function isShallowInlineTransNode(node: Node): boolean {
 function isLargeInitialFloatingLetter(
   element: HTMLElement,
   computedStyle: CSSStyleDeclaration = window.getComputedStyle(element),
+  config?: Config,
 ): boolean {
   return (
     computedStyle.float === "left" &&
     !!element.nextSibling &&
-    isShallowInlineTransNode(element.nextSibling)
+    isShallowInlineTransNode(element.nextSibling, config)
   )
 }
 
@@ -87,19 +84,20 @@ function isInlineDisplay(display: string): boolean {
 export function isShallowInlineHTMLElement(
   element: HTMLElement,
   computedStyle?: CSSStyleDeclaration,
+  config?: Config,
 ): boolean {
   // to prevent too many inline nodes that make <body> as a paragraph node
   if (!element.textContent?.trim()) {
     return false
   }
 
-  if (FORCE_BLOCK_TAGS.has(element.tagName)) {
+  if (getEffectiveTagSet(config, "forceBlockTags").has(element.tagName)) {
     return false
   }
 
   const style = computedStyle ?? window.getComputedStyle(element)
 
-  if (isLargeInitialFloatingLetter(element, style)) {
+  if (isLargeInitialFloatingLetter(element, style, config)) {
     return true
   }
 
@@ -107,11 +105,11 @@ export function isShallowInlineHTMLElement(
 }
 
 // Note: !(inline node) != block node because of `notranslate` class and all cases not in the if else block
-export function isShallowBlockTransNode(node: Node): boolean {
+export function isShallowBlockTransNode(node: Node, config?: Config): boolean {
   if (isTextNode(node)) {
     return false
   } else if (isHTMLElement(node)) {
-    return isShallowBlockHTMLElement(node)
+    return isShallowBlockHTMLElement(node, undefined, config)
   }
   return false
 }
@@ -119,18 +117,35 @@ export function isShallowBlockTransNode(node: Node): boolean {
 export function isShallowBlockHTMLElement(
   element: HTMLElement,
   computedStyle?: CSSStyleDeclaration,
+  config?: Config,
 ): boolean {
-  if (FORCE_BLOCK_TAGS.has(element.tagName)) {
+  if (getEffectiveTagSet(config, "forceBlockTags").has(element.tagName)) {
     return true
   }
 
   const style = computedStyle ?? window.getComputedStyle(element)
 
-  if (isLargeInitialFloatingLetter(element, style)) {
+  if (isLargeInitialFloatingLetter(element, style, config)) {
     return false
   }
 
   return !isInlineDisplay(style.display)
+}
+
+/**
+ * The effective tag set for one family: the site-rule override when a matched
+ * rule touched it, the shipped constant otherwise. `config` is optional so
+ * callers without one (tests, defensive paths) degrade to the defaults instead
+ * of crashing — all production callers pass it.
+ */
+export function getEffectiveTagSet(
+  config: Config | undefined,
+  family: TagSetFamily,
+): ReadonlySet<string> {
+  if (config === undefined) {
+    return DEFAULT_TAG_SETS[family]
+  }
+  return getEffectiveSiteRule(config, window.location.href)[family] ?? DEFAULT_TAG_SETS[family]
 }
 
 export function isSiteRuleExcludedElement(element: HTMLElement, config: Config): boolean {
@@ -197,7 +212,7 @@ export function isDontWalkIntoButTranslateAsChildElement(
 ): boolean {
   const dontWalkClass = element.classList.contains(NOTRANSLATE_CLASS)
 
-  const dontWalkTag = DONT_WALK_BUT_TRANSLATE_TAGS.has(element.tagName)
+  const dontWalkTag = getEffectiveTagSet(config, "dontWalkButTranslateTags").has(element.tagName)
 
   const dontWalkPreserveText =
     config !== undefined && isSiteRulePreserveTextElement(element, config)
@@ -227,7 +242,7 @@ export function isDontWalkIntoAndDontTranslateAsChildElement(
   // Cheap structural predicates first; the getComputedStyle check runs last
   // because it can force a style recalculation, and the full-page walk
   // evaluates this predicate for every element (#1881).
-  const dontWalkInvalidTag = DONT_WALK_AND_TRANSLATE_TAGS.has(element.tagName)
+  const dontWalkInvalidTag = getEffectiveTagSet(config, "dontWalkTags").has(element.tagName)
   if (dontWalkInvalidTag) return true
 
   const dontWalkHidden = element.hidden
@@ -240,7 +255,7 @@ export function isDontWalkIntoAndDontTranslateAsChildElement(
 
   const dontWalkContent =
     config.translate.page.range !== "all" &&
-    MAIN_CONTENT_IGNORE_TAGS.has(element.tagName) &&
+    getEffectiveTagSet(config, "mainContentIgnoreTags").has(element.tagName) &&
     !isInsideContentContainer(element)
   if (dontWalkContent) return true
 

--- a/src/utils/host/dom/find.ts
+++ b/src/utils/host/dom/find.ts
@@ -63,13 +63,13 @@ function findElementAt(root: Document | ShadowRoot, point: Point): Element | nul
   return findDeepestElement(initialElement)
 }
 
-export function findNearestAncestorBlockNodeFor(element: Element) {
+export function findNearestAncestorBlockNodeFor(element: Element, config?: Config) {
   const startElement = element.closest(`.${CONTENT_WRAPPER_CLASS}`)?.parentElement || element
   let currentNode = startElement
   while (
     currentNode.parentElement &&
     isHTMLElement(currentNode) &&
-    isShallowInlineHTMLElement(currentNode)
+    isShallowInlineHTMLElement(currentNode, undefined, config)
   ) {
     currentNode = currentNode.parentElement
   }
@@ -80,11 +80,11 @@ export function findNearestAncestorBlockNodeFor(element: Element) {
  * Find the nearest block node from the point
  * @param point - The point to find the nearest block node
  */
-export function findNearestAncestorBlockNodeAt(point: Point) {
+export function findNearestAncestorBlockNodeAt(point: Point, config?: Config) {
   const currentNode = findElementAt(document, point)
   if (!currentNode) return null
 
-  return findNearestAncestorBlockNodeFor(currentNode)
+  return findNearestAncestorBlockNodeFor(currentNode, config)
 }
 
 export function deepQueryTopLevelSelector(

--- a/src/utils/host/dom/traversal.ts
+++ b/src/utils/host/dom/traversal.ts
@@ -6,9 +6,9 @@ import {
   PARAGRAPH_ATTRIBUTE,
   WALKED_ATTRIBUTE,
 } from "@/utils/constants/dom-labels"
-import { FORCE_BLOCK_TAGS } from "@/utils/constants/dom-rules"
 import { DEFAULT_WALK_BUDGET_MS, yieldToMain } from "@/utils/scheduler"
 import {
+  getEffectiveTagSet,
   isDontWalkIntoAndDontTranslateAsChildElement,
   isHTMLElement,
   isShallowBlockHTMLElement,
@@ -170,7 +170,7 @@ function* walkNode(
   }
 
   // force block will force the current and ancestor elements to be block node
-  forceBlock = forceBlock || FORCE_BLOCK_TAGS.has(element.tagName)
+  forceBlock = forceBlock || getEffectiveTagSet(config, "forceBlockTags").has(element.tagName)
 
   if (element.textContent?.trim() === "" && !forceBlock) {
     setNaturalTransNodeKind(element, "none")
@@ -183,8 +183,9 @@ function* walkNode(
   // One computed-style resolution feeds both shallow-shape checks (was up to
   // four separate getComputedStyle calls per element, #1881).
   const computedStyle = window.getComputedStyle(element)
-  const naturalBlockNode = forceBlock || isShallowBlockHTMLElement(element, computedStyle)
-  const naturalInlineNode = !naturalBlockNode && isShallowInlineHTMLElement(element, computedStyle)
+  const naturalBlockNode = forceBlock || isShallowBlockHTMLElement(element, computedStyle, config)
+  const naturalInlineNode =
+    !naturalBlockNode && isShallowInlineHTMLElement(element, computedStyle, config)
   setNaturalTransNodeKind(
     element,
     naturalBlockNode ? "block" : naturalInlineNode ? "inline" : "none",

--- a/src/utils/host/translate/dom/translation-insertion.ts
+++ b/src/utils/host/translate/dom/translation-insertion.ts
@@ -143,7 +143,7 @@ export async function insertTranslatedNodeIntoWrapper(
     wrapperStyleSources,
     forceInlineStyleSelector,
   )
-  const forceInlineTranslation = isForceInlineTranslation(layoutSource, layoutSourceDisplay)
+  const forceInlineTranslation = isForceInlineTranslation(layoutSource, layoutSourceDisplay, config)
   const shortInlineTranslation =
     isShortInlineTranslationText(sourceText) && layoutSourceDisplay !== "contents"
 

--- a/src/utils/host/translate/node-manipulation.ts
+++ b/src/utils/host/translate/node-manipulation.ts
@@ -27,7 +27,7 @@ export async function removeOrShowNodeTranslation(
   config: Config,
   surface?: AnalyticsSurface,
 ): Promise<boolean> {
-  const node = findNearestAncestorBlockNodeAt(point)
+  const node = findNearestAncestorBlockNodeAt(point, config)
 
   if (!node || !isHTMLElement(node)) return false
 

--- a/src/utils/host/translate/ui/__tests__/translation-utils.test.ts
+++ b/src/utils/host/translate/ui/__tests__/translation-utils.test.ts
@@ -1,5 +1,8 @@
+// @vitest-environment jsdom
+import type { Config } from "@/types/config/config"
 import { describe, expect, it } from "vitest"
-import { isShortInlineTranslationText } from "../translation-utils"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { isForceInlineTranslation, isShortInlineTranslationText } from "../translation-utils"
 
 describe("isShortInlineTranslationText", () => {
   it.each([
@@ -19,5 +22,36 @@ describe("isShortInlineTranslationText", () => {
 
   it("normalizes surrounding and repeated horizontal whitespace", () => {
     expect(isShortInlineTranslationText("  one\t two   three four  ")).toBe(true)
+  })
+})
+
+describe("isForceInlineTranslation", () => {
+  function configWithRule(rule: Config["siteRules"]["userRules"][number]): Config {
+    const config = structuredClone(DEFAULT_CONFIG)
+    config.siteRules = { userRules: [rule], disabledBuiltInRules: [] }
+    return config
+  }
+
+  it("forces inline for the default tag set without config", () => {
+    expect(isForceInlineTranslation(document.createElement("a"), "block")).toBe(true)
+    expect(isForceInlineTranslation(document.createElement("div"), "block")).toBe(false)
+  })
+
+  it("honors forceInlineTranslationTags overrides from the effective site rule", () => {
+    Object.defineProperty(window, "location", {
+      value: new URL("https://tagset-example.org/some/path"),
+      writable: true,
+    })
+    const config = configWithRule({
+      id: "tagset",
+      matches: "tagset-example.org",
+      "forceInlineTranslationTags.add": ["ABBR"],
+      "forceInlineTranslationTags.remove": ["SPAN"],
+    })
+
+    expect(isForceInlineTranslation(document.createElement("abbr"), "block", config)).toBe(true)
+    expect(isForceInlineTranslation(document.createElement("span"), "block", config)).toBe(false)
+    // config-less calls keep the shipped default
+    expect(isForceInlineTranslation(document.createElement("span"), "block")).toBe(true)
   })
 })

--- a/src/utils/host/translate/ui/translation-utils.ts
+++ b/src/utils/host/translate/ui/translation-utils.ts
@@ -1,6 +1,6 @@
+import type { Config } from "@/types/config/config"
 import type { TransNode } from "@/types/dom"
-import { FORCE_INLINE_TRANSLATION_TAGS } from "../../../constants/dom-rules"
-import { isHTMLElement } from "../../dom/filter"
+import { getEffectiveTagSet, isHTMLElement } from "../../dom/filter"
 
 // Pattern matches numbers with optional thousand separators and decimal points
 // Examples: "123", "1,234", "1,234.56", "1 234", "1.234,56" (European format)
@@ -33,10 +33,14 @@ export function isShortInlineTranslationText(text: string): boolean {
   return cleanedText.length <= SHORT_INLINE_MAX_CHARACTERS && wordCount <= SHORT_INLINE_MAX_WORDS
 }
 
-export function isForceInlineTranslation(targetNode: TransNode, display?: string): boolean {
+export function isForceInlineTranslation(
+  targetNode: TransNode,
+  display?: string,
+  config?: Config,
+): boolean {
   if (isHTMLElement(targetNode)) {
     return (
-      FORCE_INLINE_TRANSLATION_TAGS.has(targetNode.tagName) ||
+      getEffectiveTagSet(config, "forceInlineTranslationTags").has(targetNode.tagName) ||
       (display ?? window.getComputedStyle(targetNode).display).includes("flex")
     )
   }

--- a/src/utils/site-rules/__tests__/built-in.test.ts
+++ b/src/utils/site-rules/__tests__/built-in.test.ts
@@ -409,6 +409,34 @@ describe("built-in site rules", () => {
     expect(preOnlyRules).toEqual([])
   })
 
+  // SillyTavern renders backtick narration as <p><code>…</code></p>. CODE sits
+  // in DONT_WALK_BUT_TRANSLATE_TAGS, so a code-only paragraph never became a
+  // translation unit while its text was already included whenever any sibling
+  // text existed. SillyTavern is self-hosted, so the rule keys on localhost;
+  // LAN-IP/reverse-proxy users add a user rule with the same field.
+  // See https://github.com/mengxi-ream/read-frog/issues/1951
+  it("un-blocks CODE on localhost for SillyTavern narration (issue #1951)", () => {
+    for (const url of ["http://localhost:8000/", "http://127.0.0.1:8000/chat"]) {
+      const resolved = resolveSiteRule(url, BUILT_IN_SITE_RULES, [], [])
+
+      expect(resolved.matchedRuleIds).toContain("sillytavern")
+      expect(resolved.dontWalkButTranslateTags).not.toBeNull()
+      expect(resolved.dontWalkButTranslateTags!.has("CODE")).toBe(false)
+      expect(resolved.dontWalkButTranslateTags!.has("TIME")).toBe(true)
+    }
+
+    const elsewhere = resolveSiteRule("https://example.com/", BUILT_IN_SITE_RULES, [], [])
+    expect(elsewhere.dontWalkButTranslateTags).toBeNull()
+
+    const disabled = resolveSiteRule(
+      "http://localhost:8000/",
+      BUILT_IN_SITE_RULES,
+      [],
+      ["sillytavern"],
+    )
+    expect(disabled.dontWalkButTranslateTags).toBeNull()
+  })
+
   it("retains independently verified content roots that cover their full match scope", () => {
     const paulGraham = resolveSiteRule(
       "https://paulgraham.com/greatwork.html",

--- a/src/utils/site-rules/__tests__/built-in.test.ts
+++ b/src/utils/site-rules/__tests__/built-in.test.ts
@@ -86,6 +86,20 @@ describe("built-in site rules", () => {
     expect(new Set(ids).size).toBe(ids.length)
   })
 
+  // siteRuleSchema is deliberately non-strict (unknown keys are stripped so a
+  // stored config never fails to parse), which means a typo'd delta key in a
+  // built-in rule — e.g. "dontWalkButTranslateTags.removee" — would pass the
+  // schema sweep above and silently no-op at resolve time. Catch it here.
+  it("ships no keys outside the canonical schema", () => {
+    const knownKeys = new Set(Object.keys(siteRuleSchema.shape))
+    const unknown = RAW_BUILT_IN_SITE_RULES.flatMap((rule) =>
+      Object.keys(rule)
+        .filter((key) => !knownKeys.has(key))
+        .map((key) => `${String(rule.id)}: ${key}`),
+    )
+    expect(unknown).toEqual([])
+  })
+
   it("does not ship legacy force selector keys", () => {
     const legacyOccurrences = RAW_BUILT_IN_SITE_RULES.flatMap((rule) =>
       LEGACY_FORCE_SELECTOR_KEYS.filter((key) => Object.hasOwn(rule, key)).map(

--- a/src/utils/site-rules/__tests__/effective.test.ts
+++ b/src/utils/site-rules/__tests__/effective.test.ts
@@ -56,6 +56,17 @@ describe("getEffectiveSiteRule", () => {
     expect(disabled.matchedRuleIds).not.toContain("readfrog-github")
   })
 
+  it("returns the same materialized tag set across memoized calls", () => {
+    const config = configWithUserRules([
+      { id: "user", matches: "example.com", "dontWalkButTranslateTags.remove": ["CODE"] },
+    ])
+    const first = getEffectiveSiteRule(config, "https://example.com/")
+    const second = getEffectiveSiteRule(config, "https://example.com/")
+    expect(first.dontWalkButTranslateTags).not.toBeNull()
+    expect(first.dontWalkButTranslateTags!.has("CODE")).toBe(false)
+    expect(second.dontWalkButTranslateTags).toBe(first.dontWalkButTranslateTags)
+  })
+
   it("resolves the migrated Steam inline selector as style-only", () => {
     const resolved = getEffectiveSiteRule(
       configWithUserRules([]),

--- a/src/utils/site-rules/__tests__/match.test.ts
+++ b/src/utils/site-rules/__tests__/match.test.ts
@@ -103,6 +103,13 @@ describe("urlMatchesPattern", () => {
     expect(urlMatchesPattern("https://www.amazon.de/dp/1?ref=nav", "www.amazon.*/dp/*")).toBe(true)
   })
 
+  it("matches localhost and loopback IPs regardless of port", () => {
+    expect(urlMatchesPattern("http://localhost:8000/", "localhost")).toBe(true)
+    expect(urlMatchesPattern("http://localhost/chat", "localhost")).toBe(true)
+    expect(urlMatchesPattern("http://127.0.0.1:8000/chat", "127.0.0.1")).toBe(true)
+    expect(urlMatchesPattern("http://localhost.evil.com/", "localhost")).toBe(false)
+  })
+
   it("returns false for URLs it cannot handle instead of throwing", () => {
     expect(urlMatchesPattern("not a url", "github.com")).toBe(false)
     expect(urlMatchesPattern("not a url", "www.amazon.*")).toBe(false)

--- a/src/utils/site-rules/__tests__/resolve.test.ts
+++ b/src/utils/site-rules/__tests__/resolve.test.ts
@@ -303,6 +303,131 @@ describe("resolveSiteRule", () => {
     expect(resolved.preserveTextSelector).toBe(".token")
   })
 
+  describe("tag-set families", () => {
+    it("leaves every family null when no matched rule touches it", () => {
+      const resolved = resolveSiteRule(
+        URL_ON_SITE,
+        [rule({ id: "built-in", excludeSelectors: ["nav"] })],
+        [],
+        [],
+      )
+      expect(resolved.dontWalkTags).toBeNull()
+      expect(resolved.dontWalkButTranslateTags).toBeNull()
+      expect(resolved.mainContentIgnoreTags).toBeNull()
+      expect(resolved.forceBlockTags).toBeNull()
+      expect(resolved.forceInlineTranslationTags).toBeNull()
+    })
+
+    it("seeds removals from the shipped defaults", () => {
+      const resolved = resolveSiteRule(
+        URL_ON_SITE,
+        [rule({ id: "built-in", "dontWalkButTranslateTags.remove": ["CODE"] })],
+        [],
+        [],
+      )
+      expect(resolved.dontWalkButTranslateTags).not.toBeNull()
+      expect(resolved.dontWalkButTranslateTags!.has("CODE")).toBe(false)
+      expect(resolved.dontWalkButTranslateTags!.has("TIME")).toBe(true)
+    })
+
+    it("lets a later rule re-add a tag removed by an earlier rule", () => {
+      const resolved = resolveSiteRule(
+        URL_ON_SITE,
+        [rule({ id: "built-in", "dontWalkButTranslateTags.remove": ["CODE"] })],
+        [rule({ id: "user", "dontWalkButTranslateTags.add": ["CODE"] })],
+        [],
+      )
+      expect(resolved.dontWalkButTranslateTags!.has("CODE")).toBe(true)
+    })
+
+    it("adds tags in raw, uppercase, and lowercase forms", () => {
+      const resolved = resolveSiteRule(
+        URL_ON_SITE,
+        [],
+        [rule({ id: "user", "dontWalkTags.add": ["foo-bar"] })],
+        [],
+      )
+      expect(resolved.dontWalkTags!.has("foo-bar")).toBe(true)
+      expect(resolved.dontWalkTags!.has("FOO-BAR")).toBe(true)
+    })
+
+    it("removes tags case-insensitively", () => {
+      const resolved = resolveSiteRule(
+        URL_ON_SITE,
+        [],
+        [rule({ id: "user", "dontWalkTags.remove": ["Svg", "pre"] })],
+        [],
+      )
+      expect(resolved.dontWalkTags!.has("svg")).toBe(false)
+      expect(resolved.dontWalkTags!.has("PRE")).toBe(false)
+    })
+
+    it("refuses to remove protected tags in any casing", () => {
+      const resolved = resolveSiteRule(
+        URL_ON_SITE,
+        [],
+        [rule({ id: "user", "dontWalkTags.remove": ["SCRIPT", "style", "Head"] })],
+        [],
+      )
+      expect(resolved.dontWalkTags!.has("SCRIPT")).toBe(true)
+      expect(resolved.dontWalkTags!.has("STYLE")).toBe(true)
+      expect(resolved.dontWalkTags!.has("HEAD")).toBe(true)
+    })
+
+    it("drops invalid tag names without killing valid siblings", () => {
+      const resolved = resolveSiteRule(
+        URL_ON_SITE,
+        [],
+        [
+          rule({
+            id: "user",
+            "dontWalkButTranslateTags.add": [".code", "div code", "1bad", "", "KBD"],
+          }),
+        ],
+        [],
+      )
+      expect(resolved.dontWalkButTranslateTags!.has("KBD")).toBe(true)
+      expect(resolved.dontWalkButTranslateTags!.has(".code")).toBe(false)
+      expect(resolved.dontWalkButTranslateTags!.has("div code")).toBe(false)
+    })
+
+    it("materializes the default set even for an empty delta", () => {
+      const resolved = resolveSiteRule(
+        URL_ON_SITE,
+        [],
+        [rule({ id: "user", "dontWalkButTranslateTags.add": [] })],
+        [],
+      )
+      expect(resolved.dontWalkButTranslateTags).not.toBeNull()
+      expect(resolved.dontWalkButTranslateTags!.has("CODE")).toBe(true)
+      expect(resolved.dontWalkButTranslateTags!.has("TIME")).toBe(true)
+    })
+
+    it("merges each family independently", () => {
+      const resolved = resolveSiteRule(
+        URL_ON_SITE,
+        [],
+        [
+          rule({
+            id: "user",
+            "mainContentIgnoreTags.remove": ["NAV"],
+            "forceBlockTags.add": ["X-CARD"],
+            "forceInlineTranslationTags.remove": ["SPAN"],
+          }),
+        ],
+        [],
+      )
+      expect(resolved.mainContentIgnoreTags!.has("NAV")).toBe(false)
+      expect(resolved.mainContentIgnoreTags!.has("HEADER")).toBe(true)
+      expect(resolved.forceBlockTags!.has("X-CARD")).toBe(true)
+      expect(resolved.forceBlockTags!.has("H1")).toBe(true)
+      expect(resolved.forceInlineTranslationTags!.has("SPAN")).toBe(false)
+      expect(resolved.forceInlineTranslationTags!.has("A")).toBe(true)
+      expect(resolved.dontWalkTags).toBeNull()
+      expect(resolved.dontWalkButTranslateTags).toBeNull()
+    })
+  })
+
   it("merges include and force selectors independently", () => {
     const resolved = resolveSiteRule(
       URL_ON_SITE,

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -4520,5 +4520,11 @@
       ".forum-topbar",
       ".forum-bottombar"
     ]
+  },
+  {
+    "id": "sillytavern",
+    "description": "SillyTavern renders backtick narration as <p><code>; translate CODE as part of its paragraph (fenced code blocks stay protected by PRE)",
+    "matches": ["localhost", "127.0.0.1"],
+    "dontWalkButTranslateTags.remove": ["CODE"]
   }
 ]

--- a/src/utils/site-rules/resolve.ts
+++ b/src/utils/site-rules/resolve.ts
@@ -1,4 +1,5 @@
 import type { SiteRule } from "@/types/config/site-rules"
+import { DEFAULT_TAG_SETS } from "@/utils/constants/dom-rules"
 import { logger } from "@/utils/logger"
 import { urlMatchesRule } from "./match"
 
@@ -16,6 +17,17 @@ export interface ResolvedSiteRule {
   forceInlineNodeSelector: string | null
   forceInlineStyleSelector: string | null
   preserveTextSelector: string | null
+  /**
+   * Tag-set families: `null` means no matched rule touched the family, so
+   * consumers fall back to the shipped constant Set (hot path unchanged).
+   * Non-null is the fully materialized effective set — defaults seeded in
+   * code, rule `.add`/`.remove` deltas applied.
+   */
+  dontWalkTags: ReadonlySet<string> | null
+  dontWalkButTranslateTags: ReadonlySet<string> | null
+  mainContentIgnoreTags: ReadonlySet<string> | null
+  forceBlockTags: ReadonlySet<string> | null
+  forceInlineTranslationTags: ReadonlySet<string> | null
   minCharacters: number | null
   minWords: number | null
   injectedCss: string | null
@@ -30,10 +42,31 @@ export const EMPTY_RESOLVED_SITE_RULE: ResolvedSiteRule = {
   forceInlineNodeSelector: null,
   forceInlineStyleSelector: null,
   preserveTextSelector: null,
+  dontWalkTags: null,
+  dontWalkButTranslateTags: null,
+  mainContentIgnoreTags: null,
+  forceBlockTags: null,
+  forceInlineTranslationTags: null,
   minCharacters: null,
   minWords: null,
   injectedCss: null,
 }
+
+/**
+ * Tags whose removal from `dontWalkTags` would be catastrophic (script/style
+ * text injected into translations, head metadata walked). Removal attempts are
+ * skipped with a warning. PRE is deliberately absent — un-blocking it is a
+ * legitimate per-site choice.
+ */
+export const PROTECTED_DONT_WALK_TAGS: ReadonlySet<string> = new Set([
+  "HEAD",
+  "TITLE",
+  "META",
+  "SCRIPT",
+  "NOSCRIPT",
+  "STYLE",
+  "LINK",
+])
 
 const selectorValidity = new Map<string, boolean>()
 
@@ -105,6 +138,67 @@ function mergeSelectorDelta(
   }
 
   return joinSelectors(merged)
+}
+
+const TAG_NAME_RE = /^[a-z][a-z0-9-]*$/i
+
+/**
+ * Tag-set families are seeded from the shipped default Set and patched with
+ * `.add`/`.remove` tag-name entries. Not routed through `mergeSelectorDelta`:
+ * its `querySelector` probe would happily accept class/descendant selectors
+ * that a `Set.has(tagName)` consumer can never match, silencing the mistake.
+ * Returns `null` when no matched rule references the family, so hot-path
+ * consumers keep using the constant Set untouched.
+ *
+ * Case handling: `tagName` is uppercase for HTML elements but case-preserving
+ * for SVG/MathML (e.g. "svg", "foreignObject"), so adds insert the raw,
+ * uppercase, and lowercase forms while removes delete all three. camelCase
+ * foreign tags therefore need the same casing in `.add` and `.remove`.
+ */
+function mergeTagSetDelta(
+  matched: SiteRule[],
+  addKey: keyof SiteRule,
+  removeKey: keyof SiteRule,
+  defaults: ReadonlySet<string>,
+  protectedTags?: ReadonlySet<string>,
+): ReadonlySet<string> | null {
+  if (!matched.some((rule) => rule[addKey] !== undefined || rule[removeKey] !== undefined)) {
+    return null
+  }
+
+  const merged = new Set(defaults)
+
+  const validTagNames = (entries: unknown): string[] => {
+    const tagNames: string[] = []
+    for (const entry of Array.isArray(entries) ? entries : []) {
+      const trimmed = typeof entry === "string" ? entry.trim() : ""
+      if (TAG_NAME_RE.test(trimmed)) {
+        tagNames.push(trimmed)
+      } else {
+        logger.warn(`[site-rules] Invalid tag name dropped: "${String(entry)}"`)
+      }
+    }
+    return tagNames
+  }
+
+  for (const rule of matched) {
+    for (const tagName of validTagNames(rule[addKey])) {
+      merged.add(tagName)
+      merged.add(tagName.toUpperCase())
+      merged.add(tagName.toLowerCase())
+    }
+    for (const tagName of validTagNames(rule[removeKey])) {
+      if (protectedTags?.has(tagName.toUpperCase())) {
+        logger.warn(`[site-rules] Protected tag cannot be removed: "${tagName}"`)
+        continue
+      }
+      merged.delete(tagName)
+      merged.delete(tagName.toUpperCase())
+      merged.delete(tagName.toLowerCase())
+    }
+  }
+
+  return merged
 }
 
 /**
@@ -194,6 +288,37 @@ export function resolveSiteRule(
       "preserveTextSelectors",
       "preserveTextSelectors.add",
       "preserveTextSelectors.remove",
+    ),
+    dontWalkTags: mergeTagSetDelta(
+      matched,
+      "dontWalkTags.add",
+      "dontWalkTags.remove",
+      DEFAULT_TAG_SETS.dontWalkTags,
+      PROTECTED_DONT_WALK_TAGS,
+    ),
+    dontWalkButTranslateTags: mergeTagSetDelta(
+      matched,
+      "dontWalkButTranslateTags.add",
+      "dontWalkButTranslateTags.remove",
+      DEFAULT_TAG_SETS.dontWalkButTranslateTags,
+    ),
+    mainContentIgnoreTags: mergeTagSetDelta(
+      matched,
+      "mainContentIgnoreTags.add",
+      "mainContentIgnoreTags.remove",
+      DEFAULT_TAG_SETS.mainContentIgnoreTags,
+    ),
+    forceBlockTags: mergeTagSetDelta(
+      matched,
+      "forceBlockTags.add",
+      "forceBlockTags.remove",
+      DEFAULT_TAG_SETS.forceBlockTags,
+    ),
+    forceInlineTranslationTags: mergeTagSetDelta(
+      matched,
+      "forceInlineTranslationTags.add",
+      "forceInlineTranslationTags.remove",
+      DEFAULT_TAG_SETS.forceInlineTranslationTags,
     ),
     minCharacters,
     minWords,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,14 @@ export default defineConfig({
   test: {
     exclude: [...configDefaults.exclude, "**/.claude/**", "**/repos/**"],
     environment: "node",
+    environmentOptions: {
+      // jsdom defaults to http://localhost:3000/, which built-in site rules
+      // keyed on localhost (e.g. sillytavern) silently match — tests written
+      // on the default URL would run under that site's semantics instead of
+      // the shipped defaults. Pin a neutral host no rule matches; per-file
+      // @vitest-environment-options pragmas still override this.
+      jsdom: { url: "https://neutral-test.example/" },
+    },
     globals: true,
     setupFiles: "vitest.setup.ts",
     watch: false,


### PR DESCRIPTION
Fixes #1951.

## Root cause

SillyTavern renders backtick narration as `<p><code>…</code></p>`. `CODE` is in `DONT_WALK_BUT_TRANSLATE_TAGS`, so a code-only paragraph never sets `hasInlineNodeChild`, never gets `PARAGRAPH_ATTRIBUTE`, and is skipped — while `extractTextContent` already includes code text whenever any sibling text exists (the labeling layer contradicted the category's own contract).

## Approach (supersedes the original `translateAsChildSelectors` proposal)

Instead of special-casing the walk, the five hardcoded DOM tag-set constants become per-site overridable through the existing site-rules delta machinery:

- New rule fields `dontWalkTags` / `dontWalkButTranslateTags` / `mainContentIgnoreTags` / `forceBlockTags` / `forceInlineTranslationTags`, each **`.add`/`.remove` only** (delta-only, no bare key) with **tag-name** entries — resolution materializes a `Set`, so the per-element hot path stays `Set.has` (#1881 untouched). Defaults are seeded in code inside `resolveSiteRule`; `null` means "family untouched → constant fallback".
- Removal of catastrophic tags (`HEAD/TITLE/META/SCRIPT/NOSCRIPT/STYLE/LINK`) is refused with a warning; `PRE` stays removable by design. `notranslate`/hidden/preserveText checks remain independent and un-overridable.
- Built-in rule `sillytavern` (`matches: ["localhost", "127.0.0.1"]`, `"dontWalkButTranslateTags.remove": ["CODE"]`): `<code>` becomes a normally walked inline element there and code-only paragraphs translate exactly like their `<q>` dialogue siblings — no changes to `traversal.ts`/`find.ts` needed. Fenced code blocks stay protected by `PRE`. LAN-IP/reverse-proxy users can add a user rule with the same field (docs follow-up).

## Commits

1. `feat(site-rules)` — schema keys + `mergeTagSetDelta` resolver support
2. `refactor(dom)` — thread all five constants' consumers through `getEffectiveTagSet` (byte-identical behavior with no matching rule)
3. `fix(translate)` — the sillytavern built-in rule + end-to-end tests + changeset
4. `test` — hardening from adversarial review: pin the jsdom test URL to a neutral host (jsdom's `localhost:3000` default silently matched the new rule), consumer-level tests for the two merge-only families, and an unknown-key check for `rules.json`

## Testing

- Full suite: 2465 passed; `pnpm type-check` clean.
- New coverage: resolver merge semantics (seeding, ordering, case tri-form, protected tags), effective-rule memo Set identity, editor schema accept/reject, `localhost` pattern matching, filter predicate overrides, and end-to-end walk/extract tests for the SillyTavern markup (labeled on localhost, baseline preserved elsewhere, `<pre><code>` still blocked, rule disable restores default).

Credit to @JoeJoeflyn for reproducing #1951 and pinning down the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)