### PR TITLE
style(options): widen the settings container and even out prompt previews across languages

### DIFF
--- a/.changeset/custom-action-preview-word-budget.md
+++ b/.changeset/custom-action-preview-word-budget.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(options): cut custom action prompt previews by word count instead of character count, so they stay an even length across languages

--- a/.changeset/options-container-max-width.md
+++ b/.changeset/options-container-max-width.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+style(options): widen the settings page container to give content more room

--- a/src/components/container.tsx
+++ b/src/components/container.tsx
@@ -9,7 +9,7 @@ function Container({
   return (
     <div
       ref={ref}
-      className={cn("mx-auto w-full max-w-4xl px-6 md:px-8 lg:px-14", className)}
+      className={cn("mx-auto w-full max-w-5xl px-6 md:px-8 lg:px-14", className)}
       {...props}
     >
       {children}

--- a/src/entrypoints/options/pages/api-providers/feature-providers/__tests__/system-prompt-preview.test.ts
+++ b/src/entrypoints/options/pages/api-providers/feature-providers/__tests__/system-prompt-preview.test.ts
@@ -32,11 +32,24 @@ describe("toSystemPromptPreview", () => {
     expect(preview).toBe("You are helpful. ## Goal Be concise.")
   })
 
-  it("cuts a long prompt to a fixed length and marks it with an ellipsis", () => {
-    const preview = toSystemPromptPreview(makeAction({ systemPrompt: "a".repeat(200) }))
+  it("cuts a long prompt to a fixed word count and marks it with an ellipsis", () => {
+    const preview = toSystemPromptPreview(makeAction({ systemPrompt: "word ".repeat(100) }))
 
-    // 80 characters of prompt, then the ellipsis that shows it was cut.
-    expect(preview).toBe(`${"a".repeat(80)}…`)
+    expect(preview).toBe(`${"word ".repeat(8).trimEnd()}…`)
+  })
+
+  it("gives a Chinese prompt a preview of the same word count, not the same length", () => {
+    // 你好 and 世界 are a word each, so 8 words is 4 of these sentences — 19 characters, where
+    // the character budget this replaced would have run to 160 and carried far more content.
+    const preview = toSystemPromptPreview(makeAction({ systemPrompt: "你好世界。".repeat(40) }))
+
+    expect(preview).toBe(`${"你好世界。".repeat(3)}你好世界…`)
+  })
+
+  it("falls back to a character cut for text the segmenter finds no word breaks in", () => {
+    const preview = toSystemPromptPreview(makeAction({ systemPrompt: "a".repeat(400) }))
+
+    expect(preview).toBe(`${"a".repeat(160)}…`)
   })
 
   it("does not leave a dangling space in front of the ellipsis", () => {

--- a/src/entrypoints/options/pages/api-providers/feature-providers/index.tsx
+++ b/src/entrypoints/options/pages/api-providers/feature-providers/index.tsx
@@ -19,7 +19,32 @@ import { ConfigSection } from "../../../components/config-section"
 import { SELECT_CONTENT_PROPS } from "../../../components/select-content-props"
 
 /** How much of a custom action's system prompt stands in for a description before it is cut. */
-const SYSTEM_PROMPT_PREVIEW_LENGTH = 80
+const SYSTEM_PROMPT_PREVIEW_WORDS = 8
+/** Backstop for text the segmenter finds no word breaks in, and the budget when it is missing. */
+const SYSTEM_PROMPT_PREVIEW_CHARS = 160
+/** Separators left at the cut would sit awkwardly in front of the ellipsis. */
+const TRAILING_SEPARATORS_RE = /[\s\p{P}]+$/u
+
+/**
+ * How far into `text` the preview may run, capped in words rather than characters: 80 characters
+ * of Chinese carries several times the content of 80 characters of English, so a character budget
+ * leaves previews wildly uneven between languages. The prompt's own language is unknown, so the
+ * segmenter runs on the default locale — CJK is segmented from a dictionary either way.
+ */
+function findPreviewEnd(text: string): number {
+  const capped = Math.min(text.length, SYSTEM_PROMPT_PREVIEW_CHARS)
+  // Firefox only grew Intl.Segmenter in 125, well past the 112 this extension still supports.
+  if (typeof Intl.Segmenter !== "function") return capped
+
+  const segmenter = new Intl.Segmenter(undefined, { granularity: "word" })
+  let words = 0
+  for (const { index, isWordLike } of segmenter.segment(text)) {
+    if (!isWordLike) continue
+    words += 1
+    if (words > SYSTEM_PROMPT_PREVIEW_WORDS) return Math.min(index, capped)
+  }
+  return capped
+}
 
 /**
  * Custom actions carry no description of their own, so the head of their system prompt stands
@@ -27,10 +52,11 @@ const SYSTEM_PROMPT_PREVIEW_LENGTH = 80
  */
 export function toSystemPromptPreview(action: SelectionToolbarCustomAction): string {
   const singleLine = (action.systemPrompt.trim() || action.prompt).replace(/\s+/g, " ").trim()
-  if (singleLine.length <= SYSTEM_PROMPT_PREVIEW_LENGTH) {
+  const end = findPreviewEnd(singleLine)
+  if (end >= singleLine.length) {
     return singleLine
   }
-  return `${singleLine.slice(0, SYSTEM_PROMPT_PREVIEW_LENGTH).trimEnd()}…`
+  return `${singleLine.slice(0, end).replace(TRAILING_SEPARATORS_RE, "")}…`
 }
 
 function FeatureProviderTitle({


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Fable 5

## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [x] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Two small fixes to how the settings pages use their horizontal space.

### Widen the settings container

`src/components/container.tsx` bumps the shared `Container` max width from `max-w-4xl` (896px) to `max-w-5xl` (1024px). Horizontal padding (`px-6 md:px-8 lg:px-14`) and the `mx-auto` centering are unchanged, so narrow viewports look exactly as before.

`Container` is consumed only by the options `PageLayout`, so nothing outside the settings pages is affected, and every settings page — including drill-in subpages — renders through it, so the new width applies consistently. Page sections use `@container` queries rather than viewport breakpoints, so their internal layouts adapt on their own with no per-page changes.

### Cut custom action prompt previews by word, not by character

A custom action carries no description of its own, so the head of its system prompt stands in for one on the API Providers page. That was cut at 80 characters, which made the preview length depend entirely on the language: 80 characters of Chinese carries several times the content of 80 characters of English, so Chinese previews ran to two lines while English ones sat at one.

`toSystemPromptPreview` now counts words with `Intl.Segmenter` and cuts at 8 of them, which lands on comparable content in either language:

| | before (80 chars) | after (8 words) |
| --- | --- | --- |
| Chinese | `你是一个面向语言学习者的词典助手。 ## 目标 根据给定的词语及其周围段落，生成简洁的词典条目，匹…` | `你是一个面向语言学习者的词典…` |
| English | `You are a dictionary assistant for language learners. ## Goal Based on the g…` | `You are a dictionary assistant for language learners…` |

Two details worth flagging for review:

- A 160-character backstop still applies. It covers text the segmenter finds no word breaks in (a long URL, a hash), and it is the whole budget on Firefox below 125, which has no `Intl.Segmenter` — the manifest's `strict_min_version` is still 112, and the only other use of `Intl.Segmenter` in the codebase sits behind `minWordsPerNode > 0`, which defaults to 0. Without the guard this would be a new crash surface on those versions.
- Trailing separators are stripped at the cut, so the ellipsis does not follow a stray comma or a `##` heading mark.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #2028

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

- `pnpm lint` (oxlint with `--type-aware --type-check`) passes with exit code 0.
- `pnpm test` passes: 257 test files, 2441 tests, all green.
- Three tests added to `system-prompt-preview.test.ts`: the word budget itself, a Chinese prompt getting the same word count rather than the same length, and the character backstop on text with no word breaks.
- The word budget was checked against the real built-in dictionary prompt in both `zh-CN` and `en`, which is where the table above comes from.
- No test asserted on the previous `max-w-4xl` class, so the container change needed no test updates.

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Both budgets are single constants at the top of their files, so they are cheap to retune: `max-w-6xl` (1152px) is the next step up for the container, and `SYSTEM_PROMPT_PREVIEW_WORDS` sets the preview length.
