### PR TITLE
fix(translate): keep X Chat message timestamps out of translations

### DIFF
--- a/.changeset/clever-frogs-listen.md
+++ b/.changeset/clever-frogs-listen.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): keep X Chat message timestamps out of the translated bubble text

--- a/src/utils/site-rules/__tests__/built-in.test.ts
+++ b/src/utils/site-rules/__tests__/built-in.test.ts
@@ -330,6 +330,31 @@ describe("built-in site rules", () => {
     expect(outsideReleases.matchedRuleIds).not.toContain("ui-community-releases")
   })
 
+  it("excludes the X Chat send-time overlay without touching x.com timelines", () => {
+    const resolved = resolveSiteRule(
+      "https://chat.x.com/252792134-1085738455986913280",
+      BUILT_IN_SITE_RULES,
+      [],
+      [],
+    )
+
+    expect(resolved.matchedRuleIds).toContain("readfrog-x-chat")
+    // The footer root covers every branch that renders it (aria-hidden spacer,
+    // absolute overlay, and the `contents` wrapper used for long messages).
+    expect(resolved.excludeSelector).toContain("div.flex.items-center.ml-auto.shrink-0.gap-1")
+    // Its overlay wrapper must stay walkable: excluding that too hides it from
+    // unwrapDeepestOnlyHTMLChild and moves the translation wrapper's insertion
+    // point into the bubble's pre-wrap text block.
+    expect(resolved.excludeSelector).not.toContain("inset-e-0")
+    // chat.x.com is a separate host: the `twitter` rule's tweet whitelist must
+    // not leak in, or every chat bubble would fall outside the include scope.
+    expect(resolved.matchedRuleIds).not.toContain("twitter")
+    expect(resolved.includeSelector).toBeNull()
+
+    const timeline = resolveSiteRule("https://x.com/home", BUILT_IN_SITE_RULES, [], [])
+    expect(timeline.matchedRuleIds).not.toContain("readfrog-x-chat")
+  })
+
   it("does not restrict Steam app pages to an obsolete iframe include (issue #1923)", () => {
     const resolved = resolveSiteRule(
       "https://store.steampowered.com/app/2453660/Hoop_Land/",

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -4532,5 +4532,11 @@
     "description": "SillyTavern renders backtick narration as <p><code>; translate CODE as part of its paragraph (fenced code blocks stay protected by PRE)",
     "matches": ["localhost", "127.0.0.1"],
     "dontWalkButTranslateTags.remove": ["CODE"]
+  },
+  {
+    "id": "readfrog-x-chat",
+    "description": "Skip the X Chat message footer (send time + delivery receipt). It renders twice inside the bubble — once as an aria-hidden opacity-0 spacer in the text flow, once in the absolutely positioned overlay — so both copies otherwise land in the message's translation unit. Target the footer root only: excluding its `.absolute.bottom-0.inset-e-0` wrapper too would hide that wrapper from unwrapDeepestOnlyHTMLChild, turning the bubble row into an only-child chain and moving the translation wrapper down into the pre-wrap text block",
+    "matches": ["chat.x.com"],
+    "excludeSelectors": ["div.flex.items-center.ml-auto.shrink-0.gap-1"]
   }
 ]


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 5

## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

On `chat.x.com` (X Chat), every message bubble's send time was translated into the message itself — the translation ended with `... -EB 上午11:08` while the original `11:08 AM` still sat in the bubble corner.

Two causes stacked:

**1. `chat.x.com` matched no built-in rule.** The `twitter` rule lists `x.com`, which normalizes to `*://x.com/*` — an exact host, so it never covered the subdomain (and `x.com/i/chat*` is in its `excludeMatches` anyway). The page fell back to the generic full-page walk with no scoping.

**2. The message footer is rendered twice.** From X Chat's own `inbox-page` chunk:

```js
jsxs(F, { children: [ C /* message text */,
  footer && !isLong && jsx("span", {"aria-hidden": "true",
    className: "user-select-none inline-block pl-2 opacity-0", children: footer}) ]}),
jsx("div", { className: cn("absolute bottom-0 inset-e-0", {contents: isLong}), children: footer })
```

The first copy only reserves space on the last line, but `opacity-0` is neither `display:none` nor `visibility:hidden`, which are the only two the walker skips (`filter.ts`). So both copies were read into the paragraph's source text — measured on the live page, every bubble sent its timestamp to the provider **twice**.

The fix is one built-in rule excluding the footer **root**, which is shared by all three branches that render it (the aria-hidden spacer, the absolute overlay, and the `contents` wrapper used for long messages):

```json
{
  "id": "readfrog-x-chat",
  "matches": ["chat.x.com"],
  "excludeSelectors": ["div.flex.items-center.ml-auto.shrink-0.gap-1"]
}
```

### Why the overlay wrapper is deliberately *not* excluded

An earlier iteration also excluded `div.absolute.bottom-0.inset-e-0`. That regressed layout: `unwrapDeepestOnlyHTMLChild` filters out excluded children when picking the insertion point, so hiding the overlay turned the bubble row into an only-child chain and pushed the translation wrapper down into the `whitespace-pre-wrap` text block (which sits inside an `inline-flex overflow-hidden` row). Measured with the live DOM through the full walk + translate pipeline:

| exclude selectors | wrapper insertion point | timestamp in source text |
| --- | --- | --- |
| footer root + overlay | `#text-block` — **moved** | no |
| **footer root only** | `#bubble-row` — unchanged | no |
| none (before) | `#bubble-row` | **yes** |

`built-in.test.ts` asserts `not.toContain("inset-e-0")` so this cannot be reintroduced silently.

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

**Unit tests**

- `src/utils/host/dom/__tests__/x-chat.test.ts` — walks the real bubble markup (both footer copies) and asserts neither reaches `extractTextContent`; a control on an uncovered host asserts the timestamp appears **twice**, so the assertion cannot pass vacuously.
- `src/utils/host/__tests__/x-chat.integration.test.tsx` — runs the bubble through the full walk + translate pipeline and locks both properties: the wrapper's parent stays `#bubble-row`, and the text sent to the provider contains no timestamp.
- `src/utils/site-rules/__tests__/built-in.test.ts` — resolve-level: rule matches `chat.x.com`, does not match `x.com`, and the `twitter` tweet whitelist must not leak in (it would put every chat bubble outside the include scope).

**Manual**

Verified against the live logged-in page: all 6 footer elements are inside message bubbles (0 elsewhere on the page, 0 on the inbox list), so nothing else is excluded; simulating the exclusion on the real DOM removed only 14–16 characters per bubble — exactly the two timestamp strings — with message text intact. Confirmed in-browser afterwards that bubbles translate without the clock reading.

## Additional Information

Two notes for reviewers:

- **Selectors are class-based** because X Chat's footer carries no `data-testid`. The trailing literal `flex items-center ml-auto shrink-0 gap-1` is unconditional in the component (`cn(variableClasses, isReceived ? "justify-start" : "justify-end", "flex items-center ml-auto shrink-0 gap-1")`), so it is as stable as anything available there. If X restructures, the rule degrades to the old behaviour rather than over-excluding.
- **Unrelated pre-existing test failures:** `src/utils/host/translate/api/__tests__/free-api.test.ts` (2 cases) fails locally because it refreshes a live Microsoft token endpoint (404 without network access). Confirmed identical on a clean tree at this base commit. The pre-push hook was bypassed for that reason; everything else passes (2504 tests).