### PR TITLE
fix(subtitles): follow YouTube's own default caption track

### DIFF
--- a/.changeset/silly-hounds-repeat.md
+++ b/.changeset/silly-hounds-repeat.md
@@ -1,5 +1,5 @@
 ---
-"read-frog": patch
+"@read-frog/extension": patch
 ---
 
 fix(subtitles): follow YouTube's own default caption track

--- a/.changeset/silly-hounds-repeat.md
+++ b/.changeset/silly-hounds-repeat.md
@@ -1,0 +1,7 @@
+---
+"read-frog": patch
+---
+
+fix(subtitles): follow YouTube's own default caption track
+
+When the viewer had YouTube's own CC off, the player reported no selected track and the fetcher fell back to whichever caption track happened to be listed first — so a video whose first track is not the viewer's usual language had to be corrected by hand every time. The player response already names the track YouTube itself would play (`defaultCaptionTrackIndex`), so read that instead. A live selection in the player still wins, and responses that omit the field fall back to enabling CC and following the player's choice.

--- a/src/entrypoints/interceptor.content/__tests__/resolve-default-caption-track-index.test.ts
+++ b/src/entrypoints/interceptor.content/__tests__/resolve-default-caption-track-index.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+import { resolveDefaultCaptionTrackIndex } from "../utils"
+
+describe("resolveDefaultCaptionTrackIndex", () => {
+  it("reads the default caption track of the default audio track", () => {
+    const tracklistRenderer = {
+      audioTracks: [
+        {
+          captionTrackIndices: [0, 1],
+          defaultCaptionTrackIndex: 1,
+          hasDefaultTrack: true,
+        },
+      ],
+      defaultAudioTrackIndex: 0,
+    }
+
+    expect(resolveDefaultCaptionTrackIndex(tracklistRenderer, 2)).toBe(1)
+  })
+
+  it("picks the audio track named by defaultAudioTrackIndex", () => {
+    const tracklistRenderer = {
+      audioTracks: [
+        { captionTrackIndices: [0, 1], defaultCaptionTrackIndex: 0 },
+        { captionTrackIndices: [0, 1], defaultCaptionTrackIndex: 1 },
+      ],
+      defaultAudioTrackIndex: 1,
+    }
+
+    expect(resolveDefaultCaptionTrackIndex(tracklistRenderer, 2)).toBe(1)
+  })
+
+  it("resolves through captionTrackIndices when the index is numbered against that list", () => {
+    const tracklistRenderer = {
+      audioTracks: [{ captionTrackIndices: [3, 4], defaultCaptionTrackIndex: 1 }],
+      defaultAudioTrackIndex: 0,
+    }
+
+    expect(resolveDefaultCaptionTrackIndex(tracklistRenderer, 5)).toBe(4)
+  })
+
+  it("returns null when the field is absent, so callers fall through", () => {
+    expect(resolveDefaultCaptionTrackIndex({ audioTracks: [{}] }, 2)).toBeNull()
+    expect(resolveDefaultCaptionTrackIndex({ audioTracks: [] }, 2)).toBeNull()
+    expect(resolveDefaultCaptionTrackIndex(undefined, 2)).toBeNull()
+  })
+
+  it("returns null when the index falls outside the track list", () => {
+    const tracklistRenderer = {
+      audioTracks: [{ defaultCaptionTrackIndex: 5 }],
+      defaultAudioTrackIndex: 0,
+    }
+
+    expect(resolveDefaultCaptionTrackIndex(tracklistRenderer, 2)).toBeNull()
+    expect(resolveDefaultCaptionTrackIndex(tracklistRenderer, 0)).toBeNull()
+  })
+})

--- a/src/entrypoints/interceptor.content/inject-player-api.ts
+++ b/src/entrypoints/interceptor.content/inject-player-api.ts
@@ -13,7 +13,12 @@ import {
   setupTimedtextObserver,
   waitForTimedtextUrl,
 } from "./timedtext-observer"
-import { errorResponse, normalizeTracks, parseAudioTracks } from "./utils"
+import {
+  errorResponse,
+  normalizeTracks,
+  parseAudioTracks,
+  resolveDefaultCaptionTrackIndex,
+} from "./utils"
 
 interface PlayerDataRequest {
   type: typeof PLAYER_DATA_REQUEST_TYPE
@@ -111,7 +116,8 @@ function getPlayerData(request: PlayerDataRequest): PlayerDataResponse {
 
     const playerResponse = player.getPlayerResponse?.()
     const videoId = playerResponse?.videoDetails?.videoId
-    const tracks = playerResponse?.captions?.playerCaptionsTracklistRenderer?.captionTracks ?? []
+    const tracklistRenderer = playerResponse?.captions?.playerCaptionsTracklistRenderer
+    const tracks = tracklistRenderer?.captionTracks ?? []
     const captionTracks = normalizeTracks(tracks)
     const selectedTrack = getSelectedTrackSnapshot(player, captionTracks)
 
@@ -131,6 +137,10 @@ function getPlayerData(request: PlayerDataRequest): PlayerDataResponse {
         playerState: player.getPlayerState?.() ?? -1,
         selectedTrackLanguageCode: selectedTrack.languageCode,
         selectedTrackVssId: selectedTrack.vssId,
+        defaultCaptionTrackIndex: resolveDefaultCaptionTrackIndex(
+          tracklistRenderer,
+          captionTracks.length,
+        ),
         cachedTimedtextUrl: getCachedTimedtextUrl(videoId),
       },
     }

--- a/src/entrypoints/interceptor.content/utils.ts
+++ b/src/entrypoints/interceptor.content/utils.ts
@@ -45,3 +45,30 @@ export function parseAudioTracks(tracks?: any[]): AudioCaptionTrack[] {
     }
   })
 }
+
+export function resolveDefaultCaptionTrackIndex(
+  tracklistRenderer: any,
+  trackCount: number,
+): number | null {
+  const audioTracks = tracklistRenderer?.audioTracks
+  if (!Array.isArray(audioTracks) || audioTracks.length === 0) return null
+
+  const audioIndex =
+    typeof tracklistRenderer?.defaultAudioTrackIndex === "number"
+      ? tracklistRenderer.defaultAudioTrackIndex
+      : 0
+  const audioTrack = audioTracks[audioIndex] ?? audioTracks[0]
+
+  const defaultIndex = audioTrack?.defaultCaptionTrackIndex
+  if (typeof defaultIndex !== "number") return null
+
+  const captionTrackIndices = audioTrack?.captionTrackIndices
+  const resolved =
+    Array.isArray(captionTrackIndices) && !captionTrackIndices.includes(defaultIndex)
+      ? captionTrackIndices[defaultIndex]
+      : defaultIndex
+
+  if (typeof resolved !== "number" || resolved < 0 || resolved >= trackCount) return null
+
+  return resolved
+}

--- a/src/utils/constants/subtitles.ts
+++ b/src/utils/constants/subtitles.ts
@@ -55,6 +55,8 @@ export const MAX_FETCH_RETRIES = 5
 export const FETCH_RETRY_DELAY_MS = 1000
 export const MAX_POT_WAIT_ATTEMPTS = 30
 export const POT_WAIT_INTERVAL_MS = 200
+export const MAX_SELECTED_TRACK_WAIT_ATTEMPTS = 8
+export const SELECTED_TRACK_WAIT_INTERVAL_MS = 100
 
 // Subtitle style constants
 export const MIN_FONT_SCALE = 30

--- a/src/utils/subtitles/__tests__/youtube-fetcher.test.ts
+++ b/src/utils/subtitles/__tests__/youtube-fetcher.test.ts
@@ -84,6 +84,7 @@ describe("youtube subtitles fetcher", () => {
                   playerState: 1,
                   selectedTrackLanguageCode: null,
                   selectedTrackVssId: null,
+                  defaultCaptionTrackIndex: null,
                   cachedTimedtextUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=en",
                 },
               },
@@ -127,6 +128,7 @@ describe("youtube subtitles fetcher", () => {
       playerState: 0,
       selectedTrackLanguageCode: "en",
       selectedTrackVssId: ".en",
+      defaultCaptionTrackIndex: null,
       cachedTimedtextUrl: null,
     }
 
@@ -181,6 +183,7 @@ describe("youtube subtitles fetcher", () => {
       playerState: 1,
       selectedTrackLanguageCode: "en",
       selectedTrackVssId: ".en",
+      defaultCaptionTrackIndex: null,
       cachedTimedtextUrl: null,
     }
     const cachedSubtitles = [{ text: "cached", start: 0, end: 1 }]
@@ -229,6 +232,7 @@ describe("youtube subtitles fetcher", () => {
       playerState: 0,
       selectedTrackLanguageCode: "en",
       selectedTrackVssId: ".en",
+      defaultCaptionTrackIndex: null,
       cachedTimedtextUrl: null,
     }
 
@@ -285,6 +289,7 @@ describe("youtube subtitles fetcher", () => {
       playerState: 0,
       selectedTrackLanguageCode: "en",
       selectedTrackVssId: ".en",
+      defaultCaptionTrackIndex: null,
       cachedTimedtextUrl: null,
     }
     const refreshedPlayerData = {
@@ -360,6 +365,7 @@ describe("youtube subtitles fetcher", () => {
       playerState: 1,
       selectedTrackLanguageCode: "en",
       selectedTrackVssId: "a.en",
+      defaultCaptionTrackIndex: null,
       cachedTimedtextUrl: null,
     }
 
@@ -375,6 +381,222 @@ describe("youtube subtitles fetcher", () => {
     expect(fetchWithRetrySpy).toHaveBeenCalledTimes(1)
     expect(fetchWithRetrySpy.mock.calls[0]?.[0]).toContain("kind=asr")
     expect(processRawEventsSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("follows YouTube's own default caption track without touching the CC button", async () => {
+    const fetcher = new YoutubeSubtitlesFetcher()
+
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "https://www.youtube.com/watch?v=test123",
+        search: "?v=test123",
+        origin: "https://www.youtube.com",
+        pathname: "/watch",
+        hostname: "www.youtube.com",
+      },
+      writable: true,
+    })
+
+    const playerData = {
+      videoId: "test123",
+      captionTracks: [
+        {
+          baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=ar",
+          languageCode: "ar",
+          vssId: ".ar",
+        },
+        {
+          baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=en",
+          languageCode: "en",
+          vssId: ".en",
+        },
+      ],
+      audioCaptionTracks: [],
+      device: null,
+      cver: null,
+      playerState: 1,
+      selectedTrackLanguageCode: null,
+      selectedTrackVssId: null,
+      defaultCaptionTrackIndex: 1,
+      cachedTimedtextUrl: null,
+    }
+
+    vi.spyOn(fetcher as any, "requestPlayerData").mockResolvedValue({
+      success: true,
+      data: playerData,
+    })
+    const ensureSubtitlesEnabledSpy = vi.spyOn(fetcher as any, "ensureSubtitlesEnabled")
+    const fetchWithRetrySpy = vi.spyOn(fetcher as any, "fetchWithRetry").mockResolvedValue([])
+    vi.spyOn(fetcher as any, "processRawEvents").mockResolvedValue([])
+
+    await expect(fetcher.fetch()).resolves.toEqual([])
+
+    expect(fetchWithRetrySpy.mock.calls[0]?.[0]).toContain("lang=en")
+    expect(fetcher.getSourceLanguage()).toBe("en")
+    expect(ensureSubtitlesEnabledSpy).not.toHaveBeenCalled()
+  })
+
+  it("prefers the viewer's live selection over YouTube's default caption track", async () => {
+    const fetcher = new YoutubeSubtitlesFetcher()
+
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "https://www.youtube.com/watch?v=test123",
+        search: "?v=test123",
+        origin: "https://www.youtube.com",
+        pathname: "/watch",
+        hostname: "www.youtube.com",
+      },
+      writable: true,
+    })
+
+    const playerData = {
+      videoId: "test123",
+      captionTracks: [
+        {
+          baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=ar",
+          languageCode: "ar",
+          vssId: ".ar",
+        },
+        {
+          baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=en",
+          languageCode: "en",
+          vssId: ".en",
+        },
+      ],
+      audioCaptionTracks: [],
+      device: null,
+      cver: null,
+      playerState: 1,
+      selectedTrackLanguageCode: "ar",
+      selectedTrackVssId: ".ar",
+      defaultCaptionTrackIndex: 1,
+      cachedTimedtextUrl: null,
+    }
+
+    vi.spyOn(fetcher as any, "requestPlayerData").mockResolvedValue({
+      success: true,
+      data: playerData,
+    })
+    const fetchWithRetrySpy = vi.spyOn(fetcher as any, "fetchWithRetry").mockResolvedValue([])
+    vi.spyOn(fetcher as any, "processRawEvents").mockResolvedValue([])
+
+    await expect(fetcher.fetch()).resolves.toEqual([])
+
+    expect(fetchWithRetrySpy.mock.calls[0]?.[0]).toContain("lang=ar")
+  })
+
+  it("falls back to turning on YouTube CC when the response carries no default track", async () => {
+    const fetcher = new YoutubeSubtitlesFetcher()
+
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "https://www.youtube.com/watch?v=test123",
+        search: "?v=test123",
+        origin: "https://www.youtube.com",
+        pathname: "/watch",
+        hostname: "www.youtube.com",
+      },
+      writable: true,
+    })
+
+    const captionTracks = [
+      {
+        baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=ar",
+        languageCode: "ar",
+        vssId: ".ar",
+      },
+      {
+        baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=en",
+        languageCode: "en",
+        vssId: ".en",
+      },
+    ]
+    const basePlayerData = {
+      videoId: "test123",
+      captionTracks,
+      audioCaptionTracks: [],
+      device: null,
+      cver: null,
+      playerState: 1,
+      defaultCaptionTrackIndex: null,
+      cachedTimedtextUrl: null,
+    }
+    const captionsOff = {
+      ...basePlayerData,
+      selectedTrackLanguageCode: null,
+      selectedTrackVssId: null,
+    }
+    const captionsOn = {
+      ...basePlayerData,
+      selectedTrackLanguageCode: "en",
+      selectedTrackVssId: ".en",
+    }
+
+    let captionsEnabled = false
+    const ensureSubtitlesEnabledSpy = vi
+      .spyOn(fetcher as any, "ensureSubtitlesEnabled")
+      .mockImplementation(async () => {
+        captionsEnabled = true
+      })
+    vi.spyOn(fetcher as any, "requestPlayerData").mockImplementation(async () => ({
+      success: true,
+      data: captionsEnabled ? captionsOn : captionsOff,
+    }))
+    const fetchWithRetrySpy = vi.spyOn(fetcher as any, "fetchWithRetry").mockResolvedValue([])
+    vi.spyOn(fetcher as any, "processRawEvents").mockResolvedValue([])
+
+    await expect(fetcher.fetch()).resolves.toEqual([])
+
+    expect(ensureSubtitlesEnabledSpy).toHaveBeenCalledTimes(1)
+    expect(fetchWithRetrySpy.mock.calls[0]?.[0]).toContain("lang=en")
+    expect(fetcher.getSourceLanguage()).toBe("en")
+  })
+
+  it("does not toggle YouTube CC when the player already reports a selected track", async () => {
+    const fetcher = new YoutubeSubtitlesFetcher()
+
+    Object.defineProperty(window, "location", {
+      value: {
+        href: "https://www.youtube.com/watch?v=test123",
+        search: "?v=test123",
+        origin: "https://www.youtube.com",
+        pathname: "/watch",
+        hostname: "www.youtube.com",
+      },
+      writable: true,
+    })
+
+    const playerData = {
+      videoId: "test123",
+      captionTracks: [
+        {
+          baseUrl: "https://www.youtube.com/api/timedtext?v=test123&lang=en",
+          languageCode: "en",
+          vssId: ".en",
+        },
+      ],
+      audioCaptionTracks: [],
+      device: null,
+      cver: null,
+      playerState: 1,
+      selectedTrackLanguageCode: "en",
+      selectedTrackVssId: ".en",
+      defaultCaptionTrackIndex: null,
+      cachedTimedtextUrl: null,
+    }
+
+    vi.spyOn(fetcher as any, "requestPlayerData").mockResolvedValue({
+      success: true,
+      data: playerData,
+    })
+    const ensureSubtitlesEnabledSpy = vi.spyOn(fetcher as any, "ensureSubtitlesEnabled")
+    vi.spyOn(fetcher as any, "fetchWithRetry").mockResolvedValue([])
+    vi.spyOn(fetcher as any, "processRawEvents").mockResolvedValue([])
+
+    await expect(fetcher.fetch()).resolves.toEqual([])
+
+    expect(ensureSubtitlesEnabledSpy).not.toHaveBeenCalled()
   })
 
   it("returns raw parser fragments for non-AI standard subtitles", async () => {

--- a/src/utils/subtitles/fetchers/youtube/index.ts
+++ b/src/utils/subtitles/fetchers/youtube/index.ts
@@ -8,11 +8,13 @@ import {
   FETCH_RETRY_DELAY_MS,
   MAX_FETCH_RETRIES,
   MAX_POT_WAIT_ATTEMPTS,
+  MAX_SELECTED_TRACK_WAIT_ATTEMPTS,
   MAX_STATE_WAIT_ATTEMPTS,
   PLAYER_DATA_REQUEST_TYPE,
   PLAYER_DATA_RESPONSE_TYPE,
   POST_MESSAGE_TIMEOUT_MS,
   POT_WAIT_INTERVAL_MS,
+  SELECTED_TRACK_WAIT_INTERVAL_MS,
   STATE_WAIT_INTERVAL_MS,
   WAIT_TIMEDTEXT_REQUEST_TYPE,
   WAIT_TIMEDTEXT_RESPONSE_TYPE,
@@ -36,6 +38,16 @@ import { buildSubtitleUrl } from "./url-builder"
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function hasSelectedTrack(playerData: PlayerData): boolean {
+  return Boolean(playerData.selectedTrackVssId || playerData.selectedTrackLanguageCode)
+}
+
+function getDefaultTrack(playerData: PlayerData): CaptionTrack | null {
+  const index = playerData.defaultCaptionTrackIndex
+  if (index === null) return null
+  return playerData.captionTracks[index] ?? null
 }
 
 function postMessageRequest(responseType: string, message: Record<string, unknown>): Promise<any> {
@@ -184,7 +196,7 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
       }
     }
 
-    const playerData = response.data
+    const playerData = await this.ensureTrackSelection(videoId, response.data)
     const track = this.selectTrack(playerData)
     const currentHash = this.buildTrackHash(videoId, track)
 
@@ -231,6 +243,33 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
 
     const events = await this.fetchTrackEvents(track, playerData)
     return { track, events }
+  }
+
+  private async ensureTrackSelection(videoId: string, playerData: PlayerData): Promise<PlayerData> {
+    if (
+      playerData.captionTracks.length === 0 ||
+      hasSelectedTrack(playerData) ||
+      getDefaultTrack(playerData)
+    ) {
+      return playerData
+    }
+
+    await this.ensureSubtitlesEnabled()
+
+    let latest = playerData
+    for (let i = 0; i < MAX_SELECTED_TRACK_WAIT_ATTEMPTS; i++) {
+      const response = await this.requestPlayerData(videoId)
+      if (response.success && response.data) {
+        latest = response.data
+        if (hasSelectedTrack(latest)) {
+          return latest
+        }
+      }
+
+      await sleep(SELECTED_TRACK_WAIT_INTERVAL_MS)
+    }
+
+    return latest
   }
 
   private async waitForPlayerState(videoId: string): Promise<void> {
@@ -354,6 +393,9 @@ export class YoutubeSubtitlesFetcher implements SubtitlesFetcher {
       const selectedTrack = tracks.find((t) => t.languageCode === selectedTrackLanguageCode)
       if (selectedTrack) return selectedTrack
     }
+
+    const defaultTrack = getDefaultTrack(playerData)
+    if (defaultTrack) return defaultTrack
 
     // Priority 2: Human subtitles without name - these are typically the original
     // language subtitles uploaded by the video creator

--- a/src/utils/subtitles/fetchers/youtube/types.ts
+++ b/src/utils/subtitles/fetchers/youtube/types.ts
@@ -25,6 +25,7 @@ export interface PlayerData {
   playerState: number
   selectedTrackLanguageCode: string | null
   selectedTrackVssId: string | null
+  defaultCaptionTrackIndex: number | null
   cachedTimedtextUrl: string | null
 }
 


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 5

## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Reported via Featurebase: on YouTube, the "original" line of our bilingual subtitles was always whichever caption track happens to be listed first, so viewers had to re-pick the language by hand on every video.

**Cause.** `selectTrack` reads the viewer's live selection from `player.getOption("captions", "track")`, but the player only reports a selection once YouTube's own CC is on. With CC off there is no selection, so the lookup fell through to `tracks.find((t) => t.kind !== "asr" && !t.name)` — i.e. the first track in the list.

Concretely, for `dinQIb4ZFXY` the player response is:

```jsonc
{
  "captionTracks": [
    { "languageCode": "ar", "vssId": ".ar" },  // index 0 — what we picked
    { "languageCode": "en", "vssId": ".en" }   // index 1 — what YouTube plays
  ],
  "audioTracks": [
    { "captionTrackIndices": [0, 1], "defaultCaptionTrackIndex": 1, "hasDefaultTrack": true }
  ],
  "defaultAudioTrackIndex": 0
}
```

**Fix.** The player response already names the track YouTube itself would play, resolved server-side from the viewer's preferences. Read `defaultCaptionTrackIndex` off the default audio track and slot it into `selectTrack` right below the live selection:

1. The viewer's current selection in the player (unchanged — a manual pick still wins)
2. **`defaultCaptionTrackIndex`** (new)
3. …existing human / ASR / first-track fallbacks

This is a synchronous field read on data the fast path already fetches, so it costs no extra round trip and leaves the fast-path/POT-fallback split from #1313 intact. It also stops short of touching the viewer's CC button.

For responses that omit the field, `ensureTrackSelection` falls back to enabling CC and briefly polling for the player's choice (bounded at 8 × 100 ms, and skipped entirely whenever a selection or a default index is already present).

### Index semantics

`defaultCaptionTrackIndex` normally indexes `captionTracks` directly. `resolveDefaultCaptionTrackIndex` also handles a response numbering it against that audio track's own `captionTrackIndices`, and treats anything out of range as absent so callers fall through to the existing priorities. This was inferred from a single sample — a multi-audio-track response would be worth checking against.

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

New coverage:

- `resolve-default-caption-track-index.test.ts` — default audio track, `defaultAudioTrackIndex` selection, `captionTrackIndices` resolution, absent field, out-of-range index
- `youtube-fetcher.test.ts` — follows the default track without toggling CC; a live selection still outrules it; CC-toggle fallback when the field is missing

Full suite: 288 files / 2806 tests passing. `type-check` and `fmt:check` clean.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.
