### PR TITLE
feat(providers): add a Get API key button for Atlas Cloud and Jalapen…

### DIFF
--- a/.changeset/get-api-key-button.md
+++ b/.changeset/get-api-key-button.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(providers): add a Get API key button for Atlas Cloud and Jalapeno Cloud

--- a/src/components/form/input-field-auto-save.tsx
+++ b/src/components/form/input-field-auto-save.tsx
@@ -6,12 +6,18 @@ import { useFieldContext } from "./form-context"
 export function InputFieldAutoSave({
   formForSubmit,
   label,
+  labelAfter,
   labelExtra,
   type,
   ...props
 }: {
   formForSubmit: { handleSubmit: () => void }
   label: React.ReactNode
+  /**
+   * Sits immediately beside the label, outside the `<label>` element — a link or button nested
+   * inside one would be invalid markup and would also steal the label's click.
+   */
+  labelAfter?: React.ReactNode
   labelExtra?: React.ReactNode
 } & React.InputHTMLAttributes<HTMLInputElement>) {
   const field = useFieldContext<string | number | undefined>()
@@ -39,8 +45,11 @@ export function InputFieldAutoSave({
 
   return (
     <Field data-invalid={hasError}>
-      <div className="flex w-full items-end justify-between">
-        <FieldLabel htmlFor={field.name}>{label}</FieldLabel>
+      <div className="flex w-full items-end justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <FieldLabel htmlFor={field.name}>{label}</FieldLabel>
+          {labelAfter}
+        </div>
         {labelExtra}
       </div>
       <Input

--- a/src/components/ui/base-ui/button.tsx
+++ b/src/components/ui/base-ui/button.tsx
@@ -10,6 +10,8 @@ const buttonVariants = cva(
       variant: {
         default: "bg-primary text-primary-foreground hover:bg-primary/80",
         brand: "bg-brand text-brand-foreground hover:bg-brand/80",
+        "brand-outline":
+          "border-brand/50 bg-background text-brand shadow-xs hover:border-brand hover:bg-brand/10 dark:bg-input/30 dark:hover:bg-brand/15",
         outline:
           "border-border bg-background shadow-xs hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50",
         secondary:

--- a/src/entrypoints/options/pages/api-providers/providers-config/provider-config-form/api-key-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/providers-config/provider-config-form/api-key-field.tsx
@@ -7,6 +7,7 @@ import { i18n } from "@/utils/i18n"
 import { cn } from "@/utils/styles/utils"
 import { highlightedProviderFieldAtom, PROVIDER_FIELD_HIGHLIGHT_DURATION_MS } from "../atoms"
 import { ConnectionTestButton } from "./components/connection-button"
+import { GetAPIKeyButton } from "./components/get-api-key-button"
 import { withForm } from "./form"
 
 export const APIKeyField = withForm({
@@ -41,6 +42,7 @@ export const APIKeyField = withForm({
             <field.InputFieldAutoSave
               formForSubmit={form}
               label="API Key"
+              labelAfter={<GetAPIKeyButton providerType={providerType} />}
               labelExtra={<ConnectionTestButton providerConfig={providerConfig} />}
               type={showAPIKey ? "text" : "password"}
               className={cn(isHighlighted && "animate-ring-flash")}

--- a/src/entrypoints/options/pages/api-providers/providers-config/provider-config-form/components/get-api-key-button.tsx
+++ b/src/entrypoints/options/pages/api-providers/providers-config/provider-config-form/components/get-api-key-button.tsx
@@ -1,0 +1,22 @@
+import type { APIProviderTypes } from "@/types/config/provider"
+import { Button } from "@/components/ui/base-ui/button"
+import { PROVIDER_ITEMS } from "@/utils/constants/providers"
+import { i18n } from "@/utils/i18n"
+
+/** Renders nothing for providers without an `apiKeyUrl`, which is how the button stays opt-in. */
+export function GetAPIKeyButton({ providerType }: { providerType: APIProviderTypes }) {
+  const apiKeyUrl = PROVIDER_ITEMS[providerType].apiKeyUrl
+  if (!apiKeyUrl) {
+    return null
+  }
+
+  return (
+    <Button
+      size="xs"
+      variant="brand-outline"
+      render={<a href={apiKeyUrl} target="_blank" rel="noreferrer" />}
+    >
+      {i18n.t("options.apiProviders.apiKey.getAPIKey")}
+    </Button>
+  )
+}

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -148,7 +148,7 @@ options:
         inputTranslation: Input translation
         languageDetection: Language detection
     sponsorCta: Get fast, cost-effective AI
-    sponsorCtaJalapenoCloud: 50% Off GLM 5.2
+    sponsorCtaJalapenoCloud: Get 50% Off GLM 5.2
     setApiKeyWarning:
       message: Please set your API key on the $1 page
     badges:
@@ -271,6 +271,7 @@ options:
         huggingface: Hugging Face Inference API providing access to thousands of open-source models
     apiKey:
       showAPIKey: Show API key
+      getAPIKey: Get API key
     howToConfigure: How to configure?
     testConnection:
       button: Test connection

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -148,7 +148,7 @@ options:
         inputTranslation: Traducción de entrada
         languageDetection: Detección de idioma
     sponsorCta: Obtén IA rápida y rentable
-    sponsorCtaJalapenoCloud: 50 % de descuento en GLM 5.2
+    sponsorCtaJalapenoCloud: Obtén un 50 % de descuento en GLM 5.2
     setApiKeyWarning:
       message: Configura tu clave de API en la página $1
     badges:
@@ -271,6 +271,7 @@ options:
         huggingface: API de inferencia de Hugging Face que proporciona acceso a miles de modelos de código abierto
     apiKey:
       showAPIKey: Mostrar clave API
+      getAPIKey: Obtener clave API
     howToConfigure: ¿Cómo configurar?
     testConnection:
       button: Probar conexión

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -148,7 +148,7 @@ options:
         inputTranslation: 入力翻訳
         languageDetection: 言語検出
     sponsorCta: 高速で高コスパのAIを入手
-    sponsorCtaJalapenoCloud: GLM 5.2 が 50% オフ
+    sponsorCtaJalapenoCloud: GLM 5.2 を 50% オフで入手
     setApiKeyWarning:
       message: API キーは $1 ページで設定してください
     badges:
@@ -270,6 +270,7 @@ options:
         huggingface: Hugging Face推論API、数千のオープンソースモデルへのアクセスを提供
     apiKey:
       showAPIKey: APIキーを表示
+      getAPIKey: APIキーを取得
     howToConfigure: 設定方法は?
     testConnection:
       button: 接続テスト

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -148,7 +148,7 @@ options:
         inputTranslation: 입력 번역
         languageDetection: 언어 감지
     sponsorCta: 빠르고 가성비 좋은 AI 받기
-    sponsorCtaJalapenoCloud: GLM 5.2 50% 할인
+    sponsorCtaJalapenoCloud: GLM 5.2 50% 할인 받기
     setApiKeyWarning:
       message: API 키는 $1 페이지에서 설정하세요
     badges:
@@ -270,6 +270,7 @@ options:
         huggingface: Hugging Face 추론 API, 수천 개의 오픈소스 모델 접근 제공
     apiKey:
       showAPIKey: API Key 표시
+      getAPIKey: API Key 받기
     howToConfigure: 구성 방법은?
     testConnection:
       button: 연결 테스트

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -148,7 +148,7 @@ options:
         inputTranslation: Перевод ввода
         languageDetection: Определение языка
     sponsorCta: Получить быстрый и выгодный ИИ
-    sponsorCtaJalapenoCloud: GLM 5.2 со скидкой 50 %
+    sponsorCtaJalapenoCloud: Получить GLM 5.2 со скидкой 50 %
     setApiKeyWarning:
       message: Укажите API-ключ на странице $1
     badges:
@@ -270,6 +270,7 @@ options:
         huggingface: API вывода Hugging Face с доступом к тысячам моделей с открытым кодом
     apiKey:
       showAPIKey: Показать API-ключ
+      getAPIKey: Получить API-ключ
     howToConfigure: Как настроить?
     testConnection:
       button: Проверить соединение

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -148,7 +148,7 @@ options:
         inputTranslation: Giriş çevirisi
         languageDetection: Dil algılama
     sponsorCta: Hızlı ve uygun maliyetli yapay zekâ al
-    sponsorCtaJalapenoCloud: GLM 5.2ʼde %50 indirim
+    sponsorCtaJalapenoCloud: GLM 5.2ʼde %50 indirim al
     setApiKeyWarning:
       message: API anahtarınızı $1 sayfasında ayarlayın
     badges:
@@ -270,6 +270,7 @@ options:
         huggingface: Binlerce açık kaynak modele erişim sağlayan Hugging Face Çıkarım API'si
     apiKey:
       showAPIKey: API anahtarını göster
+      getAPIKey: API anahtarı al
     howToConfigure: Nasıl yapılandırılır?
     testConnection:
       button: Bağlantıyı test et

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -148,7 +148,7 @@ options:
         inputTranslation: Dịch đầu vào
         languageDetection: Phát hiện ngôn ngữ
     sponsorCta: Nhận AI nhanh, tiết kiệm chi phí
-    sponsorCtaJalapenoCloud: Giảm 50% GLM 5.2
+    sponsorCtaJalapenoCloud: Nhận ưu đãi giảm 50% GLM 5.2
     setApiKeyWarning:
       message: Hãy đặt API Key ở trang $1
     badges:
@@ -270,6 +270,7 @@ options:
         huggingface: API suy luận Hugging Face cung cấp quyền truy cập hàng nghìn mô hình mã nguồn mở
     apiKey:
       showAPIKey: Hiển thị API Key
+      getAPIKey: Lấy API Key
     howToConfigure: Cấu hình như thế nào?
     testConnection:
       button: Kiểm tra kết nối

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -148,7 +148,7 @@ options:
         inputTranslation: 输入翻译
         languageDetection: 语言检测
     sponsorCta: 获取高速性价比 AI
-    sponsorCtaJalapenoCloud: GLM 5.2 五折优惠
+    sponsorCtaJalapenoCloud: 获取 GLM 5.2 五折优惠
     setApiKeyWarning:
       message: 请在 $1 页面设置 API Key
     badges:
@@ -271,6 +271,7 @@ options:
         huggingface: Hugging Face推理API，提供数千种开源模型访问
     apiKey:
       showAPIKey: 显示 API Key
+      getAPIKey: 获取 API Key
     howToConfigure: 如何配置?
     testConnection:
       button: 测试连接

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -148,7 +148,7 @@ options:
         inputTranslation: 輸入翻譯
         languageDetection: 語言偵測
     sponsorCta: 取得高速高性價比 AI
-    sponsorCtaJalapenoCloud: GLM 5.2 五折優惠
+    sponsorCtaJalapenoCloud: 取得 GLM 5.2 五折優惠
     setApiKeyWarning:
       message: 請在 $1 頁面設定 API 金鑰
     badges:
@@ -271,6 +271,7 @@ options:
         huggingface: Hugging Face 推理 API，提供數千種開源模型存取
     apiKey:
       showAPIKey: 顯示 API 金鑰
+      getAPIKey: 取得 API 金鑰
     howToConfigure: 如何設定？
     testConnection:
       button: 測試連線

--- a/src/utils/constants/providers.ts
+++ b/src/utils/constants/providers.ts
@@ -189,7 +189,18 @@ export const DEFAULT_LLM_PROVIDER_MODELS: LLMProviderModels = {
 
 export const PROVIDER_ITEMS: Record<
   AllProviderTypes,
-  { logo: (theme: Theme) => string; name: string; website: string; sponsor?: ProviderSponsorConfig }
+  {
+    logo: (theme: Theme) => string
+    name: string
+    website: string
+    sponsor?: ProviderSponsorConfig
+    /**
+     * Where someone signs up for or copies this provider's key. Only providers that set it get
+     * the "Get API key" button next to the API key field — absent means no button, because most
+     * providers' key pages sit behind a console we cannot link straight into.
+     */
+    apiKeyUrl?: string
+  }
 > = {
   "microsoft-translate": {
     logo: getLobeIconsCDNUrlFn("microsoft-color"),
@@ -215,6 +226,7 @@ export const PROVIDER_ITEMS: Record<
     logo: () => jalapenoCloudLogo,
     name: "Jalapeno Cloud",
     website: "https://www.jalapeno-cloud.ai/readfrog",
+    apiKeyUrl: "https://www.jalapeno-cloud.ai/readfrog",
     sponsor: {
       sponsoring: true,
       referUrl: "https://www.jalapeno-cloud.ai/readfrog",
@@ -227,6 +239,7 @@ export const PROVIDER_ITEMS: Record<
     logo: getLobeIconsCDNUrlFn("atlascloud"),
     name: "Atlas Cloud",
     website: "https://readfrog.s.gy/altas",
+    apiKeyUrl: "https://readfrog.s.gy/altas",
     sponsor: {
       sponsoring: true,
       referUrl: "https://readfrog.s.gy/altas",


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 5

## Type of Changes

<!--- Please select one type below -->

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [x] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Getting an API key was a dead end in the provider config: the form asked for a key but never said where to get one, so anyone setting up Atlas Cloud or Jalapeno Cloud had to leave the page and find the console themselves.

This adds a **Get API key** button next to the API key field label, opening the provider's sign-up page in a new tab.

**Opt-in by configuration.** `PROVIDER_ITEMS` gains an optional `apiKeyUrl`, set only for `jalapenocloud` and `atlascloud` (their referral URLs, so attribution is preserved). Providers without it render no button — which is most of them, since their key pages sit behind a console we cannot link straight into. Adding a third provider later is one line.

**Placement.** `InputFieldAutoSave` gains a `labelAfter` slot that renders immediately beside the label, *outside* the `<label>` element — an anchor nested inside a label is invalid markup and would also swallow the label's click. `Test connection` keeps its existing `labelExtra` slot at the row end and does not move.

**Styling.** A new `brand-outline` button variant (brand border and text on a transparent ground) sits alongside the existing solid `brand`, so the new button carries brand color without competing with the solid sponsor CTA in the card header.

**i18n.** `options.apiProviders.apiKey.getAPIKey` added to all 9 locales. Separately, the Jalapeno sponsor CTA now leads with a verb in every language — `Get 50% Off GLM 5.2`, `获取 GLM 5.2 五折优惠`, `取得 GLM 5.2 五折優惠`, `GLM 5.2 を 50% オフで入手`, `GLM 5.2 50% 할인 받기`, `Obtén un 50 % de descuento en GLM 5.2`, `Получить GLM 5.2 со скидкой 50 %`, `GLM 5.2ʼde %50 indirim al`, `Nhận ưu đãi giảm 50% GLM 5.2`.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

Verified against the **built extension in real Chrome** (Puppeteer, `.output/chrome-mv3`) rather than a mocked render, since this is UI placement:

- Atlas Cloud and Jalapeno Cloud render the button beside the label; OpenAI renders nothing there — the API key row reads `API Key | Get API key | Test connection` for the first two and `API Key | Test connection` for OpenAI.
- Checked in both dark and light themes.
- No page errors in the options page console.
- `pnpm test` — 283 files, 2715 tests passing.
- `pnpm lint` (oxlint `--type-aware --type-check`) and `pnpm fmt:check` clean.

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

_Atlas Cloud / Jalapeno Cloud (dark and light) — brand-outline button beside the label, Test connection unmoved. OpenAI unchanged._

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->

- **Light-mode contrast is worth a look.** `--rf-brand` is a light gold (`oklch(76% 0.124 82)`), so brand-colored *text* on the white light-mode ground lands around 2.4:1 — below the 4.5:1 WCAG threshold for body text. It is legible at this size and this is the first place brand is used as a text color rather than a background, but if it reads too washed out, a darker light-mode brand token (or `text-foreground` with a brand border) would fix it.
- For Jalapeno Cloud with no key set, the header sponsor CTA and this button both point at the same URL. The outline treatment keeps the two from competing visually, but the redundancy is intentional and worth confirming.