### PR TITLE
fix(options): show one success notification after exporting config

### DIFF
--- a/.changeset/tidy-frogs-toast-once.md
+++ b/.changeset/tidy-frogs-toast-once.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(options): show one success notification after exporting config

--- a/src/entrypoints/options/pages/preference/config/manual-config-sync/index.tsx
+++ b/src/entrypoints/options/pages/preference/config/manual-config-sync/index.tsx
@@ -136,12 +136,6 @@ function ExportConfig() {
   const { mutate: exportConfig, isPending: isExporting } = useExportConfig({
     config,
     schemaVersion: CONFIG_SCHEMA_VERSION,
-    onSuccess: () => {
-      toastManager.add({
-        type: "success",
-        title: i18n.t("options.preference.config.manualSync.exportSuccess"),
-      })
-    },
   })
 
   return (

--- a/src/hooks/use-export-config.ts
+++ b/src/hooks/use-export-config.ts
@@ -10,10 +10,9 @@ import { i18n } from "@/utils/i18n"
 interface UseExportConfigOptions {
   config: Config
   schemaVersion: number
-  onSuccess?: () => void
 }
 
-export function useExportConfig({ config, schemaVersion, onSuccess }: UseExportConfigOptions) {
+export function useExportConfig({ config, schemaVersion }: UseExportConfigOptions) {
   return useMutation({
     mutationFn: async (includeApiKeys: boolean) => {
       let exportConfig = config
@@ -38,7 +37,6 @@ export function useExportConfig({ config, schemaVersion, onSuccess }: UseExportC
         type: "success",
         title: i18n.t("options.preference.config.manualSync.exportSuccess"),
       })
-      onSuccess?.()
     },
   })
 }


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-5

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

- Remove the manual config sync page's duplicate export-success notification and keep the shared export hook as the single toast owner.
- Remove the unused `onSuccess` option from `useExportConfig` so callers cannot repeat the same notification path.

## Related Issue

No linked issue.

## How Has This Been Tested?

- [ ] Added unit tests
- [ ] Verified through manual testing

Commands run:

- `pnpm fmt:check`
- `pnpm type-check`

## Screenshots

Not applicable; this removes a duplicate notification without changing layout.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

No additional information.
