### PR TITLE
feat(note-suggestions): choose which suggested words to save

### DIFF
--- a/.changeset/fix-openai-note-suggestions.md
+++ b/.changeset/fix-openai-note-suggestions.md
@@ -1,0 +1,7 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(note-suggestions): make structured output compatible with OpenAI
+
+Note suggestions now use a required nullable summary field, preventing OpenAI's strict JSON Schema validation from rejecting the request before generation starts.

--- a/.changeset/select-note-suggestions.md
+++ b/.changeset/select-note-suggestions.md
@@ -1,0 +1,7 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(note-suggestions): choose which suggested words to save
+
+Note suggestion rows now have checkboxes, so you can remove words that are not useful before saving the rest to your Notebase.

--- a/src/components/form/input-field-auto-save.tsx
+++ b/src/components/form/input-field-auto-save.tsx
@@ -38,11 +38,9 @@ export function InputFieldAutoSave({
   }
 
   return (
-    <Field invalid={hasError}>
+    <Field data-invalid={hasError}>
       <div className="flex w-full items-end justify-between">
-        <FieldLabel nativeLabel={false} render={<div />}>
-          {label}
-        </FieldLabel>
+        <FieldLabel htmlFor={field.name}>{label}</FieldLabel>
         {labelExtra}
       </div>
       <Input
@@ -54,7 +52,7 @@ export function InputFieldAutoSave({
         aria-invalid={hasError}
         {...props}
       />
-      <FieldError match={hasError}>
+      <FieldError>
         {errors.map((error) => (typeof error === "string" ? error : error?.message)).join(", ")}
       </FieldError>
     </Field>

--- a/src/components/form/input-field.tsx
+++ b/src/components/form/input-field.tsx
@@ -34,11 +34,9 @@ export function InputField({
   }
 
   return (
-    <Field invalid={hasError}>
+    <Field data-invalid={hasError}>
       <div className="flex w-full items-end justify-between">
-        <FieldLabel nativeLabel={false} render={<div />}>
-          {label}
-        </FieldLabel>
+        <FieldLabel htmlFor={field.name}>{label}</FieldLabel>
         {labelExtra}
       </div>
       <Input
@@ -50,7 +48,7 @@ export function InputField({
         aria-invalid={hasError}
         {...props}
       />
-      <FieldError match={hasError}>
+      <FieldError>
         {errors.map((error) => (typeof error === "string" ? error : error?.message)).join(", ")}
       </FieldError>
     </Field>

--- a/src/components/form/quick-insertable-textarea-field-auto-save.tsx
+++ b/src/components/form/quick-insertable-textarea-field-auto-save.tsx
@@ -24,9 +24,10 @@ export function QuickInsertableTextareaFieldAutoSave({
   const hasError = errors.length > 0
 
   return (
-    <Field invalid={hasError}>
-      <FieldLabel>{label}</FieldLabel>
+    <Field data-invalid={hasError}>
+      <FieldLabel htmlFor={field.name}>{label}</FieldLabel>
       <QuickInsertableTextarea
+        id={field.name}
         value={field.state.value}
         onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
           field.handleChange(event.target.value)
@@ -37,7 +38,7 @@ export function QuickInsertableTextareaFieldAutoSave({
         insertCells={insertCells}
         readOnly={readOnly}
       />
-      <FieldError match={hasError}>
+      <FieldError>
         {errors.map((error) => (typeof error === "string" ? error : error?.message)).join(", ")}
       </FieldError>
     </Field>

--- a/src/components/form/quick-insertable-textarea-field.tsx
+++ b/src/components/form/quick-insertable-textarea-field.tsx
@@ -22,9 +22,10 @@ export function QuickInsertableTextareaField({
   const hasError = errors.length > 0
 
   return (
-    <Field invalid={hasError}>
-      <FieldLabel>{label}</FieldLabel>
+    <Field data-invalid={hasError}>
+      <FieldLabel htmlFor={field.name}>{label}</FieldLabel>
       <QuickInsertableTextarea
+        id={field.name}
         value={field.state.value}
         onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
           field.handleChange(event.target.value)
@@ -34,7 +35,7 @@ export function QuickInsertableTextareaField({
         className={className}
         insertCells={insertCells}
       />
-      <FieldError match={hasError}>
+      <FieldError>
         {errors.map((error) => (typeof error === "string" ? error : error?.message)).join(", ")}
       </FieldError>
     </Field>

--- a/src/components/form/select-field-auto-save.tsx
+++ b/src/components/form/select-field-auto-save.tsx
@@ -1,7 +1,7 @@
 import type * as React from "react"
 import { useSelector } from "@tanstack/react-store"
 import { useCallback } from "react"
-import { Field, FieldError, FieldLabel } from "@/components/ui/base-ui/field"
+import { Field, FieldError, FieldTitle } from "@/components/ui/base-ui/field"
 import { Select } from "@/components/ui/base-ui/select"
 import { useFieldContext } from "./form-context"
 
@@ -31,17 +31,15 @@ export function SelectFieldAutoSave({
   )
 
   return (
-    <Field invalid={hasError}>
+    <Field data-invalid={hasError}>
       <div className="flex w-full items-end justify-between">
-        <FieldLabel nativeLabel={false} render={<div />}>
-          {label}
-        </FieldLabel>
+        <FieldTitle>{label}</FieldTitle>
         {labelExtra}
       </div>
       <Select value={field.state.value} onValueChange={handleValueChange} {...props}>
         {props.children}
       </Select>
-      <FieldError match={hasError}>
+      <FieldError>
         {errors.map((error) => (typeof error === "string" ? error : error?.message)).join(", ")}
       </FieldError>
     </Field>

--- a/src/components/form/select-field.tsx
+++ b/src/components/form/select-field.tsx
@@ -1,7 +1,7 @@
 import type * as React from "react"
 import { useSelector } from "@tanstack/react-store"
 import { useCallback } from "react"
-import { Field, FieldError, FieldLabel } from "@/components/ui/base-ui/field"
+import { Field, FieldError, FieldTitle } from "@/components/ui/base-ui/field"
 import { Select } from "@/components/ui/base-ui/select"
 import { useFieldContext } from "./form-context"
 
@@ -23,14 +23,12 @@ export function SelectField({ label, ...props }: SelectFieldProps) {
   )
 
   return (
-    <Field invalid={hasError}>
-      <FieldLabel nativeLabel={false} render={<div />}>
-        {label}
-      </FieldLabel>
+    <Field data-invalid={hasError}>
+      <FieldTitle>{label}</FieldTitle>
       <Select value={field.state.value} onValueChange={handleValueChange} {...props}>
         {props.children}
       </Select>
-      <FieldError match={hasError}>
+      <FieldError>
         {errors.map((error) => (typeof error === "string" ? error : error?.message)).join(", ")}
       </FieldError>
     </Field>

--- a/src/components/llm-providers/feature-provider-selector-list.tsx
+++ b/src/components/llm-providers/feature-provider-selector-list.tsx
@@ -1,7 +1,7 @@
 import type { ComponentProps } from "react"
 import type { FeatureKey } from "@/utils/constants/feature-providers"
 import ProviderSelector from "@/components/llm-providers/provider-selector"
-import { Field, FieldGroup, FieldLabel } from "@/components/ui/base-ui/field"
+import { Field, FieldGroup, FieldTitle } from "@/components/ui/base-ui/field"
 import { FEATURE_KEYS, getFeatureLabelI18nKey } from "@/utils/constants/feature-providers"
 import { i18n } from "@/utils/i18n"
 import { cn } from "@/utils/styles/utils"
@@ -30,13 +30,10 @@ function FeatureProviderField({
 
   return (
     <Field>
-      <FieldLabel
-        nativeLabel={false}
-        render={<div className="flex flex-wrap items-center gap-2" />}
-      >
+      <FieldTitle className="flex flex-wrap items-center gap-2">
         {i18n.t(getFeatureLabelI18nKey(featureKey))}
         <SetApiKeyWarning providerConfig={providerConfig} />
-      </FieldLabel>
+      </FieldTitle>
       <ProviderSelector
         providers={providers}
         value={providerId}
@@ -68,13 +65,10 @@ function CustomActionProviderFields({
       </p>
       {actions.map((action) => (
         <Field key={action.id}>
-          <FieldLabel
-            nativeLabel={false}
-            render={<div className="flex flex-wrap items-center gap-2" />}
-          >
+          <FieldTitle className="flex flex-wrap items-center gap-2">
             {action.name}
             <SetApiKeyWarning providerConfig={getProviderConfig(action)} />
-          </FieldLabel>
+          </FieldTitle>
           <ProviderSelector
             providers={providers}
             value={action.providerId}

--- a/src/components/ui/base-ui/__tests__/field.test.tsx
+++ b/src/components/ui/base-ui/__tests__/field.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { Checkbox } from "@/components/ui/base-ui/checkbox"
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+  FieldTitle,
+} from "@/components/ui/base-ui/field"
+
+describe("Field", () => {
+  it("renders the shadcn choice-card composition", () => {
+    render(
+      <FieldLabel>
+        <Field orientation="horizontal">
+          <Checkbox defaultChecked />
+          <FieldContent>
+            <FieldTitle>Enable notifications</FieldTitle>
+            <FieldDescription>Receive product updates.</FieldDescription>
+          </FieldContent>
+        </Field>
+      </FieldLabel>,
+    )
+
+    const checkbox = screen.getByRole("checkbox", { name: /enable notifications/i })
+    const field = checkbox.closest('[data-slot="field"]')
+    const label = field?.parentElement
+
+    expect(checkbox).toBeChecked()
+    expect(field).toHaveAttribute("role", "group")
+    expect(field).toHaveAttribute("data-orientation", "horizontal")
+    expect(label).toHaveAttribute("data-slot", "field-label")
+    expect(label?.tagName).toBe("LABEL")
+    expect(label).toHaveClass("has-data-checked:bg-primary/5")
+  })
+})

--- a/src/components/ui/base-ui/field.tsx
+++ b/src/components/ui/base-ui/field.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import type { VariantProps } from "class-variance-authority"
-import { Field as FieldPrimitive } from "@base-ui/react/field"
 import { cva } from "class-variance-authority"
-import * as React from "react"
+import { useMemo } from "react"
+import { Label } from "@/components/ui/base-ui/label"
 import { Separator } from "@/components/ui/base-ui/separator"
 import { cn } from "@/utils/styles/utils"
 
@@ -10,8 +12,7 @@ function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
     <fieldset
       data-slot="field-set"
       className={cn(
-        "flex flex-col gap-6",
-        "has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        "flex flex-col gap-6 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
         className,
       )}
       {...props}
@@ -29,9 +30,7 @@ function FieldLegend({
       data-slot="field-legend"
       data-variant={variant}
       className={cn(
-        "mb-3 font-medium",
-        "data-[variant=legend]:text-base",
-        "data-[variant=label]:text-sm",
+        "mb-3 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
         className,
       )}
       {...props}
@@ -44,7 +43,7 @@ function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="field-group"
       className={cn(
-        "group/field-group @container/field-group flex w-full flex-col gap-6 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4",
+        "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
         className,
       )}
       {...props}
@@ -52,25 +51,14 @@ function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-const fieldVariants = cva("group/field flex w-full gap-2 data-[invalid]:text-destructive", {
+const fieldVariants = cva("group/field flex w-full gap-3 data-[invalid=true]:text-destructive", {
   variants: {
     orientation: {
-      vertical: ["flex-col [&>*]:w-full [&>.sr-only]:w-auto"],
-      horizontal: [
-        "flex-row items-center",
-        "[&>[data-slot=field-label]]:flex-auto",
-        "has-[>[data-slot=field-content]]:items-start has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
-      ],
-      responsive: [
-        "flex-col @md/field-group:flex-row @md/field-group:items-center [&>*]:w-full @md/field-group:[&>*]:w-auto [&>.sr-only]:w-auto",
-        "@md/field-group:[&>[data-slot=field-label]]:flex-auto",
-        "@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
-      ],
-      "responsive-compact": [
-        "flex-col @xs/field-group:flex-row @xs/field-group:items-center [&>*]:w-full @xs/field-group:[&>*]:w-auto [&>.sr-only]:w-auto",
-        "@xs/field-group:[&>[data-slot=field-label]]:flex-auto",
-        "@xs/field-group:has-[>[data-slot=field-content]]:items-start @xs/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
-      ],
+      vertical: "flex-col *:w-full [&>.sr-only]:w-auto",
+      horizontal:
+        "flex-row items-center has-[>[data-slot=field-content]]:items-start *:data-[slot=field-label]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+      responsive:
+        "flex-col *:w-full @md/field-group:flex-row @md/field-group:items-center @md/field-group:*:w-auto @md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:*:data-[slot=field-label]:flex-auto [&>.sr-only]:w-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
     },
   },
   defaultVariants: {
@@ -78,13 +66,14 @@ const fieldVariants = cva("group/field flex w-full gap-2 data-[invalid]:text-des
   },
 })
 
-function FieldRoot({
+function Field({
   className,
   orientation = "vertical",
   ...props
-}: FieldPrimitive.Root.Props & VariantProps<typeof fieldVariants>) {
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
   return (
-    <FieldPrimitive.Root
+    <div
+      role="group"
       data-slot="field"
       data-orientation={orientation}
       className={cn(fieldVariants({ orientation }), className)}
@@ -97,22 +86,19 @@ function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="field-content"
-      className={cn("group/field-content flex flex-1 flex-col gap-1.5 leading-snug", className)}
+      className={cn("group/field-content flex flex-1 flex-col gap-1 leading-snug", className)}
       {...props}
     />
   )
 }
 
-function FieldLabel({ className, ...props }: FieldPrimitive.Label.Props) {
+function FieldLabel({ className, ...props }: React.ComponentProps<typeof Label>) {
   return (
-    <FieldPrimitive.Label
+    <Label
       data-slot="field-label"
       className={cn(
-        "group/field-label peer/field-label flex w-fit gap-2 text-sm leading-snug font-medium text-foreground",
-        "group-data-[disabled]/field:opacity-50",
-        // Nested field support
-        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4",
-        "has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5 dark:has-data-[state=checked]:bg-primary/10",
+        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border *:data-[slot=field]:p-3 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
         className,
       )}
       {...props}
@@ -125,8 +111,7 @@ function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="field-label"
       className={cn(
-        "flex w-fit items-center gap-2 text-sm leading-snug font-medium",
-        "group-data-[disabled]/field:opacity-50",
+        "flex w-fit items-center gap-2 text-sm font-medium group-data-[disabled=true]/field:opacity-50",
         className,
       )}
       {...props}
@@ -134,48 +119,16 @@ function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function FieldDescription({ className, ...props }: FieldPrimitive.Description.Props) {
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
   return (
-    <FieldPrimitive.Description
+    <p
       data-slot="field-description"
       className={cn(
-        "text-sm leading-normal font-normal text-muted-foreground",
-        "group-has-[[data-orientation=horizontal]]/field:text-balance",
-        // Spacing adjustments
-        "last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5",
-        // Link styling
+        "text-left text-sm leading-normal font-normal text-muted-foreground group-has-data-horizontal/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
+        "last:mt-0 nth-last-2:-mt-1",
         "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
         className,
       )}
-      {...props}
-    />
-  )
-}
-
-function FieldControl({
-  ref: forwardedRef,
-  className,
-  ...props
-}: FieldPrimitive.Control.Props & { ref?: React.RefObject<HTMLInputElement | null> }) {
-  return (
-    <FieldPrimitive.Control
-      ref={forwardedRef}
-      data-slot="field-control"
-      className={cn(
-        "h-8 w-full rounded-md border border-input bg-background px-3 text-sm text-foreground",
-        "focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none",
-        className,
-      )}
-      {...props}
-    />
-  )
-}
-
-function FieldError({ className, ...props }: FieldPrimitive.Error.Props) {
-  return (
-    <FieldPrimitive.Error
-      data-slot="field-error"
-      className={cn("text-sm font-normal text-destructive", className)}
       {...props}
     />
   )
@@ -211,16 +164,62 @@ function FieldSeparator({
   )
 }
 
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children
+    }
+
+    if (!errors?.length) {
+      return null
+    }
+
+    const uniqueErrors = [...new Map(errors.map((error) => [error?.message, error])).values()]
+
+    if (uniqueErrors.length === 1) {
+      return uniqueErrors[0]?.message
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map(
+          (error) => error?.message && <li key={error.message}>{error.message}</li>,
+        )}
+      </ul>
+    )
+  }, [children, errors])
+
+  if (!content) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-sm font-normal text-destructive", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  )
+}
+
 export {
-  FieldRoot as Field,
+  Field,
   FieldContent,
-  FieldControl,
   FieldDescription,
   FieldError,
   FieldGroup,
   FieldLabel,
   FieldLegend,
-  FieldRoot,
   FieldSeparator,
   FieldSet,
   FieldTitle,

--- a/src/entrypoints/options/pages/api-providers/providers-config/provider-config-form/components/autosaved-json-code-editor-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/providers-config/provider-config-form/components/autosaved-json-code-editor-field.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react"
 import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from "react"
-import { Field, FieldError, FieldLabel } from "@/components/ui/base-ui/field"
+import { Field, FieldError, FieldTitle } from "@/components/ui/base-ui/field"
 import { JSONCodeEditor } from "@/components/ui/json-code-editor"
 import { useDebouncedValue } from "@/hooks/use-debounced-value"
 
@@ -116,8 +116,8 @@ export function AutosavedJsonCodeEditorField<TValue extends Record<string, unkno
   const jsonError = !parseResult.valid ? parseResult.error : null
 
   return (
-    <Field invalid={!!jsonError}>
-      <FieldLabel>{label}</FieldLabel>
+    <Field data-invalid={!!jsonError}>
+      <FieldTitle>{label}</FieldTitle>
       <JSONCodeEditor
         aria-label={editorAriaLabel}
         value={jsonInput}
@@ -128,7 +128,7 @@ export function AutosavedJsonCodeEditorField<TValue extends Record<string, unkno
         hasError={!!jsonError}
         height={height}
       />
-      {jsonError && <FieldError match={!!jsonError}>{jsonError}</FieldError>}
+      {jsonError && <FieldError>{jsonError}</FieldError>}
     </Field>
   )
 }

--- a/src/entrypoints/options/pages/custom-actions/action-config-form/icon-field.tsx
+++ b/src/entrypoints/options/pages/custom-actions/action-config-form/icon-field.tsx
@@ -3,7 +3,7 @@ import { Icon } from "@iconify/react"
 import { useSelector } from "@tanstack/react-store"
 import { useState } from "react"
 import { Button } from "@/components/ui/base-ui/button"
-import { Field, FieldLabel } from "@/components/ui/base-ui/field"
+import { Field, FieldTitle } from "@/components/ui/base-ui/field"
 import { InputGroup, InputGroupAddon, InputGroupInput } from "@/components/ui/base-ui/input-group"
 import {
   Popover,
@@ -159,9 +159,7 @@ export const IconField = withForm({
       >
         {(field) => (
           <Field>
-            <FieldLabel nativeLabel={false} render={<div />}>
-              {i18n.t("options.selectionToolbar.customActions.form.icon")}
-            </FieldLabel>
+            <FieldTitle>{i18n.t("options.selectionToolbar.customActions.form.icon")}</FieldTitle>
             <div className="flex items-center gap-2">
               <IconPickerPopover
                 open={iconPickerOpen}

--- a/src/entrypoints/options/pages/custom-actions/action-config-form/notebase-connection-field.tsx
+++ b/src/entrypoints/options/pages/custom-actions/action-config-form/notebase-connection-field.tsx
@@ -20,7 +20,7 @@ import { useCallback, useEffect, useMemo } from "react"
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "@/components/ui/base-ui/alert"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/base-ui/avatar"
 import { Button } from "@/components/ui/base-ui/button"
-import { Field, FieldGroup, FieldLabel } from "@/components/ui/base-ui/field"
+import { Field, FieldGroup, FieldTitle } from "@/components/ui/base-ui/field"
 import {
   Select,
   SelectContent,
@@ -409,9 +409,7 @@ export const NotebaseConnectionField = withForm({
     return (
       <Field className="gap-4 rounded-xl border border-dashed bg-muted/10 p-4">
         <div className="space-y-1">
-          <FieldLabel nativeLabel={false} render={<div />}>
-            {t("title")}
-          </FieldLabel>
+          <FieldTitle>{t("title")}</FieldTitle>
           <p className="text-sm text-muted-foreground">{t("description")}</p>
         </div>
 
@@ -448,9 +446,7 @@ export const NotebaseConnectionField = withForm({
           <FieldGroup className="gap-4">
             <Field>
               <div className="flex items-center justify-between gap-3">
-                <FieldLabel nativeLabel={false} render={<div />}>
-                  {t("tableLabel")}
-                </FieldLabel>
+                <FieldTitle>{t("tableLabel")}</FieldTitle>
                 <div className="flex items-center gap-2">
                   {isOwnedConnection && !!sanitizedConnection?.notebaseId && (
                     <Button
@@ -624,9 +620,7 @@ export const NotebaseConnectionField = withForm({
 
                 <Field className="gap-3">
                   <div className="flex items-center justify-between gap-3">
-                    <FieldLabel nativeLabel={false} render={<div />}>
-                      {t("mappingsLabel")}
-                    </FieldLabel>
+                    <FieldTitle>{t("mappingsLabel")}</FieldTitle>
                     <Button
                       type="button"
                       size="sm"

--- a/src/entrypoints/options/pages/custom-actions/action-config-form/provider-field.tsx
+++ b/src/entrypoints/options/pages/custom-actions/action-config-form/provider-field.tsx
@@ -3,7 +3,7 @@ import { useAtomValue } from "jotai"
 import { useMemo } from "react"
 import ProviderSelector from "@/components/llm-providers/provider-selector"
 import { useHostedAiProviderOptions } from "@/components/llm-providers/use-hosted-ai-provider-options"
-import { Field, FieldLabel } from "@/components/ui/base-ui/field"
+import { Field, FieldTitle } from "@/components/ui/base-ui/field"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { i18n } from "@/utils/i18n"
 import {
@@ -47,9 +47,9 @@ export const ProviderField = withForm({
       >
         {(field) => (
           <Field>
-            <FieldLabel nativeLabel={false} render={<div />}>
+            <FieldTitle>
               {i18n.t("options.selectionToolbar.customActions.form.provider")}
-            </FieldLabel>
+            </FieldTitle>
             <ProviderSelector
               providers={customActionProviders}
               value={field.state.value}

--- a/src/entrypoints/options/pages/video-subtitles/subtitles-style/style-editor/general-settings.tsx
+++ b/src/entrypoints/options/pages/video-subtitles/subtitles-style/style-editor/general-settings.tsx
@@ -5,7 +5,7 @@ import { useAtom } from "jotai"
 import { useEffect, useState } from "react"
 import { Button } from "@/components/ui/base-ui/button"
 import { Card } from "@/components/ui/base-ui/card"
-import { Field, FieldGroup, FieldLabel } from "@/components/ui/base-ui/field"
+import { Field, FieldGroup, FieldLabel, FieldTitle } from "@/components/ui/base-ui/field"
 import { Label } from "@/components/ui/base-ui/label"
 import {
   Select,
@@ -27,16 +27,13 @@ import {
 } from "@/utils/constants/subtitles"
 import { i18n } from "@/utils/i18n"
 
-const SLIDER_ROW_CLASS_NAME = "gap-0"
-const SLIDER_ROW_CONTENT_CLASS_NAME =
-  "flex flex-col gap-2 @xs/field-group:grid @xs/field-group:grid-cols-[12rem_minmax(0,1fr)] @xs/field-group:items-center @xs/field-group:gap-x-4"
-const SLIDER_LABEL_CLASS_NAME = "text-sm whitespace-nowrap @xs/field-group:min-w-0"
-
 export function GeneralSettings() {
   const [videoSubtitlesConfig, setVideoSubtitlesConfig] = useAtom(
     configFieldsAtomMap.videoSubtitles,
   )
   const { displayMode, translationPosition, container } = videoSubtitlesConfig.style
+  const displayModeId = "video-subtitles-display-mode"
+  const translationPositionId = "video-subtitles-translation-position"
   const [draftBackgroundOpacity, setDraftBackgroundOpacity] = useState(container.backgroundOpacity)
 
   useEffect(() => {
@@ -96,12 +93,12 @@ export function GeneralSettings() {
       </div>
 
       <FieldGroup>
-        <Field orientation="responsive-compact">
-          <FieldLabel className="text-sm whitespace-nowrap">
+        <Field orientation="responsive">
+          <FieldLabel htmlFor={displayModeId}>
             {i18n.t("options.videoSubtitles.style.displayMode.title")}
           </FieldLabel>
           <Select value={displayMode} onValueChange={handleDisplayModeChange}>
-            <SelectTrigger className="h-8">
+            <SelectTrigger id={displayModeId}>
               <SelectValue>
                 {i18n.t(`options.videoSubtitles.style.displayMode.${displayMode}`)}
               </SelectValue>
@@ -123,12 +120,12 @@ export function GeneralSettings() {
         </Field>
 
         {displayMode === "bilingual" && (
-          <Field orientation="responsive-compact">
-            <FieldLabel className="text-sm whitespace-nowrap">
+          <Field orientation="responsive">
+            <FieldLabel htmlFor={translationPositionId}>
               {i18n.t("options.videoSubtitles.style.translationPosition.title")}
             </FieldLabel>
             <Select value={translationPosition} onValueChange={handleTranslationPositionChange}>
-              <SelectTrigger className="h-8">
+              <SelectTrigger id={translationPositionId}>
                 <SelectValue>
                   {i18n.t(
                     `options.videoSubtitles.style.translationPosition.${translationPosition}`,
@@ -149,27 +146,19 @@ export function GeneralSettings() {
           </Field>
         )}
 
-        <Field className={SLIDER_ROW_CLASS_NAME}>
-          <div className={SLIDER_ROW_CONTENT_CLASS_NAME}>
-            <FieldLabel className={SLIDER_LABEL_CLASS_NAME}>
-              {i18n.t("options.videoSubtitles.style.backgroundOpacity")}
-            </FieldLabel>
-            <div className="w-full min-w-0 @xs/field-group:ml-auto @xs/field-group:max-w-[15rem]">
-              <div className="min-w-0">
-                <SliderComfortable
-                  variant="scrubber"
-                  aria-label={i18n.t("options.videoSubtitles.style.backgroundOpacity")}
-                  min={MIN_BACKGROUND_OPACITY}
-                  max={MAX_BACKGROUND_OPACITY}
-                  step={5}
-                  value={draftBackgroundOpacity}
-                  onChange={setDraftBackgroundOpacity}
-                  onCommit={(value) => handleContainerChange({ backgroundOpacity: value })}
-                  formatValue={(v) => `${v}%`}
-                />
-              </div>
-            </div>
-          </div>
+        <Field orientation="responsive">
+          <FieldTitle>{i18n.t("options.videoSubtitles.style.backgroundOpacity")}</FieldTitle>
+          <SliderComfortable
+            variant="scrubber"
+            aria-label={i18n.t("options.videoSubtitles.style.backgroundOpacity")}
+            min={MIN_BACKGROUND_OPACITY}
+            max={MAX_BACKGROUND_OPACITY}
+            step={5}
+            value={draftBackgroundOpacity}
+            onChange={setDraftBackgroundOpacity}
+            onCommit={(value) => handleContainerChange({ backgroundOpacity: value })}
+            formatValue={(v) => `${v}%`}
+          />
         </Field>
       </FieldGroup>
     </Card>

--- a/src/entrypoints/options/pages/video-subtitles/subtitles-style/style-editor/subtitles-text-style-form.tsx
+++ b/src/entrypoints/options/pages/video-subtitles/subtitles-style/style-editor/subtitles-text-style-form.tsx
@@ -3,7 +3,7 @@ import { deepmerge } from "deepmerge-ts"
 import { useAtom } from "jotai"
 import { useEffect, useState } from "react"
 import { DebouncedColorPicker } from "@/components/debounced-color-picker"
-import { Field, FieldGroup, FieldLabel } from "@/components/ui/base-ui/field"
+import { Field, FieldGroup, FieldLabel, FieldTitle } from "@/components/ui/base-ui/field"
 import {
   Select,
   SelectContent,
@@ -22,11 +22,6 @@ import {
 } from "@/utils/constants/subtitles"
 import { i18n } from "@/utils/i18n"
 
-const FIELD_ROW_CLASS_NAME = "gap-0"
-const FIELD_ROW_CONTENT_CLASS_NAME =
-  "flex flex-col gap-2 @xs/field-group:grid @xs/field-group:grid-cols-[8.5rem_minmax(0,1fr)] @xs/field-group:items-center @xs/field-group:gap-x-4"
-const FIELD_LABEL_CLASS_NAME = "text-sm whitespace-nowrap @xs/field-group:min-w-0"
-
 const FONT_FAMILY_OPTIONS: { value: SubtitlesFontFamily; label: string }[] = [
   { value: "system", label: "System Default" },
   { value: "roboto", label: "Roboto" },
@@ -43,6 +38,7 @@ export function SubtitlesTextStyleForm({ type }: SubtitlesTextStyleFormProps) {
     configFieldsAtomMap.videoSubtitles,
   )
   const textStyle = videoSubtitlesConfig.style[type]
+  const fontFamilyId = `video-subtitles-${type}-font-family`
   const [draftFontScale, setDraftFontScale] = useState(textStyle.fontScale)
   const [draftFontWeight, setDraftFontWeight] = useState(textStyle.fontWeight)
 
@@ -62,91 +58,69 @@ export function SubtitlesTextStyleForm({ type }: SubtitlesTextStyleFormProps) {
 
   return (
     <FieldGroup>
-      <Field className={FIELD_ROW_CLASS_NAME}>
-        <div className={FIELD_ROW_CONTENT_CLASS_NAME}>
-          <FieldLabel className={FIELD_LABEL_CLASS_NAME}>
-            {i18n.t("options.videoSubtitles.style.fontFamily")}
-          </FieldLabel>
-          <div className="min-w-0 @xs/field-group:min-w-0">
-            <Select
-              value={textStyle.fontFamily}
-              onValueChange={(value) => {
-                if (value) handleChange({ fontFamily: value })
-              }}
-            >
-              <SelectTrigger className="h-8 w-full">
-                <SelectValue>
-                  {FONT_FAMILY_OPTIONS.find((o) => o.value === textStyle.fontFamily)?.label}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  {FONT_FAMILY_OPTIONS.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
+      <Field orientation="responsive">
+        <FieldLabel htmlFor={fontFamilyId}>
+          {i18n.t("options.videoSubtitles.style.fontFamily")}
+        </FieldLabel>
+        <Select
+          value={textStyle.fontFamily}
+          onValueChange={(value) => {
+            if (value) handleChange({ fontFamily: value })
+          }}
+        >
+          <SelectTrigger id={fontFamilyId}>
+            <SelectValue>
+              {FONT_FAMILY_OPTIONS.find((o) => o.value === textStyle.fontFamily)?.label}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              {FONT_FAMILY_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectGroup>
+          </SelectContent>
+        </Select>
       </Field>
 
-      <Field className={FIELD_ROW_CLASS_NAME}>
-        <div className={FIELD_ROW_CONTENT_CLASS_NAME}>
-          <FieldLabel className={FIELD_LABEL_CLASS_NAME}>
-            {i18n.t("options.videoSubtitles.style.fontScale")}
-          </FieldLabel>
-          <div className="min-w-0">
-            <SliderComfortable
-              variant="scrubber"
-              aria-label={i18n.t("options.videoSubtitles.style.fontScale")}
-              min={MIN_FONT_SCALE}
-              max={MAX_FONT_SCALE}
-              step={10}
-              value={draftFontScale}
-              onChange={setDraftFontScale}
-              onCommit={(value) => handleChange({ fontScale: value })}
-              formatValue={(v) => `${v}%`}
-            />
-          </div>
-        </div>
+      <Field orientation="responsive">
+        <FieldTitle>{i18n.t("options.videoSubtitles.style.fontScale")}</FieldTitle>
+        <SliderComfortable
+          variant="scrubber"
+          aria-label={i18n.t("options.videoSubtitles.style.fontScale")}
+          min={MIN_FONT_SCALE}
+          max={MAX_FONT_SCALE}
+          step={10}
+          value={draftFontScale}
+          onChange={setDraftFontScale}
+          onCommit={(value) => handleChange({ fontScale: value })}
+          formatValue={(v) => `${v}%`}
+        />
       </Field>
 
-      <Field className={FIELD_ROW_CLASS_NAME}>
-        <div className={FIELD_ROW_CONTENT_CLASS_NAME}>
-          <FieldLabel className={FIELD_LABEL_CLASS_NAME}>
-            {i18n.t("options.videoSubtitles.style.fontWeight")}
-          </FieldLabel>
-          <div className="min-w-0">
-            <SliderComfortable
-              variant="scrubber"
-              aria-label={i18n.t("options.videoSubtitles.style.fontWeight")}
-              min={MIN_FONT_WEIGHT}
-              max={MAX_FONT_WEIGHT}
-              step={100}
-              value={draftFontWeight}
-              onChange={setDraftFontWeight}
-              onCommit={(value) => handleChange({ fontWeight: value })}
-            />
-          </div>
-        </div>
+      <Field orientation="responsive">
+        <FieldTitle>{i18n.t("options.videoSubtitles.style.fontWeight")}</FieldTitle>
+        <SliderComfortable
+          variant="scrubber"
+          aria-label={i18n.t("options.videoSubtitles.style.fontWeight")}
+          min={MIN_FONT_WEIGHT}
+          max={MAX_FONT_WEIGHT}
+          step={100}
+          value={draftFontWeight}
+          onChange={setDraftFontWeight}
+          onCommit={(value) => handleChange({ fontWeight: value })}
+        />
       </Field>
 
-      <Field className={FIELD_ROW_CLASS_NAME}>
-        <div className={FIELD_ROW_CONTENT_CLASS_NAME}>
-          <FieldLabel className={FIELD_LABEL_CLASS_NAME}>
-            {i18n.t("options.videoSubtitles.style.color")}
-          </FieldLabel>
-          <div className="flex min-w-0 @xs/field-group:justify-end">
-            <DebouncedColorPicker
-              value={textStyle.color}
-              onCommit={(color) => handleChange({ color })}
-              triggerClassName="h-8"
-            />
-          </div>
-        </div>
+      <Field orientation="responsive">
+        <FieldTitle>{i18n.t("options.videoSubtitles.style.color")}</FieldTitle>
+        <DebouncedColorPicker
+          value={textStyle.color}
+          onCommit={(color) => handleChange({ color })}
+          triggerClassName="h-8"
+        />
       </Field>
     </FieldGroup>
   )

--- a/src/entrypoints/selection.content/selection-toolbar/note-suggestion/__tests__/note-suggestion-card.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/note-suggestion/__tests__/note-suggestion-card.test.tsx
@@ -73,11 +73,14 @@ function createAction(
 
 function createSuggestion(
   actionSnapshot: SelectionToolbarCustomAction,
+  notes: Array<Record<string, string | number | null>> = [
+    { Term: "ephemeral", Definition: "lasting a very short time" },
+  ],
 ): NoteSuggestionSessionResult {
   return {
     sessionKey: "session-1",
     validated: {
-      notes: [{ Term: "ephemeral", Definition: "lasting a very short time" }],
+      notes,
       summaryFieldName: "Definition",
     },
     actionSnapshot,
@@ -98,10 +101,11 @@ function createStoreWithAction(action?: SelectionToolbarCustomAction) {
 function renderCard(
   store: ReturnType<typeof createStore>,
   actionSnapshot: SelectionToolbarCustomAction,
+  notes?: Array<Record<string, string | number | null>>,
 ) {
   return render(
     <NoteSuggestionCard
-      suggestion={createSuggestion(actionSnapshot)}
+      suggestion={createSuggestion(actionSnapshot, notes)}
       markShownOnce={() => false}
     />,
     { wrapper: wrapper(store) },
@@ -134,6 +138,45 @@ describe("NoteSuggestionCard", () => {
       analyticsProvider: { provider: "openai", backend_kind: "llm" },
     })
     expect(mocks.toastAdd).not.toHaveBeenCalled()
+  })
+
+  it("selects every suggested note by default and saves only the checked notes", async () => {
+    const action = createAction()
+    const store = createStoreWithAction(action)
+    renderCard(store, action, [
+      { Term: "ephemeral", Definition: "lasting a very short time" },
+      { Term: "transient", Definition: "not permanent" },
+    ])
+
+    const checkboxes = screen.getAllByRole("checkbox")
+    expect(checkboxes).toHaveLength(2)
+    expect(checkboxes[0]).toBeChecked()
+    expect(checkboxes[1]).toBeChecked()
+    expect(checkboxes[0]?.closest('[data-slot="field-label"]')?.firstElementChild).toHaveAttribute(
+      "data-slot",
+      "field",
+    )
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /transient/ }))
+    clickSave()
+
+    await waitFor(() => expect(mocks.save).toHaveBeenCalledTimes(1))
+    expect(mocks.save.mock.calls[0]?.[0]?.results).toEqual([
+      { Term: "ephemeral", Definition: "lasting a very short time" },
+    ])
+  })
+
+  it("disables saving when every suggested note is unchecked", () => {
+    const action = createAction()
+    const store = createStoreWithAction(action)
+    renderCard(store, action)
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /ephemeral/ }))
+
+    const saveButton = screen.getByRole("button", { name: i18n.t("noteSuggestion.save") })
+    expect(saveButton).toBeDisabled()
+    fireEvent.click(saveButton)
+    expect(mocks.save).not.toHaveBeenCalled()
   })
 
   it("marks the suggestion stale when its action was deleted", async () => {

--- a/src/entrypoints/selection.content/selection-toolbar/note-suggestion/note-suggestion-card.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/note-suggestion/note-suggestion-card.tsx
@@ -2,8 +2,16 @@ import type { NoteSuggestionSessionResult } from "./use-note-suggestion"
 import type { NoteSuggestionNoteRecord } from "@/utils/note-suggestion/types"
 import { IconBookmarkPlus } from "@tabler/icons-react"
 import { useAtom } from "jotai"
-import { useEffect, useState } from "react"
+import { useEffect, useId, useState } from "react"
 import { Button } from "@/components/ui/base-ui/button"
+import { Checkbox } from "@/components/ui/base-ui/checkbox"
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+  FieldTitle,
+} from "@/components/ui/base-ui/field"
 import { Label } from "@/components/ui/base-ui/label"
 import { Switch } from "@/components/ui/base-ui/switch"
 import { toastManager } from "@/components/ui/base-ui/toast"
@@ -25,12 +33,20 @@ function formatNoteValue(value: string | number | null): string | null {
 
 function NoteRow({
   note,
+  checkboxId,
+  checked,
+  disabled,
   primaryFieldName,
   secondaryFieldNames,
+  onCheckedChange,
 }: {
   note: NoteSuggestionNoteRecord
+  checkboxId: string
+  checked: boolean
+  disabled: boolean
   primaryFieldName: string
   secondaryFieldNames: string[]
+  onCheckedChange: (checked: boolean) => void
 }) {
   const primaryValue = formatNoteValue(note[primaryFieldName] ?? null)
   const secondaryValue = secondaryFieldNames
@@ -38,12 +54,22 @@ function NoteRow({
     .find((value) => value !== null)
 
   return (
-    <div className="rounded-md border bg-background/60 px-2.5 py-1.5">
-      <div className="text-sm font-medium [overflow-wrap:anywhere] break-words">{primaryValue}</div>
-      {secondaryValue && (
-        <div className="truncate text-xs text-muted-foreground">{secondaryValue}</div>
-      )}
-    </div>
+    <FieldLabel htmlFor={checkboxId}>
+      <Field orientation="horizontal" data-disabled={disabled || undefined} className="gap-2 p-2!">
+        <Checkbox
+          id={checkboxId}
+          checked={checked}
+          disabled={disabled}
+          onCheckedChange={onCheckedChange}
+        />
+        <FieldContent className="min-w-0 gap-0.5">
+          <FieldTitle>{primaryValue}</FieldTitle>
+          {secondaryValue && (
+            <FieldDescription className="text-xs">{secondaryValue}</FieldDescription>
+          )}
+        </FieldContent>
+      </Field>
+    </FieldLabel>
   )
 }
 
@@ -54,11 +80,14 @@ export function NoteSuggestionCard({
   suggestion: NoteSuggestionSessionResult
   markShownOnce: (sessionKey: string) => boolean
 }) {
+  const { sessionKey, validated, actionSnapshot, firedAt, analyticsProvider } = suggestion
   const [selectionToolbar, setSelectionToolbar] = useAtom(configFieldsAtomMap.selectionToolbar)
   const { save, isSaving } = useSaveToNotebase()
   const [saveState, setSaveState] = useState<"idle" | "saved" | "stale">("idle")
-
-  const { sessionKey, validated, actionSnapshot, firedAt, analyticsProvider } = suggestion
+  const checkboxBaseId = useId()
+  const [selectedNoteIndexes, setSelectedNoteIndexes] = useState(
+    () => new Set(validated.notes.map((_note, index) => index)),
+  )
 
   useEffect(() => {
     if (!markShownOnce(sessionKey)) {
@@ -90,6 +119,7 @@ export function NoteSuggestionCard({
       (field) => field.name !== aiSummaryFieldName && !field.id.includes("definition"),
     ),
   ].map((field) => field.name)
+  const selectedNotes = validated.notes.filter((_note, index) => selectedNoteIndexes.has(index))
 
   const handleSave = async () => {
     const liveAction = findSelectionToolbarAction(selectionToolbar, actionSnapshot.id)
@@ -105,7 +135,7 @@ export function NoteSuggestionCard({
 
     const outcome = await save({
       action: liveAction,
-      results: validated.notes,
+      results: selectedNotes,
       analyticsSource: "note_suggestion",
       analyticsProvider,
     })
@@ -119,7 +149,8 @@ export function NoteSuggestionCard({
     }
   }
 
-  const isButtonDisabled = isSaving || saveState !== "idle"
+  const isInteractionDisabled = isSaving || saveState !== "idle"
+  const isButtonDisabled = isInteractionDisabled || selectedNotes.length === 0
   const buttonLabel = isSaving
     ? i18n.t("action.saveToNotebaseSaving")
     : saveState === "saved"
@@ -156,14 +187,28 @@ export function NoteSuggestionCard({
         </div>
       </div>
       <p className="text-xs text-muted-foreground">{i18n.t("noteSuggestion.description")}</p>
-      <div className="space-y-1.5">
+      <div className="space-y-1">
         {validated.notes.map((note, index) => (
           <NoteRow
             // oxlint-disable-next-line react/no-array-index-key -- notes are a stable per-session snapshot
             key={index}
             note={note}
+            checkboxId={`${checkboxBaseId}-${index}`}
+            checked={selectedNoteIndexes.has(index)}
+            disabled={isInteractionDisabled}
             primaryFieldName={primaryFieldName}
             secondaryFieldNames={secondaryFieldNames}
+            onCheckedChange={(checked) => {
+              setSelectedNoteIndexes((currentIndexes) => {
+                const nextIndexes = new Set(currentIndexes)
+                if (checked) {
+                  nextIndexes.add(index)
+                } else {
+                  nextIndexes.delete(index)
+                }
+                return nextIndexes
+              })
+            }}
           />
         ))}
       </div>

--- a/src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/translate-button/provider.tsx
@@ -840,6 +840,7 @@ export function SelectionTranslationProvider({ children }: { children: ReactNode
               !error &&
               noteSuggestion?.sessionKey === noteSuggestionSessionKey && (
                 <NoteSuggestionCard
+                  key={noteSuggestion.sessionKey}
                   suggestion={noteSuggestion}
                   markShownOnce={markNoteSuggestionShownOnce}
                 />

--- a/src/entrypoints/translation-hub/components/searchable-language-selector.tsx
+++ b/src/entrypoints/translation-hub/components/searchable-language-selector.tsx
@@ -1,6 +1,6 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
 import { LanguageCombobox } from "@/components/language-combobox"
-import { FieldLabel, FieldRoot } from "@/components/ui/base-ui/field"
+import { Field, FieldTitle } from "@/components/ui/base-ui/field"
 
 interface SearchableLanguageSelectorProps {
   value: LangCodeISO6393 | "auto"
@@ -18,14 +18,14 @@ export function SearchableLanguageSelector({
   className,
 }: SearchableLanguageSelectorProps) {
   return (
-    <FieldRoot className={className}>
-      <FieldLabel>{label}</FieldLabel>
+    <Field className={className}>
+      <FieldTitle>{label}</FieldTitle>
       <LanguageCombobox
         value={value}
         onValueChange={onValueChange}
         detectedLangCode={detectedLangCode}
         className="w-full"
       />
-    </FieldRoot>
+    </Field>
   )
 }

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1224,7 +1224,7 @@ action:
   playing: Playing
 noteSuggestion:
   title: You might want to save
-  description: Save these words to your Notebase and review them anytime.
+  description: Choose which words to save to your Notebase and review anytime.
   save: Save
   saved: Saved
   staleSuggestion: This suggestion is out of date

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -1224,7 +1224,7 @@ action:
   playing: Reproduciendo
 noteSuggestion:
   title: Quizás quieras guardar
-  description: Guarda estas palabras en tu Notebase y repásalas cuando quieras.
+  description: Elige qué palabras guardar en tu Notebase y repásalas cuando quieras.
   save: Guardar
   saved: Guardado
   staleSuggestion: Esta sugerencia está desactualizada

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -1108,7 +1108,7 @@ action:
   playing: 再生中
 noteSuggestion:
   title: 保存におすすめ
-  description: 以下の単語を Notebase に保存して、いつでも復習できます。
+  description: Notebase に保存したい単語を選んで、いつでも復習できます。
   save: 保存
   saved: 保存済み
   staleSuggestion: この提案は古くなっています

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -1108,7 +1108,7 @@ action:
   playing: 재생 중
 noteSuggestion:
   title: 저장 추천
-  description: 아래 단어를 Notebase에 저장하고 언제든지 복습하세요.
+  description: Notebase에 저장할 단어를 선택하고 언제든지 복습하세요.
   save: 저장
   saved: 저장됨
   staleSuggestion: 이 제안은 더 이상 유효하지 않습니다

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -1108,7 +1108,7 @@ action:
   playing: Воспроизведение
 noteSuggestion:
   title: Стоит сохранить
-  description: Сохраните эти слова в Notebase, чтобы повторять их в любое время.
+  description: Выберите слова для сохранения в Notebase и повторяйте их в любое время.
   save: Сохранить
   saved: Сохранено
   staleSuggestion: Это предложение устарело

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -1108,7 +1108,7 @@ action:
   playing: Çalınıyor
 noteSuggestion:
   title: Kaydetmek isteyebilirsiniz
-  description: Bu kelimeleri Notebase'inize kaydedin, istediğiniz zaman tekrar edin.
+  description: Notebase'inize kaydetmek istediğiniz kelimeleri seçin ve dilediğiniz zaman tekrarlayın.
   save: Kaydet
   saved: Kaydedildi
   staleSuggestion: Bu öneri güncelliğini yitirdi

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -1108,7 +1108,7 @@ action:
   playing: Đang phát
 noteSuggestion:
   title: Có thể bạn muốn lưu
-  description: Lưu những từ dưới đây vào Notebase để ôn tập bất cứ lúc nào.
+  description: Chọn những từ bạn muốn lưu vào Notebase để ôn tập bất cứ lúc nào.
   save: Lưu
   saved: Đã lưu
   staleSuggestion: Gợi ý này đã cũ

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -1224,7 +1224,7 @@ action:
   playing: 播放中
 noteSuggestion:
   title: 猜你想存
-  description: 把下列词存入笔记库，将来随时复习
+  description: 选择要存入笔记库的词，将来随时复习
   save: 保存
   saved: 已保存
   staleSuggestion: 该建议已过期

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -1224,7 +1224,7 @@ action:
   playing: 播放中
 noteSuggestion:
   title: 猜你想存
-  description: 把下列詞存入筆記庫，將來隨時複習
+  description: 選擇要存入筆記庫的詞，將來隨時複習
   save: 儲存
   saved: 已儲存
   staleSuggestion: 該建議已過期

--- a/src/utils/note-suggestion/__tests__/types.test.ts
+++ b/src/utils/note-suggestion/__tests__/types.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+import { noteSuggestionEnvelopeSchema } from "../types"
+
+describe("noteSuggestionEnvelopeSchema", () => {
+  it("requires every property for OpenAI strict structured outputs", () => {
+    const jsonSchema = z.toJSONSchema(noteSuggestionEnvelopeSchema)
+
+    expect(jsonSchema.required).toEqual(["summaryFieldName", "notes"])
+    expect(
+      noteSuggestionEnvelopeSchema.safeParse({
+        summaryFieldName: null,
+        notes: [],
+      }).success,
+    ).toBe(true)
+    expect(noteSuggestionEnvelopeSchema.safeParse({ notes: [] }).success).toBe(false)
+  })
+})

--- a/src/utils/note-suggestion/types.ts
+++ b/src/utils/note-suggestion/types.ts
@@ -24,9 +24,10 @@ export const noteSuggestionNoteSchema = z.strictObject({
 export const noteSuggestionEnvelopeSchema = z.strictObject({
   /**
    * Display hint: which schema field's value best explains the term in one
-   * line. Optional for tolerance of models that omit the field entirely.
+   * line. The key is required and its value is nullable because OpenAI strict
+   * structured outputs do not support optional object properties.
    */
-  summaryFieldName: z.string().nullable().optional(),
+  summaryFieldName: z.string().nullable(),
   notes: z.array(noteSuggestionNoteSchema).max(NOTE_SUGGESTION_MAX_NOTES),
 })
 


### PR DESCRIPTION
# feat(note-suggestions): choose which suggested words to save

> **AI model(s) used (required):** OpenAI Codex (GPT-5)

## Type of Changes

- [x] New feature
- [x] Bug fix
- [x] UI/UX improvement
- [x] Refactor

## Description

- Add a checkbox to every Note Suggestion row, select all suggestions by default, and save only the checked notes. Saving is disabled when no notes are selected, and selection resets for each suggestion session.
- Make `summaryFieldName` required and nullable so the generated JSON Schema is accepted by OpenAI strict structured outputs while still representing a missing summary field with `null`.
- Update the shared `Field` component to the current shadcn Base UI composition and migrate existing call sites away from the previous private APIs.
- Use the standard responsive `Field` layout for video subtitle settings, while keeping only the compact density overrides needed by the Note Suggestion popup.
- Add minor and patch changesets for the user-facing selection feature and OpenAI compatibility fix.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Added unit tests
- [x] Ran the full unit test suite (`281` test files and `2674` tests passed in the pre-push checks)
- [x] Ran type-aware lint and type checking
- [x] Ran formatting checks
- [x] Built the production Chrome MV3 extension

## Screenshots

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have added the required changesets
- [x] My changes generate no new warnings

## Additional Information

The production build still reports the repository's existing large-chunk warning; this change does not introduce a new build failure or warning category.
