### PR TITLE
fix(floating-button): hide the floating button while the page is full…

### DIFF
--- a/.changeset/hide-floating-button-in-fullscreen.md
+++ b/.changeset/hide-floating-button-in-fullscreen.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(floating-button): hide the floating button while the page is fullscreen (YouTube fullscreens the whole document, so it used to stay on top of the video)

--- a/src/entrypoints/side.content/components/floating-button/index.tsx
+++ b/src/entrypoints/side.content/components/floating-button/index.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/base-ui/dropdown-menu"
 import { anchoredToastManager } from "@/components/ui/base-ui/toast"
+import { useIsFullscreen } from "@/hooks/use-is-fullscreen"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext } from "@/utils/analytics"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
@@ -130,6 +131,7 @@ export default function FloatingButton() {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
   const [isHitAreaExpanded, setIsHitAreaExpanded] = useState(false)
   const [dragPreviewPosition, setDragPreviewPosition] = useState<DragPoint | null>(null)
+  const isFullscreen = useIsFullscreen()
   const containerRef = useRef<HTMLDivElement | null>(null)
   const mainButtonRef = useRef<HTMLDivElement | null>(null)
   const pendingDragRef = useRef<PendingDragState | null>(null)
@@ -162,6 +164,24 @@ export default function FloatingButton() {
       }
     }
   }, [])
+
+  // Going fullscreen removes the button from the DOM, so an in-flight drag can
+  // never receive its pointerup: cancel it here, or the body keeps the grabbing
+  // cursor and the text-selection lock after fullscreen exits.
+  useEffect(() => {
+    if (!isFullscreen) return
+
+    const pendingDrag = pendingDragRef.current
+    if (pendingDrag) {
+      window.clearTimeout(pendingDrag.longPressTimerId)
+      pendingDragRef.current = null
+    }
+    lastDragPreviewRef.current = null
+    setDragPreviewPosition(null)
+    setIsDraggingButton(false)
+    setIsHitAreaExpanded(false)
+    setIsDropdownOpen(false)
+  }, [isFullscreen, setIsDraggingButton])
 
   const handleFloatingButtonClick = () => {
     if (floatingButton.clickAction === "translate") {
@@ -338,6 +358,7 @@ export default function FloatingButton() {
   }
 
   if (
+    isFullscreen ||
     !floatingButton.enabled ||
     floatingButton.disabledFloatingButtonPatterns.some((pattern) =>
       matchDomainPattern(window.location.href, pattern),

--- a/src/hooks/use-is-fullscreen.ts
+++ b/src/hooks/use-is-fullscreen.ts
@@ -1,0 +1,28 @@
+/**
+ * Tracks whether the document is currently in fullscreen.
+ *
+ * Only the fullscreen element's subtree gets painted, so sites that fullscreen
+ * the player itself (Bilibili, X) already hide our body-anchored overlays for
+ * free. YouTube fullscreens `document.documentElement`, which keeps the whole
+ * document painted — this lets those overlays opt out explicitly.
+ *
+ * @returns Whether a fullscreen element is active
+ */
+
+import { useEffect, useState } from "react"
+
+export function useIsFullscreen(): boolean {
+  const [isFullscreen, setIsFullscreen] = useState(() => Boolean(document.fullscreenElement))
+
+  useEffect(() => {
+    const syncFullscreenState = () => setIsFullscreen(Boolean(document.fullscreenElement))
+
+    // Fullscreen may have been entered between the initial state and this effect
+    syncFullscreenState()
+    document.addEventListener("fullscreenchange", syncFullscreenState)
+
+    return () => document.removeEventListener("fullscreenchange", syncFullscreenState)
+  }, [])
+
+  return isFullscreen
+}


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 5

## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

The floating button stayed parked on top of the video when YouTube went fullscreen, while it correctly disappeared on Bilibili, X and other players.

That difference was never ours. The Fullscreen API only paints the fullscreen element's subtree, so a site that fullscreens its player element leaves our `body`-anchored shadow host outside that subtree and the browser simply never draws it — the button vanished for free. YouTube instead calls `document.documentElement.requestFullscreen()`; the whole document keeps painting, our host included, so the frog kept sitting over the video. Verified live: on a YouTube watch page `document.fullscreenElement` is `HTML`.

This adds a `useIsFullscreen` hook (a `fullscreenchange` listener on `document`) and folds `isFullscreen` into the floating button's existing early return, next to `floatingButton.enabled` and the per-site disable patterns. That unmounts the rendered subtree rather than hiding it with CSS, so nothing of ours can paint over a fullscreen player on any site; the button comes back on exit, positioned from config as usual.

One follow-on that the early return makes necessary: the button's DOM node disappears mid-drag, so its `pointerup` never lands and `finishPointerInteraction` never runs. Since the component instance itself stays mounted, the body-style effect's cleanup would not fire either, leaving the page with `cursor: grabbing` and `user-select: none` after fullscreen exits — the page would be unselectable until the user clicked the frog once. An effect now cancels any in-flight drag on the way into fullscreen. Reaching this needs a drag held while triggering fullscreen by keyboard, but the fallout is annoying enough to close off.

Scope note: other `body`-level surfaces (docked toasts, the selection toolbar host) still sit outside the player and would likewise paint over YouTube fullscreen. This PR only covers the floating button.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

Driven with Puppeteer against the built extension in real headed Chrome (no unit tests — this is UI behaviour that only reproduces in a real browser; the 16 existing floating-button tests still pass):

- **Real youtube.com watch page** — before: button present, `fullscreenElement: null`. During fullscreen: `fullscreenElement: 'HTML'`, button gone. After exit: button back. PASS
- **Fixture, `documentElement` fullscreen** (the YouTube shape) — same three-phase result. PASS
- **Fixture, player-element fullscreen** (the Bilibili/X shape) — unchanged behaviour, no regression. PASS
- **Fixture, drag cancelled on fullscreen** — real pointer drag on the button (`cursor: 'grabbing'`, `user-select: 'none'` observed mid-drag), then fullscreen entered by keyboard without releasing: button gone and both body styles cleared; restored normally on exit. PASS
- No `Minified React error` / `NotFoundError` in the page console during any phase.

Full suite: 282 files / 2711 tests pass, `nx lint` and `nx fmt:check` clean, `tsc --noEmit` clean.

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Changeset: `patch` — a UI fix users barely notice.

Behaviour is uniform across sites rather than YouTube-specific: the button now hides for any fullscreen element, which is a no-op on the players that already hid it.