### PR TITLE
fix(popup): allow Prompt selection with Built-in AI

### DIFF
--- a/.changeset/smooth-bears-prompt.md
+++ b/.changeset/smooth-bears-prompt.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(popup): allow Prompt selection with Built-in AI

--- a/src/components/prompt-configurator/__tests__/prompt-selectors.test.tsx
+++ b/src/components/prompt-configurator/__tests__/prompt-selectors.test.tsx
@@ -8,13 +8,17 @@ import TranslatePromptSelector from "@/entrypoints/popup/components/translate-pr
 import { PromptSelector as TranslationHubPromptSelector } from "@/entrypoints/translation-hub/components/prompt-selector"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 
-const { providerAtom, selectedProvidersAtom, setTranslateMock, testState, translateAtom } =
+const { providerRefAtom, selectedProvidersAtom, setTranslateMock, testState, translateAtom } =
   vi.hoisted(() => ({
-    providerAtom: {},
+    providerRefAtom: {},
     selectedProvidersAtom: {},
     setTranslateMock: vi.fn<(value: Partial<Config["pageTranslation"]>) => Promise<void>>(),
     testState: {
       pageTranslation: null as Config["pageTranslation"] | null,
+      pageTranslationProviderRef: null as
+        | { kind: "local"; config: { provider: string } }
+        | { kind: "system"; id: string; name: string; modelTier: "normal" | "advance" }
+        | null,
     },
     translateAtom: {},
   }))
@@ -25,7 +29,7 @@ vi.mock("jotai", () => ({
     return [testState.pageTranslation, setTranslateMock]
   },
   useAtomValue: (atom: object) => {
-    if (atom === providerAtom) return { provider: "mock-llm" }
+    if (atom === providerRefAtom) return testState.pageTranslationProviderRef
     if (atom === selectedProvidersAtom) return [{ provider: "mock-llm" }]
     throw new Error("Unexpected atom")
   },
@@ -36,7 +40,7 @@ vi.mock("@/utils/atoms/config", () => ({
 }))
 
 vi.mock("@/utils/atoms/provider", () => ({
-  featureProviderConfigAtom: () => providerAtom,
+  featureProviderRefAtom: () => providerRefAtom,
 }))
 
 vi.mock("@/entrypoints/translation-hub/atoms", () => ({
@@ -45,7 +49,7 @@ vi.mock("@/entrypoints/translation-hub/atoms", () => ({
 
 vi.mock("@/types/config/provider", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/types/config/provider")>()),
-  isLLMProvider: () => true,
+  isLLMProvider: (provider: string) => provider === "mock-llm",
 }))
 
 vi.mock("@/components/help-tooltip", () => ({
@@ -116,6 +120,10 @@ function createTranslateConfig(): Config["pageTranslation"] {
 describe("translation prompt selectors", () => {
   beforeEach(() => {
     testState.pageTranslation = createTranslateConfig()
+    testState.pageTranslationProviderRef = {
+      kind: "local",
+      config: { provider: "mock-llm" },
+    }
     setTranslateMock.mockReset()
     setTranslateMock.mockResolvedValue()
   })
@@ -136,6 +144,35 @@ describe("translation prompt selectors", () => {
         promptId: "precision-rewrite",
       },
     })
+  })
+
+  it("keeps prompt selection available for Built-in AI", () => {
+    testState.pageTranslationProviderRef = {
+      kind: "system",
+      id: "read-frog-free-ai",
+      name: "Built-in AI",
+      modelTier: "normal",
+    }
+    render(<TranslatePromptSelector />)
+
+    fireEvent.click(screen.getByRole("option", { name: "Custom" }))
+    expect(setTranslateMock).toHaveBeenCalledWith({
+      customPromptsConfig: {
+        ...testState.pageTranslation!.customPromptsConfig,
+        promptId: "custom",
+      },
+    })
+  })
+
+  it("keeps prompt selection hidden for a local translation-only provider", () => {
+    testState.pageTranslationProviderRef = {
+      kind: "local",
+      config: { provider: "google-translate" },
+    }
+
+    render(<TranslatePromptSelector />)
+
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
   })
 
   it("shows the selected built-in and uses the same order in Translation Hub", () => {

--- a/src/entrypoints/popup/components/translate-prompt-selector.tsx
+++ b/src/entrypoints/popup/components/translate-prompt-selector.tsx
@@ -11,15 +11,18 @@ import {
 } from "@/components/ui/base-ui/select"
 import { isLLMProvider } from "@/types/config/provider"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
-import { featureProviderConfigAtom } from "@/utils/atoms/provider"
+import { featureProviderRefAtom } from "@/utils/atoms/provider"
 import { DEFAULT_TRANSLATE_PROMPT_ID } from "@/utils/constants/prompt"
 import { i18n } from "@/utils/i18n"
 
 export default function TranslatePromptSelector() {
-  const translateProviderConfig = useAtomValue(featureProviderConfigAtom("pageTranslation"))
+  const translateProviderRef = useAtomValue(featureProviderRefAtom("pageTranslation"))
   const [translateConfig, setTranslateConfig] = useAtom(configFieldsAtomMap.pageTranslation)
 
-  if (!translateProviderConfig?.provider || !isLLMProvider(translateProviderConfig?.provider))
+  if (
+    !translateProviderRef ||
+    (translateProviderRef.kind === "local" && !isLLMProvider(translateProviderRef.config.provider))
+  )
     return null
 
   const customPromptsConfig = translateConfig.customPromptsConfig

--- a/src/utils/atoms/__tests__/provider.test.ts
+++ b/src/utils/atoms/__tests__/provider.test.ts
@@ -1,8 +1,12 @@
 import type { PartialDeep } from "type-fest"
 import type { ProviderConfig } from "@/types/config/provider"
+import { createStore } from "jotai"
 import { describe, expect, it } from "vitest"
+import { configAtom } from "@/utils/atoms/config"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { BUILT_IN_AI_PROVIDER_ID } from "@/utils/constants/provider-ids"
 import { DEFAULT_PROVIDER_CONFIG } from "@/utils/constants/providers"
-import { updateLLMProviderConfig, updateProviderConfig } from "../provider"
+import { featureProviderRefAtom, updateLLMProviderConfig, updateProviderConfig } from "../provider"
 
 type OpenAIProviderConfig = Extract<ProviderConfig, { provider: "openai" }>
 type BedrockProviderConfig = Extract<ProviderConfig, { provider: "bedrock" }>
@@ -68,5 +72,29 @@ describe("provider config updates", () => {
     expect(() =>
       updateProviderConfig(DEFAULT_PROVIDER_CONFIG["google-translate"], invalidUpdates),
     ).toThrow(/Invalid/)
+  })
+})
+
+describe("feature provider refs", () => {
+  it("resolves Built-in AI without requiring a persisted provider config row", () => {
+    const store = createStore()
+    const config = structuredClone(DEFAULT_CONFIG)
+    config.pageTranslation.providerId = BUILT_IN_AI_PROVIDER_ID
+    store.set(configAtom, config)
+
+    expect(store.get(featureProviderRefAtom("pageTranslation"))).toMatchObject({
+      kind: "system",
+      id: BUILT_IN_AI_PROVIDER_ID,
+      modelTier: "normal",
+    })
+  })
+
+  it("continues to resolve persisted providers as local refs", () => {
+    const store = createStore()
+
+    expect(store.get(featureProviderRefAtom("pageTranslation"))).toMatchObject({
+      kind: "local",
+      id: DEFAULT_CONFIG.pageTranslation.providerId,
+    })
   })
 })

--- a/src/utils/atoms/provider.ts
+++ b/src/utils/atoms/provider.ts
@@ -5,16 +5,17 @@ import { deepmerge } from "deepmerge-ts"
 import { atom } from "jotai"
 import { atomFamily } from "jotai-family"
 import { llmProviderConfigItemSchema, providerConfigItemSchema } from "@/types/config/provider"
+import { resolveProviderRefForCapability } from "@/utils/providers/provider-registry"
 import { getProviderConfigById } from "../config/helpers"
 import { FEATURE_PROVIDER_DEFS } from "../constants/feature-providers"
 import { configAtom, configFieldsAtomMap } from "./config"
 
-export const featureProviderConfigAtom = atomFamily((featureKey: FeatureKey) =>
+export const featureProviderRefAtom = atomFamily((featureKey: FeatureKey) =>
   atom((get) => {
     const config = get(configAtom)
     const def = FEATURE_PROVIDER_DEFS[featureKey]
     const providerId = def.getProviderId(config)
-    return getProviderConfigById(config.providersConfig, providerId) ?? null
+    return resolveProviderRefForCapability(featureKey, config.providersConfig, providerId)
   }),
 )
 


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-5 (Codex)

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fix the popup Prompt selector disappearing when page translation uses Built-in AI.

Built-in AI is a system provider and intentionally has no persisted `ProviderConfig` row. The popup previously looked up only local provider configs, so selecting Built-in AI resolved to `null` and hid Prompt selection even though hosted page translation accepts the selected Prompt.

This change:

- resolves the selected feature provider through the capability registry so both local and system providers produce provider refs;
- shows Prompt selection for Built-in AI and local LLM providers;
- keeps Prompt selection hidden for translation-only local providers such as Google Translate;
- adds regression coverage for system-provider resolution and all three popup visibility cases.

## Related Issue

No matching open issue was identified.

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Validation performed:

- `pnpm fmt:check`
- `pnpm type-check`
- `SKIP_FREE_API=true pnpm test` — 282 test files passed, 1 intentionally skipped; 2750 tests passed, 4 intentionally skipped
- pre-push validation — 283 test files and 2754 tests passed
- `pnpm build`

## Screenshots

Not included. This restores an existing selector without changing its visual design.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- Includes a patch changeset for `@read-frog/extension`.
- Built-in AI remains a registry-backed system provider and is not persisted as a normal editable provider config.
