### PR TITLE
docs(skills): fix CSP eval and header-write traps in puppeteer harnes…

### DIFF
--- a/.agents/skills/extension-puppeteer-debugging/SKILL.md
+++ b/.agents/skills/extension-puppeteer-debugging/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Extension Puppeteer Debugging
 
-Drive the built extension in headed Chrome from a Node script: install it, force a known config, toggle translation via the extension's own message bus, and assert on live DOM. Every step below exists because the obvious alternative **failed in practice** (2026-07-13, issue #1846 verification).
+Drive the built extension in headed Chrome from a Node script: install it, force a known config, toggle translation via the extension's own message bus, and assert on live DOM. Every step below exists because the obvious alternative **failed in practice** (2026-07-13, issue #1846 verification; 2026-07-31, issue #2011 repro).
 
 ## Quick reference
 
@@ -16,7 +16,7 @@ Drive the built extension in headed Chrome from a Node script: install it, force
 |---|---|---|
 | Build | `pnpm build` then `test -f .output/chrome-mv3/manifest.json` | Trusting `pnpm build \| tail` exit code (tail's exit code masks failure); missing `.env.production` in a worktree kills the build with a buried error — copy it from the main checkout |
 | Load | `puppeteer.launch({ pipe: true, enableExtensions: true })` + `browser.installExtension(path)` (Puppeteer ≥22.11) | `--load-extension` / `--disable-extensions-except` — ignored by branded Chrome 137+ |
-| Config | Read-merge-write the WHOLE `config` object in `chrome.storage.local` from the service-worker target; **re-patch after ~4s and verify** (background init/migration clobbers early writes) | Patching once and navigating immediately; writing a partial config object — it fails `configSchema.safeParse` and `getLocalConfig()` silently falls back to `DEFAULT_CONFIG` (bilingual mode) |
+| Config | Read-merge-write the WHOLE `config` object in `chrome.storage.local` from the service-worker target, with mutations **inlined in the evaluated function** (pass only plain data as evaluate args); **re-patch after ~4s and verify** (background init/migration clobbers early writes) | Building the mutation from a code string via `new Function`/eval inside the SW — its CSP (`script-src 'self' 'wasm-unsafe-eval' ...`) blocks eval and throws EvalError; patching once and navigating immediately; writing a partial config object — it fails `configSchema.safeParse` and `getLocalConfig()` silently falls back to `DEFAULT_CONFIG` (bilingual mode) |
 | Target language | **Always force `config.language.targetCode = 'cmn'`** | Trusting the default — onboarding overwrites targetCode with the browser UI language, and the same-language skip then translates NOTHING on English fixtures |
 | Toggle | Send the webext-core envelope to the content script from the SW: `chrome.tabs.sendMessage(tabId, { id, type: 'askManagerToTogglePageTranslation', data: { enabled }, timestamp })` | Synthesizing Alt+E — on macOS Option+E is a dead key (`event.key !== 'e'`), the hotkey listener never fires |
 | Assert translated | CJK regex `/[一-鿿]/` on textContent; count `.read-frog-translated-content-wrapper` (fallback-B) and `[data-read-frog-translation-only]` (in-place swap) | Waiting a fixed sleep |

--- a/.agents/skills/extension-puppeteer-debugging/references/harness-template.js
+++ b/.agents/skills/extension-puppeteer-debugging/references/harness-template.js
@@ -1,7 +1,8 @@
 /* Puppeteer harness template for driving the built read-frog extension.
- * Proven working 2026-07-13 (issue #1846 E2E). Adapt EXT_PATH, PORT, fixture
- * dir, and the assertions; the extension-control plumbing below is the part
- * that is easy to get wrong — keep it.
+ * Proven working 2026-07-13 (issue #1846 E2E), re-proven 2026-07-31 (issue
+ * #2011 repro). Adapt EXT_PATH, PORT, fixture dir, and the assertions; the
+ * extension-control plumbing below is the part that is easy to get wrong —
+ * keep it.
  *
  * Setup: npm i puppeteer   (Chrome comes from ~/.cache/puppeteer)
  * Run:   node harness.js   (headed on purpose — watch it while it runs)
@@ -23,8 +24,12 @@ function serve() {
     const server = http.createServer((req, res) => {
       const file = path.join(PAGE_DIR, req.url === '/' ? 'index.html' : req.url)
       try {
+        // Read BEFORE writeHead: if the read throws after writeHead(200)
+        // (e.g. /favicon.ico), the catch's writeHead(404) double-writes
+        // headers -> ERR_HTTP_HEADERS_SENT crashes the whole harness.
+        const body = fs.readFileSync(file)
         res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'text/plain' })
-        res.end(fs.readFileSync(file))
+        res.end(body)
       } catch {
         res.writeHead(404)
         res.end()
@@ -46,22 +51,25 @@ async function getServiceWorker(browser) {
 }
 
 /* Patch the extension config. TRAPS this encodes:
+ * - the MV3 service worker CSP (script-src 'self' 'wasm-unsafe-eval' ...)
+ *   blocks eval, so `new Function(mutateSrc)` inside worker.evaluate throws
+ *   EvalError -> inline your mutations in the evaluated function below;
+ *   pass only plain data as evaluate args, never code strings
  * - background init/migration clobbers early writes -> patch, wait, re-patch
  * - onboarding overwrites targetCode with the browser UI language -> force cmn
  *   or the same-language skip silently translates nothing on English fixtures */
-async function patchConfig(browser, mutate) {
+async function patchConfig(browser) {
   const worker = await getServiceWorker(browser)
   const patch = () =>
-    worker.evaluate(async (mutateSrc) => {
+    worker.evaluate(async () => {
       const { config } = await chrome.storage.local.get('config')
       if (!config) return 'no-config-yet'
       config.language.targetCode = 'cmn'
       config.language.sourceCode = 'auto'
-      // eslint-disable-next-line no-new-func
-      new Function('config', mutateSrc)(config)
+      config.translate.mode = 'translationOnly' // <-- inline YOUR mutations here
       await chrome.storage.local.set({ config })
       return `ok mode=${config.translate.mode} target=${config.language.targetCode}`
-    }, mutate)
+    })
   let result = await patch()
   for (let i = 0; i < 20 && result === 'no-config-yet'; i++) {
     await sleep(500)
@@ -104,7 +112,7 @@ async function main() {
 
   try {
     await browser.installExtension(EXT_PATH)
-    await patchConfig(browser, `config.translate.mode = 'translationOnly'`)
+    await patchConfig(browser)
 
     const page = await browser.newPage()
     const errors = []


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Fable 5 (claude-fable-5)

## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [x] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fixes two bugs in the `extension-puppeteer-debugging` skill's harness template (`.agents/skills/extension-puppeteer-debugging/references/harness-template.js`), both discovered on 2026-07-31 while reproducing issue #2011 with a harness copied from this template:

1. **CSP blocks `new Function` in the service worker.** `patchConfig` accepted the config mutation as a code string and executed it via `new Function('config', mutateSrc)(config)` inside `worker.evaluate`. The extension's MV3 service worker CSP (`script-src 'self' 'wasm-unsafe-eval' ...`) blocks eval, so this always threw `EvalError` and the config patch never applied. The template now inlines mutations directly in the evaluated function (with a `<-- inline YOUR mutations here` marker) and documents that only plain data may be passed as evaluate args, never code strings. The retry-until-config-exists loop and the re-patch-after-4s behavior are unchanged.

2. **Static server crashes on missing files.** `serve()` called `res.writeHead(200)` before `fs.readFileSync(file)`; when the read threw (e.g. the browser requesting `/favicon.ico`), the catch block called `res.writeHead(404)` on a response whose headers were already sent, and `ERR_HTTP_HEADERS_SENT` crashed the whole harness process. The file is now read into a variable first, then `writeHead(200)` + `end(body)`.

The SKILL.md quick-reference "Config" row now leads its "NOT this" column with the `new Function`/eval CSP trap, and the "Do this" column says to inline mutations in the evaluated function.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

The corrected pattern (inlined mutations, read-before-writeHead) is lifted from the working #2011 repro harness, which ran end-to-end against the built extension on 2026-07-31 — config patch applied and verified, fixture served without crashing across repeated page loads. The updated template also passes `node --check`.

## Screenshots

N/A — tooling/documentation change only.

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

- The bugs were found during the issue #2011 investigation (auto-translate re-triggering after manual disable); this PR does not close that issue — it only fixes the debugging template that was used to reproduce it.
- No changeset: the change touches only `.agents/skills/` reference material, not shipped extension code (same as #1843, the previous skill-only PR).
- `.claude/skills/extension-puppeteer-debugging` is a symlink into `.agents/skills/`, so the skill picks the fix up automatically.