### PR TITLE
fix(selection): exclude read-frog translations from the dictionary context

### DIFF
--- a/src/entrypoints/selection.content/__tests__/utils.test.ts
+++ b/src/entrypoints/selection.content/__tests__/utils.test.ts
@@ -375,6 +375,59 @@ describe("readSelectionSnapshot", () => {
   })
 })
 
+describe("buildContextSnapshot with translated content", () => {
+  it("excludes bilingual wrapper translations from the context", () => {
+    document.body.innerHTML = `
+      <article>
+        <p id="paragraph">
+          Alpha text
+          <span class="read-frog-translated-content-wrapper">
+            <span>Alpha text</span>
+            <span class="read-frog-translated-block-content">阿尔法文本</span>
+          </span>
+          beta <strong id="selection">gamma</strong> delta.
+        </p>
+      </article>
+    `
+
+    const selectionNode = document.getElementById("selection")?.firstChild
+    if (!selectionNode) {
+      throw new Error("Selection node not found")
+    }
+
+    const range = document.createRange()
+    range.setStart(selectionNode, 0)
+    range.setEnd(selectionNode, selectionNode.textContent?.length ?? 0)
+
+    const snapshot = buildContextSnapshot(createSelectionSnapshot(range, "gamma"))
+    expect(snapshot?.text).toBe("Alpha text beta gamma delta.")
+    expect(snapshot?.paragraphs).toEqual(["Alpha text beta gamma delta."])
+  })
+
+  it("excludes in-place swapped (translation-only) text from the context", () => {
+    document.body.innerHTML = `
+      <article>
+        <p id="paragraph">
+          <span data-read-frog-translation-only="true">已经原地替换的译文</span>
+          remaining original <strong id="selection">gamma</strong> text.
+        </p>
+      </article>
+    `
+
+    const selectionNode = document.getElementById("selection")?.firstChild
+    if (!selectionNode) {
+      throw new Error("Selection node not found")
+    }
+
+    const range = document.createRange()
+    range.setStart(selectionNode, 0)
+    range.setEnd(selectionNode, selectionNode.textContent?.length ?? 0)
+
+    const snapshot = buildContextSnapshot(createSelectionSnapshot(range, "gamma"))
+    expect(snapshot?.text).toBe("remaining original gamma text.")
+  })
+})
+
 describe("truncateContextTextForCustomAction", () => {
   it("keeps only the leading characters for custom action context tokens", () => {
     expect(truncateContextTextForCustomAction("abcdefghij", 4)).toBe("abcd")

--- a/src/entrypoints/selection.content/utils.ts
+++ b/src/entrypoints/selection.content/utils.ts
@@ -1,3 +1,9 @@
+import {
+  BLOCK_CONTENT_CLASS,
+  CONTENT_WRAPPER_CLASS,
+  INLINE_CONTENT_CLASS,
+  TRANSLATION_ONLY_ATTRIBUTE,
+} from "@/utils/constants/dom-labels"
 import { READ_FROG_SUBTITLES_UI_HOST_ID } from "@/utils/constants/subtitles"
 
 export interface SelectionRangeSnapshot {
@@ -314,10 +320,36 @@ function findParagraphOwner(node: Node | null): ParagraphOwner | null {
   return semanticFallback
 }
 
+const TRANSLATED_CONTENT_SELECTOR = [
+  `.${CONTENT_WRAPPER_CLASS}`,
+  `.${INLINE_CONTENT_CLASS}`,
+  `.${BLOCK_CONTENT_CLASS}`,
+  `[${TRANSLATION_ONLY_ATTRIBUTE}]`,
+].join(", ")
+
+/**
+ * Text nodes inside read-frog's own translation output (bilingual wrappers or
+ * in-place swapped text) must not leak into the dictionary / custom-action
+ * context: the surrounding context should describe the original page text,
+ * not our own translation of it.
+ */
+function isTranslatedTextNode(node: Node) {
+  const element = node.parentElement
+  if (!element) {
+    return false
+  }
+
+  return element.closest(TRANSLATED_CONTENT_SELECTOR) !== null
+}
+
 function extractOwnerText(owner: ParagraphOwner) {
   const textParts: string[] = []
   const walker = document.createTreeWalker(owner, NodeFilter.SHOW_TEXT, {
     acceptNode(node) {
+      if (isTranslatedTextNode(node)) {
+        return NodeFilter.FILTER_REJECT
+      }
+
       return normalizeParagraphText(node.textContent ?? "") === ""
         ? NodeFilter.FILTER_REJECT
         : NodeFilter.FILTER_ACCEPT
@@ -365,6 +397,10 @@ function collectParagraphOwners(rangeSnapshots: SelectionRangeSnapshot[]) {
     const traversalRoot = getTraversalRoot(rangeSnapshot)
     const walker = document.createTreeWalker(traversalRoot, NodeFilter.SHOW_TEXT, {
       acceptNode(node) {
+        if (isTranslatedTextNode(node)) {
+          return NodeFilter.FILTER_REJECT
+        }
+
         return normalizeParagraphText(node.textContent ?? "") === ""
           ? NodeFilter.FILTER_REJECT
           : NodeFilter.FILTER_ACCEPT


### PR DESCRIPTION
## 问题

划词查询词典时，上下文快照（`buildContextSnapshot`）会收集段落内的**所有**文本节点，包括 read-frog 自己插入的双语译文节点（`read-frog-translated-content-wrapper` / inline / block）以及原地替换模式留下的译文（`data-read-frog-translation-only`）。

在已翻译页面上选词查词典时，附近句子的**译文**被当作上下文发送给词典/自定义操作，污染查询结果（#2115 中的例子：词典上下文里出现了“技能/文档/生产力……”这类已翻译的标题和段落）。

## 修复

在两处 `TreeWalker` 的 `acceptNode` 中新增 `isTranslatedTextNode` 过滤：

- `extractOwnerText`：段落文本提取时跳过译文节点；
- `collectParagraphOwners`：遍历选区相交文本节点时跳过译文节点（选择落在译文上时，回退到选区起点所在的段落，仍能拿到原文上下文）。

若某段落的文本全部是译文，`extractOwnerText` 返回空字符串，该段落会被既有的 `.filter(Boolean)` 自然排除。

## 测试

`__tests__/utils.test.ts` 新增两个用例：

- 双语 wrapper（wrapper + block 译文）中的译文不进入上下文；
- 原地替换（translation-only）的译文不进入上下文。

差分验证：撤销修复后两个新用例失败（2 failed / 11 passed），打上修复后全部通过（13 passed）。

Fixes #2115
