### PR TITLE
fix(translate): translate Ubiquiti Community release posts and comments

### DIFF
--- a/.changeset/fuzzy-geckos-translate.md
+++ b/.changeset/fuzzy-geckos-translate.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): translate Ubiquiti Community release posts and comments

--- a/src/utils/site-rules/__tests__/built-in.test.ts
+++ b/src/utils/site-rules/__tests__/built-in.test.ts
@@ -308,6 +308,28 @@ describe("built-in site rules", () => {
     }
   })
 
+  it("keeps visible Ubiquiti Community release virtual-list items walkable", () => {
+    const resolved = resolveSiteRule(
+      "https://community.ui.com/releases/Community-Update-2026-08-04/a1179dd3-e973-4495-97de-bb992962b49d",
+      BUILT_IN_SITE_RULES,
+      [],
+      [],
+    )
+
+    expect(resolved.matchedRuleIds).toContain("ui-community-releases")
+    expect(resolved.injectedCss).toContain("[style*='visibility: hidden']")
+    expect(resolved.injectedCss).toContain(":has(> div[style*='position: absolute']")
+    expect(resolved.injectedCss).toContain("visibility: visible !important")
+
+    const outsideReleases = resolveSiteRule(
+      "https://community.ui.com/questions/example",
+      BUILT_IN_SITE_RULES,
+      [],
+      [],
+    )
+    expect(outsideReleases.matchedRuleIds).not.toContain("ui-community-releases")
+  })
+
   it("does not restrict Steam app pages to an obsolete iframe include (issue #1923)", () => {
     const resolved = resolveSiteRule(
       "https://store.steampowered.com/app/2453660/Hoop_Land/",

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -4509,6 +4509,12 @@
     "preserveTextSelectors.add": ["em"]
   },
   {
+    "id": "ui-community-releases",
+    "description": "Keep Ubiquiti Community's visible virtual-list items walkable while translating release posts and comments",
+    "matches": "https://community.ui.com/releases/*",
+    "injectedCss": "div[style*='flex: 0 0 auto'][style*='position: relative'][style*='visibility: hidden']:has(> div[style*='position: absolute'][style*='visibility: visible']) { visibility: visible !important; }"
+  },
+  {
     "id": "hltv",
     "matches": ["hltv.org", "*.hltv.org"],
     "excludeSelectors": [


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-5 (Codex)

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Ubiquiti Community renders release posts and comments inside a virtual-list root whose inline style uses `visibility: hidden`. Each absolutely positioned virtual item resets itself to `visibility: visible`, so the content remains visible to users, but Read Frog treated the hidden root as a blocked subtree and stopped traversal before reaching the visible items.

This change adds a path-scoped built-in site rule for `https://community.ui.com/releases/*`. The injected CSS narrowly matches the virtual-list structure and overrides only the root's computed visibility while page translation is active. This lets Read Frog walk and translate the visible release content without changing the site's inline styles or applying the workaround elsewhere on the community site.

The change also adds regression coverage for both the release-page match and the out-of-scope community URLs.

## Related Issue

No related issue was identified.

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Automated validation:

- `SKIP_FREE_API=true pnpm exec nx test -- --exclude="**/free-api.test.ts"` — 257 test files and 2,484 tests passed
- `pnpm lint`
- `pnpm build`

Real-browser validation used the production Chrome MV3 build on the reported Ubiquiti Community release page:

- The rule matched exactly one virtual-list root.
- All 19 editor paragraphs became walkable; 15 were labeled as translation paragraphs.
- Google Translate produced Chinese output in the post/comment content with 59 translation wrappers.
- The virtual-list root, all six mounted item rectangles, and the document/body scroll heights were identical before and after applying the CSS-only workaround.
- Stopping translation restored the root to `visibility: hidden`, removed all translation wrappers, and produced no React or DOM errors.

## Screenshots

Not applicable. The workaround changes translation traversal eligibility without changing the page layout or appearance.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The rule is intentionally limited to Ubiquiti Community release pages instead of changing the global `visibility: hidden` traversal behavior. A global change could make Read Frog scan large hidden accordion or virtualized subtrees on unrelated sites.
