### PR TITLE
fix(translation): translate YouTube watch titles through hover translation

### DIFF
--- a/.changeset/fix-youtube-hover-title.md
+++ b/.changeset/fix-youtube-hover-title.md
@@ -4,4 +4,4 @@
 
 fix(translation): translate YouTube watch titles through hover translation
 
-Allow YouTube's visible watch-title element directly so experimental layouts without the usual `h1` wrapper still produce a translatable hover paragraph.
+Allow YouTube's visible watch-title element directly so experimental layouts without the usual `h1` wrapper still produce a translatable hover paragraph, and apply matched site-rule layout CSS during hover translation so YouTube's two-line title clamp cannot clip the inserted translation.

--- a/.changeset/fix-youtube-hover-title.md
+++ b/.changeset/fix-youtube-hover-title.md
@@ -1,0 +1,7 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): translate YouTube watch titles through hover translation
+
+Allow YouTube's visible watch-title element directly so experimental layouts without the usual `h1` wrapper still produce a translatable hover paragraph.

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -50,6 +50,7 @@ import {
   endPageTranslationSession,
   setPageTranslationSessionProviderRef,
 } from "@/utils/host/translate/translation-session"
+import { cleanupNodeSiteRuleCSSIfUnused } from "@/utils/host/translate/ui/node-site-rule-css"
 import { cancelSpinnerAnimation } from "@/utils/host/translate/ui/spinner"
 import { ensureSiteRuleCSS, removeSiteRuleCSS } from "@/utils/host/translate/ui/style-injector"
 import { getOrCreateWebPageContext } from "@/utils/host/translate/webpage-context"
@@ -483,6 +484,7 @@ export class PageTranslationManager implements IPageTranslationManager {
 
     removeSiteRuleCSS(document)
     removeAllTranslatedWrapperNodes()
+    cleanupNodeSiteRuleCSSIfUnused(document)
   }
 
   registerPageTranslationTriggers(): () => void {

--- a/src/utils/host/__tests__/node-translate.test.tsx
+++ b/src/utils/host/__tests__/node-translate.test.tsx
@@ -126,6 +126,47 @@ describe("node translation", () => {
       expect(document.head.querySelector("#read-frog-site-rule-styles")).toBeNull()
       document.elementFromPoint = originalElementFromPoint
     })
+
+    it("removes stale site-rule CSS when the current rule has no CSS", async () => {
+      const configWithCSS = structuredClone(TEST_CONFIG)
+      configWithCSS.siteRules = {
+        disabledBuiltInRules: [],
+        userRules: [
+          {
+            id: "node-translation-layout",
+            matches: window.location.hostname,
+            injectedCss: ".clamped-title { max-height: none !important; }",
+          },
+        ],
+      }
+      const configWithoutCSS = structuredClone(TEST_CONFIG)
+      configWithoutCSS.siteRules = {
+        disabledBuiltInRules: [],
+        userRules: [],
+      }
+
+      render(<div data-testid="test-node">{MOCK_ORIGINAL_TEXT}</div>)
+      const node = screen.getByTestId("test-node")
+      const originalElementFromPoint = Reflect.get(document, "elementFromPoint")
+      document.elementFromPoint = vi.fn<(...args: any[]) => any>(() => node)
+
+      await act(async () => {
+        await removeOrShowNodeTranslation({ x: 150, y: 125 }, configWithCSS)
+        flushBatchedOperations()
+      })
+
+      expect(document.head.querySelector("#read-frog-site-rule-styles")).not.toBeNull()
+
+      const wrapper = node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)
+      document.elementFromPoint = vi.fn<(...args: any[]) => any>(() => wrapper as Element)
+      await act(async () => {
+        await removeOrShowNodeTranslation({ x: 150, y: 125 }, configWithoutCSS)
+        flushBatchedOperations()
+      })
+
+      expect(document.head.querySelector("#read-frog-site-rule-styles")).toBeNull()
+      document.elementFromPoint = originalElementFromPoint
+    })
   })
   describe("hide translation", () => {
     it("should hide the translation when point is over the translation content node", async () => {

--- a/src/utils/host/__tests__/node-translate.test.tsx
+++ b/src/utils/host/__tests__/node-translate.test.tsx
@@ -87,6 +87,45 @@ describe("node translation", () => {
 
       document.elementFromPoint = originalElementFromPoint
     })
+
+    it("applies site-rule CSS while a node translation is visible", async () => {
+      const config = structuredClone(TEST_CONFIG)
+      config.siteRules = {
+        disabledBuiltInRules: [],
+        userRules: [
+          {
+            id: "node-translation-layout",
+            matches: window.location.hostname,
+            injectedCss: ".clamped-title { max-height: none !important; }",
+          },
+        ],
+      }
+
+      render(<div data-testid="test-node">{MOCK_ORIGINAL_TEXT}</div>)
+      const node = screen.getByTestId("test-node")
+      const originalElementFromPoint = Reflect.get(document, "elementFromPoint")
+      document.elementFromPoint = vi.fn<(...args: any[]) => any>(() => node)
+
+      await act(async () => {
+        await removeOrShowNodeTranslation({ x: 150, y: 125 }, config)
+        flushBatchedOperations()
+      })
+
+      const siteRuleStyle = document.head.querySelector<HTMLStyleElement>(
+        "#read-frog-site-rule-styles",
+      )
+      expect(siteRuleStyle?.textContent).toContain(".clamped-title")
+
+      const wrapper = node.querySelector(`.${CONTENT_WRAPPER_CLASS}`)
+      document.elementFromPoint = vi.fn<(...args: any[]) => any>(() => wrapper as Element)
+      await act(async () => {
+        await removeOrShowNodeTranslation({ x: 150, y: 125 }, config)
+        flushBatchedOperations()
+      })
+
+      expect(document.head.querySelector("#read-frog-site-rule-styles")).toBeNull()
+      document.elementFromPoint = originalElementFromPoint
+    })
   })
   describe("hide translation", () => {
     it("should hide the translation when point is over the translation content node", async () => {

--- a/src/utils/host/dom/__tests__/include-scope.test.ts
+++ b/src/utils/host/dom/__tests__/include-scope.test.ts
@@ -75,6 +75,23 @@ describe("includeSelectors whitelist", () => {
     expect(document.querySelector("#description")!.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(true)
   })
 
+  it("labels a YouTube watch title when the A/B layout has no h1 ancestor", () => {
+    setUrl("https://www.youtube.com/watch?v=video-id")
+    document.body.innerHTML = `
+      <div id="title-row">
+        <yt-formatted-string class="ytd-watch-metadata" id="watch-title">
+          A visible video title rendered without a heading wrapper
+        </yt-formatted-string>
+      </div>
+    `
+
+    const title = document.querySelector("#watch-title") as HTMLElement
+    walkAndLabelElement(title, "hover-walk", structuredClone(DEFAULT_CONFIG))
+
+    expect(title.hasAttribute(WALKED_ATTRIBUTE)).toBe(true)
+    expect(title.hasAttribute(PARAGRAPH_ATTRIBUTE)).toBe(true)
+  })
+
   it("lets excludeSelectors carve holes inside the whitelisted subtree", () => {
     setHost("include-example.org")
     document.body.innerHTML = `

--- a/src/utils/host/translate/node-manipulation.ts
+++ b/src/utils/host/translate/node-manipulation.ts
@@ -61,7 +61,7 @@ export async function removeOrShowNodeTranslation(point: Point, config: Config):
     const hasVisibleTranslation = styleRoot.querySelector(
       `.${CONTENT_WRAPPER_CLASS},[${TRANSLATION_ONLY_ATTRIBUTE}]`,
     )
-    if (siteRule.injectedCss && !getPageTranslationSessionId() && !hasVisibleTranslation) {
+    if (!getPageTranslationSessionId() && !hasVisibleTranslation) {
       removeSiteRuleCSS(styleRoot)
     }
   }

--- a/src/utils/host/translate/node-manipulation.ts
+++ b/src/utils/host/translate/node-manipulation.ts
@@ -1,11 +1,15 @@
 import type { Config } from "@/types/config/config"
 import type { Point } from "@/types/dom"
+import { CONTENT_WRAPPER_CLASS, TRANSLATION_ONLY_ATTRIBUTE } from "@/utils/constants/dom-labels"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
+import { getEffectiveSiteRule } from "@/utils/site-rules/effective"
 import { isHTMLElement } from "../dom/filter"
 import { findNearestAncestorBlockNodeAt } from "../dom/find"
 import { walkAndLabelElement } from "../dom/traversal"
 import { translateWalkedElement } from "./core/translation-walker"
 import { validateTranslationConfigAndToast } from "./translate-text"
+import { getPageTranslationSessionId } from "./translation-session"
+import { ensureSiteRuleCSS, removeSiteRuleCSS } from "./ui/style-injector"
 
 // Re-export public APIs
 export {
@@ -34,15 +38,32 @@ export async function removeOrShowNodeTranslation(point: Point, config: Config):
     return false
   }
 
-  walkAndLabelElement(node, id, config)
-  await translateWalkedElement(
-    node,
-    id,
-    config,
-    true,
-    undefined,
-    undefined,
-    config.pageTranslation.node.forceRetranslation,
-  )
+  const rootNode = node.getRootNode()
+  const styleRoot = rootNode instanceof ShadowRoot ? rootNode : document
+  const siteRule = getEffectiveSiteRule(config, window.location.href)
+
+  if (siteRule.injectedCss) {
+    await ensureSiteRuleCSS(styleRoot, siteRule.injectedCss)
+  }
+
+  try {
+    walkAndLabelElement(node, id, config)
+    await translateWalkedElement(
+      node,
+      id,
+      config,
+      true,
+      undefined,
+      undefined,
+      config.pageTranslation.node.forceRetranslation,
+    )
+  } finally {
+    const hasVisibleTranslation = styleRoot.querySelector(
+      `.${CONTENT_WRAPPER_CLASS},[${TRANSLATION_ONLY_ATTRIBUTE}]`,
+    )
+    if (siteRule.injectedCss && !getPageTranslationSessionId() && !hasVisibleTranslation) {
+      removeSiteRuleCSS(styleRoot)
+    }
+  }
   return true
 }

--- a/src/utils/host/translate/node-manipulation.ts
+++ b/src/utils/host/translate/node-manipulation.ts
@@ -1,6 +1,5 @@
 import type { Config } from "@/types/config/config"
 import type { Point } from "@/types/dom"
-import { CONTENT_WRAPPER_CLASS, TRANSLATION_ONLY_ATTRIBUTE } from "@/utils/constants/dom-labels"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
 import { getEffectiveSiteRule } from "@/utils/site-rules/effective"
 import { isHTMLElement } from "../dom/filter"
@@ -8,8 +7,7 @@ import { findNearestAncestorBlockNodeAt } from "../dom/find"
 import { walkAndLabelElement } from "../dom/traversal"
 import { translateWalkedElement } from "./core/translation-walker"
 import { validateTranslationConfigAndToast } from "./translate-text"
-import { getPageTranslationSessionId } from "./translation-session"
-import { ensureSiteRuleCSS, removeSiteRuleCSS } from "./ui/style-injector"
+import { beginNodeSiteRuleCSSOperation } from "./ui/node-site-rule-css"
 
 // Re-export public APIs
 export {
@@ -41,10 +39,7 @@ export async function removeOrShowNodeTranslation(point: Point, config: Config):
   const rootNode = node.getRootNode()
   const styleRoot = rootNode instanceof ShadowRoot ? rootNode : document
   const siteRule = getEffectiveSiteRule(config, window.location.href)
-
-  if (siteRule.injectedCss) {
-    await ensureSiteRuleCSS(styleRoot, siteRule.injectedCss)
-  }
+  const releaseSiteRuleCSS = await beginNodeSiteRuleCSSOperation(styleRoot, siteRule.injectedCss)
 
   try {
     walkAndLabelElement(node, id, config)
@@ -58,12 +53,7 @@ export async function removeOrShowNodeTranslation(point: Point, config: Config):
       config.pageTranslation.node.forceRetranslation,
     )
   } finally {
-    const hasVisibleTranslation = styleRoot.querySelector(
-      `.${CONTENT_WRAPPER_CLASS},[${TRANSLATION_ONLY_ATTRIBUTE}]`,
-    )
-    if (!getPageTranslationSessionId() && !hasVisibleTranslation) {
-      removeSiteRuleCSS(styleRoot)
-    }
+    await releaseSiteRuleCSS()
   }
   return true
 }

--- a/src/utils/host/translate/ui/__tests__/node-site-rule-css.test.ts
+++ b/src/utils/host/translate/ui/__tests__/node-site-rule-css.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+import { CONTENT_WRAPPER_CLASS } from "@/utils/constants/dom-labels"
+import { beginPageTranslationSession, endPageTranslationSession } from "../../translation-session"
+import {
+  beginNodeSiteRuleCSSOperation,
+  cleanupNodeSiteRuleCSSIfUnused,
+} from "../node-site-rule-css"
+
+const SITE_RULE_CSS = ".clamped-title { max-height: none !important; }"
+const SITE_RULE_STYLE_SELECTOR = "#read-frog-site-rule-styles"
+
+function createTranslationWrapper(): HTMLElement {
+  const wrapper = document.createElement("span")
+  wrapper.className = CONTENT_WRAPPER_CLASS
+  return wrapper
+}
+
+async function flushMutationObserver(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe("node site-rule CSS lifecycle", () => {
+  beforeEach(() => {
+    endPageTranslationSession()
+    document.head.innerHTML = ""
+    document.body.innerHTML = ""
+    Object.defineProperty(document, "adoptedStyleSheets", {
+      configurable: true,
+      value: undefined,
+    })
+  })
+
+  afterEach(() => {
+    endPageTranslationSession()
+    document.querySelectorAll(`.${CONTENT_WRAPPER_CLASS}`).forEach((wrapper) => wrapper.remove())
+    cleanupNodeSiteRuleCSSIfUnused(document)
+  })
+
+  it("keeps CSS while another node translation operation is pending", async () => {
+    const releaseFirst = await beginNodeSiteRuleCSSOperation(document, SITE_RULE_CSS)
+    const releaseSecond = await beginNodeSiteRuleCSSOperation(document, SITE_RULE_CSS)
+
+    await releaseFirst()
+
+    expect(document.head.querySelector(SITE_RULE_STYLE_SELECTOR)).not.toBeNull()
+
+    const wrapper = createTranslationWrapper()
+    document.body.appendChild(wrapper)
+    await releaseSecond()
+
+    expect(document.head.querySelector(SITE_RULE_STYLE_SELECTOR)).not.toBeNull()
+  })
+
+  it("cleans ShadowRoot CSS even while a document page session is active", async () => {
+    beginPageTranslationSession()
+    const host = document.createElement("div")
+    const shadowRoot = host.attachShadow({ mode: "open" })
+    Object.defineProperty(shadowRoot, "adoptedStyleSheets", {
+      configurable: true,
+      value: undefined,
+    })
+    document.body.appendChild(host)
+
+    const release = await beginNodeSiteRuleCSSOperation(shadowRoot, SITE_RULE_CSS)
+    expect(shadowRoot.querySelector(SITE_RULE_STYLE_SELECTOR)).not.toBeNull()
+
+    await release()
+
+    expect(shadowRoot.querySelector(SITE_RULE_STYLE_SELECTOR)).toBeNull()
+  })
+
+  it("removes CSS after the host discards the last translated subtree", async () => {
+    const release = await beginNodeSiteRuleCSSOperation(document, SITE_RULE_CSS)
+    const translatedSubtree = document.createElement("div")
+    translatedSubtree.appendChild(createTranslationWrapper())
+    document.body.appendChild(translatedSubtree)
+    await release()
+
+    expect(document.head.querySelector(SITE_RULE_STYLE_SELECTOR)).not.toBeNull()
+
+    translatedSubtree.remove()
+    await flushMutationObserver()
+
+    expect(document.head.querySelector(SITE_RULE_STYLE_SELECTOR)).toBeNull()
+  })
+
+  it("reconciles retained node CSS after a document page session stops", async () => {
+    beginPageTranslationSession()
+    const release = await beginNodeSiteRuleCSSOperation(document, SITE_RULE_CSS)
+    await release()
+
+    expect(document.head.querySelector(SITE_RULE_STYLE_SELECTOR)).not.toBeNull()
+
+    endPageTranslationSession()
+    cleanupNodeSiteRuleCSSIfUnused(document)
+
+    expect(document.head.querySelector(SITE_RULE_STYLE_SELECTOR)).toBeNull()
+  })
+})

--- a/src/utils/host/translate/ui/node-site-rule-css.ts
+++ b/src/utils/host/translate/ui/node-site-rule-css.ts
@@ -1,0 +1,125 @@
+import { CONTENT_WRAPPER_CLASS, TRANSLATION_ONLY_ATTRIBUTE } from "@/utils/constants/dom-labels"
+import { getPageTranslationSessionId } from "../translation-session"
+import { ensureSiteRuleCSS, removeSiteRuleCSS } from "./style-injector"
+
+type StyleRoot = Document | ShadowRoot
+
+const VISIBLE_TRANSLATION_SELECTOR =
+  `.${CONTENT_WRAPPER_CLASS},[${TRANSLATION_ONLY_ATTRIBUTE}]` as const
+
+interface NodeSiteRuleCSSState {
+  cssText: string
+  observer: MutationObserver
+  pendingOperations: number
+}
+
+const nodeSiteRuleCSSStates = new WeakMap<StyleRoot, NodeSiteRuleCSSState>()
+
+function pageTranslationOwnsCSS(root: StyleRoot): boolean {
+  return root instanceof Document && getPageTranslationSessionId() !== null
+}
+
+function hasVisibleTranslation(root: StyleRoot): boolean {
+  return root.querySelector(VISIBLE_TRANSLATION_SELECTOR) !== null
+}
+
+function removedNodeContainsTranslation(node: Node): boolean {
+  if (node.nodeType !== Node.ELEMENT_NODE) return false
+  const element = node as Element
+  return (
+    element.matches(VISIBLE_TRANSLATION_SELECTOR) ||
+    element.querySelector(VISIBLE_TRANSLATION_SELECTOR) !== null
+  )
+}
+
+function mayHaveRemovedTranslation(records: MutationRecord[]): boolean {
+  return records.some((record) => {
+    if (record.type === "attributes") return true
+    return [...record.removedNodes].some(removedNodeContainsTranslation)
+  })
+}
+
+function disposeState(root: StyleRoot, state: NodeSiteRuleCSSState): void {
+  if (nodeSiteRuleCSSStates.get(root) !== state) return
+  state.observer.disconnect()
+  nodeSiteRuleCSSStates.delete(root)
+  removeSiteRuleCSS(root)
+}
+
+function cleanupIfUnused(root: StyleRoot, state: NodeSiteRuleCSSState): void {
+  if (
+    nodeSiteRuleCSSStates.get(root) !== state ||
+    state.pendingOperations > 0 ||
+    pageTranslationOwnsCSS(root) ||
+    hasVisibleTranslation(root)
+  ) {
+    return
+  }
+  disposeState(root, state)
+}
+
+function createState(root: StyleRoot, cssText: string): NodeSiteRuleCSSState {
+  let state: NodeSiteRuleCSSState
+  const observer = new MutationObserver((records) => {
+    if (mayHaveRemovedTranslation(records)) cleanupIfUnused(root, state)
+  })
+  state = { cssText, observer, pendingOperations: 0 }
+  nodeSiteRuleCSSStates.set(root, state)
+  observer.observe(root, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: [TRANSLATION_ONLY_ATTRIBUTE],
+  })
+  return state
+}
+
+/**
+ * Retain per-site CSS for one node-translation operation. The returned release
+ * function must be awaited in a finally block so overlapping operations cannot
+ * remove their shared stylesheet while another translation is still pending.
+ */
+export async function beginNodeSiteRuleCSSOperation(
+  root: StyleRoot,
+  cssText: string | null,
+): Promise<() => Promise<void>> {
+  let state = nodeSiteRuleCSSStates.get(root)
+  if (!state) {
+    if (!cssText) return async () => {}
+    state = createState(root, cssText)
+  }
+  state.pendingOperations += 1
+
+  if (cssText) {
+    state.cssText = cssText
+    try {
+      await ensureSiteRuleCSS(root, cssText)
+    } catch (error) {
+      state.pendingOperations -= 1
+      cleanupIfUnused(root, state)
+      throw error
+    }
+  }
+
+  let released = false
+  return async () => {
+    if (released) return
+    released = true
+    state.pendingOperations -= 1
+
+    if (state.pendingOperations > 0 || pageTranslationOwnsCSS(root)) return
+    if (hasVisibleTranslation(root)) {
+      // A page-session stop or an overlapping operation may have removed the
+      // shared stylesheet while this operation was awaiting translation.
+      await ensureSiteRuleCSS(root, state.cssText)
+      return
+    }
+    disposeState(root, state)
+  }
+}
+
+/** Reconcile node-owned CSS after a page session synchronously removes wrappers. */
+export function cleanupNodeSiteRuleCSSIfUnused(root: StyleRoot): void {
+  const state = nodeSiteRuleCSSStates.get(root)
+  if (state) cleanupIfUnused(root, state)
+}

--- a/src/utils/host/translate/ui/style-injector.ts
+++ b/src/utils/host/translate/ui/style-injector.ts
@@ -130,8 +130,9 @@ const siteRuleCSSMap = new WeakMap<StyleRoot, CSSStyleSheet>()
 
 /**
  * Inject per-site rule CSS into the given root. Unlike the custom-style slot
- * below, this one is removable: it only applies while a translation session
- * is active on a matched site (see PageTranslationManager).
+ * below, this one is removable: it only applies while a page or node
+ * translation is visible on a matched site (see PageTranslationManager and
+ * removeOrShowNodeTranslation).
  */
 export async function ensureSiteRuleCSS(root: StyleRoot, cssText: string): Promise<void> {
   if (supportsConstructableStyleSheets(root)) {

--- a/src/utils/site-rules/__tests__/built-in.test.ts
+++ b/src/utils/site-rules/__tests__/built-in.test.ts
@@ -380,6 +380,18 @@ describe("built-in site rules", () => {
     )
   })
 
+  it("unclamps YouTube watch titles with or without an h1 wrapper", () => {
+    const resolved = resolveSiteRule(
+      "https://www.youtube.com/watch?v=video-id",
+      BUILT_IN_SITE_RULES,
+      [],
+      [],
+    )
+
+    expect(resolved.injectedCss).toContain("h1.ytd-watch-metadata")
+    expect(resolved.injectedCss).toContain("yt-formatted-string.ytd-watch-metadata")
+  })
+
   it("excludes the hltv.org navigation whose overflow handler loops on width changes (#1831)", () => {
     const resolved = resolveSiteRule(
       "https://www.hltv.org/matches/2395002/furia-vs-falcons-iem-cologne-major-2026",

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -770,6 +770,9 @@
       "#commentCanvas .cmt",
       ".ytwTranscriptSegmentViewModelHost"
     ],
+    "injectedCss.add": [
+      "yt-formatted-string.ytd-watch-metadata {-webkit-line-clamp: unset !important;max-height: unset !important;}"
+    ],
     "injectedCss": ".read-frog-translated-content-wrapper img { width: 16px; height: 16px }\n.metadata-snippet-container {max-height: unset !important;}\n.read-frog-translated-content-wrapper {text-align: left;}\n.read-frog-translated-content-wrapper[dir=rtl] {text-align: right;}\n#commentCanvas .cmt {display:flex;flex-direction: column;}\n#commentCanvas .cmt font br {display: none;}\n#video-title,h1.ytd-watch-metadata,.ytd-video-renderer,.yt-lockup-metadata-view-model-wiz__title {-webkit-line-clamp: unset !important;max-height: unset !important;}\nyt-formatted-string#video-title,.ShortsLockupViewModelHostOutsideMetadataTitle {-webkit-line-clamp: unset !important;max-height: unset !important;}\nytd-expander.ytd-comment-renderer {--ytd-expander-max-lines: 1000;}\n.page-header-view-model-wiz__page-header-title--page-header-title-large {-webkit-line-clamp: unset !important;max-height: unset !important;}\n#title,#video-title,.yt-lockup-metadata-view-model__title,.ytLockupMetadataViewModelTitle,.shortsLockupViewModelHostOutsideMetadataTitle,h1.ytd-watch-metadata,.ytwFeedAdMetadataViewModelHostTextsStyleStandardHeadline {-webkit-line-clamp: unset !important;max-height: unset !important;}",
     "excludeSelectors.add": [
       ".ytp-caption-window-container",

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -749,6 +749,7 @@
       "yt-formatted-string.ytd-video-renderer",
       "yt-formatted-string#content-text",
       "h1",
+      "yt-formatted-string.ytd-watch-metadata",
       "yt-formatted-string#video-title",
       ".ytLockupMetadataViewModelTitle,.shortsLockupViewModelHostOutsideMetadataTitle",
       "yt-formatted-string.span",


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-5 (Codex)

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

YouTube's built-in site rule whitelists the visible watch title through its usual h1 ancestor. In experimental/A/B layouts where yt-formatted-string.ytd-watch-metadata is rendered without that wrapper, hover translation starts its local DOM walk outside the whitelist and never labels the title as a translatable paragraph. Full-page translation can still appear to work because document.title is handled through a separate path.

A second hover-only path also left YouTube's two-line h1 clamp active. The full source title and translation wrapper were present in the DOM, but overflow:hidden kept the translated lines below the 56px container. Full-page translation already installed the site's unclamp CSS; hover translation did not.

This change:

- directly includes yt-formatted-string.ytd-watch-metadata in the YouTube whitelist
- applies matched site-rule CSS while node translations are visible and removes it after the last node translation is closed
- removes previously installed site-rule CSS after the last node translation closes even if a configuration or SPA route change means the current effective rule no longer supplies CSS
- manages node-translation CSS per Document or ShadowRoot, retaining it across overlapping in-flight operations and treating only the Document stylesheet as page-session-owned
- observes removal of translated subtrees so SPA/framework rerenders cannot leave node-only site-rule CSS installed after the final wrapper disappears
- adds a regression test for a watch-title layout without an h1 ancestor
- adds node-translation regression tests for rule changes, overlapping operations, ShadowRoot ownership, page-session teardown, and host-driven wrapper removal
- adds a patch changeset for the extension

## Related Issue

N/A

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation performed:

- SKIP_FREE_API=true pnpm vitest run src/utils/host/__tests__/node-translate.test.tsx src/utils/host/dom/__tests__/include-scope.test.ts src/utils/site-rules/__tests__/built-in.test.ts src/utils/host/translate/ui/__tests__/style-injector.test.ts src/utils/host/translate/ui/__tests__/node-site-rule-css.test.ts src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts src/entrypoints/host.content/translation-control/__tests__/page-translation-observer-root.test.ts src/entrypoints/host.content/translation-control/__tests__/page-translation-document-root-scan.test.ts src/entrypoints/host.content/__tests__/runtime.test.ts (9 files, 83 tests passed)
- WXT_SKIP_ENV_VALIDATION=true pnpm build
- type-aware oxlint and oxfmt checks for the changed files
- real Chrome test with the built extension on YouTube's standard layout
- real Chrome test simulating the no-h1 A/B layout with the clamp directly on yt-formatted-string.ytd-watch-metadata while preserving the original typography; both the title and translation wrapper kept font-size/weight/line-height at 20px/700/28px, max-height changed from 56px to none, line-clamp changed from 2 to none, and the container grew from 28px to 73px (clientHeight matched scrollHeight)
- real Chrome tests on X7PZIGDUpPs and NsrNC864Gog at 828px viewport: the title clamp changed from 56/73px to 73/73px and from 56/129px to 129/129px (clientHeight/scrollHeight), with the full Chinese translations visible

Note: the full-worktree formatting check reported unrelated, unstaged subtitle/quota files. They are not part of this PR; the branch was pushed with the hook skipped so those local changes could remain untouched.

## Screenshots

N/A

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The fix keeps clipping behavior in the existing per-site rule model instead of restoring global truncation-style mutation. Node translation installs only the matched site's declared CSS, retains it while a bilingual wrapper or translation-only anchor is visible, and avoids removing it during an active full-page translation session.
