### PR TITLE
feat(tts): add MiniMax speech synthesis

### DIFF
--- a/.changeset/bright-frogs-speak.md
+++ b/.changeset/bright-frogs-speak.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(tts): add MiniMax speech synthesis

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -27,6 +27,7 @@ import { setupEdgeTTSMessageHandlers } from "./edge-tts"
 import { setupHostedAiStatusHandler } from "./hosted-ai-status"
 import { setupIframeInjection } from "./iframe-injection"
 import { setupLLMGenerateTextMessageHandlers } from "./llm-generate-text"
+import { setupMiniMaxTTSMessageHandlers } from "./minimax-tts"
 import { initMockData } from "./mock-data"
 import { newUserGuide } from "./new-user-guide"
 import { setupNotebasePendingSaveProcessor } from "./notebase-pending-save"
@@ -142,6 +143,7 @@ export default defineBackground({
     setupHostedAiStatusHandler()
     setupNotebasePendingSaveProcessor(() => backgroundReady)
     setupEdgeTTSMessageHandlers()
+    setupMiniMaxTTSMessageHandlers()
     setupLLMGenerateTextMessageHandlers()
     setupTTSPlaybackMessageHandlers()
     void initMockData()

--- a/src/entrypoints/background/minimax-tts.ts
+++ b/src/entrypoints/background/minimax-tts.ts
@@ -1,0 +1,28 @@
+import { logger } from "@/utils/logger"
+import { onMessage } from "@/utils/message"
+import { synthesizeMiniMaxTTS } from "@/utils/server/minimax-tts"
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let binary = ""
+  for (let index = 0; index < bytes.length; index++) {
+    binary += String.fromCharCode(bytes[index]!)
+  }
+  return btoa(binary)
+}
+
+export function setupMiniMaxTTSMessageHandlers() {
+  onMessage("minimaxTtsSynthesize", async (message) => {
+    const response = await synthesizeMiniMaxTTS(message.data)
+    if (!response.ok) {
+      logger.warn("[Background][MiniMaxTTS] synthesize failed:", response.error)
+      return response
+    }
+
+    return {
+      ok: true as const,
+      audioBase64: arrayBufferToBase64(response.audio),
+      contentType: response.contentType,
+    }
+  })
+}

--- a/src/entrypoints/options/pages/text-to-speech/backend/index.tsx
+++ b/src/entrypoints/options/pages/text-to-speech/backend/index.tsx
@@ -1,0 +1,163 @@
+import { useAtom } from "jotai"
+import { Input } from "@/components/ui/base-ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/base-ui/select"
+import {
+  MINIMAX_SPEECH_MODELS,
+  MINIMAX_TTS_AUDIO_FORMATS,
+  MINIMAX_TTS_REGIONS,
+} from "@/types/minimax-tts"
+import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { DEFAULT_MINIMAX_TTS_CONFIG } from "@/utils/constants/tts"
+import { i18n } from "@/utils/i18n"
+import { ConfigItem } from "../../../components/config-item"
+import { ConfigSection } from "../../../components/config-section"
+
+export function TTSBackendSection() {
+  const [ttsConfig, setTtsConfig] = useAtom(configFieldsAtomMap.tts)
+  const backend = ttsConfig.backend ?? "edge"
+  const minimax = ttsConfig.minimax ?? DEFAULT_MINIMAX_TTS_CONFIG
+
+  const updateMiniMax = (patch: Partial<typeof minimax>) => {
+    void setTtsConfig({
+      minimax: {
+        ...minimax,
+        ...patch,
+      },
+    })
+  }
+
+  return (
+    <ConfigSection id="tts-backend" title={i18n.t("options.tts.backend.title")}>
+      <ConfigItem
+        id="tts-provider"
+        title={i18n.t("options.tts.backend.provider.title")}
+        description={i18n.t("options.tts.backend.provider.description")}
+      >
+        <Select
+          value={backend}
+          onValueChange={(value) => {
+            if (value === "edge" || value === "minimax") {
+              void setTtsConfig({ backend: value })
+            }
+          }}
+        >
+          <SelectTrigger className="w-64 max-w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectItem value="edge">Edge TTS</SelectItem>
+              <SelectItem value="minimax">MiniMax</SelectItem>
+            </SelectGroup>
+          </SelectContent>
+        </Select>
+      </ConfigItem>
+
+      {backend === "minimax" && (
+        <>
+          <ConfigItem
+            id="minimax-tts-region"
+            title={i18n.t("options.tts.backend.region.title")}
+            description={i18n.t("options.tts.backend.region.description")}
+          >
+            <Select
+              value={minimax.region}
+              onValueChange={(region) => {
+                if (region && MINIMAX_TTS_REGIONS.includes(region)) {
+                  updateMiniMax({ region })
+                }
+              }}
+            >
+              <SelectTrigger className="w-64 max-w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  <SelectItem value="global">
+                    {i18n.t("options.tts.backend.region.global")}
+                  </SelectItem>
+                  <SelectItem value="china">
+                    {i18n.t("options.tts.backend.region.china")}
+                  </SelectItem>
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </ConfigItem>
+          <ConfigItem
+            id="minimax-tts-model"
+            title={i18n.t("options.tts.backend.model.title")}
+            description={i18n.t("options.tts.backend.model.description")}
+          >
+            <Select
+              value={minimax.model}
+              onValueChange={(model) => {
+                if (model && MINIMAX_SPEECH_MODELS.includes(model)) {
+                  updateMiniMax({ model })
+                }
+              }}
+            >
+              <SelectTrigger className="w-64 max-w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {MINIMAX_SPEECH_MODELS.map((model) => (
+                    <SelectItem key={model} value={model}>
+                      {model}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </ConfigItem>
+          <ConfigItem
+            id="minimax-tts-voice"
+            title={i18n.t("options.tts.backend.voice.title")}
+            description={i18n.t("options.tts.backend.voice.description")}
+          >
+            <Input
+              className="w-64 max-w-full"
+              value={minimax.voiceId}
+              placeholder={i18n.t("options.tts.backend.voice.placeholder")}
+              onChange={(event) => updateMiniMax({ voiceId: event.target.value })}
+            />
+          </ConfigItem>
+          <ConfigItem
+            id="minimax-tts-format"
+            title={i18n.t("options.tts.backend.format.title")}
+            description={i18n.t("options.tts.backend.format.description")}
+          >
+            <Select
+              value={minimax.audioFormat}
+              onValueChange={(audioFormat) => {
+                if (audioFormat && MINIMAX_TTS_AUDIO_FORMATS.includes(audioFormat)) {
+                  updateMiniMax({ audioFormat })
+                }
+              }}
+            >
+              <SelectTrigger className="w-40 max-w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectGroup>
+                  {MINIMAX_TTS_AUDIO_FORMATS.map((format) => (
+                    <SelectItem key={format} value={format}>
+                      {format.toUpperCase()}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+              </SelectContent>
+            </Select>
+          </ConfigItem>
+        </>
+      )}
+    </ConfigSection>
+  )
+}

--- a/src/entrypoints/options/pages/text-to-speech/index.tsx
+++ b/src/entrypoints/options/pages/text-to-speech/index.tsx
@@ -1,10 +1,16 @@
+import { useAtomValue } from "jotai"
 import { Badge } from "@/components/ui/base-ui/badge"
+import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { i18n } from "@/utils/i18n"
 import { PageLayout } from "../../components/page-layout"
+import { TTSBackendSection } from "./backend"
 import { SpeechSection } from "./speech"
 import { VoiceSection } from "./voice"
 
 export function TextToSpeechPage() {
+  const ttsConfig = useAtomValue(configFieldsAtomMap.tts)
+  const backend = ttsConfig.backend ?? "edge"
+
   return (
     <PageLayout
       title={
@@ -18,8 +24,13 @@ export function TextToSpeechPage() {
       description={i18n.t("options.tts.pageDescription")}
       innerClassName="flex flex-col gap-10"
     >
-      <VoiceSection />
-      <SpeechSection />
+      <TTSBackendSection />
+      {backend === "edge" && (
+        <>
+          <VoiceSection />
+          <SpeechSection />
+        </>
+      )}
     </PageLayout>
   )
 }

--- a/src/hooks/use-text-to-speech.tsx
+++ b/src/hooks/use-text-to-speech.tsx
@@ -3,7 +3,9 @@ import type {
   FeatureProviderAnalytics,
   FeatureUsageContext,
 } from "@/types/analytics"
+import type { Config } from "@/types/config/config"
 import type { TTSConfig } from "@/types/config/tts"
+import type { MiniMaxTTSConfig } from "@/types/minimax-tts"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { useAtomValue } from "jotai"
 import { useRef, useState } from "react"
@@ -12,6 +14,7 @@ import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext, trackFeatureUsed } from "@/utils/analytics"
 import { EDGE_TTS_FEATURE_PROVIDER } from "@/utils/analytics-provider"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { DEFAULT_MINIMAX_TTS_CONFIG } from "@/utils/constants/tts"
 import { detectLanguage } from "@/utils/content/language"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
 import { i18n } from "@/utils/i18n"
@@ -30,6 +33,8 @@ interface SynthesizedAudioChunk {
   audioBase64: string
   contentType: string
 }
+
+type MiniMaxProviderConfig = Extract<Config["providersConfig"][number], { provider: "minimax" }>
 
 const TTS_ERROR_TOAST_ID = "tts-synthesize-error"
 
@@ -97,7 +102,7 @@ function getTTSFriendlyErrorDescription(error: Error): string | undefined {
     error.message.includes("[TOKEN_FETCH_FAILED]") ||
     error.message.includes("[TOKEN_INVALID]")
   ) {
-    return "Edge TTS is temporarily unavailable. Please check your network and retry."
+    return "The speech service is temporarily unavailable. Please check your network and retry."
   }
 
   return error.message || undefined
@@ -130,9 +135,44 @@ async function synthesizeEdgeTTSAudioChunk(
   }
 }
 
+async function synthesizeMiniMaxAudioChunk(
+  chunk: string,
+  config: MiniMaxTTSConfig,
+  apiKey: string,
+): Promise<SynthesizedAudioChunk> {
+  const response = await sendMessage("minimaxTtsSynthesize", {
+    ...config,
+    apiKey,
+    text: chunk,
+  })
+
+  if (!response.ok) {
+    throw new Error(`[${response.error.code}] ${response.error.message}`)
+  }
+
+  if (!response.audioBase64) {
+    throw new Error("The speech API returned empty audio data")
+  }
+
+  return {
+    audioBase64: response.audioBase64,
+    contentType: response.contentType,
+  }
+}
+
+function findMiniMaxProvider(
+  providersConfig: Config["providersConfig"],
+): MiniMaxProviderConfig | undefined {
+  return providersConfig.find(
+    (provider): provider is MiniMaxProviderConfig =>
+      provider.provider === "minimax" && provider.enabled && Boolean(provider.apiKey?.trim()),
+  )
+}
+
 export function useTextToSpeech(surface: AnalyticsSurface = ANALYTICS_SURFACE.SELECTION_TOOLBAR) {
   const queryClient = useQueryClient()
   const languageDetection = useAtomValue(configFieldsAtomMap.languageDetection)
+  const providersConfig = useAtomValue(configFieldsAtomMap.providersConfig)
   const [isPlaying, setIsPlaying] = useState(false)
   const [currentChunk, setCurrentChunk] = useState(0)
   const [totalChunks, setTotalChunks] = useState(0)
@@ -161,16 +201,32 @@ export function useTextToSpeech(surface: AnalyticsSurface = ANALYTICS_SURFACE.SE
       stop()
       shouldStopRef.current = false
 
+      const backend = ttsConfig.backend ?? "edge"
+      const minimaxConfig = ttsConfig.minimax ?? DEFAULT_MINIMAX_TTS_CONFIG
+      const minimaxProvider = backend === "minimax" ? findMiniMaxProvider(providersConfig) : null
+      const minimaxApiKey = minimaxProvider?.apiKey?.trim()
+      if (backend === "minimax" && !minimaxApiKey) {
+        throw new Error(
+          "Configure an enabled MiniMax provider with an API key before using MiniMax speech.",
+        )
+      }
+      if (backend === "minimax" && !minimaxConfig.voiceId.trim()) {
+        throw new Error("Enter a MiniMax voice ID before generating speech.")
+      }
+
       const requestId = getRandomUUID()
       activeRequestIdRef.current = requestId
       let didStartPlayback = false
 
-      const selectedVoice = await resolveVoiceForText(
-        text,
-        ttsConfig,
-        languageDetection.mode === "llm",
-        forcedVoice,
-      )
+      const selectedVoice =
+        backend === "edge"
+          ? await resolveVoiceForText(
+              text,
+              ttsConfig,
+              languageDetection.mode === "llm",
+              forcedVoice,
+            )
+          : minimaxConfig.voiceId.trim()
       if (shouldStopRef.current || activeRequestIdRef.current !== requestId) {
         return
       }
@@ -181,23 +237,29 @@ export function useTextToSpeech(surface: AnalyticsSurface = ANALYTICS_SURFACE.SE
       const fetchChunkAudio = async (chunk: string) => {
         logger.info("[TextToSpeech] Fetching chunk audio", {
           text: chunk,
+          backend,
           voice: selectedVoice,
-          rate: ttsConfig.rate,
-          pitch: ttsConfig.pitch,
-          volume: ttsConfig.volume,
+          model: backend === "minimax" ? minimaxConfig.model : undefined,
         })
         return queryClient.fetchQuery({
           queryKey: [
             "tts-audio",
             {
               text: chunk,
+              backend,
               voice: selectedVoice,
-              rate: ttsConfig.rate,
-              pitch: ttsConfig.pitch,
-              volume: ttsConfig.volume,
+              rate: backend === "edge" ? ttsConfig.rate : undefined,
+              pitch: backend === "edge" ? ttsConfig.pitch : undefined,
+              volume: backend === "edge" ? ttsConfig.volume : undefined,
+              region: backend === "minimax" ? minimaxConfig.region : undefined,
+              model: backend === "minimax" ? minimaxConfig.model : undefined,
+              audioFormat: backend === "minimax" ? minimaxConfig.audioFormat : undefined,
             },
           ],
-          queryFn: () => synthesizeEdgeTTSAudioChunk(chunk, selectedVoice, ttsConfig),
+          queryFn: () =>
+            backend === "edge"
+              ? synthesizeEdgeTTSAudioChunk(chunk, selectedVoice, ttsConfig)
+              : synthesizeMiniMaxAudioChunk(chunk, minimaxConfig, minimaxApiKey ?? ""),
           staleTime: Number.POSITIVE_INFINITY,
           gcTime: 1000 * 60 * 10,
           meta: {
@@ -280,13 +342,18 @@ export function useTextToSpeech(surface: AnalyticsSurface = ANALYTICS_SURFACE.SE
   })
 
   const play = (text: string, ttsConfig: TTSConfig, options?: { forcedVoice?: string }) => {
+    const providerAnalytics: FeatureProviderAnalytics =
+      (ttsConfig.backend ?? "edge") === "minimax"
+        ? { provider: "minimax", backend_kind: "llm" }
+        : EDGE_TTS_FEATURE_PROVIDER
+
     return playMutation.mutateAsync({
       text,
       ttsConfig,
       forcedVoice: options?.forcedVoice,
       analyticsContext: {
         ...createFeatureUsageContext(ANALYTICS_FEATURE.TEXT_TO_SPEECH, surface),
-        ...EDGE_TTS_FEATURE_PROVIDER,
+        ...providerAnalytics,
       },
     })
   }

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1029,6 +1029,26 @@ options:
   tts:
     title: Text to Speech
     pageDescription: Read any selection aloud with a natural voice.
+    backend:
+      title: Speech provider
+      provider:
+        title: Provider
+        description: Choose the service that generates speech. MiniMax uses the API key from the enabled MiniMax provider in API Providers.
+      region:
+        title: API region
+        description: Choose the regional speech endpoint associated with your account.
+        global: Global
+        china: China
+      model:
+        title: Speech model
+        description: Choose the model used to synthesize speech.
+      voice:
+        title: Voice ID
+        description: Enter a system or cloned voice ID available to your account.
+        placeholder: Enter a voice ID
+      format:
+        title: Audio format
+        description: Choose the audio format returned for playback.
     voice:
       title: Voice
       selectPlaceholder: Select a voice

--- a/src/types/config/__tests__/tts.test.ts
+++ b/src/types/config/__tests__/tts.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { DEFAULT_TTS_CONFIG } from "@/utils/constants/tts"
 import {
   createDefaultTTSLanguageVoices,
   EDGE_TTS_FALLBACK_VOICE,
@@ -8,9 +9,27 @@ import {
   getDefaultTTSVoiceForLanguage,
   getEdgeTTSVoiceItem,
   isKnownEdgeTTSVoice,
+  ttsConfigSchema,
 } from "../tts"
 
 describe("tts config defaults", () => {
+  it("includes the current MiniMax speech defaults without invalidating legacy TTS config", () => {
+    expect(DEFAULT_TTS_CONFIG.minimax).toMatchObject({
+      region: "global",
+      model: "speech-2.8-hd",
+      audioFormat: "mp3",
+    })
+    expect(
+      ttsConfigSchema.safeParse({
+        defaultVoice: DEFAULT_TTS_CONFIG.defaultVoice,
+        languageVoices: DEFAULT_TTS_CONFIG.languageVoices,
+        rate: 0,
+        pitch: 0,
+        volume: 0,
+      }).success,
+    ).toBe(true)
+  })
+
   it("uses Andrew Multilingual as the fallback/default US English voice", () => {
     expect(EDGE_TTS_FALLBACK_VOICE).toBe("en-US-AndrewMultilingualNeural")
     expect(getDefaultTTSVoiceForLanguage("eng")).toBe("en-US-AndrewMultilingualNeural")

--- a/src/types/config/tts.ts
+++ b/src/types/config/tts.ts
@@ -1,6 +1,11 @@
 import type { LangCodeISO6393 } from "@read-frog/definitions"
 import { LANG_CODE_ISO6393_OPTIONS, langCodeISO6393Schema } from "@read-frog/definitions"
 import { z } from "zod"
+import {
+  MINIMAX_SPEECH_MODELS,
+  MINIMAX_TTS_AUDIO_FORMATS,
+  MINIMAX_TTS_REGIONS,
+} from "@/types/minimax-tts"
 
 export type TTSVoice = string
 
@@ -3240,12 +3245,21 @@ export const ttsRateSchema = z.coerce.number().int().min(MIN_TTS_RATE).max(MAX_T
 export const ttsPitchSchema = z.coerce.number().int().min(MIN_TTS_PITCH).max(MAX_TTS_PITCH)
 export const ttsVolumeSchema = z.coerce.number().int().min(MIN_TTS_VOLUME).max(MAX_TTS_VOLUME)
 
+export const minimaxTTSConfigSchema = z.object({
+  region: z.enum(MINIMAX_TTS_REGIONS),
+  model: z.enum(MINIMAX_SPEECH_MODELS),
+  voiceId: z.string().trim(),
+  audioFormat: z.enum(MINIMAX_TTS_AUDIO_FORMATS),
+})
+
 export const ttsConfigSchema = z.object({
   defaultVoice: ttsVoiceSchema,
   languageVoices: z.record(langCodeISO6393Schema, ttsVoiceSchema),
   rate: ttsRateSchema,
   pitch: ttsPitchSchema,
   volume: ttsVolumeSchema,
+  backend: z.enum(["edge", "minimax"]).optional(),
+  minimax: minimaxTTSConfigSchema.optional(),
 })
 
 export type TTSConfig = z.infer<typeof ttsConfigSchema>

--- a/src/types/minimax-tts.ts
+++ b/src/types/minimax-tts.ts
@@ -1,0 +1,75 @@
+export const MINIMAX_TTS_ENDPOINTS = {
+  global: "https://api.minimax.io/v1/t2a_v2",
+  china: "https://api.minimaxi.com/v1/t2a_v2",
+} as const
+
+export const MINIMAX_TTS_REGIONS = ["global", "china"] as const
+export type MiniMaxTTSRegion = (typeof MINIMAX_TTS_REGIONS)[number]
+
+export const MINIMAX_SPEECH_MODELS = [
+  "speech-2.8-hd",
+  "speech-2.8-turbo",
+  "speech-2.6-hd",
+  "speech-2.6-turbo",
+  "speech-02-hd",
+  "speech-02-turbo",
+  "speech-01-hd",
+  "speech-01-turbo",
+] as const
+export type MiniMaxSpeechModel = (typeof MINIMAX_SPEECH_MODELS)[number]
+
+export const MINIMAX_TTS_AUDIO_FORMATS = ["mp3", "wav", "flac", "pcm"] as const
+export type MiniMaxTTSAudioFormat = (typeof MINIMAX_TTS_AUDIO_FORMATS)[number]
+
+export interface MiniMaxTTSConfig {
+  region: MiniMaxTTSRegion
+  model: MiniMaxSpeechModel
+  voiceId: string
+  audioFormat: MiniMaxTTSAudioFormat
+}
+
+export interface MiniMaxTTSSynthesizeRequest extends MiniMaxTTSConfig {
+  apiKey: string
+  text: string
+}
+
+export const MINIMAX_TTS_ERROR_CODES = [
+  "INVALID_CONFIG",
+  "INVALID_TEXT",
+  "REQUEST_FAILED",
+  "RATE_LIMITED",
+  "SERVER_ERROR",
+  "NETWORK_ERROR",
+  "INVALID_RESPONSE",
+] as const
+export type MiniMaxTTSErrorCode = (typeof MINIMAX_TTS_ERROR_CODES)[number]
+
+export interface MiniMaxTTSErrorPayload {
+  code: MiniMaxTTSErrorCode
+  message: string
+  retryable?: boolean
+  status?: number
+}
+
+export interface MiniMaxTTSSynthesizeSuccess {
+  ok: true
+  audio: ArrayBuffer
+  contentType: string
+}
+
+export interface MiniMaxTTSSynthesizeFailure {
+  ok: false
+  error: MiniMaxTTSErrorPayload
+}
+
+export type MiniMaxTTSSynthesizeResponse = MiniMaxTTSSynthesizeSuccess | MiniMaxTTSSynthesizeFailure
+
+export interface MiniMaxTTSSynthesizeWireSuccess {
+  ok: true
+  audioBase64: string
+  contentType: string
+}
+
+export type MiniMaxTTSSynthesizeWireResponse =
+  | MiniMaxTTSSynthesizeWireSuccess
+  | MiniMaxTTSSynthesizeFailure

--- a/src/utils/constants/tts.ts
+++ b/src/utils/constants/tts.ts
@@ -1,5 +1,13 @@
 import type { TTSConfig } from "@/types/config/tts"
+import type { MiniMaxTTSConfig } from "@/types/minimax-tts"
 import { createDefaultTTSLanguageVoices, EDGE_TTS_FALLBACK_VOICE } from "@/types/config/tts"
+
+export const DEFAULT_MINIMAX_TTS_CONFIG: MiniMaxTTSConfig = {
+  region: "global",
+  model: "speech-2.8-hd",
+  voiceId: "",
+  audioFormat: "mp3",
+}
 
 export const DEFAULT_TTS_CONFIG: TTSConfig = {
   defaultVoice: EDGE_TTS_FALLBACK_VOICE,
@@ -7,4 +15,6 @@ export const DEFAULT_TTS_CONFIG: TTSConfig = {
   rate: 0,
   pitch: 0,
   volume: 0,
+  backend: "edge",
+  minimax: DEFAULT_MINIMAX_TTS_CONFIG,
 }

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -13,6 +13,10 @@ import type {
   EdgeTTSSynthesizeRequest,
   EdgeTTSSynthesizeWireResponse,
 } from "@/types/edge-tts"
+import type {
+  MiniMaxTTSSynthesizeRequest,
+  MiniMaxTTSSynthesizeWireResponse,
+} from "@/types/minimax-tts"
 import type { ProxyRequest, ProxyResponse } from "@/types/proxy-fetch"
 import type {
   TTSPlaybackStartRequest,
@@ -164,6 +168,10 @@ interface ProtocolMap {
   edgeTtsSynthesize: (data: EdgeTTSSynthesizeRequest) => Promise<EdgeTTSSynthesizeWireResponse>
   edgeTtsListVoices: () => Promise<EdgeTTSVoice[]>
   edgeTtsHealthCheck: () => Promise<EdgeTTSHealthStatus>
+  // minimax tts
+  minimaxTtsSynthesize: (
+    data: MiniMaxTTSSynthesizeRequest,
+  ) => Promise<MiniMaxTTSSynthesizeWireResponse>
   // tts playback
   ttsPlaybackPrepare: () => Promise<{ ok: true }>
   ttsPlaybackStart: (data: TTSPlaybackStartRequest) => Promise<TTSPlaybackStartResponse>

--- a/src/utils/server/__tests__/minimax-tts.test.ts
+++ b/src/utils/server/__tests__/minimax-tts.test.ts
@@ -1,0 +1,112 @@
+import type { MiniMaxTTSSynthesizeRequest } from "@/types/minimax-tts"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { MINIMAX_TTS_ENDPOINTS } from "@/types/minimax-tts"
+import { synthesizeMiniMaxTTS } from "../minimax-tts"
+
+const baseRequest: MiniMaxTTSSynthesizeRequest = {
+  apiKey: "test-api-key",
+  text: "Hello",
+  region: "global",
+  model: "speech-2.8-hd",
+  voiceId: "test-voice",
+  audioFormat: "mp3",
+}
+
+function successResponse(audio = "494433") {
+  return new Response(
+    JSON.stringify({
+      data: { audio, status: 2 },
+      base_resp: { status_code: 0, status_msg: "success" },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("synthesizeMiniMaxTTS", () => {
+  it("maps the global request and decodes hex audio", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(successResponse())
+    vi.stubGlobal("fetch", fetchMock)
+
+    const result = await synthesizeMiniMaxTTS(baseRequest)
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe(MINIMAX_TTS_ENDPOINTS.global)
+    expect(init).toMatchObject({
+      method: "POST",
+      headers: {
+        Authorization: "Bearer test-api-key",
+        "Content-Type": "application/json",
+      },
+    })
+    if (typeof init?.body !== "string") {
+      throw new TypeError("Expected a JSON request body")
+    }
+    expect(JSON.parse(init.body)).toEqual({
+      model: "speech-2.8-hd",
+      text: "Hello",
+      stream: false,
+      language_boost: "auto",
+      output_format: "hex",
+      voice_setting: { voice_id: "test-voice" },
+      audio_setting: { format: "mp3" },
+    })
+    if (!result.ok) {
+      throw new Error(result.error.message)
+    }
+    expect([...new Uint8Array(result.audio)]).toEqual([0x49, 0x44, 0x33])
+    expect(result.contentType).toBe("audio/mpeg")
+  })
+
+  it("uses the China endpoint and preserves the selected audio format", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(successResponse("52494646"))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const result = await synthesizeMiniMaxTTS({
+      ...baseRequest,
+      region: "china",
+      model: "speech-2.8-turbo",
+      audioFormat: "wav",
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(MINIMAX_TTS_ENDPOINTS.china, expect.any(Object))
+    expect(result).toMatchObject({ ok: true, contentType: "audio/wav" })
+  })
+
+  it("rejects provider errors and incomplete audio responses", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: null,
+            base_resp: { status_code: 1004, status_msg: "invalid request" },
+          }),
+          { status: 200 },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            data: { status: 1 },
+            base_resp: { status_code: 0, status_msg: "success" },
+          }),
+          { status: 200 },
+        ),
+      )
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(synthesizeMiniMaxTTS(baseRequest)).resolves.toMatchObject({
+      ok: false,
+      error: { code: "REQUEST_FAILED" },
+    })
+    await expect(synthesizeMiniMaxTTS(baseRequest)).resolves.toMatchObject({
+      ok: false,
+      error: { code: "INVALID_RESPONSE" },
+    })
+  })
+})

--- a/src/utils/server/minimax-tts.ts
+++ b/src/utils/server/minimax-tts.ts
@@ -1,0 +1,165 @@
+import type {
+  MiniMaxTTSErrorCode,
+  MiniMaxTTSSynthesizeRequest,
+  MiniMaxTTSSynthesizeResponse,
+} from "@/types/minimax-tts"
+import { MINIMAX_TTS_ENDPOINTS } from "@/types/minimax-tts"
+
+interface MiniMaxTTSAPIResponse {
+  data?: {
+    audio?: string
+    status?: number
+  } | null
+  base_resp?: {
+    status_code?: number
+    status_msg?: string
+  }
+}
+
+class MiniMaxTTSError extends Error {
+  code: MiniMaxTTSErrorCode
+  retryable: boolean
+  status?: number
+
+  constructor(
+    code: MiniMaxTTSErrorCode,
+    message: string,
+    options?: { retryable?: boolean; status?: number },
+  ) {
+    super(message)
+    this.name = "MiniMaxTTSError"
+    this.code = code
+    this.retryable = options?.retryable ?? false
+    this.status = options?.status
+  }
+}
+
+function hexToArrayBuffer(hex: string): ArrayBuffer {
+  if (hex.length === 0 || hex.length % 2 !== 0 || !/^[\da-f]+$/i.test(hex)) {
+    throw new MiniMaxTTSError("INVALID_RESPONSE", "The speech API returned invalid audio data")
+  }
+
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let index = 0; index < bytes.length; index++) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16)
+  }
+  return bytes.buffer
+}
+
+const CONTENT_TYPES: Record<MiniMaxTTSSynthesizeRequest["audioFormat"], string> = {
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  flac: "audio/flac",
+  pcm: "audio/pcm",
+}
+
+function validateRequest(request: MiniMaxTTSSynthesizeRequest): void {
+  if (!request.apiKey.trim()) {
+    throw new MiniMaxTTSError("INVALID_CONFIG", "A MiniMax API key is required")
+  }
+  if (!request.voiceId.trim()) {
+    throw new MiniMaxTTSError("INVALID_CONFIG", "A MiniMax voice ID is required")
+  }
+  if (!request.text.trim()) {
+    throw new MiniMaxTTSError("INVALID_TEXT", "Text to speech input is empty")
+  }
+}
+
+async function requestMiniMaxTTS(
+  request: MiniMaxTTSSynthesizeRequest,
+): Promise<{ audio: ArrayBuffer; contentType: string }> {
+  validateRequest(request)
+
+  const response = await fetch(MINIMAX_TTS_ENDPOINTS[request.region], {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${request.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: request.model,
+      text: request.text,
+      stream: false,
+      language_boost: "auto",
+      output_format: "hex",
+      voice_setting: {
+        voice_id: request.voiceId,
+      },
+      audio_setting: {
+        format: request.audioFormat,
+      },
+    }),
+  })
+
+  if (!response.ok) {
+    if (response.status === 429) {
+      throw new MiniMaxTTSError("RATE_LIMITED", "The speech API rate limit was reached", {
+        retryable: true,
+        status: response.status,
+      })
+    }
+    if (response.status >= 500) {
+      throw new MiniMaxTTSError("SERVER_ERROR", "The speech API is temporarily unavailable", {
+        retryable: true,
+        status: response.status,
+      })
+    }
+    throw new MiniMaxTTSError("REQUEST_FAILED", "The speech API rejected the request", {
+      status: response.status,
+    })
+  }
+
+  const payload = (await response.json()) as MiniMaxTTSAPIResponse
+  if (payload.base_resp?.status_code !== 0) {
+    throw new MiniMaxTTSError(
+      "REQUEST_FAILED",
+      payload.base_resp?.status_msg || "The speech API rejected the request",
+    )
+  }
+  if (payload.data?.status !== 2 || typeof payload.data.audio !== "string") {
+    throw new MiniMaxTTSError("INVALID_RESPONSE", "The speech API returned no completed audio")
+  }
+
+  return {
+    audio: hexToArrayBuffer(payload.data.audio),
+    contentType: CONTENT_TYPES[request.audioFormat],
+  }
+}
+
+export async function synthesizeMiniMaxTTS(
+  request: MiniMaxTTSSynthesizeRequest,
+): Promise<MiniMaxTTSSynthesizeResponse> {
+  try {
+    const result = await requestMiniMaxTTS(request)
+    return { ok: true, ...result }
+  } catch (error) {
+    if (error instanceof MiniMaxTTSError) {
+      return {
+        ok: false,
+        error: {
+          code: error.code,
+          message: error.message,
+          retryable: error.retryable,
+          status: error.status,
+        },
+      }
+    }
+    if (error instanceof TypeError) {
+      return {
+        ok: false,
+        error: {
+          code: "NETWORK_ERROR",
+          message: "The speech API could not be reached",
+          retryable: true,
+        },
+      }
+    }
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_RESPONSE",
+        message: "The speech API returned an invalid response",
+      },
+    }
+  }
+}


### PR DESCRIPTION
Reason: Add regional MiniMax text-to-speech synthesis to the existing playback workflow.

This adds:

- selectable global and China speech endpoints
- current speech models, voice ID, and audio format settings
- background request mapping and hex audio response decoding

Checks:

- `SKIP_FREE_API=true pnpm test src/utils/server/__tests__/minimax-tts.test.ts src/types/config/__tests__/tts.test.ts src/hooks/__tests__/use-text-to-speech.test.ts`
- `SKIP_FREE_API=true pnpm test src/entrypoints/background/__tests__/background-stream.test.ts src/utils/constants/__tests__/config.test.ts --testTimeout=30000 --hookTimeout=30000`
- `pnpm type-check`
- `pnpm fmt:check`
- `WXT_SKIP_ENV_VALIDATION=true pnpm build`
