### PR TITLE
fix(translation): translate pages whose document root opts out with notranslate

### DIFF
--- a/.changeset/telegram-web-a-page-translation.md
+++ b/.changeset/telegram-web-a-page-translation.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): translate pages whose document root opts out with `notranslate`

--- a/src/utils/host/dom/__tests__/traversal.test.ts
+++ b/src/utils/host/dom/__tests__/traversal.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import {
   BLOCK_ATTRIBUTE,
   INLINE_ATTRIBUTE,
+  NOTRANSLATE_CLASS,
   PARAGRAPH_ATTRIBUTE,
   WALKED_ATTRIBUTE,
 } from "@/utils/constants/dom-labels"
@@ -435,6 +436,54 @@ describe("document root labeling guard", () => {
       ]) {
         document.documentElement.removeAttribute(attr)
       }
+    }
+  })
+})
+
+describe("document root notranslate exemption", () => {
+  function cleanUpRoot() {
+    document.documentElement.classList.remove(NOTRANSLATE_CLASS)
+    document.body.innerHTML = ""
+    for (const attr of [WALKED_ATTRIBUTE, PARAGRAPH_ATTRIBUTE, BLOCK_ATTRIBUTE, INLINE_ATTRIBUTE]) {
+      document.documentElement.removeAttribute(attr)
+    }
+  }
+
+  it("walks the page when the document root carries the notranslate class", () => {
+    // Telegram Web A ships `<html translate="no" class="notranslate">` while
+    // Telegram Web K ships a bare `<html>`. Once #1992 moved the walk root from
+    // <body> to documentElement, that one class aborted the walk on its first
+    // blocked-element check and page translation labeled nothing at all.
+    document.documentElement.classList.add(NOTRANSLATE_CLASS)
+    document.body.innerHTML = `<div><p id="msg">Message body text</p></div>`
+
+    try {
+      walkAndLabelElement(document.documentElement, "root-notranslate", DEFAULT_CONFIG)
+
+      expect(document.getElementById("msg")).toHaveAttribute(PARAGRAPH_ATTRIBUTE)
+    } finally {
+      cleanUpRoot()
+    }
+  })
+
+  it("still blocks notranslate elements nested below the document root", () => {
+    // The exemption is root-only: nested opt-outs (and read frog's own injected
+    // UI, which carries the same class) must keep blocking descent.
+    document.documentElement.classList.add(NOTRANSLATE_CLASS)
+    document.body.innerHTML = `
+      <div>
+        <p id="msg">Message body text</p>
+        <div class="${NOTRANSLATE_CLASS}"><p id="opted-out">Opted out text</p></div>
+      </div>
+    `
+
+    try {
+      walkAndLabelElement(document.documentElement, "nested-notranslate", DEFAULT_CONFIG)
+
+      expect(document.getElementById("msg")).toHaveAttribute(PARAGRAPH_ATTRIBUTE)
+      expect(document.getElementById("opted-out")).not.toHaveAttribute(PARAGRAPH_ATTRIBUTE)
+    } finally {
+      cleanUpRoot()
     }
   })
 })

--- a/src/utils/host/dom/filter.ts
+++ b/src/utils/host/dom/filter.ts
@@ -210,7 +210,20 @@ export function isDontWalkIntoButTranslateAsChildElement(
   element: HTMLElement,
   config?: Config,
 ): boolean {
-  const dontWalkClass = element.classList.contains(NOTRANSLATE_CLASS)
+  // The document root is exempt from the `notranslate` class rule. This
+  // predicate means "don't descend, but let the parent translate this as one
+  // inline chunk" — <html> has no parent to fold that text into, so blocking it
+  // drops the whole document instead of merging it. Since #1992 moved the walk
+  // root from <body> to documentElement, a site that ships
+  // `<html class="notranslate">` (Telegram Web A does; Telegram Web K does not)
+  // aborts the walk on its very first check and page translation silently
+  // labels nothing at all. Honoring an explicit page-translation request over a
+  // root-level opt-out mirrors the existing decision to ignore the
+  // `translate="no"` attribute (#459). Nested `notranslate` elements — read
+  // frog's own injected UI included — still block normally.
+  const dontWalkClass =
+    element.classList.contains(NOTRANSLATE_CLASS) &&
+    element !== element.ownerDocument.documentElement
 
   const dontWalkTag = getEffectiveTagSet(config, "dontWalkButTranslateTags").has(element.tagName)
 

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -1077,13 +1077,15 @@
       ".time",
       ".peer-title",
       ".document-wrapper",
-      ".message.spoilers-container custom-emoji-element"
+      ".message.spoilers-container custom-emoji-element",
+      ".MessageMeta"
     ],
     "includeSelectors": [
       ".text-content",
       ".message",
       ".reply-markup-button-text",
       ".bot-commands-list-element-description",
+      ".message-content-wrapper .Button",
       "[class*='tabs-tab page-password active']",
       "#auth-qr-form"
     ],


### PR DESCRIPTION
## Problem

Full-page translation is a complete no-op on Telegram Web A (`web.telegram.org/a/`) while Telegram Web K (`web.telegram.org/k/`) works fine.

The difference is one line of markup:

```
/a/  →  <html lang="en" translate="no" class="notranslate">
/k/  →  <html lang="en">
```

`b1fa3dca` (#1992) moved the page-translation walk root from `document.body` to `document.documentElement`. `walkAndLabelElement` starts with `isWalkBlockedElement(element, config)`, which checks `element.classList.contains("notranslate")` — so on any site that marks its document root `notranslate`, the walk aborts on its very first check and **not a single paragraph is labeled**. Before #1992 the walk started at `<body>`, which carries no such class, so it worked.

This is not Telegram-specific: it breaks page translation on every site that opts out at the root.

Measured on a live Telegram Web A chat:

| | paragraphs | block nodes |
|---|---|---|
| as shipped | **0** | **0** |
| with `notranslate` removed from `<html>` | **240** | **1455** |

No site rule can fix this — the class check is hard-coded, which is why the existing `telegram` rule's `"excludeSelectors.remove": [".notranslate", "[translate=no]"]` (clearly written against this same symptom) never helped.

## Fix

**1. Exempt the document root from the `notranslate` class rule.**

`isDontWalkIntoButTranslateAsChildElement` means *"don't descend, but let the parent translate this as one inline chunk."* `<html>` has no parent to fold that text into, so blocking it drops the whole document rather than merging it — the predicate's fallback simply doesn't exist at the root.

Nested `notranslate` elements — including read frog's own injected UI — still block descent exactly as before. Honoring an explicit page-translation request over a root-level opt-out mirrors the existing decision to ignore the `translate="no"` attribute (#459).

**2. Extend the `telegram` site rule for Web A's DOM.**

Web A and Web K share one rule but are different codebases (`telegram-tt` vs `tweb`), and the rule's `includeSelectors` whitelist was written against Web K's kebab-case class names. Once the walk is unblocked, all 240 labeled paragraphs on Web A land inside `.text-content` and nothing else qualifies, so:

- include `.message-content-wrapper .Button` — Web A's inline keyboard buttons (Web K's `.reply-markup-button-text` matches nothing there)
- exclude `.MessageMeta` — wraps Web A's message timestamp and view count *inside* `.text-content`, so without this they get sent for translation (Web K excludes the equivalent via `.time`)

This keeps Web A at parity with what the rule already translates on Web K. Only stable class names are used — roughly half of Web A's classes are CSS-module hashes (`JNp8AaXo`, `_8IVW0azL`, `eZi5Ws-N`) that change on every Telegram release and must never appear in a rule. Note `.message` in the existing rule can never match on Web A, which uses `.Message`.

## Testing

- Two new tests in `traversal.test.ts`: a root carrying `notranslate` walks normally, and nested `notranslate` still blocks. Both fail on `main` and pass with this change.
- `src/utils/host/dom`, `src/utils/site-rules`, `src/entrypoints/host.content/translation-control`: 249 passed.
- Full suite: 2697 passed, 20 failed in `background-stream.test.ts`, `extension-status.test.ts`, and `blog.test.ts` — all of which fail identically on a clean tree (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)