### PR TITLE
fix(translate): stop the giant-paragraph split from stranding a conta…

### DIFF
--- a/.changeset/tender-melons-shake.md
+++ b/.changeset/tender-melons-shake.md
@@ -1,0 +1,11 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): stop the giant-paragraph split from stranding a container's own text
+
+Tall containers are split into their descendant paragraphs so viewport-lazy translation still applies (#1881). That split silently drops any text the container holds directly, which is harmless on a nested `<article>` but catastrophic on `<br>`-delimited article bodies, where the bare text _is_ the article — a Blogger post kept 8% of its text and paulgraham.com/greatwork.html kept 1.1%, while the incidental inline `<i>` got its own translation inserted mid-sentence.
+
+- Refuse the split when the container owns prose of its own and has a block-level child, so the translate path re-segments it into per-line runs instead
+- Keep splitting when the container owns no prose (unchanged for docs.docker.com), when its own text carries no letters (separators, dates), when it has no block child to re-segment on, when it is `<body>`, or when the split already yields more units than the gating cap
+- Apply the same guard on the translate side's giant fallback, so both paths make one decision

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -2,6 +2,7 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { GIANT_SPLIT_STRANDED_TEXT_MAX_UNITS } from "@/utils/constants/translate"
 import {
   markExtensionDrivenNodeRemoval,
   registerBilingualTranslationState,
@@ -74,7 +75,10 @@ vi.mock("@/utils/host/dom/find", () => ({
   deepQueryTopLevelSelector: mockDeepQueryTopLevelSelector,
 }))
 
-vi.mock("@/utils/host/dom/traversal", () => ({
+// The labeling walk is mocked, but canSplitGiantWithoutStrandingOwnText is
+// kept real: it is the behavior under test in the giant-split cases below.
+vi.mock("@/utils/host/dom/traversal", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils/host/dom/traversal")>()),
   walkAndLabelElement: mockWalkAndLabelElement,
   walkAndLabelElementChunked: mockWalkAndLabelElementChunked,
 }))
@@ -179,6 +183,8 @@ function deepQueryTopLevelSelectorImpl(
   return result
 }
 
+const MOCK_BLOCK_TAGS = new Set(["P", "DIV", "BR", "UL", "LI", "SECTION", "ARTICLE", "BODY"])
+
 function isBlockedForTraversal(element: HTMLElement): boolean {
   return (
     Boolean(element.hidden) ||
@@ -210,6 +216,14 @@ function walkAndLabelVisibleParagraphs(
 
   if (element.tagName === "P" && element.textContent?.trim()) {
     element.setAttribute("data-read-frog-paragraph", "")
+  }
+
+  // The real walker labels block-level elements too, and the stranded-text
+  // guard reads that label to tell a re-segmentable container from one that
+  // would collapse into a single request. Without this the guard could never
+  // fire under the mock.
+  if (MOCK_BLOCK_TAGS.has(element.tagName)) {
+    element.setAttribute("data-read-frog-block-node", "")
   }
 
   return {
@@ -1085,13 +1099,16 @@ describe("pageTranslationManager mutation re-walk", () => {
     manager.stop()
   })
 
-  it("splits a giant paragraph into its descendant paragraphs for observation (#1881)", async () => {
+  it("splits a pure-container giant into its descendant paragraphs (#1881)", async () => {
     // docs.docker.com regression shape: one flat container labeled as a
     // paragraph spanning the whole document, with real paragraphs nested
     // inside. Built via DOM APIs — the HTML parser refuses nested <p>.
+    // The container owns NO direct text, which is what makes the split
+    // lossless — measured on the real page, its <article>'s own text is 0
+    // chars. (An earlier version of this fixture appended a direct text node,
+    // which the real page does not have and which the split would strand.)
     const giant = document.createElement("p")
     giant.id = "giant"
-    giant.append("direct inline text of the giant")
     const inner1 = document.createElement("p")
     inner1.id = "inner1"
     inner1.textContent = "Nested paragraph one"
@@ -1125,5 +1142,110 @@ describe("pageTranslationManager mutation re-walk", () => {
     expect(observed).toContain(unsplittable)
 
     manager.stop()
+  })
+
+  it("refuses to split a giant that owns prose beside block children", async () => {
+    // Blogger / paulgraham.com shape: the container's own bare text IS the
+    // article and the labeled descendants are incidental fragments. Splitting
+    // here observed only the fragments and stranded 92% of the post.
+    const flow = document.createElement("p")
+    flow.id = "flow"
+    const strayInner = document.createElement("p")
+    strayInner.id = "strayInner"
+    strayInner.textContent = "an incidental fragment"
+    flow.append("bare sentence one, which is the actual article", strayInner)
+    flow.append("bare sentence two, also the actual article")
+    document.body.append(flow)
+    flow.getBoundingClientRect = () => ({ height: 200_000 }) as DOMRect
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observed = intersectionObservers[0]!.observe.mock.calls.map((call) => call[0])
+    // Observed whole, so the translate path re-segments it into runs and the
+    // bare sentences are translated instead of dropped.
+    expect(observed).toContain(flow)
+    expect(observed).not.toContain(strayInner)
+
+    manager.stop()
+  })
+
+  it("still splits a giant that owns prose but has no block child", async () => {
+    // Without a block-labeled child the translate path takes its single-node
+    // branch, so observing whole would ship the entire container as ONE
+    // request. Lossy-but-gated beats one doomed payload.
+    const flow = document.createElement("p")
+    flow.id = "flow"
+    const inlinePara = document.createElement("span")
+    inlinePara.id = "inlinePara"
+    inlinePara.textContent = "an inline fragment"
+    inlinePara.setAttribute("data-read-frog-paragraph", "")
+    inlinePara.setAttribute("data-read-frog-inline-node", "")
+    flow.append("bare sentence one", inlinePara, "bare sentence two")
+    document.body.append(flow)
+    flow.getBoundingClientRect = () => ({ height: 200_000 }) as DOMRect
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observed = intersectionObservers[0]!.observe.mock.calls.map((call) => call[0])
+    expect(observed).toContain(inlinePara)
+    expect(observed).not.toContain(flow)
+
+    manager.stop()
+  })
+
+  it("still splits a giant whose split already yields many units", async () => {
+    // Safety valve: above the unit cap, keeping viewport gating beats
+    // rescuing the container's own text — refusing would enqueue the whole
+    // page at once, which is #1881 verbatim.
+    const giant = document.createElement("p")
+    giant.id = "giant"
+    giant.append("a stray sentence the split will strand")
+    const inners: HTMLElement[] = []
+    for (let i = 0; i < GIANT_SPLIT_STRANDED_TEXT_MAX_UNITS + 1; i++) {
+      const inner = document.createElement("p")
+      inner.textContent = `Nested paragraph ${i}`
+      inners.push(inner)
+      giant.append(inner)
+    }
+    document.body.append(giant)
+    giant.getBoundingClientRect = () => ({ height: 200_000 }) as DOMRect
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observed = intersectionObservers[0]!.observe.mock.calls.map((call) => call[0])
+    expect(observed).not.toContain(giant)
+    expect(observed).toContain(inners[0])
+
+    manager.stop()
+  })
+
+  it("never refuses to split <body>", async () => {
+    // <body> is force-block and picks up a paragraph label from any stray
+    // direct text node. Refusing there would collapse the whole document into
+    // one observed unit. The mock walk only labels <p>, so label body the way
+    // the real walker would.
+    const real = document.createElement("p")
+    real.id = "real"
+    real.textContent = "Real paragraph"
+    document.body.append("Loading…", real)
+    document.body.setAttribute("data-read-frog-paragraph", "")
+    document.body.getBoundingClientRect = () => ({ height: 200_000 }) as DOMRect
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observed = intersectionObservers[0]!.observe.mock.calls.map((call) => call[0])
+    expect(observed).not.toContain(document.body)
+    expect(observed).toContain(real)
+
+    manager.stop()
+    document.body.removeAttribute("data-read-frog-paragraph")
   })
 })

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-observer-root.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-observer-root.test.ts
@@ -34,7 +34,8 @@ vi.mock("@/utils/host/dom/find", () => ({
   deepQueryTopLevelSelector: mockDeepQueryTopLevelSelector,
 }))
 
-vi.mock("@/utils/host/dom/traversal", () => ({
+vi.mock("@/utils/host/dom/traversal", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils/host/dom/traversal")>()),
   walkAndLabelElement: mockWalkAndLabelElement,
   walkAndLabelElementChunked: vi
     .fn<(...args: any[]) => any>()

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-title.test.ts
@@ -50,7 +50,8 @@ vi.mock("@/utils/host/dom/find", () => ({
   deepQueryTopLevelSelector: mockDeepQueryTopLevelSelector,
 }))
 
-vi.mock("@/utils/host/dom/traversal", () => ({
+vi.mock("@/utils/host/dom/traversal", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils/host/dom/traversal")>()),
   walkAndLabelElement: mockWalkAndLabelElement,
   walkAndLabelElementChunked: vi
     .fn<(...args: any[]) => any>()

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -20,6 +20,7 @@ import {
   GIANT_PARAGRAPH_MAX_SPLIT_DEPTH,
   GIANT_PARAGRAPH_SPLIT_MIN_VIEWPORT_PX,
   GIANT_PARAGRAPH_SPLIT_VIEWPORT_MULTIPLIER,
+  GIANT_SPLIT_STRANDED_TEXT_MAX_UNITS,
 } from "@/utils/constants/translate"
 import { getRandomUUID } from "@/utils/crypto-polyfill"
 import {
@@ -28,7 +29,11 @@ import {
   isWalkBlockedElement as isWalkBlockedElementFilter,
 } from "@/utils/host/dom/filter"
 import { deepQueryTopLevelSelector } from "@/utils/host/dom/find"
-import { walkAndLabelElement, walkAndLabelElementChunked } from "@/utils/host/dom/traversal"
+import {
+  canSplitGiantWithoutStrandingOwnText,
+  walkAndLabelElement,
+  walkAndLabelElementChunked,
+} from "@/utils/host/dom/traversal"
 import {
   findStaleBilingualLayoutSource,
   findStaleTranslationOnlyAnchor,
@@ -733,10 +738,14 @@ export class PageTranslationManager implements IPageTranslationManager {
    * paragraphs are split: their next-level descendant paragraphs are observed
    * individually instead.
    *
-   * Known tradeoff: direct inline children of a split giant (e.g. those date
-   * <em>s) are not covered by any observed unit and stay untranslated. Stray
-   * standalone inlines in a >3-viewport flat container are rare, and
-   * numeric-only text is skipped by the pipeline anyway.
+   * The split is only sound when the giant owns no prose of its own: by the
+   * labeling rule every other character inside it already sits in one of the
+   * chosen units. That holds on docs.docker.com (its <article>'s own direct
+   * text is zero chars) but inverts on <br>-delimited article bodies, where
+   * the bare text IS the article and the inline <i>/<span> fragments are the
+   * strays — splitting there stranded 92% of a Blogger post and 98.9% of
+   * paulgraham.com/greatwork.html, and gave the stray <i> its own
+   * mid-sentence translation. See canSplitGiantWithoutStrandingOwnText.
    *
    * Exception: a newline-preserving flow container is never split into
    * inline descendants — see canSplitParagraphIntoDescendants.
@@ -772,6 +781,22 @@ export class PageTranslationManager implements IPageTranslationManager {
     )
     if (innerTopLevelParagraphs.length === 0) {
       // Unsplittable giant (no nested paragraphs) — observe it whole.
+      observer.observe(element)
+      return
+    }
+    if (
+      // Bounded by the very thing #1881 measures as harm: how many units one
+      // intersection enqueues. Above the cap, keeping viewport gating beats
+      // rescuing the giant's own text.
+      innerTopLevelParagraphs.length <= GIANT_SPLIT_STRANDED_TEXT_MAX_UNITS &&
+      // <body> is force-block and picks up a paragraph label from any stray
+      // direct text node, so refusing there would collapse the whole document
+      // into ONE observed unit — the outcome the traversal's document-root
+      // guard exists to prevent (gating dies, and the translated-region
+      // querySelector becomes a document-wide silent skip).
+      element !== element.ownerDocument.body &&
+      !canSplitGiantWithoutStrandingOwnText(element)
+    ) {
       observer.observe(element)
       return
     }

--- a/src/utils/constants/translate.ts
+++ b/src/utils/constants/translate.ts
@@ -43,6 +43,14 @@ export const GIANT_PARAGRAPH_SPLIT_VIEWPORT_MULTIPLIER = 3
 export const GIANT_PARAGRAPH_SPLIT_MIN_VIEWPORT_PX = 800
 // Defensive bound on split recursion.
 export const GIANT_PARAGRAPH_MAX_SPLIT_DEPTH = 10
+// Safety valve on the stranded-text refusal: #1881's harm metric is
+// units-enqueued-at-once, so bound the refusal by exactly that. Measured
+// separation is two orders of magnitude — the containers the refusal exists
+// for yield 11 (a Blogger post body), 77 (paulgraham.com/greatwork.html) and
+// ~100 (a tc39 <li>) units, while the containers #1881 exists for yield 1.8k
+// (a Wikipedia <body>), 4k (docs.docker.com's <main>) and 28k (tc39's <body>).
+// Above this, keeping viewport gating beats rescuing a stray sentence.
+export const GIANT_SPLIT_STRANDED_TEXT_MAX_UNITS = 128
 
 export const MIN_CHARACTERS_PER_NODE = 0
 export const MAX_CHARACTERS_PER_NODE = 1000

--- a/src/utils/host/dom/__tests__/giant-split-stranded-text.test.ts
+++ b/src/utils/host/dom/__tests__/giant-split-stranded-text.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { canSplitGiantWithoutStrandingOwnText, walkAndLabelElement } from "../traversal"
+
+/**
+ * Build a fixture and run the REAL labeling walk over it, so the block labels
+ * the predicate reads are the ones production writes.
+ */
+function walked(markup: string): HTMLElement {
+  const root = document.createElement("div")
+  root.innerHTML = markup
+  document.body.append(root)
+  walkAndLabelElement(root, "walk-1", DEFAULT_CONFIG)
+  return root
+}
+
+describe("canSplitGiantWithoutStrandingOwnText", () => {
+  beforeEach(() => {
+    document.body.innerHTML = ""
+  })
+
+  it("refuses when the container owns prose beside block children (Blogger post body)", () => {
+    // The <br>s make it re-segmentable; the bare text between them is the
+    // article itself, and a descendant split would strand all of it.
+    const root = walked(
+      `While f/stop and shutter speed both control exposure<br><br>` +
+        `Since the light from your flash is instantaneous<i>as long as you are at sync speed</i>`,
+    )
+
+    expect(canSplitGiantWithoutStrandingOwnText(root)).toBe(false)
+  })
+
+  it("allows the split when the container owns no text at all (docs.docker.com)", () => {
+    const root = walked(`<p>First paragraph</p><em>2026-08-17</em><p>Second paragraph</p>`)
+
+    expect(canSplitGiantWithoutStrandingOwnText(root)).toBe(true)
+  })
+
+  it("allows the split when only whitespace sits between block children", () => {
+    const root = walked(`
+      <p>First paragraph</p>
+      <p>Second paragraph</p>
+    `)
+
+    expect(canSplitGiantWithoutStrandingOwnText(root)).toBe(true)
+  })
+
+  it("allows the split when the container owns prose but has no block child", () => {
+    // Refusing here would send the whole container as one request, because the
+    // translate path takes its single-node branch without a block child.
+    const root = walked(`bare sentence one<span>an inline fragment</span>bare sentence two`)
+
+    expect(canSplitGiantWithoutStrandingOwnText(root)).toBe(true)
+  })
+
+  it.each([
+    ["a separator", "·"],
+    ["a pipe", " | "],
+    ["an em dash", "—"],
+    ["an ISO date", "2026-08-17"],
+    ["a formatted number", "1,234.56"],
+  ])("allows the split when the only own text is %s", (_label, stray) => {
+    const root = walked(`<p>First paragraph</p>${stray}<p>Second paragraph</p>`)
+
+    expect(canSplitGiantWithoutStrandingOwnText(root)).toBe(true)
+  })
+
+  it("refuses for CJK own text, which carries no ASCII letters", () => {
+    const root = walked(`<p>First paragraph</p>这是正文，不能被拆掉<p>Second paragraph</p>`)
+
+    expect(canSplitGiantWithoutStrandingOwnText(root)).toBe(false)
+  })
+
+  it("ignores script and style bodies, which are never bare text children", () => {
+    const root = walked(
+      `<p>First paragraph</p><script>const a = "text"</script>` +
+        `<style>.a { color: red }</style><p>Second paragraph</p>`,
+    )
+
+    expect(canSplitGiantWithoutStrandingOwnText(root)).toBe(true)
+  })
+})

--- a/src/utils/host/dom/traversal.ts
+++ b/src/utils/host/dom/traversal.ts
@@ -264,3 +264,63 @@ export async function walkAndLabelElementChunked(
   }
   return step.value
 }
+
+/**
+ * Text counts as prose only when it contains a letter. Deliberately NARROWER
+ * than the `.trim()` test walkNode itself uses above: a stray "·", "|", "—" or
+ * a bare "2026-08-17" sitting between two block children is not text a reader
+ * would miss, and treating it as prose would forfeit viewport gating on
+ * exactly the flat containers #1881 was about. `\p{L}` covers Han/Hiragana/
+ * Hangul and subsumes isNumericContent, whose /^[\d\s,.-]+$/ admits no letter.
+ */
+const OWN_PROSE_RE = /\p{L}/u
+
+/**
+ * Giant-paragraph split guard — the CONTENT counterpart to
+ * `canSplitParagraphIntoDescendants`, which guards paragraph STRUCTURE.
+ *
+ * Splitting a giant observes its descendant paragraphs INSIDE what is really
+ * one translation unit. That is free on docs.docker.com (a 203k-px <article>
+ * whose own direct text is ZERO chars) and catastrophic on a Blogger post body
+ * or paulgraham.com (a flat <br>-delimited container whose only labeled
+ * descendants are inline <i>/<span>/<a> fragments — 8% and 1.1% of the article
+ * respectively; the rest is bare text nodes that belong to no observed unit
+ * and are never enqueued, while the <i> gets its own translation inserted
+ * mid-sentence).
+ *
+ * Only DIRECT text children can be stranded. By the labeling rule above, any
+ * element with a non-whitespace direct text child is itself labeled a
+ * paragraph, so every deeper text node already lies inside one of the chosen
+ * units. One loop over childNodes is therefore complete — and structurally
+ * blind to <script>, <style>, <pre>, hidden subtrees and our own translation
+ * wrappers, none of which can be a bare Text child.
+ *
+ * The refusal additionally requires a block-labeled child, i.e. that
+ * translateWalkedElement will really take its run path and re-segment the
+ * container. Without one it takes the single-node path and the whole giant
+ * ships as ONE request — a single node is never split by length. Note this is
+ * the MIRROR-OPPOSITE precondition to the pre-wrap clause in
+ * `canSplitParagraphIntoDescendants`, which refuses only in the all-inline
+ * shape; the two refusal domains are disjoint by construction.
+ */
+export function canSplitGiantWithoutStrandingOwnText(element: HTMLElement): boolean {
+  let hasOwnProse = false
+  let hasBlockChild = false
+
+  for (const child of element.childNodes) {
+    // nodeType directly, matching walkNode above — this predicate runs inside
+    // the observation gate, where the filter module may be stubbed out.
+    if (child.nodeType === Node.TEXT_NODE) {
+      if (!hasOwnProse && OWN_PROSE_RE.test(child.textContent ?? "")) {
+        hasOwnProse = true
+      }
+      continue
+    }
+    if (!hasBlockChild && isHTMLElement(child) && child.hasAttribute(BLOCK_ATTRIBUTE)) {
+      hasBlockChild = true
+    }
+    if (hasOwnProse && hasBlockChild) return false
+  }
+
+  return !(hasOwnProse && hasBlockChild)
+}

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -28,7 +28,7 @@ import {
 } from "../../dom/filter"
 import { unwrapDeepestOnlyHTMLChild } from "../../dom/find"
 import { getOwnerDocument } from "../../dom/node"
-import { extractTextContent } from "../../dom/traversal"
+import { canSplitGiantWithoutStrandingOwnText, extractTextContent } from "../../dom/traversal"
 import {
   buildVirtualParagraphPlan,
   canMaterializeVirtualParagraphUnits,
@@ -780,6 +780,11 @@ async function translateNonMaterializableGiant(
   forceRetranslation: boolean,
 ): Promise<boolean> {
   if (!isGiantParagraphUnit(layoutSource)) return false
+  // Same content guard the observation gate applies: splitting into descendant
+  // paragraphs drops the container's own direct text. Falling back to the
+  // single run keeps that text rather than silently losing it here, after the
+  // observer already refused to lose it.
+  if (!canSplitGiantWithoutStrandingOwnText(layoutSource)) return false
 
   const paragraphs = collectTopLevelParagraphDescendants(layoutSource)
   if (paragraphs.length === 0) return false


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 5

## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Tall containers are split into their descendant paragraphs so viewport-lazy translation still applies (#1881). That split silently drops any text the container holds **directly**, and nothing ever notices — the text simply belongs to no observed unit and is never enqueued.

That is harmless on a nested `<article>`, which is what #1881 was measured against. It inverts completely on `<br>`-delimited article bodies, where the bare text *is* the article and the inline `<i>`/`<span>`/`<a>` fragments are the strays:

| Page | Container | Chars | Covered by the split today |
|---|---|---|---|
| docs.docker.com/desktop/release-notes/ | `<article>` 203,000px | 237,975 | ~100% (owns **0** chars of direct text) |
| strobist.blogspot.com (Blogger post body) | flow `div` 5,077px | 6,580 | 527 — **8%** |
| paulgraham.com/greatwork.html | `<font>` 23,385px, 599 `<br>` | 66,529 | 723 — **1.1%** |

The same defect causes the second, more visible symptom: a mid-sentence `<i>` becomes its own observed unit, so its translation is inserted into the middle of the sentence rather than after it.

The existing comment in `observeParagraphUnit` acknowledged the tradeoff and assumed "stray standalone inlines in a >3-viewport flat container are rare". On the pages above the assumption is exactly backwards. Its cited example — the docker release-date `<em>`s — turns out to be covered already, since each `<em>` is a direct child and a labeled paragraph in its own right.

### The guard

> A giant paragraph may be split into descendant units only when it owns **no prose of its own**.

This rests on a property of the labeling walk: a non-whitespace `Text` child sets `hasInlineNodeChild`, which alone sets `PARAGRAPH_ATTRIBUTE`. So **every non-whitespace text node's immediate parent is itself labeled a paragraph**, and combined with the `innerTopLevelParagraphs` filter, a text node inside giant `G` can only be stranded when its parent *is* `G`.

One loop over `G.childNodes` is therefore complete — no `TreeWalker`, no `getComputedStyle`, and structurally unable to see `<script>` bodies, `<pre>`, hidden subtrees, shadow content or our own translation wrappers, since none of those can be a bare `Text` child. (An earlier subtree-scanning prototype miscounted an inline `<script>` source as 746 chars of stranded text on docs.docker.com.)

Four deliberate escape hatches, each pinned by its own test:

- **No letters, no prose** (`\p{L}`) — a stray `·`, `|`, `—` or `2026-08-17` between two block children is not text a reader would miss. This is a definition of prose, not a materiality threshold.
- **Requires a block-labeled child** — without one, `translateWalkedElement` takes its single-node branch and the refused giant ships as *one* request (a single node is never split by length). Lossy-but-gated beats one doomed payload. Note this is the mirror-opposite precondition to the pre-wrap clause in `canSplitParagraphIntoDescendants`, which refuses only in the all-inline shape; the two refusal domains are disjoint by construction.
- **Never `<body>`** — `BODY` is force-block and picks up a paragraph label from any stray direct text node. Refusing there would collapse the whole document into one observed unit, the exact outcome the traversal's document-root guard exists to prevent.
- **Unit-count cap (128)** — #1881's harm metric is units-enqueued-at-once, so the refusal is bounded by exactly that. Measured separation is two orders of magnitude: the containers this guard exists for yield 11 / 77 / ~100 units; the containers #1881 exists for yield 1.8k / 4k / 28k.

The translate side's giant fallback (`translateNonMaterializableGiant`) splits by the same descendant rule and had the same hole, so it consults the same predicate — preserving the invariant already documented on `canMaterializeVirtualParagraphUnits` that both paths share one decision.

## Related Issue

<!-- No existing issue matched this report; reported directly. -->

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

**Unit tests** — full suite green (2,775 tests), lint and format clean.

- 11 new tests for `canSplitGiantWithoutStrandingOwnText` running the *real* labeling walk: owns prose + block child → refuse; owns nothing → split; whitespace-only between blocks → split; owns prose without a block child → split; separator / pipe / em-dash / ISO date / formatted number → split; CJK own text → refuse; `<script>`/`<style>` bodies ignored.
- The `#1881` observation test is reworked and forked into five. Its fixture appended a direct text node the page it names does not have — i.e. it encoded the stranded-text assumption in its assertions. It now models the real docker shape (no own text), plus new cases for refuse / no-block-child / above-the-cap / `<body>`.
- The mock walk in that file never set `BLOCK_ATTRIBUTE`, so the guard could not have fired under it; it now labels block elements the way the real walker does.
- Each clause was mutation-checked: removing the guard fails exactly the refuse test; removing the cap and `<body>` exclusion fails exactly those two; removing the block-child requirement fails exactly that one.

**Real browser** (built extension in Chrome via Puppeteer, default 1200×900 viewport):

| Page | Before | After |
|---|---|---|
| strobist.blogspot.com | 11 wrappers, 8% of the body | **41 wrappers, full body**; 3 mid-sentence `<i>` and none splits its sentence |
| paulgraham.com/greatwork.html | 1.1% of the essay | **236 wrappers, all translated** |
| docs.docker.com/desktop/release-notes/ | gated | **still gated** — 80 wrappers before scrolling, 583 after, of 5,376 paragraphs |

## Screenshots

Before/after on strobist.blogspot.com at the same scroll position — the body paragraphs go from untranslated to translated, and `as long as you are at or below your camera's top "sync" speed` is absorbed back into its sentence instead of receiving its own mid-sentence translation.

<!-- attach: before (11 wrappers) and after (41 wrappers) -->

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

**Known cost, stated deliberately.** A refused giant's runs insert their wrapper as a *sibling*, which fails the `layoutSource.contains(wrapper)` check, so their bilingual state is not registered; bare-`Text` runs never register at all. Those runs therefore lose staleness retranslation and the #1918 wrapper-tamper repair. This is not introduced here — it is how the run path has always behaved, and it is exactly what the same page produces today at a viewport tall enough to fall under the giant threshold — but it is new for the fragments that were previously single-element units. A complete, correct sentence beats a mid-sentence insertion with staleness tracking.

**Refused containers are one observed unit.** paulgraham.com enqueues all 236 runs on first intersection rather than incrementally on scroll. That is inherent — a `<br>`-delimited flow has no element to observe per line — and is bounded by the background request queue (rate 8/s). No freeze; the `<body>` exclusion and the 128-unit cap keep this away from document-scale containers.

**No dedicated test for the translate-side twin.** `translateNonMaterializableGiant` has no existing test harness, and reaching it requires translationOnly + pre-wrap + giant + a non-materializable plan + own prose simultaneously. Building that harness for a two-line defensive guard was disproportionate; the predicate it calls has 11 unit tests.

**Deliberately out of scope, worth follow-ups:**

1. The B2 run loop in `translateWalkedElement` is completely unpaced — `pauseIfBudgetSpent` is consumed only at function entry, so a container's runs are all issued in one task. Adding a pause inside the loop looks obvious but may be inert: the pacer is checked at *callee entry*, before the callee does work, so a whole fan-out generation shares one stale clock. Needs measurement with a non-zero budget first; every existing pacing test uses `createWorkPacer(0)` and cannot see the difference.
2. Nested observed units: if a mutation adds a subtree inside a whole-observed container and it is observed separately, the `querySelector('.read-frog-translated-content-wrapper')` guard makes the whole container a silent skip. This predates the change (the unsplittable-giant branch already observes whole); the guard here widens the surface, bounded by the `<body>` exclusion and the unit cap. It must **not** be fixed by relaxing that querySelector — `findPreviousTranslatedWrapperInside` returns `null` for `Text`, so bare-text runs have no per-run dedupe and the coarse guard is load-bearing.