### PR TITLE
fix(site-rules): stop LinkedIn from clipping and merging translations

### DIFF
--- a/.changeset/linkedin-site-rule.md
+++ b/.changeset/linkedin-site-rule.md
@@ -1,0 +1,7 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(site-rules): stop LinkedIn from clipping and merging translations
+
+Replaces the dead `linkedinFeed` rule with a working `linkedin` one. Post and comment bodies no longer get cut off (their collapse container is `max-height:100px`, which only an `!important` override beats), actor headlines wrap instead of ellipsizing, and the post actor block stops collapsing into one oversized paragraph — its wrapper anchor is `display:inline` where the comment equivalent is `block`, so it is forced to a block node. Page chrome (nav, footer, sidebar, ads), author names and the "Visit my website" link are excluded from translation.

--- a/src/utils/site-rules/__tests__/built-in.test.ts
+++ b/src/utils/site-rules/__tests__/built-in.test.ts
@@ -103,8 +103,11 @@ describe("built-in site rules", () => {
       forceInlineStyleSelectors: selectorFamilyStats("forceInlineStyleSelectors"),
       forceInlineNodeSelectors: selectorFamilyStats("forceInlineNodeSelectors"),
     }).toEqual({
-      forceBlockNodeSelectors: { rules: 47, selectorStrings: 75 },
-      forceBlockStyleSelectors: { rules: 47, selectorStrings: 75 },
+      // +1 selector each: the linkedin rule forces `.update-components-actor__meta-link`
+      // (an inline <a> wrapping name + degree + headline) to a block node, so the post
+      // actor block stops collapsing into one 16px paragraph. See the dedicated test below.
+      forceBlockNodeSelectors: { rules: 48, selectorStrings: 76 },
+      forceBlockStyleSelectors: { rules: 48, selectorStrings: 76 },
       forceInlineStyleSelectors: { rules: 26, selectorStrings: 45 },
       forceInlineNodeSelectors: { rules: 0, selectorStrings: 0 },
     })
@@ -199,6 +202,80 @@ describe("built-in site rules", () => {
     const resolved = resolveSiteRule("https://www.cnbc.com/", BUILT_IN_SITE_RULES, [], [])
     expect(resolved.injectedCss).toContain("-webkit-line-clamp: unset !important")
     expect(resolved.injectedCss).toContain("max-height: unset !important")
+  })
+
+  // `linkedinFeed` shipped as `https://linkedin.com/feed/*`, but LinkedIn 301s the
+  // bare host, so the extension only ever sees `www.linkedin.com` and the rule never
+  // matched. Restoring it by adding `www` would be worse than leaving it dead: both of
+  // its include selectors are stale, and `includeSelectors` is a whitelist. Verified
+  // live on /feed/update/, the only `h1` is `h1.visually-hidden` ("Feed detail update",
+  // 1x1px) and `.feed-shared-update-v2__description-wrapper` matches nothing, so the
+  // whitelist would reduce every /feed/* page to translating a screen-reader label.
+  // Same disposal as the other stale whitelists above: drop it, keep the site.
+  it("does not resurrect the linkedinFeed whitelist that would blank out /feed/*", () => {
+    expect(BUILT_IN_SITE_RULES.find((rule) => rule.id === "linkedinFeed")).toBeUndefined()
+
+    const stale = BUILT_IN_SITE_RULES.filter((rule) =>
+      (rule.includeSelectors ?? []).includes(".feed-shared-update-v2__description-wrapper"),
+    )
+    expect(stale).toEqual([])
+  })
+
+  // LinkedIn clips translations two ways: the collapsed post/comment body sits in
+  // `.feed-shared-inline-show-more-text` (max-height:100px, overflow:hidden), and the
+  // actor headline is `white-space:nowrap` + `text-overflow:ellipsis`. Measured live on
+  // a post page: the comment body needed 164px inside a 100px box, and the comment
+  // headline needed 1589px inside 416px. LinkedIn's own class rule beats a plain
+  // single-class override, so `max-height` only lands with `!important`.
+  it("unclamps LinkedIn post/comment bodies and lets actor headlines wrap", () => {
+    for (const url of [
+      "https://www.linkedin.com/feed/",
+      // Logged-in permalink form: linkedin.com and /posts/ both land here.
+      "https://www.linkedin.com/feed/update/urn:li:activity:7488678448039735296/",
+      "https://www.linkedin.com/posts/example_post-activity-7485343256633942018-0UTg/",
+    ]) {
+      const resolved = resolveSiteRule(url, BUILT_IN_SITE_RULES, [], [])
+
+      expect(resolved.matchedRuleIds).toContain("linkedin")
+      expect(resolved.includeSelector).toBeNull()
+
+      expect(resolved.injectedCss).toContain(".feed-shared-inline-show-more-text")
+      expect(resolved.injectedCss).toContain("max-height: none !important")
+      expect(resolved.injectedCss).toContain(".comments-comment-meta__description-subtitle")
+      expect(resolved.injectedCss).toContain("white-space: normal !important")
+
+      // linkedinFeed's surviving intent: skip page chrome. Verified in a real
+      // logged-in browser driving the built extension — with these excludes the
+      // nav and footer carry zero translation wrappers while the post and its
+      // comments still translate.
+      expect(resolved.excludeSelector).toContain("#global-nav")
+      expect(resolved.excludeSelector).toContain(".global-footer-compact")
+      expect(resolved.excludeSelector).toContain(".scaffold-layout__sidebar")
+
+      // Post actor blocks collapsed into one oversized paragraph because
+      // `.update-components-actor__meta-link` is an inline <a> wrapping the name,
+      // the connection degree and the headline. An inline child makes its parent
+      // `.update-components-actor__meta` a paragraph (traversal.ts), so the whole
+      // block translated as one unit at the parent's 16px instead of the headline's
+      // own 12px. The comment equivalent is already display:block and behaves
+      // correctly, so forcing this one to a block node matches that.
+      expect(resolved.forceBlockNodeSelector).toContain(".update-components-actor__meta-link")
+
+      // The author's "Visit my website" link is the other inline <a> in that block.
+      // It carries no stable class (`ember-view pb0` plus an auto-generated
+      // `id="ember36"`), so it is matched as "the direct anchor child that is not the
+      // profile link". Excluding it drops the last inline child, so
+      // `.update-components-actor__meta` stops being a paragraph at all.
+      expect(resolved.excludeSelector).toContain(
+        ".update-components-actor__meta > a:not(.update-components-actor__meta-link)",
+      )
+
+      // Forcing the anchor to a block node promotes `.update-components-actor__title`
+      // (the author name plus the "• 3rd+" degree) to its own paragraph, which then
+      // gets transliterated — "Ruffin Mitchener" became "拉芬·米切纳". Names are not
+      // content to translate, so the title is excluded outright.
+      expect(resolved.excludeSelector).toContain(".update-components-actor__title")
+    }
   })
 
   // Vercel `prose-vercel` docs hide `[data-docs-heading] a span`, which also

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -1214,9 +1214,20 @@
     ]
   },
   {
-    "id": "linkedinFeed",
-    "matches": "https://linkedin.com/feed/*",
-    "includeSelectors": ["h1", ".feed-shared-update-v2__description-wrapper"]
+    "id": "linkedin",
+    "description": "Replaces linkedinFeed, whose host was missing www so it never matched; its include whitelist is dropped because both selectors went stale. Keeps that rule's intent (skip page chrome) as excludes. Post/comment bodies collapse at max-height:100px and actor headlines are nowrap+ellipsis, so translations get clipped",
+    "matches": "*.linkedin.com",
+    "excludeSelectors.add": [
+      "#global-nav",
+      ".global-footer-compact",
+      ".ad-banner-container",
+      ".scaffold-layout__sidebar",
+      ".update-components-actor__meta > a:not(.update-components-actor__meta-link)",
+      ".update-components-actor__title"
+    ],
+    "forceBlockNodeSelectors": [".update-components-actor__meta-link"],
+    "forceBlockStyleSelectors": [".update-components-actor__meta-link"],
+    "injectedCss": ".feed-shared-inline-show-more-text,.comments-comment-item__inline-show-more-text { max-height: none !important; }\n.update-components-actor__description,.comments-comment-meta__description-subtitle { white-space: normal !important;text-overflow: clip !important;overflow: visible !important;height: auto !important; }"
   },
   {
     "id": "indiehackers",


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 5

## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Replaces the `linkedinFeed` rule with a working `linkedin` one and fixes three layout defects on LinkedIn.

### The old rule never ran, and reviving it would have been worse

`linkedinFeed` matched `https://linkedin.com/feed/*`, which requires the host to be exactly `linkedin.com` — but LinkedIn 301s that to `www.linkedin.com`, so the rule never applied. Adding the missing `www` looks like the fix, but it is worse than leaving it dead: `includeSelectors` is a whitelist and both of its selectors are stale.

Verified on `/feed/update/`:

| Selector | Today |
|---|---|
| `h1` | The only `h1` is `h1.visually-hidden`, 1×1px, text "Feed detail update" — a screen-reader landmark, not content |
| `.feed-shared-update-v2__description-wrapper` | **0 matches** (today it is `.feed-shared-update-v2__description`, no `-wrapper`) |

So restoring it would reduce every `/feed/*` page — the logged-in home feed *and* every post permalink (`/feed/update/urn:li:activity:<id>/`) — to translating a hidden accessibility label. It is dropped the same way the other stale whitelists were (see the existing `does not restrict migrated sites to stale include selectors` test), keeping only its intent, "skip page chrome", as excludes.

### Three defects, each measured in a logged-in browser

**1. Comment and post bodies were cut off.** The collapse container `.feed-shared-inline-show-more-text` is `max-height:100px; overflow:hidden`; a translated comment needed 164px. This one **requires `!important`** — without it the computed value stays `100px`, because LinkedIn's own class rule wins on specificity. Same failure mode as #1918 (CNBC).

**2. Actor headlines were ellipsized.** `.update-components-actor__description` and `.comments-comment-meta__description-subtitle` are `white-space:nowrap` + `text-overflow:ellipsis`; a translated comment headline needed 1589px inside 416px. Not a width problem — they simply were not allowed to wrap.

**3. The post actor block translated as one oversized paragraph.** The name, the `• 3rd+` degree, the headline and the website link all came out as a single 16px block instead of just the headline at its own 12px. Root cause is a one-property difference:

```
comment  a.comments-comment-meta__description-container  → display: block   ✓ correct
post     a.update-components-actor__meta-link            → display: inline  ✗ broken
```

An inline child makes its parent a paragraph (`traversal.ts`), so `.update-components-actor__meta` swallowed the whole block. Forcing that anchor to a block node makes the post case behave like the comment case, which was already correct.

Forcing it to a block then promoted `.update-components-actor__title` to its own paragraph, which transliterated author names ("Ruffin Mitchener" → "拉芬·米切纳"), so the title is excluded. The "Visit my website" anchor is excluded too — it renders at the wrong size and has no stable class (`ember-view pb0` plus a generated `id="ember36"`), so it is matched structurally as the direct anchor child that is not the profile link. Excluding it also drops the last inline child, so the actor meta stops being a paragraph at all.

Note that paragraph segmentation reads **only `display`** — never `overflow`, `white-space`, `max-height` or `height` — so the CSS in this rule cannot affect it.

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Unit tests cover rule resolution for `/feed/`, `/feed/update/urn:li:activity:.../` and `/posts/...`, and pin the stale whitelist so it cannot come back. Each assertion carries the measured reason in a comment.

End-to-end with Puppeteer driving the **built** extension in real Chrome on a logged-in post, translating with `microsoft-translate-default`:

```
maxHeight: none          whiteSpace: normal
bodiesClipped: 0         headsClipped: 0
nav: 0   footer: 0   sidebar: 0          (translation wrappers)
metaIsParagraph: false   headlineIsParagraph: true
headlineFontSize: 12px   headlineTranslationFontSize: 12px
nameWrappers: 0          websiteLinkWrappers: 0
```

Attribution was checked explicitly, to rule out the rule breaking translation outright:

```
example.com (provider health)   wrappers=3
linkedin, rule DISABLED         wrappers=83
linkedin, rule ENABLED          wrappers=87
```

**Not verified:** the `/feed/` home feed does not render its post list or nav under automation, so the nav/footer/sidebar excludes were confirmed on `/feed/update/...` and `/posts/...` only. They are shared app-shell components, so the home feed should behave the same, but it was not observed directly.

## Additional Information

`forceBlockNodeSelectors` and `forceBlockStyleSelectors` must stay identical (an existing test pins that invariant), and the hard-coded family counts in `built-in.test.ts` were updated from 47/75 to 48/76 accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
