### PR TITLE
fix(site-rules): wrap translated JavDB titles

### DIFF
--- a/.changeset/wrap-javdb-titles.md
+++ b/.changeset/wrap-javdb-titles.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(site-rules): wrap translated JavDB titles instead of clipping them

--- a/src/utils/site-rules/__tests__/built-in.test.ts
+++ b/src/utils/site-rules/__tests__/built-in.test.ts
@@ -218,6 +218,13 @@ describe("built-in site rules", () => {
     expect(resolved.injectedCss).toContain("max-height: unset !important")
   })
 
+  it("lets JavDB titles and their inline translations wrap instead of clipping", () => {
+    const resolved = resolveSiteRule("https://javdb.com/", BUILT_IN_SITE_RULES, [], [])
+    expect(resolved.injectedCss).toContain("white-space: normal !important")
+    expect(resolved.injectedCss).toContain("overflow: visible !important")
+    expect(resolved.injectedCss).toContain("text-overflow: clip !important")
+  })
+
   // `linkedinFeed` shipped as `https://linkedin.com/feed/*`, but LinkedIn 301s the
   // bare host, so the extension only ever sees `www.linkedin.com` and the rule never
   // matched. Restoring it by adding `www` would be worse than leaving it dead: both of

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -1387,7 +1387,7 @@
     "id": "javdb",
     "matches": "https://javdb*.com/*",
     "excludeSelectors": [".video-number", ".score", ".has-addons"],
-    "injectedCss": ".video-title { white-space:unset; }"
+    "injectedCss": ".video-title { white-space: normal !important; overflow: visible !important; text-overflow: clip !important; }"
   },
   {
     "id": "jable",


### PR DESCRIPTION
> **AI model(s) used (required):** OpenAI GPT-5.6 Codex

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

JavDB card titles keep the site's single-line truncation styles after page translation. Long original titles and translated titles are therefore clipped, and an inline translation can be hidden completely to the right of the card and appear as if it was never translated.

This PR strengthens the existing JavDB site rule so `.video-title` uses normal wrapping, visible overflow, and clipped rather than ellipsis text overflow while translation is active. The declarations use `!important` so they override JavDB's more specific host styles.

It also adds regression coverage for the resolved built-in rule and a patch changeset for `@read-frog/extension`.

## Related Issue

No linked issue.

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation performed:

- `pnpm fmt:check`
- `pnpm lint`
- `pnpm test` — 288 test files and 2800 tests passed in the pre-push hook
- `pnpm build`
- Real Edge test with the production `.output/chrome-mv3` build on `https://javdb.com/`

The live test confirmed that the `HONB-498` translation wrapper existed within one second but was hidden by the parent title's single-line overflow. Before the fix, that title measured 331 px client width versus 641 px scroll width at 34 px height. With the matched site-rule stylesheet, it measured 331/331 px and expanded to 82 px so the inline translation wrapped visibly. Longer block translations also wrapped and expanded their title containers without horizontal clipping.

## Screenshots

Not included because the live reproduction page contains explicit media. The manual verification used computed styles, translation-wrapper presence, and element geometry as described above.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The fix remains scoped to the existing JavDB built-in site rule; it does not change the shared translation insertion or DOM traversal behavior.
