### PR TITLE
fix(options): recognize configured LLM providers for language detection

### DIFF
--- a/.changeset/tidy-frogs-detect.md
+++ b/.changeset/tidy-frogs-detect.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(options): recognize configured LLM providers for language detection

--- a/src/components/llm-providers/provider-selector.tsx
+++ b/src/components/llm-providers/provider-selector.tsx
@@ -18,7 +18,7 @@ import {
   getProviderLogo,
   getProviderName,
   isProviderSelectorOptionDisabled,
-  isProviderSelectorItem,
+  isSystemProviderSelectorItem,
 } from "@/utils/providers/provider-display"
 import { useTheme } from "../providers/theme-provider"
 
@@ -49,12 +49,13 @@ interface ProviderSelectorProps {
 export function getProviderSelectorGroups(
   providers: ProviderSelectorOption[],
 ): ProviderSelectorGroup[] {
-  const builtInProviders = providers.filter(isProviderSelectorItem)
+  const builtInProviders = providers.filter(isSystemProviderSelectorItem)
   const llmProviders = providers.filter(
-    (provider) => !isProviderSelectorItem(provider) && isLLMProviderConfig(provider),
+    (provider) => !isSystemProviderSelectorItem(provider) && isLLMProviderConfig(provider),
   )
   const pureTranslateProviders = providers.filter(
-    (provider) => !isProviderSelectorItem(provider) && isPureTranslateProviderConfig(provider),
+    (provider) =>
+      !isSystemProviderSelectorItem(provider) && isPureTranslateProviderConfig(provider),
   )
 
   // Built-in models sit last: the user's own configured providers are the
@@ -77,7 +78,7 @@ function ProviderOptionContent({
   theme: Theme
   tooltipContainer?: ComponentProps<typeof UltraBadge>["tooltipContainer"]
 }) {
-  const requiresUltra = isProviderSelectorItem(provider) && provider.requiresUltra === true
+  const requiresUltra = isSystemProviderSelectorItem(provider) && provider.requiresUltra === true
 
   return (
     <div className="flex min-w-0 flex-1 items-center justify-between gap-2">

--- a/src/components/llm-providers/use-feature-providers.ts
+++ b/src/components/llm-providers/use-feature-providers.ts
@@ -11,7 +11,7 @@ import {
   FEATURE_PROVIDER_DEFS,
 } from "@/utils/constants/feature-providers"
 import { getSelectionToolbarActions, patchSelectionToolbarAction } from "@/utils/custom-actions"
-import { isProviderSelectorItem } from "@/utils/providers/provider-display"
+import { isSystemProviderSelectorItem } from "@/utils/providers/provider-display"
 import { getSelectableProvidersForCapability } from "@/utils/providers/provider-registry"
 import { providerSupportsTranslationOnlyMode } from "@/utils/providers/translation-only-gate"
 import { useHostedAiProviderOptions } from "./use-hosted-ai-provider-options"
@@ -44,7 +44,8 @@ export function useFeatureProvider(featureKey: FeatureKey): FeatureProviderBindi
     }
     return candidates.filter(
       (option) =>
-        isProviderSelectorItem(option) || providerSupportsTranslationOnlyMode(option.provider),
+        isSystemProviderSelectorItem(option) ||
+        providerSupportsTranslationOnlyMode(option.provider),
     )
   }, [featureKey, providersConfig, hideTranslationOnlyUnsupported])
   const providers = useHostedAiProviderOptions(featureKey, baseProviders)

--- a/src/components/llm-providers/use-hosted-ai-provider-options.ts
+++ b/src/components/llm-providers/use-hosted-ai-provider-options.ts
@@ -5,7 +5,7 @@ import {
   getHostedFeatureForCapability,
   isDurablyUnusableTier,
 } from "@/utils/providers/provider-availability"
-import { isProviderSelectorItem } from "@/utils/providers/provider-display"
+import { isSystemProviderSelectorItem } from "@/utils/providers/provider-display"
 import { getHostedAiModelTier, isBuiltInAiProviderId } from "@/utils/providers/provider-registry"
 import { useHostedAiStatus } from "./use-hosted-ai-status"
 
@@ -21,7 +21,7 @@ export function useHostedAiProviderOptions(
   }
 
   return providers.map((provider) => {
-    if (!isProviderSelectorItem(provider) || !isBuiltInAiProviderId(provider.id)) {
+    if (!isSystemProviderSelectorItem(provider) || !isBuiltInAiProviderId(provider.id)) {
       return provider
     }
 

--- a/src/entrypoints/options/pages/api-providers/language-detection/__tests__/language-detection.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/language-detection/__tests__/language-detection.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+
+import type { ProviderSelectorOption } from "@/utils/providers/provider-display"
+import { render, screen } from "@testing-library/react"
+import { Provider, createStore } from "jotai"
+import { describe, expect, it, vi } from "vitest"
+import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { DEFAULT_PROVIDER_CONFIG } from "@/utils/constants/providers"
+import { LanguageDetectionConfig } from ".."
+
+vi.mock("@/utils/atoms/config", async () => {
+  const { atom } = await vi.importActual<typeof import("jotai")>("jotai")
+  return {
+    configFieldsAtomMap: {
+      languageDetection: atom({ mode: "basic" as const, providerId: undefined }),
+      providersConfig: atom([]),
+    },
+  }
+})
+
+vi.mock("@/components/llm-providers/provider-selector", () => ({
+  default: ({ value }: { value: string }) => <div data-testid="provider-selector">{value}</div>,
+}))
+
+vi.mock("@/components/llm-providers/use-hosted-ai-provider-options", () => ({
+  useHostedAiProviderOptions: (
+    _capability: string,
+    providers: ProviderSelectorOption[],
+  ): ProviderSelectorOption[] =>
+    providers.map((provider) =>
+      "kind" in provider && provider.kind === "system" ? { ...provider, disabled: true } : provider,
+    ),
+}))
+
+vi.mock("@/components/llm-providers/use-hosted-ai-status", () => ({
+  useHostedAiStatus: () => ({
+    status: undefined,
+    isSignedIn: false,
+    isPending: false,
+    isError: false,
+  }),
+}))
+
+const localProvider = structuredClone(DEFAULT_PROVIDER_CONFIG.openai)
+
+function renderLanguageDetection(mode: "basic" | "llm") {
+  const store = createStore()
+  void store.set(configFieldsAtomMap.providersConfig, [localProvider])
+  void store.set(
+    configFieldsAtomMap.languageDetection,
+    mode === "llm" ? { mode, providerId: localProvider.id } : { mode },
+  )
+
+  return render(
+    <Provider store={store}>
+      <LanguageDetectionConfig />
+    </Provider>,
+  )
+}
+
+describe("LanguageDetectionConfig", () => {
+  it("enables LLM mode when a local LLM is the only usable provider", () => {
+    renderLanguageDetection("basic")
+
+    expect(
+      screen.getByRole("radio", {
+        name: "options.apiProviders.languageDetection.mode.llm",
+      }),
+    ).toBeEnabled()
+    expect(
+      screen.getByText("options.apiProviders.languageDetection.status.basicRecommend"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("options.apiProviders.languageDetection.status.noProviders"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows LLM detection as enabled for a selected local provider", () => {
+    renderLanguageDetection("llm")
+
+    expect(
+      screen.getByText("options.apiProviders.languageDetection.status.llmEnabled"),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("provider-selector")).toHaveTextContent(localProvider.id)
+    expect(
+      screen.queryByText("options.apiProviders.languageDetection.status.noProviders"),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/entrypoints/options/pages/api-providers/language-detection/index.tsx
+++ b/src/entrypoints/options/pages/api-providers/language-detection/index.tsx
@@ -8,7 +8,7 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/base-ui/radio-group"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { resolveLanguageDetectionConfigForModeChange } from "@/utils/config/helpers"
 import { i18n } from "@/utils/i18n"
-import { isProviderSelectorItem } from "@/utils/providers/provider-display"
+import { isProviderSelectorOptionDisabled } from "@/utils/providers/provider-display"
 import { getSelectableProvidersForCapability } from "@/utils/providers/provider-registry"
 import { ConfigItem } from "../../../components/config-item"
 import { ConfigSection } from "../../../components/config-section"
@@ -30,13 +30,10 @@ export function LanguageDetectionConfig() {
   const providerOptions = useHostedAiProviderOptions("languageDetection", selectableProviders)
   const { status } = useHostedAiStatus()
 
-  // Usable, not merely present. Built-in AI is in every capability list, so a
-  // length check here was always true and painted a green "LLM detection
-  // enabled" dot for accounts whose plan does not fund hosted detection —
-  // over a code path that returns null on every call and falls back to franc.
-  const hasProviders = providerOptions.some(
-    (option) => isProviderSelectorItem(option) && !option.disabled,
-  )
+  // Local providers do not carry a disabled flag, while Built-in AI can be
+  // disabled by account access. Count every selectable option so a configured
+  // local LLM keeps this control usable even when hosted AI is unavailable.
+  const hasProviders = providerOptions.some((option) => !isProviderSelectorOptionDisabled(option))
   const isLLMMode = languageDetection.mode === "llm"
 
   const statusIndicator = useMemo(() => {

--- a/src/utils/config/__tests__/feature-providers.test.ts
+++ b/src/utils/config/__tests__/feature-providers.test.ts
@@ -3,7 +3,7 @@ import type { HostedAiStatus, HostedAiTierStatus } from "@/utils/hosted-ai/types
 import { describe, expect, it } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { buildFeatureProviderPatch } from "@/utils/constants/feature-providers"
-import { isProviderSelectorItem } from "@/utils/providers/provider-display"
+import { isSystemProviderSelectorItem } from "@/utils/providers/provider-display"
 import {
   BUILT_IN_AI_PROVIDER_LOGO,
   getSelectableProvidersForCapability,
@@ -106,8 +106,8 @@ describe("feature providers", () => {
       ])
 
       const builtInAiProvider = providers[0]
-      expect(builtInAiProvider && isProviderSelectorItem(builtInAiProvider)).toBe(true)
-      if (!builtInAiProvider || !isProviderSelectorItem(builtInAiProvider)) {
+      expect(builtInAiProvider && isSystemProviderSelectorItem(builtInAiProvider)).toBe(true)
+      if (!builtInAiProvider || !isSystemProviderSelectorItem(builtInAiProvider)) {
         throw new Error("Built-in AI provider selector item was not returned")
       }
       expect(builtInAiProvider.logo("light")).toBe(BUILT_IN_AI_PROVIDER_LOGO)

--- a/src/utils/providers/provider-display.ts
+++ b/src/utils/providers/provider-display.ts
@@ -2,7 +2,7 @@ import type { ProviderConfig } from "@/types/config/provider"
 import type { Theme } from "@/types/config/theme"
 import { PROVIDER_ITEMS } from "@/utils/constants/providers"
 
-export interface ProviderSelectorItem {
+export interface SystemProviderSelectorItem {
   kind: "system"
   id: string
   logo: (theme: Theme) => string
@@ -12,16 +12,16 @@ export interface ProviderSelectorItem {
   requiresUltra?: boolean
 }
 
-export type ProviderSelectorOption = ProviderConfig | ProviderSelectorItem
+export type ProviderSelectorOption = ProviderConfig | SystemProviderSelectorItem
 
-export function isProviderSelectorItem(
+export function isSystemProviderSelectorItem(
   provider: ProviderSelectorOption,
-): provider is ProviderSelectorItem {
+): provider is SystemProviderSelectorItem {
   return "kind" in provider && provider.kind === "system"
 }
 
 export function getProviderLogo(provider: ProviderSelectorOption, theme: Theme): string {
-  return isProviderSelectorItem(provider)
+  return isSystemProviderSelectorItem(provider)
     ? provider.logo(theme)
     : PROVIDER_ITEMS[provider.provider].logo(theme)
 }
@@ -31,5 +31,5 @@ export function getProviderName(provider: ProviderSelectorOption): string {
 }
 
 export function isProviderSelectorOptionDisabled(provider: ProviderSelectorOption): boolean {
-  return isProviderSelectorItem(provider) && provider.disabled === true
+  return isSystemProviderSelectorItem(provider) && provider.disabled === true
 }

--- a/src/utils/providers/provider-registry.ts
+++ b/src/utils/providers/provider-registry.ts
@@ -3,8 +3,8 @@ import type { ProviderConfig, ProvidersConfig } from "@/types/config/provider"
 import type { Theme } from "@/types/config/theme"
 import type { FeatureKey } from "@/utils/constants/feature-providers"
 import type {
-  ProviderSelectorItem,
   ProviderSelectorOption,
+  SystemProviderSelectorItem,
 } from "@/utils/providers/provider-display"
 import readFrogLogo from "@/assets/providers/read-frog-provider.png?url&no-inline"
 import { isLLMProviderConfig, isTranslateProviderConfig } from "@/types/config/provider"
@@ -126,7 +126,7 @@ function getSystemProviderName(def: SystemProviderDef): string {
   return i18n.t(def.nameKey as never) || def.fallbackName
 }
 
-function createSystemProviderSelectorItem(def: SystemProviderDef): ProviderSelectorItem {
+function createSystemProviderSelectorItem(def: SystemProviderDef): SystemProviderSelectorItem {
   return {
     kind: "system",
     id: def.id,


### PR DESCRIPTION
> **AI model(s) used (required):** OpenAI GPT-5 (Codex)

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fix the Detection provider setting so enabled local LLM providers count as usable options even when the account cannot use Built-in AI.

Previously, the availability check filtered options through `isProviderSelectorItem`, which matched only synthetic system-provider entries. Configured providers such as Atlas Cloud and OpenAI were ignored, leaving the LLM radio disabled and the status stuck on “Configure an LLM provider first” even when a local provider was already selected.

This change:

- checks whether any provider option is selectable, covering both local and system providers;
- preserves account-based disabling for Built-in AI tiers;
- adds regression coverage for enabling LLM mode and showing the correct selected-provider status;
- renames `ProviderSelectorItem` and `isProviderSelectorItem` to `SystemProviderSelectorItem` and `isSystemProviderSelectorItem` so their system-only semantics are explicit;
- adds a patch changeset for `@read-frog/extension`.

## Related Issue

None provided.

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Validation completed:

- `pnpm exec nx fmt:check`
- `pnpm exec nx lint`
- `SKIP_FREE_API=true pnpm exec nx test -- --exclude="**/free-api.test.ts"` — 283 test files and 2,755 tests passed
- `pnpm build`

## Screenshots

Not included.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary (no documentation update required)
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The live external free-API test was intentionally excluded during local validation according to the repository testing instructions.
