### PR TITLE
fix(translation): explain stale extension context instead of the raw error

### DIFF
--- a/.changeset/stale-frogs-reload.md
+++ b/.changeset/stale-frogs-reload.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): tell users to reload the page when the extension was updated, instead of showing the raw "Extension context invalidated." error

--- a/src/components/translation/error/__tests__/shadow-portal.test.tsx
+++ b/src/components/translation/error/__tests__/shadow-portal.test.tsx
@@ -77,4 +77,21 @@ describe("translation error shadow portals", () => {
     expect(hoverCard).toHaveTextContent("Request failed")
     expect(shadowWrapper.contains(hoverCard)).toBe(true)
   })
+
+  it("swaps the stale-context error for a reload hint and drops the fake status code", async () => {
+    const error = { message: "Extension context invalidated." } as APICallError
+
+    const { container, shadowWrapper } = renderInShadow(<ErrorButton error={error} />)
+    fireEvent.mouseEnter(container.querySelector("[data-slot='hover-card-trigger']")!)
+
+    await waitFor(() => {
+      expect(shadowWrapper.querySelector("[data-slot='hover-card-content']")).toBeTruthy()
+    })
+
+    const hoverCard = shadowWrapper.querySelector("[data-slot='hover-card-content']")
+
+    expect(hoverCard).toHaveTextContent("translation.extensionContextInvalidated")
+    expect(hoverCard).not.toHaveTextContent("Extension context invalidated.")
+    expect(hoverCard).not.toHaveTextContent("Status Code")
+  })
 })

--- a/src/components/translation/error/error-button.tsx
+++ b/src/components/translation/error/error-button.tsx
@@ -3,10 +3,15 @@ import { IconAlertCircle } from "@tabler/icons-react"
 import { use } from "react"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/base-ui/alert"
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/base-ui/hover-card"
+import { isExtensionContextInvalidatedError } from "@/utils/error/extension-context"
+import { i18n } from "@/utils/i18n"
 import { ShadowWrapperContext } from "@/utils/react-shadow-host/create-shadow-host"
 
 export function ErrorButton({ error }: { error: APICallError }) {
   const shadowWrapper = use(ShadowWrapperContext)
+  // A stale content script left behind by an extension update has no HTTP
+  // exchange to report, so the status-code row would be a fabricated 500.
+  const isContextInvalidated = isExtensionContextInvalidatedError(error)
 
   return (
     <HoverCard>
@@ -21,9 +26,11 @@ export function ErrorButton({ error }: { error: APICallError }) {
         <IconAlertCircle className="size-4 text-red-500!" />
         <AlertTitle>Translation Error</AlertTitle>
         <AlertDescription className="break-all">
-          <StatusCode statusCode={error.statusCode ?? 500} />
+          {!isContextInvalidated && <StatusCode statusCode={error.statusCode ?? 500} />}
           <p className="text-zinc-900 dark:text-zinc-100">
-            {error.message || "Something went wrong"}
+            {isContextInvalidated
+              ? i18n.t("translation.extensionContextInvalidated")
+              : error.message || "Something went wrong"}
           </p>
         </AlertDescription>
       </HoverCardContent>

--- a/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
+++ b/src/entrypoints/selection.content/selection-toolbar/__tests__/request-rerun.test.tsx
@@ -969,6 +969,22 @@ describe("selection toolbar requests", () => {
     expect(screen.queryByRole("alert")).toBeNull()
   })
 
+  it("replaces the raw stale-context error with a reload hint", async () => {
+    translateTextCoreMock.mockRejectedValueOnce(new Error("Extension context invalidated."))
+    getOrCreateWebPageContextMock.mockResolvedValue(null)
+
+    const store = createStore()
+    store.set(configAtom, cloneConfig(DEFAULT_CONFIG))
+    setSelectionState(store, { text: "Selected text" })
+    renderWithProviders(<TranslateButton />, store)
+
+    fireEvent.click(screen.getByRole("button", { name: "action.translation" }))
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("translation.extensionContextInvalidated")
+    expect(alert).not.toHaveTextContent("Extension context invalidated.")
+  })
+
   it("shows a precheck alert when the translate provider is unavailable", async () => {
     const store = createStore()
     const updatedConfig = cloneConfig(DEFAULT_CONFIG)

--- a/src/entrypoints/selection.content/selection-toolbar/inline-error.ts
+++ b/src/entrypoints/selection.content/selection-toolbar/inline-error.ts
@@ -1,3 +1,4 @@
+import { isExtensionContextInvalidatedError } from "@/utils/error/extension-context"
 import { extractAISDKErrorMessage } from "@/utils/error/extract-message"
 import { i18n } from "@/utils/i18n"
 
@@ -36,6 +37,12 @@ function getPrecheckErrorDescription(code: SelectionToolbarPrecheckErrorCode) {
 }
 
 function toErrorDescription(kind: SelectionToolbarErrorKind, error: unknown) {
+  // Raw "Extension context invalidated." tells the user nothing actionable, and
+  // the popover's retry button can never recover from it — only a reload can.
+  if (isExtensionContextInvalidatedError(error)) {
+    return i18n.t("translation.extensionContextInvalidated")
+  }
+
   const message = extractAISDKErrorMessage(error)
   if (!message || message === UNEXPECTED_ERROR_MESSAGE) {
     return getErrorFallbackDescription(kind)

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1184,6 +1184,7 @@ languageDetection:
 translation:
   sameLanguage: Source and target languages must be different
   autoModeSameLanguage: Detected language '$1' is the same as target language
+  extensionContextInvalidated: The extension was updated. Refresh this page and try again.
 speak:
   fetchingAudio: Generating audio...
   playingAudio: Playing audio...

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -1184,6 +1184,7 @@ languageDetection:
 translation:
   sameLanguage: Los idiomas de origen y destino deben ser diferentes
   autoModeSameLanguage: El idioma detectado '$1' es el mismo que el idioma de destino
+  extensionContextInvalidated: La extensión se actualizó. Actualiza esta página e inténtalo de nuevo.
 speak:
   fetchingAudio: Generando audio...
   playingAudio: Reproduciendo audio...

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -1068,6 +1068,7 @@ languageDetection:
 translation:
   sameLanguage: ソース言語とターゲット言語は異なる必要があります
   autoModeSameLanguage: 検出された言語 '$1' はターゲット言語と同じです
+  extensionContextInvalidated: 拡張機能が更新されました。このページを再読み込みしてからもう一度お試しください。
 speak:
   fetchingAudio: 音声を生成しています...
   playingAudio: 音声を再生しています...

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -1068,6 +1068,7 @@ languageDetection:
 translation:
   sameLanguage: 원본 언어와 대상 언어는 달라야 합니다
   autoModeSameLanguage: 감지된 언어 '$1'은(는) 대상 언어와 같습니다
+  extensionContextInvalidated: 확장 프로그램이 업데이트되었습니다. 이 페이지를 새로고침한 후 다시 시도하세요.
 speak:
   fetchingAudio: 오디오 생성 중...
   playingAudio: 오디오 재생 중...

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -1068,6 +1068,7 @@ languageDetection:
 translation:
   sameLanguage: Исходный и целевой языки должны различаться
   autoModeSameLanguage: Обнаруженный язык '$1' совпадает с целевым языком
+  extensionContextInvalidated: Расширение обновлено. Обновите эту страницу и повторите попытку.
 speak:
   fetchingAudio: Генерация аудио...
   playingAudio: Воспроизведение аудио...

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -1068,6 +1068,7 @@ languageDetection:
 translation:
   sameLanguage: Kaynak ve hedef diller farklı olmalıdır
   autoModeSameLanguage: Algılanan dil '$1' hedef dille aynı
+  extensionContextInvalidated: Uzantı güncellendi. Bu sayfayı yenileyip tekrar deneyin.
 speak:
   fetchingAudio: Ses oluşturuluyor...
   playingAudio: Ses çalınıyor...

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -1068,6 +1068,7 @@ languageDetection:
 translation:
   sameLanguage: Ngôn ngữ nguồn và đích phải khác nhau
   autoModeSameLanguage: Ngôn ngữ phát hiện '$1' giống với ngôn ngữ đích
+  extensionContextInvalidated: Tiện ích đã được cập nhật. Hãy tải lại trang này rồi thử lại.
 speak:
   fetchingAudio: Đang tạo âm thanh...
   playingAudio: Đang phát âm thanh...

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -1184,6 +1184,7 @@ languageDetection:
 translation:
   sameLanguage: 源语言和目标语言必须不同
   autoModeSameLanguage: 检测到的语言 '$1' 与目标语言相同
+  extensionContextInvalidated: 扩展已更新，请刷新此页面后重试。
 speak:
   fetchingAudio: 正在获取音频...
   playingAudio: 正在播放音频...

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -1184,6 +1184,7 @@ languageDetection:
 translation:
   sameLanguage: 來源語言和目標語言必須不同
   autoModeSameLanguage: 偵測到的語言「$1」與目標語言相同
+  extensionContextInvalidated: 擴充功能已更新，請重新整理此頁面後再試一次。
 speak:
   fetchingAudio: 正在取得音訊…
   playingAudio: 正在播放音訊…

--- a/src/utils/error/__tests__/extension-context.test.ts
+++ b/src/utils/error/__tests__/extension-context.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { browser } from "#imports"
+import { isExtensionContextAlive, isExtensionContextInvalidatedError } from "../extension-context"
+
+const liveRuntimeId = browser.runtime.id
+
+function killExtensionContext() {
+  Object.defineProperty(browser.runtime, "id", { configurable: true, value: undefined })
+}
+
+afterEach(() => {
+  Object.defineProperty(browser.runtime, "id", { configurable: true, value: liveRuntimeId })
+})
+
+describe("isExtensionContextAlive", () => {
+  it("is alive while runtime.id is set", () => {
+    expect(isExtensionContextAlive()).toBe(true)
+  })
+
+  it("is dead once Chrome clears runtime.id on the stale side of an update", () => {
+    killExtensionContext()
+    expect(isExtensionContextAlive()).toBe(false)
+  })
+})
+
+describe("isExtensionContextInvalidatedError", () => {
+  it("matches the error Chrome throws from a stale content script", () => {
+    expect(isExtensionContextInvalidatedError(new Error("Extension context invalidated."))).toBe(
+      true,
+    )
+  })
+
+  it("matches the wording variants and plain strings", () => {
+    expect(isExtensionContextInvalidatedError("Extension context was invalidated.")).toBe(true)
+    expect(isExtensionContextInvalidatedError({ message: "extension context invalidated" })).toBe(
+      true,
+    )
+  })
+
+  it("leaves ordinary translation failures alone", () => {
+    expect(isExtensionContextInvalidatedError(new Error("401 Unauthorized"))).toBe(false)
+    expect(isExtensionContextInvalidatedError(undefined)).toBe(false)
+    // A missing background worker is a different, self-healing failure — the
+    // page does not need a reload for it.
+    expect(
+      isExtensionContextInvalidatedError(
+        new Error("Could not establish connection. Receiving end does not exist."),
+      ),
+    ).toBe(false)
+  })
+
+  it("treats any failure as invalidation once the context itself is dead", () => {
+    killExtensionContext()
+    expect(isExtensionContextInvalidatedError(new Error("401 Unauthorized"))).toBe(true)
+  })
+})

--- a/src/utils/error/extension-context.ts
+++ b/src/utils/error/extension-context.ts
@@ -1,0 +1,44 @@
+import { browser } from "#imports"
+
+/**
+ * Chrome destroys the old extension instance on update, reload or reinstall,
+ * but it does NOT re-inject content scripts into already-open tabs. Those
+ * scripts keep running against a dead `chrome.runtime`, so the next message to
+ * the background rejects with "Extension context invalidated." — and every
+ * retry in place rejects the same way, because the channel itself is gone.
+ * Only a page reload gets the tab a live content script again.
+ */
+const INVALIDATED_MESSAGE_PATTERN = /extension context (?:was |is )?invalidated/i
+
+/**
+ * `browser.runtime.id` is the authoritative liveness signal: Chrome clears it
+ * on the stale side of an update while leaving the `runtime` object in place.
+ */
+export function isExtensionContextAlive(): boolean {
+  try {
+    return typeof browser.runtime?.id === "string"
+  } catch {
+    // Touching a torn-down runtime can throw instead of returning undefined.
+    return false
+  }
+}
+
+export function isExtensionContextInvalidatedError(error: unknown): boolean {
+  // A dead context makes every in-flight failure unrecoverable, whatever the
+  // original error said, so reloading is always the right advice here.
+  if (!isExtensionContextAlive()) return true
+
+  return INVALIDATED_MESSAGE_PATTERN.test(readErrorMessage(error))
+}
+
+function readErrorMessage(error: unknown): string {
+  if (typeof error === "string") return error
+  if (error instanceof Error) return error.message
+
+  if (typeof error === "object" && error !== null) {
+    const { message } = error as { message?: unknown }
+    if (typeof message === "string") return message
+  }
+
+  return ""
+}


### PR DESCRIPTION
## Problem

Users report translations failing with a bare English string in the error box:

> **翻译失败**
> Extension context invalidated.

This is Chrome's native error, surfaced verbatim. It tells the user nothing actionable, so the reaction is "the extension is broken" — retry, reinstall, or file a report — when the actual fix is a page reload.

## Why it happens

Chrome destroys the old extension instance on update, reload or reinstall, but it does **not** re-inject content scripts into already-open tabs. The old script keeps running with a dead `chrome.runtime`, so the next `sendMessage` to the background rejects with `Extension context invalidated.` Store auto-updates are the dominant source; our release cadence makes it common for tabs that have been open a while.

Nothing in the tab notices. WXT's `ctx.isInvalid` is a lazy getter — it only marks the context dead when something *reads* it, or when a newer content script announces itself in the same page. Neither happens after a store update (we don't poll it, and Chrome doesn't re-inject), so the `ctx.onInvalidated` teardown in `host.content/runtime.ts` and `selection.content/index.tsx` never fires. The popover stays mounted and clickable, and its retry button can never recover the channel.

## Change

Detect the dead context and show a localized hint instead of the raw error, on both content-script surfaces that display translation failures:

- selection popover — `selection-toolbar/inline-error.ts`
- page-translation inline error card — `translation/error/error-button.tsx` (also drops the fabricated `Status Code: 500` row, since there was no HTTP exchange)

New shared helper `utils/error/extension-context.ts` checks `browser.runtime.id` (authoritative — Chrome clears it on the stale side) plus the message wording, and new `translation.extensionContextInvalidated` string across all 9 locales.

`Could not establish connection. Receiving end does not exist.` is deliberately **not** matched: a cold background worker is a different, self-healing failure that does not need a reload.

## Scope

Message only. No teardown/heartbeat and no re-injection on update — those are separate calls worth making on their own merits.

The translation hub is untouched: it's an extension page (`/translation-hub.html`), which Chrome tears down on update rather than leaving stale.

## Testing

- New unit tests for the helper, including the non-match for the receiving-end error
- Regression test in the selection popover asserting the raw string is gone
- Regression test on the error hover card asserting the message swap and the dropped status row
- Full suite: 2764 passed, 1 file skipped (`free-api.test.ts`, `SKIP_FREE_API=true`)
- `oxlint --type-aware --type-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
