### PR TITLE
fix(background): scope auth cache invalidation and stop the config-ba…

### DIFF
--- a/.changeset/lazy-donkeys-brake.md
+++ b/.changeset/lazy-donkeys-brake.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(background): scope auth cache invalidation and stop the config-backup wake loop

--- a/src/entrypoints/background/config-backup.ts
+++ b/src/entrypoints/background/config-backup.ts
@@ -9,10 +9,16 @@ import { logger } from "@/utils/logger"
 const CONFIG_BACKUP_ALARM = "config-backup"
 
 export function setUpConfigBackup() {
-  // Set up periodic alarm for config backup
-  void browser.alarms.create(CONFIG_BACKUP_ALARM, {
-    delayInMinutes: 1,
-    periodInMinutes: BACKUP_INTERVAL_MINUTES,
+  // Set up periodic alarm for config backup (only if it doesn't exist yet —
+  // re-creating it on every service-worker start resets the timer, which
+  // would wake the worker `delayInMinutes` later in a perpetual loop)
+  void browser.alarms.get(CONFIG_BACKUP_ALARM).then((existingAlarm) => {
+    if (!existingAlarm) {
+      void browser.alarms.create(CONFIG_BACKUP_ALARM, {
+        delayInMinutes: BACKUP_INTERVAL_MINUTES,
+        periodInMinutes: BACKUP_INTERVAL_MINUTES,
+      })
+    }
   })
 
   // Listen for alarm events

--- a/src/entrypoints/background/proxy-fetch.ts
+++ b/src/entrypoints/background/proxy-fetch.ts
@@ -1,11 +1,15 @@
 import type { ProxyResponse } from "@/types/proxy-fetch"
 import { AUTH_COOKIE_PATTERNS } from "@read-frog/definitions"
-import { browser } from "#imports"
+import { browser, storage } from "#imports"
 import { env } from "@/env"
-import { DEFAULT_PROXY_CACHE_TTL_MS } from "@/utils/constants/proxy-fetch"
+import { AUTH_CACHE_GROUP_KEY, DEFAULT_PROXY_CACHE_TTL_MS } from "@/utils/constants/proxy-fetch"
 import { logger } from "@/utils/logger"
 import { onMessage } from "@/utils/message"
 import { SessionCacheGroupRegistry } from "../../utils/session-cache/session-cache-group-registry"
+
+// Last-seen auth cookie values, kept in session storage so the comparison
+// survives service-worker restarts (cleared with the browser session)
+const AUTH_COOKIE_LAST_SEEN_KEY = "session:proxyFetchAuthCookieLastSeen"
 
 function encodeArrayBufferToBase64(buffer: ArrayBuffer) {
   const bytes = new Uint8Array(buffer)
@@ -32,57 +36,67 @@ export function proxyFetch() {
     await SessionCacheGroupRegistry.clearAllCacheGroup()
   }
 
+  // Auth-scoped cache invalidation: session cookie changes only affect the auth group
+  async function invalidateAuthCache() {
+    const sessionCache = await getSessionCache(AUTH_CACHE_GROUP_KEY)
+    await sessionCache.clear()
+  }
+
   // Listen for cookie changes to invalidate auth-related cache
   if (browser.cookies?.onChanged) {
     browser.cookies.onChanged.addListener(async (changeInfo) => {
-      const { cookie, removed } = changeInfo
+      const { cookie, removed, cause } = changeInfo
       // Check if it's an auth-related cookie for monitored domains
       if (
-        cookie.domain &&
-        env.WXT_AUTH_COOKIE_DOMAINS.some((domain: string) => cookie.domain.includes(domain))
+        !cookie.domain ||
+        !env.WXT_AUTH_COOKIE_DOMAINS.some((domain: string) => cookie.domain.includes(domain))
       ) {
-        // Check against defined auth cookie patterns
-        if (AUTH_COOKIE_PATTERNS.some((name) => cookie.name.includes(name))) {
-          // Get current cookie value for before/after comparison
-          let beforeValue: string | undefined
-          let afterValue: string | undefined
-
-          if (removed) {
-            // Cookie was removed - before value was the cookie value, after is undefined
-            beforeValue = cookie.value
-            afterValue = undefined
-          } else {
-            // Cookie was added/updated - get the previous value by querying all cookies
-            try {
-              const existingCookies = await browser.cookies.getAll({
-                domain: cookie.domain,
-                name: cookie.name,
-              })
-              // If cookie exists, this was an update; if not, this was creation
-              beforeValue =
-                existingCookies.length > 0 && existingCookies[0]!.value !== cookie.value
-                  ? existingCookies[0]!.value
-                  : undefined
-              afterValue = cookie.value
-            } catch (error) {
-              logger.warn("[ProxyFetch] Could not retrieve previous cookie value:", error)
-              beforeValue = "unknown"
-              afterValue = cookie.value
-            }
-          }
-
-          logger.info("[ProxyFetch] Auth cookie changed, invalidating cache:", {
-            cookieName: cookie.name,
-            domain: cookie.domain,
-            removed,
-            beforeValue,
-            afterValue,
-          })
-          invalidateAllCache().catch((error) =>
-            logger.error("[ProxyFetch] Failed to invalidate cache:", error),
-          )
-        }
+        return
       }
+      // Check against defined auth cookie patterns
+      if (!AUTH_COOKIE_PATTERNS.some((name) => cookie.name.includes(name))) {
+        return
+      }
+
+      // A cookie re-set fires two events: an "overwrite" removal followed by an
+      // add. Only the add carries the new value, so skip the overwrite half —
+      // otherwise every server-side cookie refresh double-invalidates the cache.
+      if (removed && cause === "overwrite") {
+        return
+      }
+
+      const lastSeenKey = `${cookie.domain}|${cookie.name}`
+      const newValue = removed ? undefined : cookie.value
+
+      try {
+        const lastSeen =
+          (await storage.getItem<Record<string, string>>(AUTH_COOKIE_LAST_SEEN_KEY)) ?? {}
+        // Same token re-issued (e.g. expiry extended): session identity didn't
+        // change, so the cached session is still valid — don't invalidate, or
+        // every get-session response would evict the cache it just filled.
+        if (!removed && lastSeen[lastSeenKey] === newValue) {
+          return
+        }
+        if (newValue === undefined) {
+          delete lastSeen[lastSeenKey]
+        } else {
+          lastSeen[lastSeenKey] = newValue
+        }
+        await storage.setItem(AUTH_COOKIE_LAST_SEEN_KEY, lastSeen)
+      } catch (error) {
+        // Can't tell whether the token changed — invalidate to stay correct
+        logger.warn("[ProxyFetch] Could not read last-seen auth cookie state:", error)
+      }
+
+      logger.info("[ProxyFetch] Auth cookie changed, invalidating auth cache:", {
+        cookieName: cookie.name,
+        domain: cookie.domain,
+        removed,
+        cause,
+      })
+      invalidateAuthCache().catch((error) =>
+        logger.error("[ProxyFetch] Failed to invalidate auth cache:", error),
+      )
     })
   }
 

--- a/src/utils/auth/auth-client.ts
+++ b/src/utils/auth/auth-client.ts
@@ -2,6 +2,7 @@ import type { CacheConfig } from "@/types/proxy-fetch"
 import { AUTH_BASE_PATH } from "@read-frog/definitions"
 import { createAuthClient } from "better-auth/react"
 import { env } from "@/env"
+import { AUTH_CACHE_GROUP_KEY } from "@/utils/constants/proxy-fetch"
 import { sendMessage } from "@/utils/message"
 import { normalizeHeaders } from "../http"
 
@@ -45,7 +46,7 @@ export const authClient = createAuthClient({
     credentials: "include",
     customFetchImpl: createCustomFetch({
       enabled: true,
-      groupKey: "auth",
+      groupKey: AUTH_CACHE_GROUP_KEY,
     }),
   },
 })

--- a/src/utils/constants/proxy-fetch.ts
+++ b/src/utils/constants/proxy-fetch.ts
@@ -1,1 +1,3 @@
 export const DEFAULT_PROXY_CACHE_TTL_MS = 24 * 60 * 60 * 1000
+
+export const AUTH_CACHE_GROUP_KEY = "auth"


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Fable 5

## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Two independent background service-worker bugs, both found while tracing why `GET /api/identity/get-session` accounts for **~75–88% of all API request volume** (~30k requests/day, a sustained 20.6 req/min that never drops to zero) in the production Railway logs.

**1. Any auth cookie change wiped every proxy-fetch cache group (`proxy-fetch.ts`)**

The extension caches proxied GETs in `browser.storage.session`, grouped by key (`auth`, `blog-fetch`, …), and listens on `browser.cookies.onChanged` to drop stale auth state. Three problems compounded there:

| Problem | Effect |
| --- | --- |
| Invalidated **all** groups, not just `auth` | A session refresh also evicted the unrelated `blog-fetch` cache, sending clients back to `www` |
| The before/after comparison read the cookie store *after* the change landed | `getAll()` returned the new value, so it compared the new value against itself — the guard never suppressed anything |
| A cookie re-set fires **two** events (an `overwrite` removal, then an add) | Every refresh triggered two full cache clears |

Because a `get-session` response itself re-sets the session cookie, the cache was evicted right after being filled — the fetch that populated the cache invalidated it. The logs show the resulting loop directly: eight separate runs of a single client refetching `get-session` at ~2.5 req/s (one run held that rate for 18 consecutive requests), plus a 50-request burst inside 0.5 s.

The listener now skips the `overwrite` half of a re-set, records the last-seen cookie value in session storage (so an unchanged, merely re-issued token is a no-op), and clears only the `auth` group. Storage read failures fall through to invalidating, so correctness is preserved when the comparison is unavailable.

**2. The config-backup alarm re-armed itself every service-worker start (`config-backup.ts`)**

`setUpConfigBackup()` called `browser.alarms.create(…, { delayInMinutes: 1 })` unconditionally on every background start. MV3 tears the worker down after ~30 s idle, so each start scheduled a wake one minute out; that wake restarted the worker, which re-created the alarm, which scheduled another wake — a self-sustaining ~1-minute loop (roughly 1,440 worker starts/day) for a task that only needs to run hourly. `db-cleanup.ts` already had the correct pattern; this now matches it by guarding on `alarms.get` and using the backup interval for the initial delay too.

This one costs battery rather than bandwidth — the background startup path makes no unconditional network calls — but it keeps the worker awake around the clock for no reason.

Also extracts the `"auth"` cache group key into a shared `AUTH_CACHE_GROUP_KEY` constant so the producer (`auth-client.ts`) and the invalidator can no longer drift apart via a string literal.

## Related Issue

Closes #

## How Has This Been Tested?

- [ ] Added unit tests
- [x] Verified through manual testing

- Full suite green: 267 files / 2540 tests, plus `oxlint --type-aware --type-check` clean.
- Diagnosis is grounded in production Railway data, not inference: 30 days of per-service metrics across all 15 environments, and HTTP log samples from the production `server` service (a 1,000-request `get-session` sample over 48.7 min was gap-histogrammed to isolate the 0.4 s-interval runs from ordinary per-pageload traffic).
- No unit tests added: both changed paths are browser-extension lifecycle code (`browser.cookies.onChanged` event shapes and MV3 alarm rescheduling across worker teardown) whose real failure mode — the `overwrite`/add event pair and the restart timing — is exactly what a mocked `fakeBrowser` would have to stub, so a test would assert the mock rather than the behavior. Per repo convention, verify in a real browser instead.

> **Note for review:** the pre-push hook failed once with six 5 s test timeouts (`context-menu`, `config`, `translator`, `free-api`). None of those files import either changed module, all pass in isolation, and a re-run of the same `nx test` command was fully green — Nx flagged the task as flaky itself. Load-induced, not a regression.

## Screenshots

N/A (background service-worker behavior)

## Additional Information

**Not addressed here.** The dominant share of that `get-session` volume is not the cookie loop — it is `selection.content` (registered on `*://*/*`) calling `authClient.useSession()` on every page the user visits, via `save-to-notebase-button.tsx`, `use-save-to-notebase.ts`, and `save-to-notebase-dialog-host.tsx`. Resolving the session once in the background and broadcasting it to content scripts would remove most of the remaining traffic, but that is a larger change and belongs in its own PR.

Worth noting for cost expectations: Railway bills on resident memory, not request count, so neither fix moves the bill much on its own. The billing waste lives in the preview environments (`bgutil` and per-PR `redis` never sleep) and is handled separately in the monorepo. These two fixes are about correctness and client battery.

Two related backend-side items from the same investigation, also outside this repo: a permanent `403` retry loop on `videoTranscript/getUsage`, and the AI-subtitles client polling `videoTranscript.get` at 1 Hz for up to 5 minutes (~300 requests per job).