### PR TITLE
fix(i18n): follow configured UI language for What's New

### DIFF
--- a/.changeset/fuzzy-frogs-follow-ui-language.md
+++ b/.changeset/fuzzy-frogs-follow-ui-language.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(i18n): follow the configured UI language for What's New content

--- a/src/entrypoints/options/app-sidebar/__tests__/whats-new-footer.test.tsx
+++ b/src/entrypoints/options/app-sidebar/__tests__/whats-new-footer.test.tsx
@@ -6,6 +6,7 @@ import * as React from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { WhatsNewFooter } from "../whats-new-footer"
 
+const getBlogLocaleFromUILanguageMock = vi.fn<(...args: any[]) => any>(() => "zh")
 const getLastViewedBlogDateMock = vi.fn<(...args: any[]) => any>()
 const getLatestBlogDateMock = vi.fn<(...args: any[]) => any>()
 const saveLastViewedBlogDateMock = vi.fn<(...args: any[]) => any>()
@@ -14,6 +15,11 @@ vi.mock("#imports", () => ({
   i18n: {
     t: (key: string) => key,
   },
+}))
+
+vi.mock("jotai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("jotai")>()),
+  useAtomValue: () => "zh-CN",
 }))
 
 vi.mock("@iconify/react", () => ({
@@ -115,7 +121,7 @@ vi.mock("@/components/ui/base-ui/popover", async () => {
 vi.mock("@/utils/blog", async () => {
   return {
     buildBilibiliEmbedUrl: vi.fn<(...args: any[]) => any>(() => null),
-    getBlogLocaleFromUILanguage: vi.fn<(...args: any[]) => any>(() => "zh"),
+    getBlogLocaleFromUILanguage: (...args: unknown[]) => getBlogLocaleFromUILanguageMock(...args),
     getLastViewedBlogDate: (...args: unknown[]) => getLastViewedBlogDateMock(...args),
     getLatestBlogDate: (...args: unknown[]) => getLatestBlogDateMock(...args),
     hasNewBlogPost: (latestViewedDate: Date | null, latestDate: Date | null) => {
@@ -195,6 +201,7 @@ describe("whatsNewFooter", () => {
     renderWhatsNewFooter()
 
     await waitFor(() => {
+      expect(getBlogLocaleFromUILanguageMock).toHaveBeenCalledWith("zh-CN")
       expect(getLatestBlogDateMock).toHaveBeenCalledWith(
         "https://www.readfrog.app/api/blog/latest",
         "zh",

--- a/src/entrypoints/options/app-sidebar/whats-new-footer.tsx
+++ b/src/entrypoints/options/app-sidebar/whats-new-footer.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@iconify/react"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useAtomValue } from "jotai"
 import { useCallback, useEffect, useEffectEvent, useState } from "react"
 import {
   Popover,
@@ -11,6 +12,7 @@ import {
 } from "@/components/ui/base-ui/popover"
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "@/components/ui/base-ui/sidebar"
 import { env } from "@/env"
+import { configFieldsAtomMap } from "@/utils/atoms/config"
 import {
   buildBilibiliEmbedUrl,
   getBlogLocaleFromUILanguage,
@@ -25,7 +27,8 @@ import { version } from "../../../../package.json"
 export function WhatsNewFooter() {
   const queryClient = useQueryClient()
   const [open, setOpen] = useState(false)
-  const blogLocale = getBlogLocaleFromUILanguage()
+  const uiLanguage = useAtomValue(configFieldsAtomMap.uiLanguage)
+  const blogLocale = getBlogLocaleFromUILanguage(uiLanguage)
 
   const { data: lastViewedDate, isFetched: isLastViewedDateFetched } = useQuery({
     queryKey: ["last-viewed-blog-date"],

--- a/src/entrypoints/popup/components/__tests__/blog-notification.test.tsx
+++ b/src/entrypoints/popup/components/__tests__/blog-notification.test.tsx
@@ -6,6 +6,7 @@ import * as React from "react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import BlogNotification from "../blog-notification"
 
+const getBlogLocaleFromUILanguageMock = vi.fn<(...args: any[]) => any>(() => "zh")
 const getLastViewedBlogDateMock = vi.fn<(...args: any[]) => any>()
 const getLatestBlogDateMock = vi.fn<(...args: any[]) => any>()
 const saveLastViewedBlogDateMock = vi.fn<(...args: any[]) => any>()
@@ -14,6 +15,11 @@ vi.mock("#imports", () => ({
   i18n: {
     t: (key: string) => key,
   },
+}))
+
+vi.mock("jotai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("jotai")>()),
+  useAtomValue: () => "zh-CN",
 }))
 
 vi.mock("@/components/ui/base-ui/button", () => ({
@@ -54,7 +60,7 @@ vi.mock("@iconify/react/dist/iconify.js", () => ({
 
 vi.mock("@/utils/blog", async () => {
   return {
-    getBlogLocaleFromUILanguage: vi.fn<(...args: any[]) => any>(() => "zh"),
+    getBlogLocaleFromUILanguage: (...args: unknown[]) => getBlogLocaleFromUILanguageMock(...args),
     getLastViewedBlogDate: (...args: unknown[]) => getLastViewedBlogDateMock(...args),
     getLatestBlogDate: (...args: unknown[]) => getLatestBlogDateMock(...args),
     hasNewBlogPost: (latestViewedDate: Date | null, latestDate: Date | null) => {
@@ -105,6 +111,7 @@ describe("blogNotification", () => {
     renderBlogNotification()
 
     await waitFor(() => {
+      expect(getBlogLocaleFromUILanguageMock).toHaveBeenCalledWith("zh-CN")
       expect(getLatestBlogDateMock).toHaveBeenCalledWith(
         "https://www.readfrog.app/api/blog/latest",
         "zh",

--- a/src/entrypoints/popup/components/blog-notification.tsx
+++ b/src/entrypoints/popup/components/blog-notification.tsx
@@ -1,8 +1,10 @@
 import { Icon } from "@iconify/react/dist/iconify.js"
 import { useQuery, useQueryClient } from "@tanstack/react-query"
+import { useAtomValue } from "jotai"
 import { Button } from "@/components/ui/base-ui/button"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/base-ui/tooltip"
 import { env } from "@/env"
+import { configFieldsAtomMap } from "@/utils/atoms/config"
 import {
   getBlogLocaleFromUILanguage,
   getLastViewedBlogDate,
@@ -15,7 +17,8 @@ import { version } from "../../../../package.json"
 
 export default function BlogNotification() {
   const queryClient = useQueryClient()
-  const blogLocale = getBlogLocaleFromUILanguage()
+  const uiLanguage = useAtomValue(configFieldsAtomMap.uiLanguage)
+  const blogLocale = getBlogLocaleFromUILanguage(uiLanguage)
 
   const { data: lastViewedDate } = useQuery({
     queryKey: ["last-viewed-blog-date"],

--- a/src/utils/__tests__/blog.test.ts
+++ b/src/utils/__tests__/blog.test.ts
@@ -4,6 +4,7 @@ import { z } from "zod"
 import {
   buildBilibiliEmbedUrl,
   extractBilibiliVideoId,
+  getBlogLocaleFromUILanguage,
   hasNewBlogPost,
   resolveBlogLocale,
 } from "../blog"
@@ -178,6 +179,11 @@ describe("bilibili helpers", () => {
 })
 
 describe("resolveBlogLocale", () => {
+  it("uses an explicit configured UI language instead of the browser language", () => {
+    expect(getBlogLocaleFromUILanguage("zh-CN")).toBe("zh")
+    expect(getBlogLocaleFromUILanguage("zh-TW")).toBe("zh-TW")
+  })
+
   it("maps simplified Chinese locales to zh", () => {
     expect(resolveBlogLocale("zh")).toBe("zh")
     expect(resolveBlogLocale("zh-CN")).toBe("zh")

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -1,4 +1,5 @@
 import type { LatestBlogPost } from "@read-frog/definitions"
+import type { UiLanguage } from "@/types/config/config"
 import {
   bilibiliVideoUrlSchema,
   getBilibiliVideoIdFromUrl,
@@ -99,14 +100,18 @@ export function resolveBlogLocale(uiLocale?: string | null): BlogLocale {
   )
 }
 
-export function getBlogLocaleFromUILanguage(): BlogLocale {
-  const uiLocale =
+export function getBlogLocaleFromUILanguage(uiLanguage: UiLanguage): BlogLocale {
+  if (uiLanguage !== "auto") {
+    return resolveBlogLocale(uiLanguage)
+  }
+
+  const browserLocale =
     browser.i18n.getUILanguage?.() ||
     browser.i18n.getMessage?.("@@ui_locale") ||
     globalThis.navigator?.language ||
     DEFAULT_BLOG_LOCALE
 
-  return resolveBlogLocale(uiLocale)
+  return resolveBlogLocale(browserLocale)
 }
 
 /**


### PR DESCRIPTION
> **AI model(s) used (required):** OpenAI Codex (GPT-5)

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

The What's New surfaces fetched blog metadata using the browser UI language even when the user had explicitly selected a different Read Frog interface language. This could render the extension UI in Chinese while showing an English update title, description, and image.

This change:

- reads the configured `uiLanguage` in both the Options sidebar and Popup notification;
- uses explicit language settings directly and only consults the browser language when the setting is `auto`;
- keeps the React Query locale key aligned with the configured UI language so localized update metadata is fetched correctly;
- adds regression coverage for Simplified and Traditional Chinese mappings and both What's New entry points.

## Related Issue

No related issue identified.

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Validation performed:

- `SKIP_FREE_API=true pnpm test` — 283 test files and 2,751 tests passed
- `pnpm lint`
- `pnpm fmt:check`
- `pnpm build`
- `pnpm exec changeset status`

## Screenshots

Not included; this changes locale selection behavior without changing layout.

## Checklist

- [x] I have tested these changes locally
- [x] Documentation updates are not required for this bug fix
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- Includes a patch changeset for `@read-frog/extension`.
