### PR TITLE
fix(translate): correct X tweet formatting — note-tweet paragraph interleaving + Google line-break preservation

### DIFF
--- a/.changeset/x-tweet-line-structure.md
+++ b/.changeset/x-tweet-line-structure.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): correct X tweet formatting — interleave long note-tweet paragraphs with their translations, and preserve line breaks and list dashes through Google Translate

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -470,7 +470,6 @@ export function setUpWebPageTranslationQueue(): void {
         hash,
         textFormat,
         preserveLineBreaks,
-        detectedSourceCode,
         webTitle,
         webDescription,
         webContent,
@@ -566,7 +565,6 @@ export function setUpWebPageTranslationQueue(): void {
         executeTranslate(text, langConfig, providerConfig, getTranslatePrompt, {
           textFormat,
           preserveLineBreaks,
-          detectedSourceCode,
           signal,
         })
       result = await requestQueue.enqueue(thunk, scheduleAt, hash, scope ? [scope] : undefined)

--- a/src/entrypoints/background/translation-queues.ts
+++ b/src/entrypoints/background/translation-queues.ts
@@ -469,6 +469,8 @@ export function setUpWebPageTranslationQueue(): void {
         scheduleAt,
         hash,
         textFormat,
+        preserveLineBreaks,
+        detectedSourceCode,
         webTitle,
         webDescription,
         webContent,
@@ -563,6 +565,8 @@ export function setUpWebPageTranslationQueue(): void {
       const thunk = (signal?: AbortSignal) =>
         executeTranslate(text, langConfig, providerConfig, getTranslatePrompt, {
           textFormat,
+          preserveLineBreaks,
+          detectedSourceCode,
           signal,
         })
       result = await requestQueue.enqueue(thunk, scheduleAt, hash, scope ? [scope] : undefined)

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -44,6 +44,7 @@ import {
   wasCharacterDataChangeExtensionDriven,
   wasNodeRemovedByExtension,
 } from "@/utils/host/translate/core/translation-state"
+import { canSplitParagraphIntoDescendants } from "@/utils/host/translate/dom/paragraph-segmentation"
 import {
   removeAllTranslatedWrapperNodes,
   translateNodes,
@@ -677,6 +678,9 @@ export class PageTranslationManager implements IPageTranslationManager {
    * <em>s) are not covered by any observed unit and stay untranslated. Stray
    * standalone inlines in a >3-viewport flat container are rare, and
    * numeric-only text is skipped by the pipeline anyway.
+   *
+   * Exception: a newline-preserving flow container is never split into
+   * inline descendants — see canSplitParagraphIntoDescendants.
    */
   private observeParagraphUnit(element: HTMLElement, walkId: string, depth: number): void {
     const observer = this.intersectionObserver
@@ -704,6 +708,15 @@ export class PageTranslationManager implements IPageTranslationManager {
     )
     if (innerTopLevelParagraphs.length === 0) {
       // Unsplittable giant (no nested paragraphs) — observe it whole.
+      observer.observe(element)
+      return
+    }
+    if (!canSplitParagraphIntoDescendants(element, innerTopLevelParagraphs)) {
+      // A newline-preserving flow (X note tweet: pre-wrap div of inline
+      // rich-text <span> paragraphs) must not be split — per-span observation
+      // translates each span as one blob at the span's end instead of
+      // interleaving per blank-line paragraph. Observed whole, the div-level
+      // virtual-paragraph plan segments it correctly.
       observer.observe(element)
       return
     }

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -713,10 +713,11 @@ export class PageTranslationManager implements IPageTranslationManager {
     }
     if (!canSplitParagraphIntoDescendants(element, innerTopLevelParagraphs)) {
       // A newline-preserving flow (X note tweet: pre-wrap div of inline
-      // rich-text <span> paragraphs) must not be split — per-span observation
-      // translates each span as one blob at the span's end instead of
-      // interleaving per blank-line paragraph. Observed whole, the div-level
-      // virtual-paragraph plan segments it correctly.
+      // rich-text <span> paragraphs,
+      // https://x.com/davidjpark96/status/1789773192435060737) must not be
+      // split — per-span observation translates each span as one blob at the
+      // span's end instead of interleaving per blank-line paragraph. Observed
+      // whole, the div-level virtual-paragraph plan segments it correctly.
       observer.observe(element)
       return
     }

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -650,7 +650,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       container.hasAttribute("data-read-frog-paragraph") &&
       container.getAttribute("data-read-frog-walked") === walkId
     ) {
-      this.observeParagraphUnit(container, walkId, 0)
+      this.observeParagraphUnit(container, walkId, config, 0)
       return
     }
 
@@ -662,7 +662,7 @@ export class PageTranslationManager implements IPageTranslationManager {
       //  • the ancestor is *not* inside container
       return !ancestor || !container.contains(ancestor)
     })
-    topLevelParagraphs.forEach((el) => this.observeParagraphUnit(el, walkId, 0))
+    topLevelParagraphs.forEach((el) => this.observeParagraphUnit(el, walkId, config, 0))
   }
 
   /**
@@ -682,7 +682,12 @@ export class PageTranslationManager implements IPageTranslationManager {
    * Exception: a newline-preserving flow container is never split into
    * inline descendants — see canSplitParagraphIntoDescendants.
    */
-  private observeParagraphUnit(element: HTMLElement, walkId: string, depth: number): void {
+  private observeParagraphUnit(
+    element: HTMLElement,
+    walkId: string,
+    config: Config,
+    depth: number,
+  ): void {
     const observer = this.intersectionObserver
     if (!observer) return
 
@@ -711,18 +716,24 @@ export class PageTranslationManager implements IPageTranslationManager {
       observer.observe(element)
       return
     }
-    if (!canSplitParagraphIntoDescendants(element, innerTopLevelParagraphs)) {
+    if (
+      config.translate.mode === "bilingual" &&
+      !canSplitParagraphIntoDescendants(element, innerTopLevelParagraphs)
+    ) {
       // A newline-preserving flow (X note tweet: pre-wrap div of inline
       // rich-text <span> paragraphs,
       // https://x.com/davidjpark96/status/1789773192435060737) must not be
       // split — per-span observation translates each span as one blob at the
       // span's end instead of interleaving per blank-line paragraph. Observed
       // whole, the div-level virtual-paragraph plan segments it correctly.
+      // Bilingual only: translationOnly has no virtual-paragraph plan, swaps
+      // text in place (no blob-at-span-end problem), and would lose viewport
+      // gating plus batch one giant request if observed whole.
       observer.observe(element)
       return
     }
     for (const paragraph of innerTopLevelParagraphs) {
-      this.observeParagraphUnit(paragraph, walkId, depth + 1)
+      this.observeParagraphUnit(paragraph, walkId, config, depth + 1)
     }
   }
 

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -718,7 +718,7 @@ export class PageTranslationManager implements IPageTranslationManager {
     }
     if (
       config.translate.mode === "bilingual" &&
-      !canSplitParagraphIntoDescendants(element, innerTopLevelParagraphs)
+      !canSplitParagraphIntoDescendants(element, innerTopLevelParagraphs, config)
     ) {
       // A newline-preserving flow (X note tweet: pre-wrap div of inline
       // rich-text <span> paragraphs,

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -623,7 +623,12 @@ describe("translate", () => {
           await removeOrShowPageTranslation("bilingual", true)
 
           expect(translateTextForPage).toHaveBeenCalledTimes(1)
-          expect(translateTextForPage).toHaveBeenCalledWith(sourceText, "plain")
+          expect(translateTextForPage).toHaveBeenCalledWith(
+            sourceText,
+            "plain",
+            undefined,
+            expect.any(Object),
+          )
           const wrapper = expectTranslationWrapper(deepestSpan, "bilingual")
           expect(wrapper).toBe(deepestSpan.lastChild)
           expectTranslatedContent(wrapper, BLOCK_CONTENT_CLASS)
@@ -656,7 +661,12 @@ describe("translate", () => {
           await removeOrShowPageTranslation("bilingual", true)
 
           expect(translateTextForPage).toHaveBeenCalledTimes(1)
-          expect(translateTextForPage).toHaveBeenCalledWith(sourceText, "plain")
+          expect(translateTextForPage).toHaveBeenCalledWith(
+            sourceText,
+            "plain",
+            undefined,
+            expect.any(Object),
+          )
           const [wrapper] = expectBlockTranslations(tweet, [translatedText])
           expect(sourceSpan.querySelector(`.${CONTENT_WRAPPER_CLASS}`)).toBeFalsy()
           expect([...tweet.children]).toEqual([sourceSpan, ...emojiImages, wrapper])
@@ -748,7 +758,13 @@ describe("translate", () => {
 
           expect(translateTextForPage).toHaveBeenCalledTimes(2)
           paragraphs.forEach((paragraph, index) => {
-            expect(translateTextForPage).toHaveBeenNthCalledWith(index + 1, paragraph, "plain")
+            expect(translateTextForPage).toHaveBeenNthCalledWith(
+              index + 1,
+              paragraph,
+              "plain",
+              undefined,
+              expect.any(Object),
+            )
           })
           const wrappers = expectBlockTranslations(tweet, translations)
           expect(wrappers[0]!.previousSibling).toBe(emojiImages[1])
@@ -844,9 +860,27 @@ describe("translate", () => {
           })
 
           expect(translateTextForPage).toHaveBeenCalledTimes(3)
-          expect(translateTextForPage).toHaveBeenNthCalledWith(1, truncatedRequestText, "plain")
-          expect(translateTextForPage).toHaveBeenNthCalledWith(2, expandedFirstParagraph, "plain")
-          expect(translateTextForPage).toHaveBeenNthCalledWith(3, hashtagParagraph, "plain")
+          expect(translateTextForPage).toHaveBeenNthCalledWith(
+            1,
+            truncatedRequestText,
+            "plain",
+            undefined,
+            expect.any(Object),
+          )
+          expect(translateTextForPage).toHaveBeenNthCalledWith(
+            2,
+            expandedFirstParagraph,
+            "plain",
+            undefined,
+            expect.any(Object),
+          )
+          expect(translateTextForPage).toHaveBeenNthCalledWith(
+            3,
+            hashtagParagraph,
+            "plain",
+            undefined,
+            expect.any(Object),
+          )
           expectBlockTranslations(tweet, [translations.expanded, translations.hashtags])
           expect(tweet).not.toHaveTextContent(translations.truncated)
           expectTextInDocumentOrder(tweet, [
@@ -958,8 +992,20 @@ describe("translate", () => {
           resolveFirst(translations[0]!)
           await translationPromise
 
-          expect(translateTextForPage).toHaveBeenNthCalledWith(1, paragraphs[0], "plain")
-          expect(translateTextForPage).toHaveBeenNthCalledWith(2, paragraphs[1], "plain")
+          expect(translateTextForPage).toHaveBeenNthCalledWith(
+            1,
+            paragraphs[0],
+            "plain",
+            undefined,
+            expect.any(Object),
+          )
+          expect(translateTextForPage).toHaveBeenNthCalledWith(
+            2,
+            paragraphs[1],
+            "plain",
+            undefined,
+            expect.any(Object),
+          )
           expectBlockTranslations(tweet, translations)
           expectTextInDocumentOrder(tweet, [
             paragraphs[0]!,
@@ -1173,7 +1219,13 @@ describe("translate", () => {
 
           expect(translateTextForPage).toHaveBeenCalledTimes(5)
           paragraphs.forEach((paragraph, index) => {
-            expect(translateTextForPage).toHaveBeenNthCalledWith(index + 1, paragraph, "plain")
+            expect(translateTextForPage).toHaveBeenNthCalledWith(
+              index + 1,
+              paragraph,
+              "plain",
+              undefined,
+              expect.any(Object),
+            )
           })
           expectBlockTranslations(tweet, translations)
           expectTextInDocumentOrder(
@@ -1231,7 +1283,13 @@ describe("translate", () => {
 
           expect(translateTextForPage).toHaveBeenCalledTimes(3)
           paragraphs.forEach((paragraph, index) => {
-            expect(translateTextForPage).toHaveBeenNthCalledWith(index + 1, paragraph, "plain")
+            expect(translateTextForPage).toHaveBeenNthCalledWith(
+              index + 1,
+              paragraph,
+              "plain",
+              undefined,
+              expect.any(Object),
+            )
           })
           expectBlockTranslations(tweet, translations)
           expectTextInDocumentOrder(
@@ -1262,7 +1320,12 @@ describe("translate", () => {
             await removeOrShowPageTranslation("bilingual", true)
 
             expect(translateTextForPage).toHaveBeenCalledTimes(1)
-            expect(translateTextForPage).toHaveBeenCalledWith(sourceText, "plain")
+            expect(translateTextForPage).toHaveBeenCalledWith(
+              sourceText,
+              "plain",
+              undefined,
+              expect.any(Object),
+            )
             expectBlockTranslations(tweet, ["【整段译文】"])
           })
         },
@@ -1282,7 +1345,12 @@ describe("translate", () => {
           await removeOrShowPageTranslation("bilingual", true)
 
           expect(translateTextForPage).toHaveBeenCalledTimes(1)
-          expect(translateTextForPage).toHaveBeenCalledWith(sourceText, "plain")
+          expect(translateTextForPage).toHaveBeenCalledWith(
+            sourceText,
+            "plain",
+            undefined,
+            expect.any(Object),
+          )
           expectBlockTranslations(tweet, ["【标签整段译文】"])
         })
       })
@@ -1303,7 +1371,12 @@ describe("translate", () => {
           await removeOrShowPageTranslation("bilingual", true)
 
           expect(translateTextForPage).toHaveBeenCalledTimes(1)
-          expect(translateTextForPage).toHaveBeenCalledWith("Translate this paragraph.", "plain")
+          expect(translateTextForPage).toHaveBeenCalledWith(
+            "Translate this paragraph.",
+            "plain",
+            undefined,
+            expect.any(Object),
+          )
           expectBlockTranslations(tweet, ["【唯一译文】"])
           expectTextInDocumentOrder(tweet, [
             "Translate this paragraph.",
@@ -1395,8 +1468,18 @@ describe("translate", () => {
         await removeOrShowPageTranslation("bilingual", true)
 
         expect(translateTextForPage).toHaveBeenCalledTimes(2)
-        expect(translateTextForPage).toHaveBeenCalledWith(nestedText, "plain")
-        expect(translateTextForPage).toHaveBeenCalledWith(mixedText, "plain")
+        expect(translateTextForPage).toHaveBeenCalledWith(
+          nestedText,
+          "plain",
+          undefined,
+          expect.any(Object),
+        )
+        expect(translateTextForPage).toHaveBeenCalledWith(
+          mixedText,
+          "plain",
+          undefined,
+          expect.any(Object),
+        )
 
         const nestedWrapper = expectTranslationWrapper(deepestSpan, "bilingual")
         expect(nestedWrapper).toBe(deepestSpan.lastChild)
@@ -2826,6 +2909,8 @@ describe("translate", () => {
           expect(translateTextForPage).toHaveBeenCalledWith(
             "perf(main): drop localhost label routes when a worktree is removed by @taiiiyang in #7557",
             "plain",
+            undefined,
+            expect.any(Object),
           )
           expect(document.querySelector(".user-mention")!.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(
             false,
@@ -2875,6 +2960,8 @@ describe("translate", () => {
           expect(translateTextForPage).toHaveBeenCalledWith(
             "#1837 feat(translate): return a NO_TRANSLATION_NEEDED sentinel",
             "plain",
+            undefined,
+            expect.any(Object),
           )
           // Preserved as source text, not promoted to its own paragraph/walked node.
           const prLink = document.querySelector("a[data-hovercard-type='pull_request']")!
@@ -3614,6 +3701,8 @@ describe("translate", () => {
         expect(translateTextForPage).toHaveBeenCalledWith(
           `${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`,
           "plain",
+          undefined,
+          expect.any(Object),
         )
       })
     })
@@ -3632,6 +3721,8 @@ describe("translate", () => {
         expect(translateTextForPage).toHaveBeenCalledWith(
           `${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`,
           "plain",
+          undefined,
+          expect.any(Object),
         )
       })
     })
@@ -3644,7 +3735,12 @@ describe("translate", () => {
         render(<div data-testid="test-node">{`\n${MOCK_ORIGINAL_TEXT} \n`}</div>)
         await removeOrShowPageTranslation("bilingual", true)
 
-        expect(translateTextForPage).toHaveBeenCalledWith(MOCK_ORIGINAL_TEXT, "plain")
+        expect(translateTextForPage).toHaveBeenCalledWith(
+          MOCK_ORIGINAL_TEXT,
+          "plain",
+          undefined,
+          expect.any(Object),
+        )
       })
 
       it("bilingual mode: space leading/trailing is trimmed before translation", async () => {
@@ -3654,7 +3750,12 @@ describe("translate", () => {
         await removeOrShowPageTranslation("bilingual", true)
 
         // Final text is trimmed before translation
-        expect(translateTextForPage).toHaveBeenCalledWith(MOCK_ORIGINAL_TEXT, "plain")
+        expect(translateTextForPage).toHaveBeenCalledWith(
+          MOCK_ORIGINAL_TEXT,
+          "plain",
+          undefined,
+          expect.any(Object),
+        )
       })
     })
 
@@ -3674,6 +3775,8 @@ describe("translate", () => {
         expect(translateTextForPage).toHaveBeenCalledWith(
           `${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`,
           "plain",
+          undefined,
+          expect.any(Object),
         )
       })
 
@@ -3690,6 +3793,8 @@ describe("translate", () => {
         expect(translateTextForPage).toHaveBeenCalledWith(
           `${MOCK_ORIGINAL_TEXT} ${MOCK_ORIGINAL_TEXT}`,
           "plain",
+          undefined,
+          expect.any(Object),
         )
       })
     })
@@ -3708,8 +3813,20 @@ describe("translate", () => {
 
         // BR elements are handled as paragraph separators, each paragraph translated separately
         expect(translateTextForPage).toHaveBeenCalledTimes(2)
-        expect(translateTextForPage).toHaveBeenNthCalledWith(1, MOCK_ORIGINAL_TEXT, "plain")
-        expect(translateTextForPage).toHaveBeenNthCalledWith(2, MOCK_ORIGINAL_TEXT, "plain")
+        expect(translateTextForPage).toHaveBeenNthCalledWith(
+          1,
+          MOCK_ORIGINAL_TEXT,
+          "plain",
+          undefined,
+          expect.any(Object),
+        )
+        expect(translateTextForPage).toHaveBeenNthCalledWith(
+          2,
+          MOCK_ORIGINAL_TEXT,
+          "plain",
+          undefined,
+          expect.any(Object),
+        )
       })
 
       it("translationOnly mode: should handle BR elements as paragraph separators", async () => {

--- a/src/utils/host/translate/__tests__/filter-small-paragraph.test.ts
+++ b/src/utils/host/translate/__tests__/filter-small-paragraph.test.ts
@@ -120,9 +120,11 @@ describe.each(["bilingual", "translationOnly"] as const)("%s translation", (mode
     await translateNodes([textNode], "walk-id", false, createConfig({ mode }))
 
     expect(mocks.translateTextForPage).toHaveBeenCalledOnce()
-    expect(mocks.translateTextForPage).toHaveBeenCalledWith(
-      "Hello @openai",
-      mode === "translationOnly" ? "html" : "plain",
-    )
+    // Bilingual passes a trailing actionContext/options pair; the
+    // translationOnly html path calls with (text, format) only — assert on
+    // the leading args shared by both shapes.
+    const callArgs = mocks.translateTextForPage.mock.calls.at(-1)!
+    expect(callArgs[0]).toBe("Hello @openai")
+    expect(callArgs[1]).toBe(mode === "translationOnly" ? "html" : "plain")
   })
 })

--- a/src/utils/host/translate/__tests__/google-roundtrip.test.ts
+++ b/src/utils/host/translate/__tests__/google-roundtrip.test.ts
@@ -96,6 +96,7 @@ describe("google translate escape/decode round trip", () => {
   })
 
   it.each([
+    // Bullet shape from https://x.com/davidjpark96/status/1789773192435060737
     ["single newlines (bullet lists)", "- Organic\n- SEO\n- Paid Ads"],
     ["blank-line paragraphs", "First paragraph\n\nSecond paragraph"],
     ["CRLF line endings", "First\r\nSecond"],
@@ -104,6 +105,12 @@ describe("google translate escape/decode round trip", () => {
     ["numbered list lines", "1. Find a face\n2. Craft a series\n3. Multiply accounts"],
     ["negative numbers keep their sign", "-5°C outside\n-3 points"],
     ["tag-like text on its own line", "if x <b then stop\nsecond line"],
+    // Plain-line shape from https://x.com/EpsteinJeffrey0/status/2083709421386080579
+    // — a tweet of consecutive single-"\n" lines with no blank-line separators.
+    [
+      "plain single-newline tweet lines",
+      "The first statement stands alone\nThe second makes a related point\nWhy? Because this line asks a question",
+    ],
   ])("preserves %s with preserveLineBreaks", async (_name, text) => {
     const result = await executeTranslate(text, langConfig, googleProviderConfig, vi.fn(), {
       preserveLineBreaks: true,

--- a/src/utils/host/translate/__tests__/google-roundtrip.test.ts
+++ b/src/utils/host/translate/__tests__/google-roundtrip.test.ts
@@ -7,22 +7,32 @@ import { executeTranslate } from "../execute-translate"
 // input is parsed as HTML — an unescaped tag-open swallows the rest of the
 // string (live behavior for "<b then stop"), entities (including legacy
 // semicolon-less ones such as "&copy") are resolved, literal newlines collapse
-// as HTML whitespace, leading indentation collapses too, and the model strips
-// leading dash-family list bullets (worst case: from EVERY item) — then the
-// resulting plain text is re-serialized as escaped HTML. executeTranslate must
-// therefore return the original text byte-for-byte only when the request was
-// escaped and, for multi-line text, split into per-line items with indentation
-// and bullet prefixes extracted client-side.
+// as HTML whitespace, line-break marker tags survive as tags, and within each
+// marker-delimited segment leading indentation collapses and the model strips
+// a leading dash-family list bullet (worst case: from EVERY segment) — then
+// the resulting plain text is re-serialized as escaped HTML. executeTranslate
+// must therefore return the original text byte-for-byte only when the request
+// was escaped and, for multi-line text, marker-joined with indentation and
+// bullet prefixes captured client-side.
+const LINE_BREAK_MARKER = '<br data-read-frog-lb="1">'
+
 function simulateTranslateHtmlEndpoint(requestText: string): string {
-  const withoutBogusTag = requestText.replace(/<[a-z][\s\S]*$/i, "")
-  return (
-    escapeText(decodeHTML(withoutBogusTag))
-      // Newlines and leading indentation are HTML whitespace to the parser.
-      .replace(/[^\S\r\n]*[\r\n]\s*/g, " ")
-      .replace(/^[ \t]+/, "")
-      // The model eats leading list dashes (live-observed on x.com bullets).
-      .replace(/^[-–—•·▪◦‣⁃*][ \t]+/, "")
-  )
+  return requestText
+    .split(LINE_BREAK_MARKER)
+    .map((segment) => {
+      const withoutBogusTag = segment.replace(/<[a-z][\s\S]*$/i, "")
+      return (
+        escapeText(decodeHTML(withoutBogusTag))
+          // Newlines and leading indentation are HTML whitespace to the parser.
+          .replace(/[^\S\r\n]*[\r\n]\s*/g, " ")
+          .replace(/^[ \t]+/, "")
+          // The model eats leading list dashes (live-observed on x.com bullets;
+          // a bullet-only segment "- " comes back as a bare "-").
+          .replace(/^[-–—•·▪◦‣⁃*][ \t]+(?=[^ \t])/, "")
+          .replace(/^[-–—•·▪◦‣⁃*][ \t]+$/, "-")
+      )
+    })
+    .join(LINE_BREAK_MARKER)
 }
 
 const fetchMock = vi.fn<(...args: any[]) => any>()
@@ -46,21 +56,22 @@ describe("google translate escape/decode round trip", () => {
     fetchMock.mockReset()
     fetchMock.mockImplementation((_url: string, init: { body: string }) => {
       const requestTexts: string[] = JSON.parse(init.body)[0][0]
-      // The endpoint rejects empty batch items.
-      if (requestTexts.some((text) => text === "")) {
+      // The endpoint rejects empty batch items; the marker transport must
+      // always send exactly one non-empty item.
+      if (requestTexts.length !== 1 || requestTexts[0] === "") {
         return Promise.resolve({
           ok: false,
           status: 400,
           statusText: "Bad Request",
           json: async () => ({}),
-          text: async () => "empty batch item",
+          text: async () => "invalid batch",
         })
       }
       return Promise.resolve({
         ok: true,
         status: 200,
         statusText: "OK",
-        json: async () => [requestTexts.map((text) => simulateTranslateHtmlEndpoint(text))],
+        json: async () => [[simulateTranslateHtmlEndpoint(requestTexts[0]!)]],
         text: async () => "",
       })
     })
@@ -119,26 +130,31 @@ describe("google translate escape/decode round trip", () => {
     expect(result).toBe(text.replace(/\r\n?/g, "\n"))
   })
 
-  it("sends each non-empty line as its own item, bullet kept for context", async () => {
-    await executeTranslate("- alpha\n\n  • beta", langConfig, googleProviderConfig, vi.fn(), {
+  it("sends ONE marker-joined item so the endpoint detects the whole unit", async () => {
+    // Whole-unit transport is a correctness invariant: per-line items are
+    // language-detected independently and short lines misread ("- SEO" alone
+    // with sl=auto -> "- 这"). The source language must stay untouched.
+    await executeTranslate(
+      "- alpha\n\n  • beta",
+      { ...langConfig, sourceCode: "auto" as const },
+      googleProviderConfig,
+      vi.fn(),
+      { preserveLineBreaks: true },
+    )
+
+    const [payload] = JSON.parse(fetchMock.mock.calls.at(-1)![1].body)
+    expect(payload[0]).toEqual([
+      `- alpha${LINE_BREAK_MARKER}${LINE_BREAK_MARKER}${LINE_BREAK_MARKER}${LINE_BREAK_MARKER}• beta`,
+    ])
+    expect(payload[1]).toBe("auto")
+  })
+
+  it("keeps a bullet-only line without doubling its dash", async () => {
+    const result = await executeTranslate("- \nhello", langConfig, googleProviderConfig, vi.fn(), {
       preserveLineBreaks: true,
     })
 
-    const requestTexts = JSON.parse(fetchMock.mock.calls.at(-1)![1].body)[0][0]
-    expect(requestTexts).toEqual(["- alpha", "• beta"])
-  })
-
-  it("uses the page-level detected language instead of per-item auto", async () => {
-    await executeTranslate(
-      "- SEO\n- Paid Ads",
-      { ...langConfig, sourceCode: "auto" },
-      googleProviderConfig,
-      vi.fn(),
-      { preserveLineBreaks: true, detectedSourceCode: "eng" },
-    )
-
-    const sourceLang = JSON.parse(fetchMock.mock.calls.at(-1)![1].body)[0][1]
-    expect(sourceLang).toBe("en")
+    expect(result).toBe("- \nhello")
   })
 
   it("normalizes a model-restyled bullet back to the source prefix", async () => {

--- a/src/utils/host/translate/__tests__/google-roundtrip.test.ts
+++ b/src/utils/host/translate/__tests__/google-roundtrip.test.ts
@@ -5,13 +5,24 @@ import { executeTranslate } from "../execute-translate"
 // Integration coverage for the escape -> translateHtml -> decode pipeline. The
 // fetch stub emulates the endpoint's observed identity-translation behavior:
 // input is parsed as HTML — an unescaped tag-open swallows the rest of the
-// string (live behavior for "<b then stop") and entities (including legacy
-// semicolon-less ones such as "&copy") are resolved — then the resulting plain
-// text is re-serialized as escaped HTML. executeTranslate must therefore return
-// the original plain text byte-for-byte only when the request was escaped.
+// string (live behavior for "<b then stop"), entities (including legacy
+// semicolon-less ones such as "&copy") are resolved, literal newlines collapse
+// as HTML whitespace, leading indentation collapses too, and the model strips
+// leading dash-family list bullets (worst case: from EVERY item) — then the
+// resulting plain text is re-serialized as escaped HTML. executeTranslate must
+// therefore return the original text byte-for-byte only when the request was
+// escaped and, for multi-line text, split into per-line items with indentation
+// and bullet prefixes extracted client-side.
 function simulateTranslateHtmlEndpoint(requestText: string): string {
   const withoutBogusTag = requestText.replace(/<[a-z][\s\S]*$/i, "")
-  return escapeText(decodeHTML(withoutBogusTag))
+  return (
+    escapeText(decodeHTML(withoutBogusTag))
+      // Newlines and leading indentation are HTML whitespace to the parser.
+      .replace(/[^\S\r\n]*[\r\n]\s*/g, " ")
+      .replace(/^[ \t]+/, "")
+      // The model eats leading list dashes (live-observed on x.com bullets).
+      .replace(/^[-–—•·▪◦‣⁃*][ \t]+/, "")
+  )
 }
 
 const fetchMock = vi.fn<(...args: any[]) => any>()
@@ -34,12 +45,22 @@ describe("google translate escape/decode round trip", () => {
   beforeEach(() => {
     fetchMock.mockReset()
     fetchMock.mockImplementation((_url: string, init: { body: string }) => {
-      const requestText = JSON.parse(init.body)[0][0][0]
+      const requestTexts: string[] = JSON.parse(init.body)[0][0]
+      // The endpoint rejects empty batch items.
+      if (requestTexts.some((text) => text === "")) {
+        return Promise.resolve({
+          ok: false,
+          status: 400,
+          statusText: "Bad Request",
+          json: async () => ({}),
+          text: async () => "empty batch item",
+        })
+      }
       return Promise.resolve({
         ok: true,
         status: 200,
         statusText: "OK",
-        json: async () => [[simulateTranslateHtmlEndpoint(requestText)]],
+        json: async () => [requestTexts.map((text) => simulateTranslateHtmlEndpoint(text))],
         text: async () => "",
       })
     })
@@ -59,5 +80,72 @@ describe("google translate escape/decode round trip", () => {
     const result = await executeTranslate(text, langConfig, googleProviderConfig, vi.fn())
 
     expect(result).toBe(text)
+  })
+
+  it("collapses newlines without preserveLineBreaks (endpoint behavior)", async () => {
+    const result = await executeTranslate(
+      "- Organic\n- SEO\n- Paid Ads",
+      langConfig,
+      googleProviderConfig,
+      vi.fn(),
+    )
+
+    // The simulator also emulates the model eating the leading list dash —
+    // without the flag nothing protects it. The point here: lines collapse.
+    expect(result).toBe("Organic - SEO - Paid Ads")
+  })
+
+  it.each([
+    ["single newlines (bullet lists)", "- Organic\n- SEO\n- Paid Ads"],
+    ["blank-line paragraphs", "First paragraph\n\nSecond paragraph"],
+    ["CRLF line endings", "First\r\nSecond"],
+    ["mixed blank lines and single breaks", "Title\n\n- a\n- b\n\nOutro"],
+    ["unicode bullets and indentation", "• first\n  – second level\nplain"],
+    ["numbered list lines", "1. Find a face\n2. Craft a series\n3. Multiply accounts"],
+    ["negative numbers keep their sign", "-5°C outside\n-3 points"],
+    ["tag-like text on its own line", "if x <b then stop\nsecond line"],
+  ])("preserves %s with preserveLineBreaks", async (_name, text) => {
+    const result = await executeTranslate(text, langConfig, googleProviderConfig, vi.fn(), {
+      preserveLineBreaks: true,
+    })
+
+    expect(result).toBe(text.replace(/\r\n?/g, "\n"))
+  })
+
+  it("sends each non-empty line as its own item, bullet kept for context", async () => {
+    await executeTranslate("- alpha\n\n  • beta", langConfig, googleProviderConfig, vi.fn(), {
+      preserveLineBreaks: true,
+    })
+
+    const requestTexts = JSON.parse(fetchMock.mock.calls.at(-1)![1].body)[0][0]
+    expect(requestTexts).toEqual(["- alpha", "• beta"])
+  })
+
+  it("uses the page-level detected language instead of per-item auto", async () => {
+    await executeTranslate(
+      "- SEO\n- Paid Ads",
+      { ...langConfig, sourceCode: "auto" },
+      googleProviderConfig,
+      vi.fn(),
+      { preserveLineBreaks: true, detectedSourceCode: "eng" },
+    )
+
+    const sourceLang = JSON.parse(fetchMock.mock.calls.at(-1)![1].body)[0][1]
+    expect(sourceLang).toBe("en")
+  })
+
+  it("normalizes a model-restyled bullet back to the source prefix", async () => {
+    // The simulator eats the bullet; reassembly must restore the source's own.
+    const result = await executeTranslate(
+      "• kept bullet\n- kept dash",
+      langConfig,
+      googleProviderConfig,
+      vi.fn(),
+      {
+        preserveLineBreaks: true,
+      },
+    )
+
+    expect(result).toBe("• kept bullet\n- kept dash")
   })
 })

--- a/src/utils/host/translate/api/google.ts
+++ b/src/utils/host/translate/api/google.ts
@@ -41,8 +41,14 @@ export async function isGoogleTranslateReachable(options?: {
 
 // The endpoint treats literal newlines as collapsible HTML whitespace, so
 // multi-line plain text loses its line structure — no escape survives
-// ("&#10;" collapses too). Three further live-verified behaviors shape the
-// preserveLineBreaks strategy:
+// ("&#10;" collapses too). Reported on X tweets rendered under
+// white-space: pre-wrap, where "\n" is the only line structure:
+//   https://x.com/davidjpark96/status/1789773192435060737 (bullet lists
+//   squashed onto one line) and
+//   https://x.com/EpsteinJeffrey0/status/2083709421386080579 (five
+//   single-"\n" lines merged into one run-on translation).
+// Three further live-verified behaviors shape the preserveLineBreaks
+// strategy:
 //   - the endpoint natively accepts multiple texts per request
 //     ([[[t1, t2, …], sl, tl], client]) and returns them in order;
 //   - the model strips leading dash-family list bullets from translated

--- a/src/utils/host/translate/api/google.ts
+++ b/src/utils/host/translate/api/google.ts
@@ -39,35 +39,104 @@ export async function isGoogleTranslateReachable(options?: {
   }
 }
 
+// The endpoint treats literal newlines as collapsible HTML whitespace, so
+// multi-line plain text loses its line structure — no escape survives
+// ("&#10;" collapses too). Three further live-verified behaviors shape the
+// preserveLineBreaks strategy:
+//   - the endpoint natively accepts multiple texts per request
+//     ([[[t1, t2, …], sl, tl], client]) and returns them in order;
+//   - the model strips leading dash-family list bullets from translated
+//     lines (even when each line is its own batch item);
+//   - leading indentation collapses like any HTML whitespace.
+// So when the caller signals semantic line breaks, each line becomes its own
+// batch item, and per-line indentation plus bullet prefix are extracted
+// before the request and reattached verbatim afterwards. The gating matters:
+// only the content layer knows whether the source's white-space CSS (or an
+// input box) makes newlines meaningful — ordinary pages wrap sentences
+// across pretty-printed source lines and RELY on the collapsing (a forced
+// per-line split would translate sentence fragments separately).
+const LINE_SPLIT_REGEX = /\r\n?|\n/
+const LINE_INDENT_REGEX = /^[ \t]*/
+// A dash-family bullet must be followed by horizontal whitespace so negative
+// numbers ("-5°C") and emphasis ("*bold*") never count as list markers.
+const LINE_BULLET_REGEX = /^[-–—•·▪◦‣⁃*][ \t]+/
+// Output-side normalization: whatever bullet/indentation the model emitted is
+// replaced by the source line's own prefix, so the prefix survives verbatim
+// whether the model kept, dropped, or restyled it.
+const TRANSLATED_LINE_PREFIX_REGEX = /^[ \t]*(?:[-–—•·▪◦‣⁃*][ \t]+)?[ \t]*/
+
+export interface PreservedLine {
+  /** Indentation + bullet exactly as written; reattached verbatim. */
+  prefix: string
+  /**
+   * The line minus indentation, bullet INCLUDED: an isolated bare token
+   * translates measurably worse (live-observed: item "SEO" → "这", while
+   * "- SEO" → "搜索引擎优化"), so the bullet stays in the request for
+   * context and is normalized away from the response instead.
+   */
+  content: string
+}
+
+export function splitPreservedLines(text: string): PreservedLine[] {
+  return text.split(LINE_SPLIT_REGEX).map((line) => {
+    const indent = LINE_INDENT_REGEX.exec(line)?.[0] ?? ""
+    const rest = line.slice(indent.length)
+    const bullet = LINE_BULLET_REGEX.exec(rest)?.[0] ?? ""
+    return { content: rest, prefix: indent + bullet }
+  })
+}
+
+export function reassemblePreservedLine(line: PreservedLine, translation: string): string {
+  return line.prefix + translation.replace(TRANSLATED_LINE_PREFIX_REGEX, "")
+}
+
 export async function googleTranslate(
   sourceText: string,
   fromLang: string,
   toLang: string,
-  options?: { textFormat?: TranslationTextFormat; signal?: AbortSignal },
+  options?: {
+    textFormat?: TranslationTextFormat
+    /**
+     * Caller-owned signal that the source's line breaks are semantic (the
+     * source container preserves newlines, or the text is user-typed input).
+     * Plain format only — html payloads carry their own structure. Known gap:
+     * literal newlines inside html-format text nodes still collapse.
+     */
+    preserveLineBreaks?: boolean
+    signal?: AbortSignal
+  },
 ): Promise<string> {
   // translateHtml parses the request text as HTML, so plain source text must be
   // escaped (& < > nbsp) before sending, while html input (translationOnly page
   // mode) is sent as-is so the endpoint preserves its tags. The response stays
   // HTML-encoded and is decoded exactly once by normalizeTranslationOutput in
-  // executeTranslate.
-  //
-  // Known issue: the endpoint also treats newlines as collapsible HTML whitespace,
-  // so multi-line text loses its line structure (e.g. X tweet paragraphs separated
-  // by literal "\n\n" under white-space: pre-wrap in translationOnly mode, or
-  // multi-line input translation). No escape can protect "\n" ("&#10;" collapses
-  // too). A future fix must inject <br> markers before sending and restore them
-  // after (a lone <br> can be merged away by the sentence segmenter, a "\n\n" pair
-  // never is) — gated by a content-layer signal, because only the content script
-  // knows whether the container's white-space CSS makes newlines meaningful;
-  // ordinary pages rely on this collapsing for pretty-printed source newlines.
-  const requestText = options?.textFormat === "html" ? sourceText : escapeText(sourceText)
+  // executeTranslate — line reassembly happens before that and only ever
+  // concatenates response items with plain prefixes, so it cannot interfere.
+  const preserveLineBreaks = options?.preserveLineBreaks === true && options?.textFormat !== "html"
+  let preservedLines: PreservedLine[] | undefined
+  let requestTexts: string[]
+  if (options?.textFormat === "html") {
+    requestTexts = [sourceText]
+  } else if (!preserveLineBreaks) {
+    requestTexts = [escapeText(sourceText)]
+  } else {
+    preservedLines = splitPreservedLines(sourceText)
+    // The endpoint rejects empty batch items (400), so blank lines stay out
+    // of the request and are restored positionally during reassembly.
+    requestTexts = preservedLines
+      .filter((line) => line.content !== "")
+      .map((line) => escapeText(line.content))
+    if (requestTexts.length === 0) {
+      return sourceText
+    }
+  }
   const resp = await fetch(GOOGLE_TRANSLATE_HTML_URL, {
     method: "POST",
     headers: {
       "Content-Type": "application/json+protobuf",
       "X-Goog-API-Key": GOOGLE_TRANSLATE_HTML_API_KEY,
     },
-    body: JSON.stringify([[[requestText], fromLang, toLang], GOOGLE_TRANSLATE_HTML_CLIENT]),
+    body: JSON.stringify([[requestTexts, fromLang, toLang], GOOGLE_TRANSLATE_HTML_CLIENT]),
     signal: options?.signal,
   }).catch((error) => {
     throw attachRequestErrorMeta(new Error(`Network error during translation: ${error.message}`), {
@@ -94,11 +163,28 @@ export async function googleTranslate(
   try {
     const result = await resp.json()
 
-    if (!Array.isArray(result) || !Array.isArray(result[0]) || typeof result[0][0] !== "string") {
+    if (
+      !Array.isArray(result) ||
+      !Array.isArray(result[0]) ||
+      result[0].length !== requestTexts.length ||
+      !result[0].every((item: unknown) => typeof item === "string")
+    ) {
       throw new TypeError("Unexpected response format from translation API")
     }
+    const translations: string[] = result[0]
 
-    return result[0][0]
+    if (!preservedLines) {
+      return translations[0]!
+    }
+
+    let translationIndex = 0
+    return preservedLines
+      .map((line) =>
+        line.content === ""
+          ? line.prefix
+          : reassemblePreservedLine(line, translations[translationIndex++]!),
+      )
+      .join("\n")
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`Failed to parse translation response: ${message}`, { cause: error })

--- a/src/utils/host/translate/api/google.ts
+++ b/src/utils/host/translate/api/google.ts
@@ -47,20 +47,39 @@ export async function isGoogleTranslateReachable(options?: {
 //   squashed onto one line) and
 //   https://x.com/EpsteinJeffrey0/status/2083709421386080579 (five
 //   single-"\n" lines merged into one run-on translation).
-// Three further live-verified behaviors shape the preserveLineBreaks
-// strategy:
-//   - the endpoint natively accepts multiple texts per request
-//     ([[[t1, t2, …], sl, tl], client]) and returns them in order;
+// Live-verified behaviors that shape the preserveLineBreaks strategy:
+//   - <br> marker tags survive translation; a lone <br> can be merged away
+//     by the sentence segmenter, but a marker PAIR never is, and the data
+//     attribute keeps decoding unambiguous (escaped source text mentioning
+//     "<br>" travels as entities and can never collide);
 //   - the model strips leading dash-family list bullets from translated
-//     lines (even when each line is its own batch item);
-//   - leading indentation collapses like any HTML whitespace.
-// So when the caller signals semantic line breaks, each line becomes its own
-// batch item, and per-line indentation plus bullet prefix are extracted
-// before the request and reattached verbatim afterwards. The gating matters:
-// only the content layer knows whether the source's white-space CSS (or an
-// input box) makes newlines meaningful — ordinary pages wrap sentences
-// across pretty-printed source lines and RELY on the collapsing (a forced
-// per-line split would translate sentence fragments separately).
+//     lines, and leading indentation collapses like any HTML whitespace —
+//     both are restored client-side from the source lines;
+//   - CRITICALLY, the text must stay ONE request item: the endpoint
+//     language-detects each item independently, and a short line misreads
+//     ("- SEO" alone with sl=auto → "- 这"), while inside the whole unit the
+//     same line translates correctly. Whole-unit transport keeps sl=auto
+//     working on mixed-language pages with zero language forcing.
+// The gating matters: only the content layer knows whether the source's
+// white-space CSS (or an input box) makes newlines meaningful — ordinary
+// pages wrap sentences across pretty-printed source lines and RELY on the
+// collapsing.
+const GOOGLE_LINE_BREAK_MARKER = '<br data-read-frog-lb="1">'
+const GOOGLE_LINE_BREAK_MARKER_PAIR = GOOGLE_LINE_BREAK_MARKER.repeat(2)
+// Tolerates self-closing serialization and translation-inserted horizontal
+// whitespace around markers (the sentence joiner adds spaces; they are
+// artifacts, not content, so they fold into the restored line boundary).
+const GOOGLE_LINE_BREAK_MARKER_UNIT = String.raw`<br data-read-frog-lb="1"\s*/?>`
+const GOOGLE_LINE_BREAK_MARKER_PAIR_PATTERN = String.raw`[^\S\r\n]*(?:${GOOGLE_LINE_BREAK_MARKER_UNIT}[^\S\r\n]*){2}`
+const GOOGLE_LINE_BREAK_MARKER_PAIR_SPLIT_REGEX = new RegExp(GOOGLE_LINE_BREAK_MARKER_PAIR_PATTERN)
+const GOOGLE_LINE_BREAK_MARKER_PAIR_GLOBAL_REGEX = new RegExp(
+  GOOGLE_LINE_BREAK_MARKER_PAIR_PATTERN,
+  "g",
+)
+const GOOGLE_LINE_BREAK_MARKER_SINGLE_REGEX = new RegExp(
+  String.raw`[^\S\r\n]*${GOOGLE_LINE_BREAK_MARKER_UNIT}[^\S\r\n]*`,
+  "g",
+)
 const LINE_SPLIT_REGEX = /\r\n?|\n/
 const LINE_INDENT_REGEX = /^[ \t]*/
 // A dash-family bullet must be followed by horizontal whitespace so negative
@@ -68,17 +87,18 @@ const LINE_INDENT_REGEX = /^[ \t]*/
 const LINE_BULLET_REGEX = /^[-–—•·▪◦‣⁃*][ \t]+/
 // Output-side normalization: whatever bullet/indentation the model emitted is
 // replaced by the source line's own prefix, so the prefix survives verbatim
-// whether the model kept, dropped, or restyled it.
-const TRANSLATED_LINE_PREFIX_REGEX = /^[ \t]*(?:[-–—•·▪◦‣⁃*][ \t]+)?[ \t]*/
+// whether the model kept, dropped, or restyled it. End-of-string counts as a
+// bullet terminator so a bullet-only line ("- " → model returns "-") is
+// normalized instead of doubling its dash.
+const TRANSLATED_LINE_PREFIX_REGEX = /^[ \t]*(?:[-–—•·▪◦‣⁃*](?:[ \t]+|$))?[ \t]*/
 
 export interface PreservedLine {
   /** Indentation + bullet exactly as written; reattached verbatim. */
   prefix: string
   /**
-   * The line minus indentation, bullet INCLUDED: an isolated bare token
-   * translates measurably worse (live-observed: item "SEO" → "这", while
-   * "- SEO" → "搜索引擎优化"), so the bullet stays in the request for
-   * context and is normalized away from the response instead.
+   * The line minus indentation, bullet INCLUDED: the bullet stays in the
+   * request for context and is normalized away from the response instead
+   * (the model may keep, drop, or restyle it).
    */
   content: string
 }
@@ -120,21 +140,19 @@ export async function googleTranslate(
   // concatenates response items with plain prefixes, so it cannot interfere.
   const preserveLineBreaks = options?.preserveLineBreaks === true && options?.textFormat !== "html"
   let preservedLines: PreservedLine[] | undefined
-  let requestTexts: string[]
+  let requestText: string
   if (options?.textFormat === "html") {
-    requestTexts = [sourceText]
+    requestText = sourceText
   } else if (!preserveLineBreaks) {
-    requestTexts = [escapeText(sourceText)]
+    requestText = escapeText(sourceText)
   } else {
+    // ONE item joined by marker pairs — never per-line items, so the
+    // endpoint detects the language of the whole unit (see notes above).
+    // Blank lines become adjacent pairs and survive verbatim.
     preservedLines = splitPreservedLines(sourceText)
-    // The endpoint rejects empty batch items (400), so blank lines stay out
-    // of the request and are restored positionally during reassembly.
-    requestTexts = preservedLines
-      .filter((line) => line.content !== "")
+    requestText = preservedLines
       .map((line) => escapeText(line.content))
-    if (requestTexts.length === 0) {
-      return sourceText
-    }
+      .join(GOOGLE_LINE_BREAK_MARKER_PAIR)
   }
   const resp = await fetch(GOOGLE_TRANSLATE_HTML_URL, {
     method: "POST",
@@ -142,7 +160,7 @@ export async function googleTranslate(
       "Content-Type": "application/json+protobuf",
       "X-Goog-API-Key": GOOGLE_TRANSLATE_HTML_API_KEY,
     },
-    body: JSON.stringify([[requestTexts, fromLang, toLang], GOOGLE_TRANSLATE_HTML_CLIENT]),
+    body: JSON.stringify([[[requestText], fromLang, toLang], GOOGLE_TRANSLATE_HTML_CLIENT]),
     signal: options?.signal,
   }).catch((error) => {
     throw attachRequestErrorMeta(new Error(`Network error during translation: ${error.message}`), {
@@ -169,28 +187,37 @@ export async function googleTranslate(
   try {
     const result = await resp.json()
 
-    if (
-      !Array.isArray(result) ||
-      !Array.isArray(result[0]) ||
-      result[0].length !== requestTexts.length ||
-      !result[0].every((item: unknown) => typeof item === "string")
-    ) {
+    if (!Array.isArray(result) || !Array.isArray(result[0]) || typeof result[0][0] !== "string") {
       throw new TypeError("Unexpected response format from translation API")
     }
-    const translations: string[] = result[0]
+    const translatedText: string = result[0][0]
 
     if (!preservedLines) {
-      return translations[0]!
+      return translatedText
     }
 
-    let translationIndex = 0
-    return preservedLines
-      .map((line) =>
-        line.content === ""
-          ? line.prefix
-          : reassemblePreservedLine(line, translations[translationIndex++]!),
-      )
-      .join("\n")
+    const segments = translatedText.split(GOOGLE_LINE_BREAK_MARKER_PAIR_SPLIT_REGEX)
+    if (segments.length === preservedLines.length) {
+      return preservedLines
+        .map((line, index) =>
+          line.content === ""
+            ? line.prefix
+            : reassemblePreservedLine(
+                line,
+                // A stray unpaired marker inside a segment must never leak
+                // markup into the rendered translation.
+                segments[index]!.replace(GOOGLE_LINE_BREAK_MARKER_SINGLE_REGEX, " "),
+              ),
+        )
+        .join("\n")
+    }
+
+    // Segment drift (a pair merged or duplicated by the model — never seen in
+    // sampling, but the failure must degrade gracefully): keep the line
+    // structure by folding markers into newlines and skip prefix restoration.
+    return translatedText
+      .replace(GOOGLE_LINE_BREAK_MARKER_PAIR_GLOBAL_REGEX, "\n")
+      .replace(GOOGLE_LINE_BREAK_MARKER_SINGLE_REGEX, "\n")
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     throw new Error(`Failed to parse translation response: ${message}`, { cause: error })

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -27,6 +27,7 @@ import { getOwnerDocument } from "../../dom/node"
 import { extractTextContent } from "../../dom/traversal"
 import {
   buildVirtualParagraphPlan,
+  isNewlinePreservingElement,
   moveParagraphInsertionBoundaryAfterTrailingInlineImages,
   type VirtualParagraphUnit,
 } from "../dom/paragraph-segmentation"
@@ -218,7 +219,9 @@ async function translateVirtualParagraph(
     wrapper,
     isCurrent,
     "plain",
-    actionContext ? () => translateTextForPage(unit.text, "plain", actionContext) : undefined,
+    // Virtual units exist only inside newline-preserving containers, so their
+    // interior single newlines (bullet lists) are always semantic.
+    () => translateTextForPage(unit.text, "plain", actionContext, { preserveLineBreaks: true }),
   )
   if (!isCurrent()) {
     disposeVirtualParagraphGroup(group)
@@ -597,6 +600,17 @@ export async function translateNodesBilingualMode(
         ? isBilingualTranslationStateCurrent(bilingualState)
         : translatedWrapperNode.isConnected
 
+    // Newline-preserving containers render single "\n" as real line breaks
+    // (an X tweet whose lines have no blank-line separators is ONE unit here),
+    // so the provider must not collapse them. white-space inherits, so a text
+    // node's parent reports the effective value.
+    const layoutSourceElement = isHTMLElement(layoutSource)
+      ? layoutSource
+      : layoutSource.parentElement
+    const preserveLineBreaks = layoutSourceElement
+      ? isNewlinePreservingElement(layoutSourceElement)
+      : false
+
     const realTranslatedText = await getTranslatedTextAndRemoveSpinner(
       nodes,
       textContent,
@@ -604,7 +618,7 @@ export async function translateNodesBilingualMode(
       translatedWrapperNode,
       isCurrent,
       "plain",
-      actionContext ? () => translateTextForPage(textContent, "plain", actionContext) : undefined,
+      () => translateTextForPage(textContent, "plain", actionContext, { preserveLineBreaks }),
     )
 
     if (!isCurrent()) {

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -601,7 +601,9 @@ export async function translateNodesBilingualMode(
         : translatedWrapperNode.isConnected
 
     // Newline-preserving containers render single "\n" as real line breaks
-    // (an X tweet whose lines have no blank-line separators is ONE unit here),
+    // (an X tweet whose lines have no blank-line separators is ONE unit here,
+    // e.g. https://x.com/EpsteinJeffrey0/status/2083709421386080579 — five
+    // lines split by single "\n" that Google merged into one run-on line),
     // so the provider must not collapse them. white-space inherits, so a text
     // node's parent reports the effective value.
     const layoutSourceElement = isHTMLElement(layoutSource)

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -604,14 +604,15 @@ export async function translateNodesBilingualMode(
     // (an X tweet whose lines have no blank-line separators is ONE unit here,
     // e.g. https://x.com/EpsteinJeffrey0/status/2083709421386080579 — five
     // lines split by single "\n" that Google merged into one run-on line),
-    // so the provider must not collapse them. white-space inherits, so a text
-    // node's parent reports the effective value.
-    const layoutSourceElement = isHTMLElement(layoutSource)
-      ? layoutSource
-      : layoutSource.parentElement
-    const preserveLineBreaks = layoutSourceElement
-      ? isNewlinePreservingElement(layoutSourceElement)
-      : false
+    // so the provider must not collapse them. The FLOW CONTAINER's white-space
+    // governs how the run's newlines render: for an inline layout source
+    // (e.g. a GitHub inline <code> with its own break-spaces inside a normal
+    // paragraph) the parent's value is authoritative, not the element's own.
+    const flowContainer =
+      isHTMLElement(layoutSource) && isBlockTransNode(layoutSource)
+        ? layoutSource
+        : layoutSource.parentElement
+    const preserveLineBreaks = flowContainer ? isNewlinePreservingElement(flowContainer) : false
 
     const realTranslatedText = await getTranslatedTextAndRemoveSpinner(
       nodes,

--- a/src/utils/host/translate/dom/__tests__/paragraph-segmentation.test.ts
+++ b/src/utils/host/translate/dom/__tests__/paragraph-segmentation.test.ts
@@ -384,6 +384,10 @@ describe("canSplitParagraphIntoDescendants", () => {
     return root
   }
 
+  // Regression shape: https://x.com/davidjpark96/status/1789773192435060737 —
+  // a 22k-char note tweet whose pre-wrap tweetText div holds sibling inline
+  // spans (bold headings as their own spans); splitting observed each span as
+  // an independent unit and destroyed the blank-line paragraph interleaving.
   it("refuses to split a pre-wrap flow into inline span paragraphs (X note tweet)", () => {
     const root = walkedFixture(
       "<span>First paragraph\n\nSecond paragraph</span><span>Bold heading</span>",

--- a/src/utils/host/translate/dom/__tests__/paragraph-segmentation.test.ts
+++ b/src/utils/host/translate/dom/__tests__/paragraph-segmentation.test.ts
@@ -3,8 +3,10 @@ import type { Config } from "@/types/config/config"
 import { beforeEach, describe, expect, it } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { CONTENT_WRAPPER_CLASS } from "@/utils/constants/dom-labels"
+import { walkAndLabelElement } from "@/utils/host/dom/traversal"
 import {
   buildVirtualParagraphUnits,
+  canSplitParagraphIntoDescendants,
   liftParagraphInsertionBoundary,
   moveParagraphInsertionBoundaryAfterTrailingInlineImages,
   type DOMBoundary,
@@ -370,5 +372,58 @@ describe("buildVirtualParagraphUnits", () => {
       "1",
       "2",
     ])
+  })
+})
+
+describe("canSplitParagraphIntoDescendants", () => {
+  function walkedFixture(markup: string, whiteSpace: string): HTMLElement {
+    const root = createRoot(whiteSpace)
+    root.innerHTML = markup
+    document.body.appendChild(root)
+    walkAndLabelElement(root, "walk-split", DEFAULT_CONFIG)
+    return root
+  }
+
+  it("refuses to split a pre-wrap flow into inline span paragraphs (X note tweet)", () => {
+    const root = walkedFixture(
+      "<span>First paragraph\n\nSecond paragraph</span><span>Bold heading</span>",
+      "pre-wrap",
+    )
+    const spans = [...root.querySelectorAll("span")]
+
+    expect(canSplitParagraphIntoDescendants(root, spans)).toBe(false)
+  })
+
+  it("allows splitting a pre-wrap container into block paragraphs", () => {
+    const root = walkedFixture(
+      "<div>First message paragraph</div><div>Second message paragraph</div>",
+      "pre-wrap",
+    )
+    const divs = [...root.querySelectorAll("div")]
+
+    expect(canSplitParagraphIntoDescendants(root, divs)).toBe(true)
+  })
+
+  it("allows splitting a normal white-space container into inline paragraphs (#1881)", () => {
+    const root = walkedFixture(
+      "<span>First flat segment</span><span>Second flat segment</span>",
+      "normal",
+    )
+    const spans = [...root.querySelectorAll("span")]
+
+    expect(canSplitParagraphIntoDescendants(root, spans)).toBe(true)
+  })
+
+  it("allows splitting a pre-wrap flow with mixed block and inline paragraphs", () => {
+    // With a block descendant present the translation walker takes the
+    // per-child branch, so refusing the split would not reach the
+    // container-level virtual-paragraph plan — it would only lose gating.
+    const root = walkedFixture(
+      "<div>Block paragraph</div><span>Inline segment\n\nwith blank line</span>",
+      "pre-wrap",
+    )
+    const children = [...root.children] as HTMLElement[]
+
+    expect(canSplitParagraphIntoDescendants(root, children)).toBe(true)
   })
 })

--- a/src/utils/host/translate/dom/__tests__/paragraph-segmentation.test.ts
+++ b/src/utils/host/translate/dom/__tests__/paragraph-segmentation.test.ts
@@ -395,7 +395,7 @@ describe("canSplitParagraphIntoDescendants", () => {
     )
     const spans = [...root.querySelectorAll("span")]
 
-    expect(canSplitParagraphIntoDescendants(root, spans)).toBe(false)
+    expect(canSplitParagraphIntoDescendants(root, spans, DEFAULT_CONFIG)).toBe(false)
   })
 
   it("allows splitting a pre-wrap container into block paragraphs", () => {
@@ -405,7 +405,7 @@ describe("canSplitParagraphIntoDescendants", () => {
     )
     const divs = [...root.querySelectorAll("div")]
 
-    expect(canSplitParagraphIntoDescendants(root, divs)).toBe(true)
+    expect(canSplitParagraphIntoDescendants(root, divs, DEFAULT_CONFIG)).toBe(true)
   })
 
   it("allows splitting a normal white-space container into inline paragraphs (#1881)", () => {
@@ -415,7 +415,7 @@ describe("canSplitParagraphIntoDescendants", () => {
     )
     const spans = [...root.querySelectorAll("span")]
 
-    expect(canSplitParagraphIntoDescendants(root, spans)).toBe(true)
+    expect(canSplitParagraphIntoDescendants(root, spans, DEFAULT_CONFIG)).toBe(true)
   })
 
   it("allows splitting a pre-wrap flow with mixed block and inline paragraphs", () => {
@@ -428,6 +428,19 @@ describe("canSplitParagraphIntoDescendants", () => {
     )
     const children = [...root.children] as HTMLElement[]
 
-    expect(canSplitParagraphIntoDescendants(root, children)).toBe(true)
+    expect(canSplitParagraphIntoDescendants(root, children, DEFAULT_CONFIG)).toBe(true)
+  })
+
+  it("allows splitting a pre-wrap flow whose text has no blank-line delimiters", () => {
+    // A single-newline-only giant (log/code views) yields an EMPTY virtual
+    // plan; refusing the split would translate the whole giant as ONE
+    // request and forfeit viewport gating.
+    const root = walkedFixture(
+      "<span>line one\nline two</span><span>line three\nline four</span>",
+      "pre-wrap",
+    )
+    const spans = [...root.querySelectorAll("span")]
+
+    expect(canSplitParagraphIntoDescendants(root, spans, DEFAULT_CONFIG)).toBe(true)
   })
 })

--- a/src/utils/host/translate/dom/paragraph-segmentation.ts
+++ b/src/utils/host/translate/dom/paragraph-segmentation.ts
@@ -27,7 +27,10 @@ export function isNewlinePreservingElement(element: HTMLElement): boolean {
  * descendant paragraph units is only sound when those units are block
  * elements. In a newline-preserving flow container — an X note tweet is a
  * pre-wrap div whose rich-text runs are sibling inline <span>s, each labeled
- * a paragraph — the inline descendants are segments of ONE text flow.
+ * a paragraph (reported on
+ * https://x.com/davidjpark96/status/1789773192435060737, a 22k-char note
+ * whose bold headings are their own spans) — the inline descendants are
+ * segments of ONE text flow.
  * Observing them individually translates each segment as a single blob whose
  * wrapper lands at the segment's end, destroying the blank-line paragraph
  * structure. Such containers must be observed whole so the virtual-paragraph

--- a/src/utils/host/translate/dom/paragraph-segmentation.ts
+++ b/src/utils/host/translate/dom/paragraph-segmentation.ts
@@ -43,13 +43,23 @@ export function isNewlinePreservingElement(element: HTMLElement): boolean {
  * descendant present the walker would take the per-child branch instead —
  * refusing the split there would lose viewport gating without gaining the
  * container-level plan.
+ *
+ * The refusal is also conditioned on the plan actually segmenting the
+ * container: a newline-preserving giant with only single-newline lines and
+ * no blank-line delimiters (long pre-wrapped log/code views) yields an EMPTY
+ * plan, and observing it whole would translate the entire giant as ONE
+ * request — losing viewport gating and risking provider length limits.
+ * The same plan builder the translate path uses makes the decision, so the
+ * observation-time judgment cannot drift from translate-time behavior.
  */
 export function canSplitParagraphIntoDescendants(
   element: HTMLElement,
   descendantParagraphs: readonly HTMLElement[],
+  config: Config,
 ): boolean {
   if (!isNewlinePreservingElement(element)) return true
-  return descendantParagraphs.some((paragraph) => isBlockTransNode(paragraph))
+  if (descendantParagraphs.some((paragraph) => isBlockTransNode(paragraph))) return true
+  return buildVirtualParagraphPlan(element, config).units.length < 2
 }
 
 const BLANK_LINE_DELIMITER_RE = /(?:\r\n?|\n)[^\S\r\n]*(?:\r\n?|\n)(?:[^\S\r\n]*(?:\r\n?|\n))*/g

--- a/src/utils/host/translate/dom/paragraph-segmentation.ts
+++ b/src/utils/host/translate/dom/paragraph-segmentation.ts
@@ -1,6 +1,7 @@
 import type { VirtualParagraphSourceSnapshot } from "../core/translation-state"
 import type { Config } from "@/types/config/config"
 import {
+  isBlockTransNode,
   isDontWalkIntoAndDontTranslateAsChildElement,
   isDontWalkIntoButTranslateAsChildElement,
   isHTMLElement,
@@ -10,6 +11,43 @@ import {
 } from "../../dom/filter"
 
 const PRESERVED_NEWLINE_WHITE_SPACE = new Set(["pre", "pre-wrap", "pre-line", "break-spaces"])
+
+/**
+ * True when the element's computed white-space renders literal newlines, i.e.
+ * blank lines in its text are real paragraph boundaries (the precondition for
+ * buildVirtualParagraphPlan).
+ */
+export function isNewlinePreservingElement(element: HTMLElement): boolean {
+  const whiteSpace = window.getComputedStyle(element).whiteSpace.trim().toLowerCase()
+  return PRESERVED_NEWLINE_WHITE_SPACE.has(whiteSpace)
+}
+
+/**
+ * Giant-paragraph split guard (#1881): splitting a giant paragraph into its
+ * descendant paragraph units is only sound when those units are block
+ * elements. In a newline-preserving flow container — an X note tweet is a
+ * pre-wrap div whose rich-text runs are sibling inline <span>s, each labeled
+ * a paragraph — the inline descendants are segments of ONE text flow.
+ * Observing them individually translates each segment as a single blob whose
+ * wrapper lands at the segment's end, destroying the blank-line paragraph
+ * structure. Such containers must be observed whole so the virtual-paragraph
+ * plan provides the split instead.
+ *
+ * The refusal is deliberately limited to the ALL-inline shape, judged by the
+ * same effective (post-site-rule) block marker the translation walker splits
+ * on: only then does observing the container whole guarantee the walker takes
+ * the single-node path where the virtual-paragraph plan runs. With any block
+ * descendant present the walker would take the per-child branch instead —
+ * refusing the split there would lose viewport gating without gaining the
+ * container-level plan.
+ */
+export function canSplitParagraphIntoDescendants(
+  element: HTMLElement,
+  descendantParagraphs: readonly HTMLElement[],
+): boolean {
+  if (!isNewlinePreservingElement(element)) return true
+  return descendantParagraphs.some((paragraph) => isBlockTransNode(paragraph))
+}
 
 const BLANK_LINE_DELIMITER_RE = /(?:\r\n?|\n)[^\S\r\n]*(?:\r\n?|\n)(?:[^\S\r\n]*(?:\r\n?|\n))*/g
 
@@ -447,8 +485,7 @@ export function buildVirtualParagraphPlan(
   layoutSource: HTMLElement,
   config: Config,
 ): VirtualParagraphPlan {
-  const whiteSpace = window.getComputedStyle(layoutSource).whiteSpace.trim().toLowerCase()
-  if (!PRESERVED_NEWLINE_WHITE_SPACE.has(whiteSpace)) {
+  if (!isNewlinePreservingElement(layoutSource)) {
     return { units: [], sourceSnapshots: [] }
   }
 

--- a/src/utils/host/translate/execute-translate.ts
+++ b/src/utils/host/translate/execute-translate.ts
@@ -1,4 +1,3 @@
-import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { PromptResolver } from "./api/ai"
 import type { Config } from "@/types/config/config"
 import type { ProviderConfig } from "@/types/config/provider"
@@ -26,9 +25,6 @@ export async function executeTranslate<TContext>(
     // "\n" as HTML whitespace. Microsoft preserves newlines in both textTypes
     // (live-verified); LLM prompts already mandate format preservation.
     preserveLineBreaks?: boolean
-    // Page-level detection for per-line requests: the endpoint auto-detects
-    // each batch item independently, and a short line ("- SEO") misdetects.
-    detectedSourceCode?: LangCodeISO6393
     signal?: AbortSignal
   },
 ) {
@@ -48,14 +44,7 @@ export async function executeTranslate<TContext>(
       throw new Error(`Invalid target language code: ${langConfig.targetCode}`)
     }
     if (provider === "google-translate") {
-      const detectedSourceLang = options?.detectedSourceCode
-        ? ISO6393_TO_6391[options.detectedSourceCode]
-        : undefined
-      const googleSourceLang =
-        sourceLang === "auto" && options?.preserveLineBreaks && detectedSourceLang
-          ? detectedSourceLang
-          : sourceLang
-      translatedText = await googleTranslate(preparedText, googleSourceLang, targetLang, {
+      translatedText = await googleTranslate(preparedText, sourceLang, targetLang, {
         textFormat: options?.textFormat,
         preserveLineBreaks: options?.preserveLineBreaks,
         signal: options?.signal,

--- a/src/utils/host/translate/execute-translate.ts
+++ b/src/utils/host/translate/execute-translate.ts
@@ -1,3 +1,4 @@
+import type { LangCodeISO6393 } from "@read-frog/definitions"
 import type { PromptResolver } from "./api/ai"
 import type { Config } from "@/types/config/config"
 import type { ProviderConfig } from "@/types/config/provider"
@@ -21,6 +22,13 @@ export async function executeTranslate<TContext>(
     isBatch?: boolean
     context?: TContext
     textFormat?: TranslationTextFormat
+    // Only Google needs protection: its translateHtml transport collapses
+    // "\n" as HTML whitespace. Microsoft preserves newlines in both textTypes
+    // (live-verified); LLM prompts already mandate format preservation.
+    preserveLineBreaks?: boolean
+    // Page-level detection for per-line requests: the endpoint auto-detects
+    // each batch item independently, and a short line ("- SEO") misdetects.
+    detectedSourceCode?: LangCodeISO6393
     signal?: AbortSignal
   },
 ) {
@@ -40,8 +48,16 @@ export async function executeTranslate<TContext>(
       throw new Error(`Invalid target language code: ${langConfig.targetCode}`)
     }
     if (provider === "google-translate") {
-      translatedText = await googleTranslate(preparedText, sourceLang, targetLang, {
+      const detectedSourceLang = options?.detectedSourceCode
+        ? ISO6393_TO_6391[options.detectedSourceCode]
+        : undefined
+      const googleSourceLang =
+        sourceLang === "auto" && options?.preserveLineBreaks && detectedSourceLang
+          ? detectedSourceLang
+          : sourceLang
+      translatedText = await googleTranslate(preparedText, googleSourceLang, targetLang, {
         textFormat: options?.textFormat,
+        preserveLineBreaks: options?.preserveLineBreaks,
         signal: options?.signal,
       })
     } else if (provider === "microsoft-translate") {

--- a/src/utils/host/translate/translate-text.ts
+++ b/src/utils/host/translate/translate-text.ts
@@ -83,7 +83,6 @@ async function buildWebPageHashComponents(
   enableAIContentAware: boolean,
   textFormat: TranslationTextFormat,
   preserveLineBreaks: boolean,
-  detectedSourceCode?: LangCodeISO6393,
   webPageContext?: WebPagePromptContext,
   promptExperimentVariant?: PromptExperimentVariant,
 ): Promise<string[]> {
@@ -101,16 +100,14 @@ async function buildWebPageHashComponents(
     // cache entries must too. This component also orphans entries cached before
     // the format-aware pipeline existed, which could hold corrupted output.
     hashComponents.push(`textFormat:${textFormat}`)
-    // Pushed only when set so cache entries written before the flag existed
-    // stay valid; flagged requests get fresh entries (any old collapsed-line
-    // output for the same text is orphaned rather than reused).
-    if (preserveLineBreaks) {
+    // Pushed only when the flag actually changes the provider request —
+    // today that is Google alone — so cache entries written before the flag
+    // existed stay valid and identical Microsoft/DeepL requests are not
+    // fragmented. Flagged Google requests get fresh entries (any old
+    // collapsed-line output for the same text is orphaned rather than
+    // reused).
+    if (preserveLineBreaks && providerConfig.provider === "google-translate") {
       hashComponents.push("preserveLineBreaks:true")
-      // The effective source language of a per-line request; a changed
-      // detection must not reuse a translation made under the old one.
-      if (detectedSourceCode) {
-        hashComponents.push(`detectedSourceCode:${detectedSourceCode}`)
-      }
     }
     return hashComponents
   }
@@ -159,8 +156,6 @@ export interface TranslateTextOptions {
   textFormat?: TranslationTextFormat
   // Source line breaks are semantic — see the enqueueTranslateRequest field.
   preserveLineBreaks?: boolean
-  // Page-level language detection; replaces per-item "auto" in per-line mode.
-  detectedSourceCode?: LangCodeISO6393
   // Page-translation session id used for cancellation scoping. Deliberately
   // NOT part of the cache hash — cache identity must not vary per session.
   sessionId?: string
@@ -187,7 +182,6 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     webPageContext,
     textFormat = "plain",
     preserveLineBreaks = false,
-    detectedSourceCode,
     sessionId,
     configuredPrompt,
     translationActionContext = getPageTranslationActionContext() ?? undefined,
@@ -225,7 +219,6 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     enableAIContentAware,
     textFormat,
     preserveLineBreaks,
-    detectedSourceCode,
     normalizedWebPageContext,
     promptExperimentVariant,
   )
@@ -252,7 +245,6 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     hash: Sha256Hex(...hashComponents),
     textFormat,
     preserveLineBreaks,
-    detectedSourceCode,
     webTitle: normalizedWebPageContext?.webTitle,
     webDescription: normalizedWebPageContext?.webDescription,
     webContent: normalizedWebPageContext?.webContent,

--- a/src/utils/host/translate/translate-text.ts
+++ b/src/utils/host/translate/translate-text.ts
@@ -82,6 +82,8 @@ async function buildWebPageHashComponents(
   partialLangConfig: { sourceCode: LangCodeISO6393 | "auto"; targetCode: LangCodeISO6393 },
   enableAIContentAware: boolean,
   textFormat: TranslationTextFormat,
+  preserveLineBreaks: boolean,
+  detectedSourceCode?: LangCodeISO6393,
   webPageContext?: WebPagePromptContext,
   promptExperimentVariant?: PromptExperimentVariant,
 ): Promise<string[]> {
@@ -99,6 +101,17 @@ async function buildWebPageHashComponents(
     // cache entries must too. This component also orphans entries cached before
     // the format-aware pipeline existed, which could hold corrupted output.
     hashComponents.push(`textFormat:${textFormat}`)
+    // Pushed only when set so cache entries written before the flag existed
+    // stay valid; flagged requests get fresh entries (any old collapsed-line
+    // output for the same text is orphaned rather than reused).
+    if (preserveLineBreaks) {
+      hashComponents.push("preserveLineBreaks:true")
+      // The effective source language of a per-line request; a changed
+      // detection must not reuse a translation made under the old one.
+      if (detectedSourceCode) {
+        hashComponents.push(`detectedSourceCode:${detectedSourceCode}`)
+      }
+    }
     return hashComponents
   }
 
@@ -144,6 +157,10 @@ export interface TranslateTextOptions {
   extraHashTags?: string[]
   webPageContext?: WebPagePromptContext
   textFormat?: TranslationTextFormat
+  // Source line breaks are semantic — see the enqueueTranslateRequest field.
+  preserveLineBreaks?: boolean
+  // Page-level language detection; replaces per-item "auto" in per-line mode.
+  detectedSourceCode?: LangCodeISO6393
   // Page-translation session id used for cancellation scoping. Deliberately
   // NOT part of the cache hash — cache identity must not vary per session.
   sessionId?: string
@@ -169,6 +186,8 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     extraHashTags = [],
     webPageContext,
     textFormat = "plain",
+    preserveLineBreaks = false,
+    detectedSourceCode,
     sessionId,
     configuredPrompt,
     translationActionContext = getPageTranslationActionContext() ?? undefined,
@@ -205,6 +224,8 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     { sourceCode: langConfig.sourceCode, targetCode: langConfig.targetCode },
     enableAIContentAware,
     textFormat,
+    preserveLineBreaks,
+    detectedSourceCode,
     normalizedWebPageContext,
     promptExperimentVariant,
   )
@@ -230,6 +251,8 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     scheduleAt: Date.now(),
     hash: Sha256Hex(...hashComponents),
     textFormat,
+    preserveLineBreaks,
+    detectedSourceCode,
     webTitle: normalizedWebPageContext?.webTitle,
     webDescription: normalizedWebPageContext?.webDescription,
     webContent: normalizedWebPageContext?.webContent,

--- a/src/utils/host/translate/translate-variants.ts
+++ b/src/utils/host/translate/translate-variants.ts
@@ -69,7 +69,6 @@ async function translateTextUsingPageConfig(
     preserveLineBreaks?: boolean
     // Session captured at pipeline entry by the caller; see translateTextForPage.
     sessionId?: string
-    detectedSourceCode?: LangCodeISO6393
     configuredPrompt?: "default" | "custom"
     translationActionContext?: TranslationActionContext
     forceRetranslation?: boolean
@@ -81,15 +80,6 @@ async function translateTextUsingPageConfig(
   }
 
   const providerConfig = resolveProviderConfig(config, "translate")
-
-  // Per-line requests (preserveLineBreaks) make the provider's own per-item
-  // auto-detection unreliable — a 3-letter acronym line detects as the wrong
-  // language ("SEO" → "这"). The page-level detection is the reliable signal,
-  // so resolve it here where storage is reachable and pass it as a hint.
-  const detectedSourceCode =
-    options.preserveLineBreaks && config.language.sourceCode === "auto"
-      ? ((await getDetectedCodeFromStorage()) ?? undefined)
-      : undefined
 
   // Backstop only: the page modes hoist this check before DOM insertion, but
   // other callers (e.g. the page title) still rely on it here.
@@ -125,7 +115,6 @@ async function translateTextUsingPageConfig(
     webPageContext: options.webPageContext,
     textFormat: options.textFormat,
     preserveLineBreaks: options.preserveLineBreaks,
-    detectedSourceCode,
     sessionId: options.sessionId,
     configuredPrompt: options.configuredPrompt,
     translationActionContext: options.translationActionContext,

--- a/src/utils/host/translate/translate-variants.ts
+++ b/src/utils/host/translate/translate-variants.ts
@@ -66,8 +66,10 @@ async function translateTextUsingPageConfig(
       webSummary?: string | null
     }
     textFormat?: TranslationTextFormat
+    preserveLineBreaks?: boolean
     // Session captured at pipeline entry by the caller; see translateTextForPage.
     sessionId?: string
+    detectedSourceCode?: LangCodeISO6393
     configuredPrompt?: "default" | "custom"
     translationActionContext?: TranslationActionContext
     forceRetranslation?: boolean
@@ -79,6 +81,15 @@ async function translateTextUsingPageConfig(
   }
 
   const providerConfig = resolveProviderConfig(config, "translate")
+
+  // Per-line requests (preserveLineBreaks) make the provider's own per-item
+  // auto-detection unreliable — a 3-letter acronym line detects as the wrong
+  // language ("SEO" → "这"). The page-level detection is the reliable signal,
+  // so resolve it here where storage is reachable and pass it as a hint.
+  const detectedSourceCode =
+    options.preserveLineBreaks && config.language.sourceCode === "auto"
+      ? ((await getDetectedCodeFromStorage()) ?? undefined)
+      : undefined
 
   // Backstop only: the page modes hoist this check before DOM insertion, but
   // other callers (e.g. the page title) still rely on it here.
@@ -113,6 +124,8 @@ async function translateTextUsingPageConfig(
     extraHashTags: options.extraHashTags,
     webPageContext: options.webPageContext,
     textFormat: options.textFormat,
+    preserveLineBreaks: options.preserveLineBreaks,
+    detectedSourceCode,
     sessionId: options.sessionId,
     configuredPrompt: options.configuredPrompt,
     translationActionContext: options.translationActionContext,
@@ -128,6 +141,7 @@ export async function translateTextForPage(
   text: string,
   textFormat: TranslationTextFormat = "plain",
   translationActionContext?: TranslationActionContext,
+  options?: { preserveLineBreaks?: boolean },
 ): Promise<string> {
   // Capture the session id synchronously at pipeline entry. Reading it later
   // (after the awaits below, e.g. the network-backed page summary) could see
@@ -145,6 +159,7 @@ export async function translateTextForPage(
   return translateTextUsingPageConfig(config, text, {
     webPageContext,
     textFormat,
+    preserveLineBreaks: options?.preserveLineBreaks,
     sessionId,
     configuredPrompt: config.translate.customPromptsConfig.promptId === null ? "default" : "custom",
     translationActionContext,
@@ -228,5 +243,7 @@ export async function translateTextForInput(
     providerConfig,
     enableAIContentAware: config.translate.enableAIContentAware,
     webPageContext,
+    // User-typed newlines are always meaningful.
+    preserveLineBreaks: true,
   })
 }

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -109,6 +109,11 @@ interface ProtocolMap {
     scheduleAt: number
     hash: string
     textFormat?: TranslationTextFormat
+    // Source line breaks are semantic (newline-preserving container or typed
+    // input); providers whose transport collapses "\n" must protect them.
+    preserveLineBreaks?: boolean
+    // Page-level detection; replaces per-item "auto" in per-line requests.
+    detectedSourceCode?: LangCodeISO6393
     webTitle?: string | null
     webDescription?: string | null
     webContent?: string | null

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -112,8 +112,6 @@ interface ProtocolMap {
     // Source line breaks are semantic (newline-preserving container or typed
     // input); providers whose transport collapses "\n" must protect them.
     preserveLineBreaks?: boolean
-    // Page-level detection; replaces per-item "auto" in per-line requests.
-    detectedSourceCode?: LangCodeISO6393
     webTitle?: string | null
     webDescription?: string | null
     webContent?: string | null


### PR DESCRIPTION
## Problem

Two independent bugs broke translation formatting on X/Twitter.

Reported cases:
- https://x.com/davidjpark96/status/1789773192435060737 — 22k-char note tweet: translations displaced/merged (bug 1), and its bullet list squashed onto one line under Google Translate (bug 2)
- https://x.com/EpsteinJeffrey0/status/2083709421386080579 — regular tweet of five single-`\n` lines: Google merged them into one run-on translation (bug 2)

**1. Long note tweets: translations displaced / merged (any provider)**

A 20k+-char note tweet renders as ONE pre-wrap `tweetText` div whose rich-text runs are sibling inline `<span>`s — paragraphs are literal blank lines *inside* the spans, so span boundaries ≠ paragraph boundaries. The #1881 giant-paragraph split (>3 viewports) observed each span as an independent translation unit, and an inline span can never enter the virtual-paragraph path. Every span translated as one blob whose wrapper landed at the span's end:

- bold heading spans got inline translations glued mid-line (`- 付费广告Organic Short-form content  有机短视频内容`)
- a 5k-char plain span's translation landed ~25 paragraphs below its content

**2. Google Translate: line breaks eaten (any multi-line tweet)**

Google's `translateHtml` endpoint parses plain text as HTML, so literal `\n` collapses as whitespace — bullet lists and single-newline tweets became one merged run-on line with merged-sentence translations. No escape survives (`&#10;` collapses too).

## Fix

**Commit 1 — `canSplitParagraphIntoDescendants` guard:** a newline-preserving container whose descendant paragraphs are all inline is never split — observed whole, it routes through the virtual-paragraph plan, which interleaves translations per blank-line paragraph. Containers with block descendants (chat-style pre-wrap lists) keep splitting, preserving #1881 viewport gating. The predicate uses the same effective block marker the walker dispatches on.

**Commits 2+4 — `preserveLineBreaks` flag + whole-unit marker transport:** the caller signals that line breaks are semantic (newline-preserving flow container / typed input); only the Google provider acts on it, per live-verified endpoint behavior:

- lines are joined into **ONE request item with `<br>` marker pairs** (a lone `<br>` can be merged away by the sentence segmenter; a pair never is) — so the endpoint language-detects the **whole unit** and `sl=auto` is never overridden. This is the correctness invariant: per-line items are detected independently and short lines misread (`- SEO` alone → `- 这`), while inside its own tweet the same line translates correctly. A Japanese tweet on an English page also stays correct — the extension never forces a language (E2E-verified).
- the model strips leading dash bullets from list lines regardless of transport → indentation + bullet prefix captured client-side and restored per marker segment; graceful marker-fold fallback if segment counts ever drift
- the giant-split refusal from commit 1 applies only in **bilingual** mode (translationOnly swaps text in place per span and keeps viewport gating); the flag's gate samples the **flow container's** white-space (a GitHub inline `<code>` with `break-spaces` no longer flags a normal paragraph)

An earlier iteration (per-line batch items + page-level detected-language override) was found unsound by adversarial review — the override broke mixed-language pages and the detection default (`und` → `eng`) forced English during the startup race — and was replaced wholesale; the `detectedSourceCode` threading is deleted. Cache hash gains a `preserveLineBreaks` component only for Google requests, keeping existing entries and other providers' entries valid. Microsoft is unchanged (it already preserves `\n`); LLM prompts already mandate format preservation. Known gap: translationOnly's html-format payloads still collapse (serialization-layer work, documented in `google.ts`).

## Verification

- Puppeteer E2E against the built extension on faithful fixtures of both reported tweets (22k-char rich-text note with bold heading spans; single-`\n` 5-line tweet): before = pixel-level reproduction of the reported layouts; after = 141 correctly interleaved per-paragraph wrappers, bullets/dashes/lines all preserved, with both Microsoft and Google
- Both reported URLs are referenced in code comments at the fix sites (`paragraph-segmentation.ts`, `page-translation.ts`, `google.ts`, `translation-modes.ts`) and in the regression tests (`paragraph-segmentation.test.ts` note-tweet split case; `google-roundtrip.test.ts` bullet-list and plain single-newline cases)
- All endpoint behaviors (newline collapse, dash eating, per-item auto misdetection, multi-item form, empty-item 400) verified against the live `translateHtml` API
- Full suite: 2455 tests pass; new regression tests for the split guard and a Google round-trip simulator emulating collapse/dash-eating/indent-stripping
- Multi-agent adversarial review of commit 1 confirmed + fixed one guard-predicate edge (mixed block+inline giants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

