### PR TITLE
fix(translate): allow page translation through root body notranslate …

### DIFF
--- a/.changeset/translate-edstem-body.md
+++ b/.changeset/translate-edstem-body.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): allow page translation through root body notranslate markers

--- a/src/utils/host/dom/__tests__/traversal.test.ts
+++ b/src/utils/host/dom/__tests__/traversal.test.ts
@@ -440,9 +440,10 @@ describe("document root labeling guard", () => {
   })
 })
 
-describe("document root notranslate exemption", () => {
+describe("document shell notranslate exemption", () => {
   function cleanUpRoot() {
     document.documentElement.classList.remove(NOTRANSLATE_CLASS)
+    document.body.classList.remove(NOTRANSLATE_CLASS, "feat-webkit", "theme-dark", "enable-motion")
     document.body.innerHTML = ""
     for (const attr of [WALKED_ATTRIBUTE, PARAGRAPH_ATTRIBUTE, BLOCK_ATTRIBUTE, INLINE_ATTRIBUTE]) {
       document.documentElement.removeAttribute(attr)
@@ -466,10 +467,30 @@ describe("document root notranslate exemption", () => {
     }
   })
 
-  it("still blocks notranslate elements nested below the document root", () => {
-    // The exemption is root-only: nested opt-outs (and read frog's own injected
-    // UI, which carries the same class) must keep blocking descent.
-    document.documentElement.classList.add(NOTRANSLATE_CLASS)
+  it("walks EdStem content when body carries the notranslate class", () => {
+    document.body.classList.add(NOTRANSLATE_CLASS, "feat-webkit", "theme-dark", "enable-motion")
+    document.body.innerHTML = `
+      <main>
+        <p id="edstem-content" class="amber-el amber-paragraph amber-content">
+          Welcome to the worksheets for Programming and Software Development!
+        </p>
+      </main>
+    `
+
+    try {
+      walkAndLabelElement(document.documentElement, "body-notranslate", DEFAULT_CONFIG)
+
+      expect(document.body).toHaveAttribute(WALKED_ATTRIBUTE, "body-notranslate")
+      expect(document.getElementById("edstem-content")).toHaveAttribute(PARAGRAPH_ATTRIBUTE)
+    } finally {
+      cleanUpRoot()
+    }
+  })
+
+  it("still blocks notranslate elements nested below the document shell", () => {
+    // The exemption is shell-only: nested opt-outs (and read frog's own
+    // injected UI, which carries the same class) must keep blocking descent.
+    document.body.classList.add(NOTRANSLATE_CLASS)
     document.body.innerHTML = `
       <div>
         <p id="msg">Message body text</p>
@@ -480,6 +501,7 @@ describe("document root notranslate exemption", () => {
     try {
       walkAndLabelElement(document.documentElement, "nested-notranslate", DEFAULT_CONFIG)
 
+      expect(document.body).toHaveAttribute(WALKED_ATTRIBUTE, "nested-notranslate")
       expect(document.getElementById("msg")).toHaveAttribute(PARAGRAPH_ATTRIBUTE)
       expect(document.getElementById("opted-out")).not.toHaveAttribute(PARAGRAPH_ATTRIBUTE)
     } finally {

--- a/src/utils/host/dom/filter.ts
+++ b/src/utils/host/dom/filter.ts
@@ -210,20 +210,19 @@ export function isDontWalkIntoButTranslateAsChildElement(
   element: HTMLElement,
   config?: Config,
 ): boolean {
-  // The document root is exempt from the `notranslate` class rule. This
+  // The document shell is exempt from the `notranslate` class rule. This
   // predicate means "don't descend, but let the parent translate this as one
-  // inline chunk" — <html> has no parent to fold that text into, so blocking it
-  // drops the whole document instead of merging it. Since #1992 moved the walk
-  // root from <body> to documentElement, a site that ships
-  // `<html class="notranslate">` (Telegram Web A does; Telegram Web K does not)
-  // aborts the walk on its very first check and page translation silently
-  // labels nothing at all. Honoring an explicit page-translation request over a
-  // root-level opt-out mirrors the existing decision to ignore the
-  // `translate="no"` attribute (#459). Nested `notranslate` elements — read
-  // frog's own injected UI included — still block normally.
-  const dontWalkClass =
-    element.classList.contains(NOTRANSLATE_CLASS) &&
-    element !== element.ownerDocument.documentElement
+  // inline chunk" — neither <html> nor <body> has a translatable parent to fold
+  // that text into, so blocking either one drops the whole document instead of
+  // merging it. Telegram Web A ships `<html class="notranslate">`, while EdStem
+  // and Featurebase ship `<body class="notranslate">`. Honoring an explicit
+  // page-translation request over a page-shell opt-out mirrors the existing
+  // decision to ignore the `translate="no"` attribute (#459). Nested
+  // `notranslate` elements — read frog's own injected UI included — still block
+  // normally.
+  const isDocumentShell =
+    element === element.ownerDocument.documentElement || element === element.ownerDocument.body
+  const dontWalkClass = element.classList.contains(NOTRANSLATE_CLASS) && !isDocumentShell
 
   const dontWalkTag = getEffectiveTagSet(config, "dontWalkButTranslateTags").has(element.tagName)
 


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-5 Codex

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Pages such as EdStem and Featurebase can place `class="notranslate"` on the document body. Read Frog previously exempted only `documentElement` from this traversal block, so the walker stopped at `<body>` and never created paragraph labels or translation requests for otherwise translatable content.

This change:

- treats both `<html>` and `<body>` as document-shell elements that explicit page translation may traverse;
- continues to block nested `.notranslate` regions, including Read Frog's own injected UI;
- adds an EdStem-shaped regression fixture using its body and paragraph classes;
- adds a patch changeset for `@read-frog/extension`.

## Related Issue

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation performed:

- `SKIP_FREE_API=true pnpm test` — 287 test files and 2,797 tests passed through the pre-push hook.
- Repository formatting and type-aware lint passed through the pre-push hook.
- Chrome MV3 production and development builds completed successfully.
- A built-extension Chrome fixture confirmed that a `body.notranslate` page is walked and its source paragraph is labeled, while a nested `.notranslate` paragraph remains unwalked.
- Translation requests were intentionally suppressed in the fixture so no saved course content was sent to an external provider.

## Screenshots

Not applicable; this changes DOM traversal behavior without changing the UI.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The original failure was captured in a SingleFile snapshot: `<html>` had a Read Frog walk label, but `<body class="notranslate ...">` and its visible paragraphs had none. The regression test preserves the important boundary by asserting both document-shell traversal and nested opt-out behavior.
