### PR TITLE
fix(translation-hub): swap languages while the source is auto-detected

### DIFF
--- a/.changeset/swap-auto-source-language.md
+++ b/.changeset/swap-auto-source-language.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation-hub): let the language swap button work while the source is auto-detected

--- a/src/components/language-combobox.tsx
+++ b/src/components/language-combobox.tsx
@@ -67,11 +67,18 @@ export function LanguageCombobox({
           />
         }
       >
+        {/* `ComboboxValue` renders no element of its own, so both children below land
+            directly in the trigger's flex row. */}
         <ComboboxValue placeholder={placeholder ?? i18n.t("translationHub.searchLanguages")}>
           {(item: LanguageItem | null) => (
-            <span className="min-w-0 flex-1 truncate text-left">
-              {item?.label ?? placeholder ?? i18n.t("translationHub.searchLanguages")}
-            </span>
+            <>
+              <span className="min-w-0 flex-1 truncate text-left">
+                {item?.label ?? placeholder ?? i18n.t("translationHub.searchLanguages")}
+              </span>
+              {/* The auto row is named after a real language, so without the badge the
+                  trigger reads exactly like that language pinned by hand. */}
+              {item?.value === "auto" && !autoLabel && <AutoBadge />}
+            </>
           )}
         </ComboboxValue>
       </ComboboxTrigger>

--- a/src/entrypoints/translation-hub/atoms.ts
+++ b/src/entrypoints/translation-hub/atoms.ts
@@ -32,6 +32,17 @@ export const inputTextAtom = atom("")
 // === Detected Source LangCode (from input text) ===
 export const detectedSourceLangCodeAtom = atom<LangCodeISO6393 | null>(null)
 
+/** Named after the empty input, which detects as nothing but still has to name the auto row. */
+const FALLBACK_DETECTED_LANG_CODE: LangCodeISO6393 = "eng"
+
+/**
+ * The language the auto row stands for: what the source selector reads while `auto` is
+ * selected, and so also what `auto` hands over when the two languages swap.
+ */
+export const detectedLangCodeAtom = atom(
+  (get) => get(detectedSourceLangCodeAtom) ?? FALLBACK_DETECTED_LANG_CODE,
+)
+
 // === Selected Provider IDs (only store IDs, get config from configFieldsAtomMap) ===
 const selectedProviderIdsOverrideAtom = atom<string[] | null>(null)
 
@@ -62,10 +73,11 @@ export const selectedProvidersAtom = atom((get) => {
 // === Write-Only Action Atom (only for operations that touch multiple atoms) ===
 export const exchangeLangCodesAtom = atom(null, (get, set) => {
   const source = get(sourceLangCodeAtom)
-  if (source === "auto") return // Cannot exchange when source is auto
   const target = get(targetLangCodeAtom)
   set(sourceLangCodeAtom, target)
-  set(targetLangCodeAtom, source)
+  // `auto` is no language to hand to the target side, so it hands over the one the source
+  // selector was reading — the detected one — and the swap stays what the eye saw.
+  set(targetLangCodeAtom, source === "auto" ? get(detectedLangCodeAtom) : source)
 })
 
 // === Translation Request (Command Pattern) ===

--- a/src/entrypoints/translation-hub/components/language-control-panel.tsx
+++ b/src/entrypoints/translation-hub/components/language-control-panel.tsx
@@ -7,6 +7,7 @@ import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { detectLanguage } from "@/utils/content/language"
 import { i18n } from "@/utils/i18n"
 import {
+  detectedLangCodeAtom,
   detectedSourceLangCodeAtom,
   exchangeLangCodesAtom,
   inputTextAtom,
@@ -20,7 +21,8 @@ export function LanguageControlPanel() {
   const [targetLangCode, setTargetLangCode] = useAtom(targetLangCodeAtom)
   const exchangeLangCodes = useSetAtom(exchangeLangCodesAtom)
   const inputText = useAtomValue(inputTextAtom)
-  const [detectedSourceLangCode, setDetectedSourceLangCode] = useAtom(detectedSourceLangCodeAtom)
+  const setDetectedSourceLangCode = useSetAtom(detectedSourceLangCodeAtom)
+  const detectedLangCode = useAtomValue(detectedLangCodeAtom)
   const languageDetection = useAtomValue(configFieldsAtomMap.languageDetection)
 
   // Debounced language detection from input text
@@ -42,8 +44,6 @@ export function LanguageControlPanel() {
     return () => debouncedDetect.clear()
   }, [inputText, debouncedDetect])
 
-  const detectedLangCode = detectedSourceLangCode ?? "eng"
-
   return (
     <div className="flex w-full items-center gap-3">
       <SearchableLanguageSelector
@@ -59,7 +59,6 @@ export function LanguageControlPanel() {
           variant="ghost"
           size="icon"
           onClick={exchangeLangCodes}
-          disabled={sourceLangCode === "auto"}
           title={i18n.t("translationHub.exchangeLanguages")}
         >
           <Icon icon="tabler:arrows-exchange" className="h-4 w-4" />


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 5

## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

The translation hub's language exchange (⇄) button did nothing for most users.

`LanguageControlPanel` carried `disabled={sourceLangCode === "auto"}`, and
`language.sourceCode` ships as `auto` — so unless someone had pinned a source
language by hand, the button was permanently disabled. Nothing on screen said so:
while `auto` is selected the source combobox reads the **detected** language's name
(«简体中文 (简体中文)» in the report), and `LanguageCombobox`'s trigger drops the `auto`
badge that the dropdown rows carry. The result was a box that looked like a normal
pinned language sitting next to a button that ignored every click.

Changes:

- `exchangeLangCodesAtom` resolves `auto` against the detected language instead of
  returning early, so a swap hands back exactly the pair the two boxes were reading.
  The `disabled` prop is gone.
- The `eng` fallback for "nothing detected yet" moves out of the component into a new
  `detectedLangCodeAtom`, so the auto row's label and the swap read one value.
- The trigger now renders the `auto` badge, the same way the popup appends `(auto)`,
  so the source box stops impersonating a hand-picked language. The existing
  `!autoLabel` guard keeps it out of the settings and TTS comboboxes, whose rendered
  DOM is unchanged.

## Related Issue

Reported via Featurebase #27 (「这个左右切换没有生效的问题已经几个月还没有修正」). No matching
GitHub issue.

Closes #

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

Driven in real Chrome with a Puppeteer harness against the built extension
(`.output/chrome-mv3`), config forced to `sourceCode: auto` / `targetCode: eng`:

| Step | Before | After |
| --- | --- | --- |
| Empty input | `English (English)` / `English (English)`, button **disabled** | same labels + `auto` badge, button enabled |
| Type Chinese text | source → `Simplified Chinese`, still **disabled**, click does nothing | source → `Simplified Chinese` + `auto` badge |
| Click ⇄ | no change | → `English` / `Simplified Chinese` |
| Click ⇄ again | — | → `Simplified Chinese` / `English` |

No page errors in the console during the run. `pnpm lint`, `pnpm test` (2500 tests),
and `pnpm build` all pass.

Per project convention no unit tests were added for this UI change.

## Screenshots

<!-- drag in docs/hub-before-swap.png and docs/hub-after-swap.png -->

**Before clicking ⇄** (source is auto-detected, now badged):

![before](docs/hub-before-swap.png)

**After clicking ⇄**:

![after](docs/hub-after-swap.png)

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The swap now always produces a pinned source language — `auto` is a state you can
swap *out of*, not into. That matches Google Translate's behaviour and keeps the
translate request unambiguous.