### PR TITLE
fix(config): disable AI smart context by default

### DIFF
--- a/.changeset/tidy-context-default.md
+++ b/.changeset/tidy-context-default.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(config): disable AI smart context by default

--- a/src/utils/constants/config.ts
+++ b/src/utils/constants/config.ts
@@ -103,7 +103,7 @@ export const DEFAULT_CONFIG: Config = {
       enableTargetLanguageSkip: true,
       skipLanguages: [],
     },
-    enableAIContentAware: true,
+    enableAIContentAware: false,
     customPromptsConfig: DEFAULT_TRANSLATE_PROMPTS_CONFIG,
     requestQueueConfig: {
       capacity: DEFAULT_REQUEST_CAPACITY,


### PR DESCRIPTION
## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Disable AI smart context in the default configuration so fresh installations start with the feature turned off.

Existing users keep their saved preference because this changes only the fresh/default configuration and does not add a migration.

This also includes a patch changeset for `@read-frog/extension`.

## Related Issue

None.

## How Has This Been Tested?

- [ ] Added unit tests
- [ ] Verified through manual testing

Commands run:

- `pnpm fmt:check`
- `pnpm lint`
- `WXT_SKIP_ENV_VALIDATION=true pnpm build`
- Push hook CI-equivalent checks — 2,483 existing tests passed with `free-api.test.ts` excluded

## Screenshots

Not applicable; this changes only the fresh-install default state.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

No schema migration is required because the configuration shape is unchanged and existing users' saved setting should be preserved.
