### PR TITLE
docs: update retired Claude model ids in add-provider command

### DIFF
--- a/.claude/commands/add-provider.md
+++ b/.claude/commands/add-provider.md
@@ -29,5 +29,5 @@ Common provider patterns:
 Example models to suggest:
 
 - OpenRouter: read="deepseek/deepseek-chat-v3.1:free", translate="x-ai/grok-4-fast:free"
-- Anthropic: read="claude-3-5-sonnet-20241022", translate="claude-3-5-haiku-20241022"
+- Anthropic: read="claude-sonnet-4-6", translate="claude-haiku-4-5"
 - Mistral: read="mistral-large-latest", translate="mistral-small-latest"


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 5

## Type of Changes

- [x] 📝 Documentation change (docs)

## Description

`.claude/commands/add-provider.md` suggests `claude-3-5-sonnet-20241022` and `claude-3-5-haiku-20241022` as the Anthropic example models. Both ids are retired, the sonnet one since 28 October 2025 and the haiku one since 19 February 2026, so an agent following this command wires a new provider to ids the API no longer serves.

| Line | Before | After |
| --- | --- | --- |
| 32 | `read="claude-3-5-sonnet-20241022"` | `read="claude-sonnet-4-6"` |
| 32 | `translate="claude-3-5-haiku-20241022"` | `translate="claude-haiku-4-5"` |

Retirement dates come from https://platform.claude.com/docs/en/about-claude/model-deprecations

Both replacements are already in the `anthropic` list in `src/utils/constants/models.ts`, and I used the alias form rather than a dated id to match how that list is written.

## What I left alone

`src/utils/config/migration-scripts/v078-to-v079.ts` maps old ids onto current ones, so the retired ids there are the keys the migration needs. `src/utils/constants/models.ts` keeps a Bedrock id list where the older entries are catalogue data rather than a suggestion. Neither should change.

## How Has This Been Tested?

- [x] Verified through manual testing

The change is one line of a command prompt file, so nothing in `src` is affected and the type check is untouched by it.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model ids, so I am saying that up front rather than leaving you to wonder. The checker only proposed the haiku replacement on its own, I made the sonnet call myself because leaving one half of that line on a retired id looked worse than changing both. I have not run either id against the API to reproduce a failure, the claim rests on the published retirement dates. If you would rather handle this your own way, or would rather not get this kind of contribution at all, tell me and I will not send another.
