### PR TITLE
fix(subtitles): initialize YouTube subtitles on /live/ URLs

### DIFF
--- a/.changeset/tidy-frogs-live.md
+++ b/.changeset/tidy-frogs-live.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(subtitles): show the translate button on YouTube /live/ URLs

--- a/src/entrypoints/subtitles.content/init-youtube-subtitles.ts
+++ b/src/entrypoints/subtitles.content/init-youtube-subtitles.ts
@@ -1,6 +1,7 @@
 import type { ContentScriptContext } from "#imports"
 import {
   YOUTUBE_EMBED_PATH_PATTERN,
+  YOUTUBE_LIVE_PATH_PATTERN,
   YOUTUBE_NAVIGATE_FINISH_EVENT,
   YOUTUBE_SHORTS_PATH_PATTERN,
   YOUTUBE_WATCH_URL_PATTERN,
@@ -15,6 +16,10 @@ import { mountSubtitlesUI } from "./renderer/mount-subtitles-ui"
 
 function isYoutubeWatch(): boolean {
   return window.location.href.includes(YOUTUBE_WATCH_URL_PATTERN)
+}
+
+function isYoutubeLive(): boolean {
+  return YOUTUBE_LIVE_PATH_PATTERN.test(window.location.pathname)
 }
 
 function isYoutubeEmbed(): boolean {
@@ -35,7 +40,7 @@ export function initYoutubeSubtitles(ctx: ContentScriptContext) {
   const config = getYoutubeConfig({ mode })
 
   const tryInit = async () => {
-    if (!isYoutubeWatch() && !embedded && !shorts) {
+    if (!isYoutubeWatch() && !isYoutubeLive() && !embedded && !shorts) {
       return
     }
 

--- a/src/utils/constants/subtitles.ts
+++ b/src/utils/constants/subtitles.ts
@@ -30,6 +30,7 @@ export const TRANSLATE_BUTTON_CLASS = "read-frog-subtitles-translate-button"
 export const YOUTUBE_WATCH_URL_PATTERN = "youtube.com/watch"
 export const YOUTUBE_EMBED_PATH_PATTERN = /\/embed\/[^/?]+/
 export const YOUTUBE_SHORTS_PATH_PATTERN = /\/shorts\/[^/?]+/
+export const YOUTUBE_LIVE_PATH_PATTERN = /\/live\/[^/?]+/
 export const YOUTUBE_NAVIGATE_START_EVENT = "yt-navigate-start"
 export const YOUTUBE_NAVIGATE_FINISH_EVENT = "yt-navigate-finish"
 export const YOUTUBE_NATIVE_SUBTITLES_CLASS = ".ytp-caption-window-container"


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Fable 5

## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

A user reported that the translate button never appears on some YouTube videos, and suspected auto-generated ("English (auto-generated)") captions were the cause. The real cause is unrelated to caption kind — the reported video was served at a `youtube.com/live/<id>` URL.

`initYoutubeSubtitles` only bootstrapped on `youtube.com/watch`, `/embed/`, and `/shorts/` URLs. Live and post-live VOD pages, which YouTube often serves directly at `/live/<id>` without redirecting to `/watch`, never mounted the adapter, so no translate button was rendered at all. The control video in the report happened to be a `/watch?v=` URL, which is why it worked.

For the record, there is no ASR filtering anywhere in the subtitle pipeline: `selectTrack` explicitly falls back to `kind === "asr"` tracks, and `hasAvailableSubtitles` only checks `captionTracks.length > 0`.

Changes:

- Add `YOUTUBE_LIVE_PATH_PATTERN` alongside the existing embed/shorts patterns.
- Add `isYoutubeLive()` and include it in the `tryInit` guard. `/live/` pages use the standard watch player (`#movie_player .ytp-right-controls`), so they keep the default `watch` mode; video ID extraction already supported the `/live/` path segment via `getVideoIdFromUrl`.

Known limitation, unchanged by this PR: for streams that are *currently live*, `createYoutubeAiSubtitlesContext` still returns `null` because `video.duration` is `Infinity`, so AI subtitles stay disabled. Native caption tracks translate normally, and post-live VODs are unaffected.

## Related Issue

<!-- No matching issue found; reported via user bug report. -->

## How Has This Been Tested?

- [x] Verified through manual testing

Ran the subtitle test suites: 22 files, 220 tests passing (`pnpm vitest run src/entrypoints/subtitles.content src/utils/subtitles`).

## Checklist

- [x] I have tested these changes locally
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.
