### PR TITLE
fix(translate): stop auto-translation from re-enabling a page the use…

### DIFF
--- a/.changeset/respect-manual-translation-off.md
+++ b/.changeset/respect-manual-translation-off.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): stop auto-translation from re-enabling a page the user manually turned off (#2011) — a manual "show original" (popup, floating button, shortcut, touch gesture, context menu) now records a per-tab, per-origin refusal that the tab-activation language re-detection respects until the tab leaves that origin

--- a/src/entrypoints/background/__tests__/context-menu.test.ts
+++ b/src/entrypoints/background/__tests__/context-menu.test.ts
@@ -5,6 +5,7 @@ import { i18n } from "@/utils/i18n"
 
 const sendMessageMock = vi.fn<(...args: any[]) => any>()
 const ensureInitializedConfigMock = vi.fn<(...args: any[]) => any>()
+const storageSetItemMock = vi.fn<(...args: any[]) => any>()
 const contextMenuClickListeners: Array<(info: any, tab?: any) => Promise<void> | void> = []
 
 vi.mock("@/utils/message", () => ({
@@ -51,7 +52,8 @@ describe("background context menu", () => {
 
     storage.watch = vi.fn<(...args: any[]) => any>()
     storage.getItem = vi.fn<(...args: any[]) => any>().mockResolvedValue({ enabled: true })
-    storage.setItem = vi.fn<(...args: any[]) => any>().mockResolvedValue(undefined)
+    storage.setItem = storageSetItemMock
+    storageSetItemMock.mockResolvedValue(undefined)
 
     i18n.t = vi.fn<(...args: any[]) => any>(
       (key: string) =>
@@ -151,6 +153,29 @@ describe("background context menu", () => {
     expect(browser.contextMenus.removeAll).toHaveBeenCalledOnce()
     expect(browser.contextMenus.create).not.toHaveBeenCalled()
     expect(browser.contextMenus.update).not.toHaveBeenCalled()
+  })
+
+  it("records a scoped user refusal when the translate menu disables translation", async () => {
+    const { MENU_ID_TRANSLATE, registerContextMenuListeners } = await import("../context-menu")
+
+    registerContextMenuListeners()
+
+    const clickHandler = contextMenuClickListeners[0]
+    if (!clickHandler) {
+      throw new Error("Context menu click listener was not registered")
+    }
+
+    // storage.getItem defaults to { enabled: true }, so this click toggles off.
+    await clickHandler(
+      { menuItemId: MENU_ID_TRANSLATE },
+      { id: 5, url: "https://example.com/articles/1" },
+    )
+
+    expect(storageSetItemMock).toHaveBeenCalledWith("session:translationState.5", {
+      enabled: false,
+      userDisabled: true,
+      origin: "https://example.com",
+    })
   })
 
   it("routes selection menu clicks to the matching tab and frame", async () => {

--- a/src/entrypoints/background/__tests__/page-translation-state.test.ts
+++ b/src/entrypoints/background/__tests__/page-translation-state.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { storage } from "#imports"
+import { getTranslationStateKey } from "@/utils/constants/storage-keys"
+import {
+  isAutoTranslationSuppressed,
+  isPageTranslationStateInUrlScope,
+  setPageTranslationEnabled,
+} from "../page-translation-state"
+
+const storageSetItemMock = vi.fn<(...args: any[]) => any>()
+
+describe("setPageTranslationEnabled", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storage.setItem = storageSetItemMock
+    storageSetItemMock.mockResolvedValue(undefined)
+  })
+
+  it("stores the origin scope when enabling with a URL", async () => {
+    await setPageTranslationEnabled(42, true, "https://example.com/articles/1")
+
+    expect(storageSetItemMock).toHaveBeenCalledWith(getTranslationStateKey(42), {
+      enabled: true,
+      origin: "https://example.com",
+    })
+  })
+
+  it("stores a bare enable without a URL", async () => {
+    await setPageTranslationEnabled(42, true)
+
+    expect(storageSetItemMock).toHaveBeenCalledWith(getTranslationStateKey(42), { enabled: true })
+  })
+
+  it("records a scoped user refusal for user-initiated disables", async () => {
+    await setPageTranslationEnabled(42, false, "https://example.com/articles/1", true)
+
+    expect(storageSetItemMock).toHaveBeenCalledWith(getTranslationStateKey(42), {
+      enabled: false,
+      userDisabled: true,
+      origin: "https://example.com",
+    })
+  })
+
+  it("stores a bare disable for programmatic disables", async () => {
+    await setPageTranslationEnabled(42, false, "https://example.com/articles/1")
+
+    expect(storageSetItemMock).toHaveBeenCalledWith(getTranslationStateKey(42), { enabled: false })
+  })
+
+  it("stores a bare disable when a user-initiated disable has no scopable origin", async () => {
+    await setPageTranslationEnabled(42, false, "file:///Users/me/report.html", true)
+
+    expect(storageSetItemMock).toHaveBeenCalledWith(getTranslationStateKey(42), { enabled: false })
+  })
+})
+
+describe("isAutoTranslationSuppressed", () => {
+  const userDisabledState = {
+    enabled: false,
+    userDisabled: true,
+    origin: "https://example.com",
+  }
+
+  it("suppresses when the user refused this origin", () => {
+    expect(isAutoTranslationSuppressed(userDisabledState, "https://example.com/other")).toBe(true)
+  })
+
+  it("does not suppress a different origin", () => {
+    expect(isAutoTranslationSuppressed(userDisabledState, "https://other.example.net/page")).toBe(
+      false,
+    )
+  })
+
+  it("does not suppress on bare disabled state", () => {
+    expect(isAutoTranslationSuppressed({ enabled: false }, "https://example.com/a")).toBe(false)
+  })
+
+  it("does not suppress on enabled state", () => {
+    expect(
+      isAutoTranslationSuppressed(
+        { enabled: true, origin: "https://example.com" },
+        "https://example.com/a",
+      ),
+    ).toBe(false)
+  })
+
+  it("does not suppress without state or URL", () => {
+    expect(isAutoTranslationSuppressed(null, "https://example.com/a")).toBe(false)
+    expect(isAutoTranslationSuppressed(userDisabledState, undefined)).toBe(false)
+  })
+})
+
+describe("isPageTranslationStateInUrlScope", () => {
+  it("is unaffected by the userDisabled marker", () => {
+    expect(
+      isPageTranslationStateInUrlScope(
+        { enabled: false, userDisabled: true, origin: "https://example.com" },
+        "https://example.com/a",
+      ),
+    ).toBe(false)
+    expect(
+      isPageTranslationStateInUrlScope(
+        { enabled: true, origin: "https://example.com" },
+        "https://example.com/a",
+      ),
+    ).toBe(true)
+  })
+})

--- a/src/entrypoints/background/__tests__/translation-signal.test.ts
+++ b/src/entrypoints/background/__tests__/translation-signal.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { browser, storage } from "#imports"
-import { DEFAULT_DETECTED_CODE } from "@/utils/constants/config"
+import { CONFIG_STORAGE_KEY, DEFAULT_DETECTED_CODE } from "@/utils/constants/config"
 import { getDetectedCodeStateKey, getTranslationStateKey } from "@/utils/constants/storage-keys"
 
 const sendMessageMock = vi.fn<(...args: any[]) => any>()
@@ -11,6 +11,7 @@ const storageRemoveItemMock = vi.fn<(...args: any[]) => any>()
 const tabsOnRemovedAddListenerMock = vi.fn<(...args: any[]) => any>()
 const tabsOnActivatedAddListenerMock = vi.fn<(...args: any[]) => any>()
 const tabsQueryMock = vi.fn<(...args: any[]) => any>()
+const tabsGetMock = vi.fn<(...args: any[]) => any>()
 const webNavigationOnCommittedAddListenerMock = vi.fn<(...args: any[]) => any>()
 const injectHostContentIntoTabIframesMock = vi.fn<(...args: any[]) => any>()
 const injectHostContentIntoCurrentTabIframesAfterNodeTranslationMock =
@@ -34,6 +35,7 @@ vi.mock("@/utils/logger", () => ({
   logger: {
     error: loggerErrorMock,
     warn: loggerWarnMock,
+    info: vi.fn<(...args: any[]) => any>(),
   },
 }))
 
@@ -88,6 +90,7 @@ describe("translationMessage", () => {
     browser.tabs.onRemoved.addListener = tabsOnRemovedAddListenerMock
     browser.tabs.onActivated.addListener = tabsOnActivatedAddListenerMock
     browser.tabs.query = tabsQueryMock
+    browser.tabs.get = tabsGetMock
     browser.webNavigation.onCommitted.addListener = webNavigationOnCommittedAddListenerMock
     storage.getItem = storageGetItemMock
     storage.setItem = storageSetItemMock
@@ -99,6 +102,7 @@ describe("translationMessage", () => {
     })
     sendMessageMock.mockResolvedValue(undefined)
     tabsQueryMock.mockResolvedValue([{ id: 42 }])
+    tabsGetMock.mockRejectedValue(new Error("tab not found"))
     storageGetItemMock.mockResolvedValue(undefined)
     storageSetItemMock.mockResolvedValue(undefined)
     storageRemoveItemMock.mockResolvedValue(undefined)
@@ -450,5 +454,232 @@ describe("translationMessage", () => {
 
     expect(storageGetItemMock).not.toHaveBeenCalled()
     expect(storageRemoveItemMock).not.toHaveBeenCalled()
+  })
+
+  describe("user-disable suppression (#2011)", () => {
+    const USER_DISABLED_STATE = {
+      enabled: false,
+      userDisabled: true,
+      origin: "https://example.com",
+    }
+
+    function mockConfigAndState(state: unknown) {
+      storageGetItemMock.mockImplementation(async (key: string) => {
+        if (key === `local:${CONFIG_STORAGE_KEY}`) return {}
+        if (key === getTranslationStateKey(42)) return state
+        return undefined
+      })
+    }
+
+    it("records a user refusal with origin when the popup disables page translation", async () => {
+      await setupSubject()
+      tabsGetMock.mockResolvedValue({ id: 42, url: "https://example.com/articles/1" })
+
+      await getHandler("tryToSetEnablePageTranslationByTabId")({
+        data: { tabId: 42, enabled: false },
+      })
+
+      expect(storageSetItemMock).toHaveBeenCalledWith(
+        getTranslationStateKey(42),
+        USER_DISABLED_STATE,
+      )
+    })
+
+    it("falls back to a bare disable when the popup disables on an origin-less URL", async () => {
+      await setupSubject()
+      tabsGetMock.mockResolvedValue({ id: 42, url: "chrome://newtab/" })
+
+      await getHandler("tryToSetEnablePageTranslationByTabId")({
+        data: { tabId: 42, enabled: false },
+      })
+
+      expect(storageSetItemMock).toHaveBeenCalledWith(getTranslationStateKey(42), {
+        enabled: false,
+      })
+    })
+
+    it("records a user refusal when a content-script surface disables page translation", async () => {
+      await setupSubject()
+
+      await getHandler("tryToSetEnablePageTranslationOnContentScript")({
+        data: { enabled: false },
+        sender: { tab: { id: 42, url: "https://example.com/articles/1" } },
+      })
+
+      expect(storageSetItemMock).toHaveBeenCalledWith(
+        getTranslationStateKey(42),
+        USER_DISABLED_STATE,
+      )
+    })
+
+    it("records a user refusal from a user-initiated top-frame manager stop echo", async () => {
+      await setupSubject()
+
+      await getHandler("setAndNotifyPageTranslationStateChangedByManager")({
+        data: { enabled: false, url: "https://example.com/articles/1", userInitiated: true },
+        sender: { tab: { id: 42 }, frameId: 0 },
+      })
+
+      expect(storageSetItemMock).toHaveBeenCalledWith(
+        getTranslationStateKey(42),
+        USER_DISABLED_STATE,
+      )
+    })
+
+    it("does not invent a user refusal for programmatic manager stop echoes", async () => {
+      await setupSubject()
+
+      await getHandler("setAndNotifyPageTranslationStateChangedByManager")({
+        data: { enabled: false, url: "https://example.com/articles/1" },
+        sender: { tab: { id: 42 }, frameId: 0 },
+      })
+
+      expect(storageSetItemMock).toHaveBeenCalledWith(getTranslationStateKey(42), {
+        enabled: false,
+      })
+    })
+
+    it("never writes tab state from iframe disable echoes, even user-initiated ones", async () => {
+      await setupSubject()
+      storageGetItemMock.mockResolvedValue({ enabled: true, origin: "https://example.com" })
+
+      await getHandler("setAndNotifyPageTranslationStateChangedByManager")({
+        data: { enabled: false, url: "https://embed.example.net/frame", userInitiated: true },
+        sender: { tab: { id: 42 }, frameId: 7 },
+      })
+
+      expect(storageSetItemMock).not.toHaveBeenCalled()
+      // The top frame is still translating; the iframe echo must not make the
+      // UI claim translation is off.
+      expect(sendMessageMock).not.toHaveBeenCalledWith(
+        "notifyTranslationStateChanged",
+        { enabled: false },
+        42,
+      )
+    })
+
+    it("re-broadcasts iframe disable echoes that agree with the stored state without writing", async () => {
+      await setupSubject()
+      storageGetItemMock.mockResolvedValue({ enabled: false })
+
+      await getHandler("setAndNotifyPageTranslationStateChangedByManager")({
+        data: { enabled: false, url: "https://embed.example.net/frame" },
+        sender: { tab: { id: 42 }, frameId: 7 },
+      })
+
+      expect(storageSetItemMock).not.toHaveBeenCalled()
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        "notifyTranslationStateChanged",
+        { enabled: false },
+        42,
+      )
+    })
+
+    it("suppresses auto-translation for the origin the user refused", async () => {
+      await setupSubject()
+      shouldEnableAutoTranslationMock.mockResolvedValue(true)
+      mockConfigAndState(USER_DISABLED_STATE)
+
+      await getHandler("reportDetectedPageLanguage")({
+        data: { detectedCodeOrUnd: "eng", url: "https://example.com/articles/2" },
+        sender: { tab: { id: 42 }, frameId: 0 },
+      })
+
+      // Detected-language caching and notification still happen.
+      expect(storageSetItemMock).toHaveBeenCalledWith(getDetectedCodeStateKey(42), "eng")
+      expect(sendMessageMock).not.toHaveBeenCalledWith(
+        "askManagerToTogglePageTranslation",
+        expect.objectContaining({ enabled: true }),
+        42,
+      )
+    })
+
+    it("still auto-translates other origins after a refusal elsewhere", async () => {
+      await setupSubject()
+      shouldEnableAutoTranslationMock.mockResolvedValue(true)
+      mockConfigAndState(USER_DISABLED_STATE)
+
+      await getHandler("reportDetectedPageLanguage")({
+        data: { detectedCodeOrUnd: "eng", url: "https://other.example.net/page" },
+        sender: { tab: { id: 42 }, frameId: 0 },
+      })
+
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        "askManagerToTogglePageTranslation",
+        expect.objectContaining({ enabled: true }),
+        42,
+      )
+    })
+
+    it("does not let a bare disabled state suppress auto-translation", async () => {
+      // Programmatic stops (SPA navigation, mode changes) write {enabled:false}
+      // without userDisabled; those must never veto auto-translation.
+      await setupSubject()
+      shouldEnableAutoTranslationMock.mockResolvedValue(true)
+      mockConfigAndState({ enabled: false })
+
+      await getHandler("reportDetectedPageLanguage")({
+        data: { detectedCodeOrUnd: "eng", url: "https://example.com/articles/2" },
+        sender: { tab: { id: 42 }, frameId: 0 },
+      })
+
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        "askManagerToTogglePageTranslation",
+        expect.objectContaining({ enabled: true }),
+        42,
+      )
+    })
+
+    it("keeps the user refusal on same-origin navigation", async () => {
+      await setupSubject()
+      storageGetItemMock.mockResolvedValue(USER_DISABLED_STATE)
+
+      await getOnCommittedListener()({
+        tabId: 42,
+        frameId: 0,
+        url: "https://example.com/articles/3",
+      })
+
+      expect(storageRemoveItemMock).not.toHaveBeenCalled()
+    })
+
+    it("clears the user refusal when the tab leaves the origin", async () => {
+      await setupSubject()
+      storageGetItemMock.mockResolvedValue(USER_DISABLED_STATE)
+
+      await getOnCommittedListener()({
+        tabId: 42,
+        frameId: 0,
+        url: "https://other.example.net/page",
+      })
+
+      expect(storageRemoveItemMock).toHaveBeenCalledWith(getTranslationStateKey(42))
+    })
+
+    it("clears the user refusal when the tab commits to an origin-less URL", async () => {
+      await setupSubject()
+      storageGetItemMock.mockResolvedValue(USER_DISABLED_STATE)
+
+      await getOnCommittedListener()({
+        tabId: 42,
+        frameId: 0,
+        url: "chrome://newtab/",
+      })
+
+      expect(storageRemoveItemMock).toHaveBeenCalledWith(getTranslationStateKey(42))
+    })
+
+    it("leaves bare disabled records untouched on navigation", async () => {
+      await setupSubject()
+      storageGetItemMock.mockResolvedValue({ enabled: false })
+
+      await getOnCommittedListener()({
+        tabId: 42,
+        frameId: 0,
+        url: "https://other.example.net/page",
+      })
+
+      expect(storageRemoveItemMock).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src/entrypoints/background/context-menu.ts
+++ b/src/entrypoints/background/context-menu.ts
@@ -178,7 +178,7 @@ async function handleContextMenuClick(
   }
 
   if (info.menuItemId === MENU_ID_TRANSLATE) {
-    await handleTranslateClick(tab.id)
+    await handleTranslateClick(tab.id, tab.url)
     return
   }
 
@@ -208,12 +208,12 @@ async function handleContextMenuClick(
 /**
  * Handle translate menu click - toggle page translation
  */
-async function handleTranslateClick(tabId: number) {
+async function handleTranslateClick(tabId: number, tabUrl?: string) {
   const isCurrentlyTranslated = await getPageTranslationEnabled(tabId)
   const newState = !isCurrentlyTranslated
 
   if (!newState) {
-    await setPageTranslationEnabled(tabId, false)
+    await setPageTranslationEnabled(tabId, false, tabUrl, true)
     void sendMessage("notifyTranslationStateChanged", { enabled: false }, tabId)
   }
 

--- a/src/entrypoints/background/page-translation-state.ts
+++ b/src/entrypoints/background/page-translation-state.ts
@@ -16,12 +16,28 @@ export async function setPageTranslationEnabled(
   tabId: number,
   enabled: boolean,
   url?: string,
+  userInitiated?: boolean,
 ): Promise<void> {
-  const origin = enabled && url ? getPageTranslationOriginScope(url) : null
+  if (enabled) {
+    const origin = url ? getPageTranslationOriginScope(url) : null
+
+    await storage.setItem<TranslationState>(
+      getTranslationStateKey(tabId),
+      origin ? { enabled, origin } : { enabled },
+    )
+    return
+  }
+
+  // A user-initiated disable is remembered with the origin it was rejected
+  // on, so auto-translation cannot force the page back on until the tab
+  // leaves that origin. Origin-less URLs (file://, chrome://) cannot be
+  // scoped and fall back to a bare disable. Always a full replace-write:
+  // message handlers are not serialized, so read-modify-write here would race.
+  const origin = userInitiated && url ? getPageTranslationOriginScope(url) : null
 
   await storage.setItem<TranslationState>(
     getTranslationStateKey(tabId),
-    origin ? { enabled, origin } : { enabled },
+    origin ? { enabled: false, userDisabled: true, origin } : { enabled: false },
   )
 }
 
@@ -30,6 +46,15 @@ export function isPageTranslationStateInUrlScope(
   url: string | undefined,
 ): boolean {
   if (!state?.enabled || !state.origin || !url) return false
+
+  return state.origin === getPageTranslationOriginScope(url)
+}
+
+export function isAutoTranslationSuppressed(
+  state: TranslationState | null | undefined,
+  url: string | undefined,
+): boolean {
+  if (!state || state.enabled || state.userDisabled !== true || !state.origin || !url) return false
 
   return state.origin === getPageTranslationOriginScope(url)
 }

--- a/src/entrypoints/background/translation-signal.ts
+++ b/src/entrypoints/background/translation-signal.ts
@@ -10,6 +10,7 @@ import { getDetectedCodeStateKey, getTranslationStateKey } from "@/utils/constan
 import { shouldEnableAutoTranslation } from "@/utils/host/translate/auto-translation"
 import { logger } from "@/utils/logger"
 import { onMessage, sendMessage } from "@/utils/message"
+import { getPageTranslationOriginScope } from "@/utils/url"
 import {
   injectHostContentIntoCurrentTabIframesAfterNodeTranslation,
   injectHostContentIntoTabIframes,
@@ -17,6 +18,7 @@ import {
 import {
   getPageTranslationEnabled,
   getPageTranslationState,
+  isAutoTranslationSuppressed,
   isPageTranslationStateInUrlScope,
   setPageTranslationEnabled,
 } from "./page-translation-state"
@@ -125,6 +127,12 @@ export function translationMessage() {
 
       const shouldEnable = await shouldEnableAutoTranslation(url, detectedCodeOrUnd, config)
       if (shouldEnable) {
+        // Honor an explicit user refusal for this origin (#2011): language is
+        // re-detected on every tab activation, so without this check a manual
+        // "show original" would be force-overridden on the next tab switch.
+        const state = await getPageTranslationState(tabId)
+        if (isAutoTranslationSuppressed(state, url)) return
+
         requestManagerToTogglePageTranslation(
           tabId,
           true,
@@ -157,7 +165,13 @@ export function translationMessage() {
   onMessage("tryToSetEnablePageTranslationByTabId", async (msg) => {
     const { tabId, enabled, analyticsContext } = msg.data
     if (!enabled) {
-      await setPageTranslationEnabled(tabId, false)
+      // Record the user's refusal before asking the manager to stop, so a
+      // concurrent tab-activation re-detection cannot re-enable in between.
+      const tabUrl = await browser.tabs
+        .get(tabId)
+        .then((tab) => tab.url)
+        .catch(() => undefined)
+      await setPageTranslationEnabled(tabId, false, tabUrl, true)
       notifyPageTranslationStateChanged(tabId, false)
     }
     requestManagerToTogglePageTranslation(tabId, enabled, analyticsContext)
@@ -172,7 +186,7 @@ export function translationMessage() {
         tabId,
       })
       if (!enabled) {
-        await setPageTranslationEnabled(tabId, false)
+        await setPageTranslationEnabled(tabId, false, msg.sender?.tab?.url, true)
         notifyPageTranslationStateChanged(tabId, false)
       }
       requestManagerToTogglePageTranslation(tabId, enabled, analyticsContext)
@@ -183,24 +197,28 @@ export function translationMessage() {
 
   onMessage("setAndNotifyPageTranslationStateChangedByManager", async (msg) => {
     const tabId = msg.sender?.tab?.id
-    const { enabled, url } = msg.data
+    const { enabled, url, userInitiated } = msg.data
     if (typeof tabId === "number") {
       const senderFrameId = msg.sender?.frameId
 
-      if (enabled && isIframe(senderFrameId)) {
-        // Iframe enabled echoes only synchronize UI; they must not write
-        // tab-level state because that state is scoped to the top-frame origin.
-        const currentState = await getPageTranslationState(tabId)
-        if (!currentState?.enabled) return
+      if (isIframe(senderFrameId)) {
+        // Iframe echoes only synchronize UI; they must not write tab-level
+        // state (including the userDisabled marker) because that state is
+        // scoped to the top-frame origin and iframe echoes carry iframe URLs.
+        // Only re-broadcast when the echo agrees with the stored state, so an
+        // iframe-only stop cannot make the UI contradict a still-translating
+        // top frame.
+        const currentEnabled = await getPageTranslationEnabled(tabId)
+        if (enabled !== currentEnabled) return
 
-        notifyPageTranslationStateChanged(tabId, true)
+        notifyPageTranslationStateChanged(tabId, currentEnabled)
         return
       }
 
-      await setPageTranslationEnabled(tabId, enabled, url ?? msg.sender?.tab?.url)
+      await setPageTranslationEnabled(tabId, enabled, url ?? msg.sender?.tab?.url, userInitiated)
       notifyPageTranslationStateChanged(tabId, enabled)
 
-      if (enabled && !isIframe(senderFrameId)) {
+      if (enabled) {
         void injectHostContentIntoTabIframes(tabId)
       }
     } else {
@@ -223,16 +241,29 @@ export function translationMessage() {
     await publishAndRefreshActiveTab(activeInfo.tabId)
   })
 
-  // Clear translation state only when the tab leaves the origin where it was enabled.
+  // Clear translation state only when the tab leaves the origin where it was
+  // enabled (or where the user manually disabled it).
   browser.webNavigation.onCommitted.addListener(async (details) => {
     // Only handle main frame navigations, not iframes
     if (details.frameId !== 0) return
 
     const state = await getPageTranslationState(details.tabId)
-    if (!state?.enabled) return
+    if (!state) return
 
-    if (isPageTranslationStateInUrlScope(state, details.url)) return
+    if (state.enabled) {
+      if (isPageTranslationStateInUrlScope(state, details.url)) return
 
-    await storage.removeItem(getTranslationStateKey(details.tabId))
+      await storage.removeItem(getTranslationStateKey(details.tabId))
+      return
+    }
+
+    // A user's manual-off marker only applies to the origin it was set on;
+    // clear it once the tab commits to a different origin (or an origin-less
+    // URL like chrome://) so other sites keep auto-translating.
+    if (state.userDisabled) {
+      if (state.origin && state.origin === getPageTranslationOriginScope(details.url)) return
+
+      await storage.removeItem(getTranslationStateKey(details.tabId))
+    }
   })
 }

--- a/src/entrypoints/host.content/runtime.ts
+++ b/src/entrypoints/host.content/runtime.ts
@@ -92,7 +92,11 @@ export async function bootstrapHostContent(
     if (enabled) {
       void manager.start(window === window.top ? analyticsContext : undefined)
     } else {
-      manager.stop()
+      // Invariant: every sender of askManagerToTogglePageTranslation with
+      // enabled=false is a user surface (popup button, floating button,
+      // context menu) — the auto-translation path only ever sends
+      // enabled=true — so a disable here is always user-initiated.
+      manager.stop({ userInitiated: true })
     }
   })
 

--- a/src/entrypoints/host.content/translation-control/bind-translation-shortcut.ts
+++ b/src/entrypoints/host.content/translation-control/bind-translation-shortcut.ts
@@ -28,7 +28,7 @@ export async function bindTranslationShortcutKey(pageTranslationManager: PageTra
     shortcut as Hotkey,
     () => {
       if (pageTranslationManager.isActive) {
-        pageTranslationManager.stop()
+        pageTranslationManager.stop({ userInitiated: true })
       } else {
         void pageTranslationManager.start(
           createFeatureUsageContext(ANALYTICS_FEATURE.PAGE_TRANSLATION, ANALYTICS_SURFACE.SHORTCUT),

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -91,9 +91,12 @@ interface IPageTranslationManager {
 
   /**
    * Stops the automatic page translation functionality
-   * Cleans up all observers and removes translated content and set storage
+   * Cleans up all observers and removes translated content and set storage.
+   * Pass `userInitiated` when the stop comes from a user surface (shortcut,
+   * touch gesture, popup/floating-button toggle) so the background records
+   * the refusal and auto-translation stops re-enabling the page (#2011).
    */
-  stop: () => void
+  stop: (options?: { userInitiated?: boolean }) => void
 
   /**
    * Re-resolves the site rule for the current URL and swaps injected CSS in
@@ -339,8 +342,8 @@ export class PageTranslationManager implements IPageTranslationManager {
     }
   }
 
-  stop(): void {
-    this.stopInternal({ notify: true })
+  stop(options?: { userInitiated?: boolean }): void {
+    this.stopInternal({ notify: true, userInitiated: options?.userInitiated })
   }
 
   async refreshSiteRuleCSS(): Promise<void> {
@@ -365,7 +368,13 @@ export class PageTranslationManager implements IPageTranslationManager {
     }
   }
 
-  private stopInternal({ notify }: { notify: boolean }): void {
+  private stopInternal({
+    notify,
+    userInitiated,
+  }: {
+    notify: boolean
+    userInitiated?: boolean
+  }): void {
     if (!this.isPageTranslating) {
       console.warn("PageTranslationManager is already inactive")
       return
@@ -375,6 +384,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       void sendMessage("setAndNotifyPageTranslationStateChangedByManager", {
         enabled: false,
         url: window.location.href,
+        userInitiated,
       })
     }
 
@@ -446,7 +456,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       if (!startTouches) return
       if (performance.now() - startTime < PageTranslationManager.MAX_DURATION) {
         if (this.isPageTranslating) {
-          this.stop()
+          this.stop({ userInitiated: true })
         } else {
           void this.start(
             createFeatureUsageContext(

--- a/src/types/translation-state.ts
+++ b/src/types/translation-state.ts
@@ -3,6 +3,10 @@ import { z } from "zod"
 export const translationStateSchema = z.object({
   enabled: z.boolean(),
   origin: z.string().optional(),
+  // Set when the user manually turned translation off (popup, floating
+  // button, shortcut, touch gesture, context menu). Scoped by `origin`;
+  // auto-translation must not force the page back on while this is set.
+  userDisabled: z.boolean().optional(),
 })
 
 export type TranslationState = z.infer<typeof translationStateSchema>

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -61,6 +61,7 @@ interface ProtocolMap {
   setAndNotifyPageTranslationStateChangedByManager: (data: {
     enabled: boolean
     url?: string
+    userInitiated?: boolean
   }) => void
   notifyTranslationStateChanged: (data: { enabled: boolean }) => void
   ensureIframeHostContentInjected: (data: { tabId?: number }) => void


### PR DESCRIPTION
> **AI model(s) used (required):** claude-fable-5 (Claude Code)

## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Since v1.33.6 (#1504), `tabs.onActivated` re-detects the page language and re-runs the auto-translate decision on **every tab activation**. A manual "show original" only wrote a bare `{enabled:false}` — indistinguishable from "never translated" — and the auto-enable path never read it. Result (#2011): any page whose detected language lands in `autoTranslateLanguages` was force-re-translated on every tab switch, even right after the user cancelled. The blast radius is larger than it looks because detection (franc, no confidence threshold) is near-random on digit-heavy pages and overrides `<html lang>`: a `zh-CN` data report with one English column detects as `eng`/`fra`/etc., so a small Latin-language list gets hit by misdetection roulette.

**Fix — one mechanism, two halves:**

- **Producer:** every user-initiated disable (popup button, floating button, page-translation shortcut, touch gesture, context menu) now records `{enabled: false, userDisabled: true, origin}` in the per-tab session state. The shortcut/touch paths plumb a `userInitiated` flag through `manager.stop()` → the `setAndNotifyPageTranslationStateChangedByManager` echo; popup/floating-button/context-menu paths write it directly in their background handlers (before asking the manager to stop, closing the race with a concurrent tab-activation re-detection).
- **Consumer:** the `reportDetectedPageLanguage` auto-enable gate skips force-enabling when `isAutoTranslationSuppressed(state, url)` — i.e. the user refused this origin. The `webNavigation.onCommitted` cleanup clears the marker once the tab leaves the origin, so other sites keep auto-translating.

**Deliberately unchanged:**

- Programmatic stops (SPA cross-origin navigation, translation-mode changes) still write a bare `{enabled:false}` which never vetoes auto-translation — gating on the bare flag would suppress legitimate auto-translation after SPA navigations (the bare record is origin-less and survives navigation).
- The detection/decision logic itself is untouched: first-time misdetection triggers can still occur; this PR turns "endlessly re-forced" into "at most once per tab, refusal respected".
- All state writes stay full replace-writes — message handlers are not serialized, so read-modify-write would race on stop→start sequences.

**Drive-by fix:** `askManagerToTogglePageTranslation` broadcasts to all frames, so iframe managers also stop and echo with **iframe URLs**. The old handler only guarded the `enabled=true` direction; disable echoes fell through and overwrote tab-level state with iframe origins. Iframe echoes now never write tab state in either direction (they only re-broadcast UI sync when they agree with the stored state).

## Related Issue

Closes #2011

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

- 20 new unit tests: the five user-disable entry points write the scoped marker; suppression honors origin matching; **bare `{enabled:false}` must not suppress** (protects SPA flows); iframe echoes never write state; `onCommitted` keeps/clears the marker by origin (incl. origin-less `chrome://`); full suite 2303 tests green.
- E2E (Puppeteer, real Chrome, built extension, `lang="zh-CN"` fixture mimicking the issue's data report): before the fix, manual disable + tab switch re-enabled translation 100%; after the fix — auto-translation on load still fires (no regression), manual disable survives tab switches, manual re-enable works (refusal cleared), and a second refusal survives again.

## Screenshots

N/A (behavioral fix; E2E transcript in the test description above).

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Known limitation (documented in code): origin-less pages (`file://`) cannot scope a refusal and fall back to a bare disable, so #2011 remains unfixed there — content scripts on `file://` require explicit user opt-in anyway. The refusal marker lives in session storage scoped to tab+origin: opening the same site in a new tab starts fresh by design.