### PR TITLE
fix(translate): stop the no-translation marker from dropping translat…

### DIFF
--- a/.changeset/sentinel-stops-eating-paragraphs.md
+++ b/.changeset/sentinel-stops-eating-paragraphs.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): stop the no-translation marker from dropping translatable paragraphs

--- a/src/utils/constants/prompt.ts
+++ b/src/utils/constants/prompt.ts
@@ -161,6 +161,13 @@ export const DEFAULT_SUBTITLE_TRANSLATE_PROMPTS_CONFIG = {
   patterns: [],
 }
 
+/**
+ * Shared by the webpage and subtitles batch pipelines. The worked example below
+ * must keep a real translation in every output slot: demonstrating
+ * NO_TRANSLATION_SENTINEL in one of them taught models a ~1-in-3 base rate for
+ * the marker and silently dropped paragraphs that needed translating. See
+ * DEFAULT_SENTINEL_TRANSLATE_PROMPT for the measurements.
+ */
 export const DEFAULT_BATCH_TRANSLATE_PROMPT = `## Multi-paragraph Translation Rules
 1. If input contains a standalone line containing only ${BATCH_SEPARATOR}, use a standalone ${BATCH_SEPARATOR} line in your output. If input has no standalone ${BATCH_SEPARATOR} line, don't use ${BATCH_SEPARATOR} in your output.
 2. **CRITICAL**: Treat ${BATCH_SEPARATOR} as a separator only when it appears on its own line. Do not treat ${BATCH_SEPARATOR} as a separator when it appears inside normal text, code, quotes, or punctuation.
@@ -200,32 +207,55 @@ Single paragraph content
 Direct translation without separators
 `
 
-export const DEFAULT_SENTINEL_TRANSLATE_PROMPT = `## Already-translated Input Rule
-If a paragraph of the input is already entirely written in ${getTokenCellText(TARGET_LANGUAGE)} and needs no translation, output the exact marker ${NO_TRANSLATION_SENTINEL} as that paragraph's entire translation instead of repeating the paragraph. Never mix the marker with translated text. If only part of a paragraph is in ${getTokenCellText(TARGET_LANGUAGE)}, translate the whole paragraph normally.`
-
 /**
- * Batch prompt for the WEBPAGE pipeline only: the format example demonstrates
- * the no-translation marker in place, which measurably doubles marker usage on
- * mixed batches versus the rule alone (models imitate examples more reliably
- * than they follow rules). Subtitles keep DEFAULT_BATCH_TRANSLATE_PROMPT —
- * their pipeline has no sentinel mapping and must never see the marker.
- * Derived via replace; the prompt unit tests pin that both anchors matched.
+ * The marker rule: a heading plus a single body line. Both sentences in that
+ * line are load-bearing — the language test, and the ban on mixing the marker
+ * into translated text (isNoTranslationSentinel matches the marker exactly, so
+ * mixed output reaches the page verbatim).
+ *
+ * Benchmarked on 120 real paragraphs scraped from react.dev / MDN / Wikipedia /
+ * vitejs / arXiv, each hand-labelled for whether a translation is actually owed
+ * — identifiers like `ArrayBuffer` and pure code are excluded, since dropping
+ * those is correct rather than a bug, leaving 107. 4 runs x 8 models:
+ * deepseek-v4-pro/flash, glm-4.7, qwen3.5-27b, gpt-5-nano, gpt-5.4-nano/mini,
+ * gpt-4o-mini, target language Simplified Chinese. Share of owed paragraphs
+ * that rendered nothing:
+ *
+ *   original wording, marker shown in the example   7.9%   (deepseek-v4-pro 18.0%)
+ *   this wording, marker absent from the example    4.7%   (deepseek-v4-pro  1.6%)
+ *   two longer variants, same removal               4.2% and 4.9%
+ *
+ * Original vs any fix is significant (z = -5.5); the three fixes are not
+ * distinguishable from each other (|z| < 1.3). One edit carries the win —
+ * deleting the marked slot from the worked example — so among wordings that
+ * measure the same, take the shortest. Concretely, do not add back:
+ *
+ * 1. The marked example slot. Showing one of three example segments marked
+ *    taught a ~1-in-3 marker base rate that outweighed the rule. Re-wording that
+ *    segment does not help, only deleting it does — which is why the page
+ *    pipeline now uses the same plain DEFAULT_BATCH_TRANSLATE_PROMPT that
+ *    subtitles use. See the "keeps the marker out of the batch format example"
+ *    test, which is what actually guards this.
+ * 2. A negative list of the misfiring shapes (headings, API names, bibliography
+ *    entries, error messages). It costs +894 characters on every batch request
+ *    and buys nothing measurable. It also made gpt-5-nano worse — and gpt-5-nano
+ *    never emits the marker at all, so the block was not changing its marker
+ *    decisions; naming those shapes primed it to leave them untranslated by
+ *    echoing the source, which the equality check in getDisplayTranslation then
+ *    renders as nothing just the same.
+ * 3. The clause "instead of repeating the paragraph". Told not to repeat, models
+ *    produce something different rather than nothing: already-target-language
+ *    paragraphs translated back into the source language rose from 8 to 22
+ *    occurrences over the same runs.
+ *
+ * The wording that caused the bug was the conjunct "and needs no translation",
+ * read by models as an independent trigger for anything they judged
+ * untranslatable — a smaller effect than the example, but the same failure.
+ * Code maps the marker to "", so each such paragraph rendered as nothing. Keep
+ * the condition a pure language test.
  */
-export const DEFAULT_BATCH_TRANSLATE_PROMPT_WITH_SENTINEL = DEFAULT_BATCH_TRANSLATE_PROMPT.replace(
-  `Paragraph B
-
-${BATCH_SEPARATOR}`,
-  `Paragraph B (this one is already written in ${getTokenCellText(TARGET_LANGUAGE)})
-
-${BATCH_SEPARATOR}`,
-).replace(
-  `Translation B
-
-${BATCH_SEPARATOR}`,
-  `${NO_TRANSLATION_SENTINEL}
-
-${BATCH_SEPARATOR}`,
-)
+export const DEFAULT_SENTINEL_TRANSLATE_PROMPT = `## Already-translated Input Rule
+Use the exact marker ${NO_TRANSLATION_SENTINEL} as a paragraph's entire translation only when every word of it is already ${getTokenCellText(TARGET_LANGUAGE)}; otherwise always translate. Never mix the marker with translated text.`
 
 // === Subtitles Segmentation Prompts ===
 

--- a/src/utils/prompts/__tests__/translate.test.ts
+++ b/src/utils/prompts/__tests__/translate.test.ts
@@ -2,6 +2,8 @@ import type { Config } from "@/types/config/config"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import {
+  DEFAULT_BATCH_TRANSLATE_PROMPT,
+  DEFAULT_SENTINEL_TRANSLATE_PROMPT,
   DEFAULT_TRANSLATE_PROMPT_ID,
   isNoTranslationSentinel,
   NO_TRANSLATION_SENTINEL,
@@ -306,31 +308,60 @@ describe("no-translation sentinel", () => {
 
     expect(result.systemPrompt).toContain("Already-translated Input Rule")
     expect(result.systemPrompt).toContain(NO_TRANSLATION_SENTINEL)
-    expect(result.systemPrompt).toContain("already entirely written in Simplified Chinese")
+    expect(result.systemPrompt).toContain(
+      "only when every word of it is already Simplified Chinese",
+    )
     expect(result.systemPrompt).not.toContain("{{targetLanguage}}")
   })
 
-  it("demonstrates the sentinel inside the batch format example (both anchors replaced)", () => {
+  it("keeps the marker out of the batch format example", () => {
     const result = getTranslatePromptFromConfig(defaultPromptsConfig, "Simplified Chinese", "Hi", {
       isBatch: true,
     })
 
-    // Input example: Paragraph B is annotated as already in the target language.
-    expect(result.systemPrompt).toContain(
-      "Paragraph B (this one is already written in Simplified Chinese)",
-    )
-    // Output example: Paragraph B's slot is the sentinel, not "Translation B".
-    expect(result.systemPrompt).toContain(`${NO_TRANSLATION_SENTINEL}\n\n%%`)
-    expect(result.systemPrompt).not.toContain("Translation B")
+    // A marked slot in the worked example taught models a ~1-in-3 marker base
+    // rate that dominated the rule and silently dropped paragraphs. Every
+    // example segment must show a real translation.
+    expect(result.systemPrompt).toContain("Translation B")
+    expect(result.systemPrompt).not.toContain(`${NO_TRANSLATION_SENTINEL}\n\n%%`)
+    expect(result.systemPrompt).not.toContain("this one is already written in")
+    // The page batch block is byte-identical to the one subtitles use.
+    expect(result.systemPrompt).toContain(DEFAULT_BATCH_TRANSLATE_PROMPT)
+  })
+
+  it("keeps the marker rule small and free of the wordings that misfired", () => {
+    // Three wordings this block has already been burned by, none of them
+    // visible to a behavioural test, so pin the shape instead:
+    //   - "and needs no translation" let models treat "untranslatable" as a
+    //     trigger — the wording that caused the missing-paragraph bug;
+    //   - enumerating the misfiring shapes (headings, API names, bibliography
+    //     entries, error messages) primes small models to skip them;
+    //   - "instead of repeating the paragraph" pushed models to render
+    //     already-target-language paragraphs back into the source language.
+    // The body is deliberately ONE line: a list would be appended as further
+    // lines, which a sentence count split on ". " cannot see.
+    const lines = DEFAULT_SENTINEL_TRANSLATE_PROMPT.split("\n")
+    expect(lines).toHaveLength(2)
+    expect(lines[1]!.length).toBeLessThan(240)
+    expect(DEFAULT_SENTINEL_TRANSLATE_PROMPT).not.toContain("needs no translation")
+    expect(DEFAULT_SENTINEL_TRANSLATE_PROMPT).not.toContain("instead of repeating the paragraph")
+    // The one clause in here that is not part of the language test. Without it
+    // a model can mix the marker into otherwise translated output, which
+    // isNoTranslationSentinel (exact match only) would then render verbatim.
+    expect(DEFAULT_SENTINEL_TRANSLATE_PROMPT).toContain("Never mix the marker with translated text")
   })
 
   it("never leaks the sentinel into subtitle prompts, which share the batch rules", async () => {
     mockGetLocalConfig.mockResolvedValue(DEFAULT_CONFIG)
 
     const result = await getSubtitlesTranslatePrompt("Japanese", "Hello world", {
+      isBatch: true,
       context: { webTitle: "Video", webDescription: "Desc", videoSummary: "Sum" },
     })
 
+    // isBatch is what appends the shared batch block — assert it actually
+    // arrived, or the marker check below passes vacuously.
+    expect(result.systemPrompt).toContain(DEFAULT_BATCH_TRANSLATE_PROMPT)
     // The subtitle pipeline has no sentinel mapping; the marker must never
     // appear in its prompts (rule or example).
     expect(result.systemPrompt).not.toContain(NO_TRANSLATION_SENTINEL)

--- a/src/utils/prompts/translate.ts
+++ b/src/utils/prompts/translate.ts
@@ -9,7 +9,7 @@ import { DEFAULT_CONFIG } from "../constants/config"
 import {
   BATCH_SEPARATOR,
   BUILT_IN_PAGE_TRANSLATE_PROMPTS,
-  DEFAULT_BATCH_TRANSLATE_PROMPT_WITH_SENTINEL,
+  DEFAULT_BATCH_TRANSLATE_PROMPT,
   DEFAULT_SENTINEL_TRANSLATE_PROMPT,
   DEFAULT_TRANSLATE_PROMPT_ID,
   getTokenCellText,
@@ -66,16 +66,17 @@ export function getTranslatePromptFromConfig(
 
   let { systemPrompt, prompt } = selectedPrompt
 
-  // For batch mode, append batch rules to system prompt. The sentinel rule and
-  // the sentinel-bearing format example are appended ONLY here: batch prompts
-  // are built exclusively for the background translation pipeline, whose
-  // results all return through translateTextCore where the sentinel is mapped
-  // — the selection-toolbar streaming path never sees this instruction and can
-  // never render the marker raw.
+  // For batch mode, append batch rules to system prompt. The batch block is the
+  // same one subtitles use — the marker appears only in the sentinel rule that
+  // follows, never inside the format example (see DEFAULT_SENTINEL_TRANSLATE_PROMPT).
+  // The sentinel rule is appended ONLY here: batch prompts are built exclusively
+  // for the background translation pipeline, whose results all return through
+  // translateTextCore where the sentinel is mapped — the selection-toolbar
+  // streaming path never sees this instruction and can never render the marker raw.
   if (options?.isBatch) {
     systemPrompt = `${systemPrompt}
 
-${DEFAULT_BATCH_TRANSLATE_PROMPT_WITH_SENTINEL}
+${DEFAULT_BATCH_TRANSLATE_PROMPT}
 
 ${DEFAULT_SENTINEL_TRANSLATE_PROMPT}`
   }


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 5 (investigation, benchmarking, patch). Benchmarked against deepseek-ai/deepseek-v4-pro, deepseek-ai/deepseek-v4-flash, zai-org/glm-4.7, qwen/qwen3.5-27b (Atlas Cloud) and gpt-5-nano, gpt-5.4-nano, gpt-5.4-mini, gpt-4o-mini (OpenAI).

## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Paragraphs go missing from page translations — most visibly with DeepSeek models, where whole
sentences render nothing at all.

**Root cause.** Two independent code paths turn "the model declined to translate this paragraph"
into rendering nothing: `isNoTranslationSentinel` maps the literal `{{NO_TRANSLATION_NEEDED}}`
marker to `""`, and `getDisplayTranslation` maps a translation equal to its source to `""`. The
prompt was over-triggering the first one, for two reasons:

1. **The batch format example demonstrated the marker in one of its three output slots.** Models
   imitated that as a base rate and emitted the marker for roughly one paragraph in three,
   regardless of language. This is the dominant cause. The constant that produced it,
   `DEFAULT_BATCH_TRANSLATE_PROMPT_WITH_SENTINEL`, was introduced deliberately in #1837 — its own
   comment noted it "measurably doubles marker usage", which turned out to be the bug rather than
   the feature.
2. **The rule said "already entirely written in X *and needs no translation*".** Models read the
   second conjunct as an independent trigger and fired the marker on anything they judged
   untranslatable: headings, API names, bibliography entries, error messages, proper-noun-dense
   prose — and, for `deepseek-v4-pro`, ordinary prose.

**The fix is a net deletion.** The page pipeline now uses the same plain
`DEFAULT_BATCH_TRANSLATE_PROMPT` the subtitles pipeline already used, and the marker rule is one
sentence stating a pure language test. The assembled batch system prompt goes from 2106 to 1888
characters — shorter than before the bug existed.

```diff
  ### Multi-paragraph Input:
- Paragraph B (this one is already written in {{targetLanguage}})
+ Paragraph B

  ### Multi-paragraph Output:
- {{NO_TRANSLATION_NEEDED}}
+ Translation B

  ## Already-translated Input Rule
- If a paragraph of the input is already entirely written in {{targetLanguage}} and needs no
- translation, output the exact marker {{NO_TRANSLATION_NEEDED}} as that paragraph's entire
- translation instead of repeating the paragraph. Never mix the marker with translated text.
- If only part of a paragraph is in {{targetLanguage}}, translate the whole paragraph normally.
+ Use the exact marker {{NO_TRANSLATION_NEEDED}} as a paragraph's entire translation only when
+ every word of it is already {{targetLanguage}}; otherwise always translate. Never mix the
+ marker with translated text.
```

The system prompt's Translation Rules are untouched. Both built-in prompts benefit, since the batch
blocks are appended to whichever prompt is selected.

### Results

Benchmarked on 120 paragraphs scraped from react.dev, MDN, Wikipedia, vitejs and arXiv. Each was
hand-labelled for whether a translation is actually owed — identifiers like `ArrayBuffer`, pure code
blocks and already-Chinese text are excluded, because dropping those is correct behaviour, not a
bug. 107 qualify. 4 runs × 8 models, target language Simplified Chinese.

**Share of owed paragraphs that rendered nothing:**

| Model | Before | After |
| --- | --- | --- |
| deepseek-v4-pro | **18.0%** | **1.6%** |
| deepseek-v4-flash | 3.7% | 0.5% |
| glm-4.7 | 11.0% | 11.4% |
| qwen3.5-27b | 9.6% | 6.6% |
| gpt-5-nano | 19.6% | 16.1% |
| gpt-4o-mini | 1.4% | 0.9% |
| gpt-5.4-mini | 0.0% | 0.2% |
| gpt-5.4-nano | 0.0% | 0.0% |
| **All models** | **7.9%** | **4.7%** |

The difference between the old prompt and the fix is significant (z = −5.51). Two variants that
*added* text — a bulleted list of the misfiring shapes, and restoring the old "instead of repeating
the paragraph" clause — were also measured and are **not** used: neither beat this one by a
significant margin, the list costs +894 characters on every batch request, and the clause tripled
the rate of already-Chinese paragraphs being translated back into English (8 → 22 occurrences).
The reasoning is recorded in the doc comment above `DEFAULT_SENTINEL_TRANSLATE_PROMPT` so the next
person does not re-add them.

The `precision-rewrite` built-in prompt was affected identically and is fixed by the same change
(deepseek-v4-pro: 30.0% → 4.2% on an all-English corpus).

Suppression of paragraphs already in the target language — what the marker exists for — is
unchanged at 97–99%, because the `getDisplayTranslation` equality check independently catches them.

### Known trade-offs

- **The translation cache fully invalidates on upgrade.** The assembled `systemPrompt` is a hash
  component in `buildWebPageHashComponents`, so every user re-translates previously cached pages
  once. Unavoidable for any prompt edit.
- Models now translate slightly more of the paragraphs that are pure identifiers (65.9% → 54.6% left
  untouched), which occasionally produces `Math` → 数学 or `Meta AI` → 元人工智能. Harmless in
  bilingual mode where the original stays visible; wrong in translation-only mode. Roughly 1–2
  occurrences per page, against a 3.2 point reduction in genuinely missing paragraphs.
- **What this does not fix:** the remaining 4.7% is almost entirely the second code path — the model
  echoing the source verbatim — concentrated in Wikipedia bibliography lines and MDN error strings.
  `gpt-5-nano` and `glm-4.7` lose paragraphs this way and no prompt wording measurably helps them;
  addressing it means changing `getDisplayTranslation`, not the prompt.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [x] Added unit tests
- [x] Verified through manual testing

- Full suite green: 267 files, 2540 tests.
- `src/utils/prompts/__tests__/translate.test.ts` gains assertions that fail if the marker is
  re-added to the worked example, if the rule body grows past one line, or if either the
  "and needs no translation" conjunct or the "instead of repeating the paragraph" clause comes
  back — none of those regressions are visible to a behavioural test.
- **Fixed a pre-existing dead guard found while reviewing this.** The test asserting the marker
  never reaches subtitle prompts never passed `isBatch`, so it inspected a prompt with no batch
  block at all. Confirmed by mutation: injecting the marker into the shared
  `DEFAULT_BATCH_TRANSLATE_PROMPT` left all 22 tests green. It now passes `isBatch: true` and
  asserts the block actually arrived. This matters more after this PR, since the page pipeline now
  shares that block — and the subtitles pipeline has no sentinel mapping, so a marker leaking in
  would render on screen as subtitle text.
- The measurements above were produced by driving the real prompt constants through the real AI SDK
  path (`createOpenAICompatible` / `createOpenAI` + `generateText`) against live providers, with
  verdicts computed using the extension's own `isNoTranslationSentinel` and
  `normalizeForComparison`.

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

n/a — the user-visible change is that paragraphs stop disappearing.

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Found while investigating this, but **not** fixed here — worth its own issue: the built-in OpenAI
provider ships `reasoning: "none"`, and `getProviderOptionsWithOverride` discards the per-model
recommendation whenever the provider supports top-level reasoning. The OpenAI API rejects `"none"`
for `gpt-5`, `gpt-5-mini`, `gpt-5-nano` (which need `"minimal"`), for the `*-pro` models, and for
the `*-chat-latest` models — 9 of the 24 models the extension offers under that provider fail on
every request with the shipped default. `OPENAI_GPT5_REASONING_EFFORT_POLICIES` in
`utils/constants/models.ts` already encodes the supported values per model, but
`getOpenAIGPT5ReasoningEffortPolicy` is exported, unit-tested and never called from `src`, and
`reasoning-field.tsx` renders every value unconditionally. Note that no single default works across
generations: the 5.4 family accepts `"none"` and rejects `"minimal"`, the 5.0 family the reverse.