### PR TITLE
chore(agents): pin changeset package name in PR workflows

### DIFF
--- a/.agents/skills/create-pr/SKILL.md
+++ b/.agents/skills/create-pr/SKILL.md
@@ -27,6 +27,17 @@ Follow these steps:
 
 4. **Add changeset record if necessary**
    - Manually add a file in `.changeset/` directory following changeset convention
+   - The package name is always `@read-frog/extension`. This is a single-package workspace and changesets matches the header against the `name` in the root `package.json`; a bare `read-frog` is not a workspace package and makes the release plan fail.
+   - File shape — fill in the bump level and the summary, leave the package name as written:
+
+     ```markdown
+     ---
+     "@read-frog/extension": patch
+     ---
+
+     fix(subtitles): follow YouTube's own default caption track
+     ```
+
    - Changeset summary should use conventional commit style and should match the descriptive PR title
    - **Versioning rules:**
      - `patch` (0.0.x) — Users barely notice
@@ -46,6 +57,7 @@ Follow these steps:
        - Removal of existing features
        - API/storage structure breaking changes
        - Fundamental migrations (e.g., Manifest V2 → V3)
+   - Verify the changeset before committing: `pnpm exec changeset status` must list the expected bump under `@read-frog/extension`. A non-zero exit means the changeset is malformed and the release plan will not generate.
 
 5. **Ensure all changes are committed**
    - Stage and commit any uncommitted changes

--- a/.agents/skills/prepare-pr/SKILL.md
+++ b/.agents/skills/prepare-pr/SKILL.md
@@ -27,6 +27,17 @@ Follow these steps:
 
 4. **Add changeset record if necessary**
    - Manually add a file in `.changeset/` directory following changeset convention
+   - The package name is always `@read-frog/extension`. This is a single-package workspace and changesets matches the header against the `name` in the root `package.json`; a bare `read-frog` is not a workspace package and makes the release plan fail.
+   - File shape — fill in the bump level and the summary, leave the package name as written:
+
+     ```markdown
+     ---
+     "@read-frog/extension": patch
+     ---
+
+     fix(subtitles): follow YouTube's own default caption track
+     ```
+
    - Changeset summary should use conventional commit style and should match the descriptive PR title
    - **Versioning rules:**
      - `patch` (0.0.x) — Users barely notice
@@ -46,6 +57,7 @@ Follow these steps:
        - Removal of existing features
        - API/storage structure breaking changes
        - Fundamental migrations (e.g., Manifest V2 → V3)
+   - Verify the changeset before committing: `pnpm exec changeset status` must list the expected bump under `@read-frog/extension`. A non-zero exit means the changeset is malformed and the release plan will not generate.
 
 5. **Ensure all changes are committed**
    - Stage and commit any uncommitted changes

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -25,6 +25,17 @@ Follow these steps:
 
 4. **Add changeset record if necessary**
    - Manually add a file in `.changeset/` directory following changeset convention
+   - The package name is always `@read-frog/extension`. This is a single-package workspace and changesets matches the header against the `name` in the root `package.json`; a bare `read-frog` is not a workspace package and makes the release plan fail.
+   - File shape — fill in the bump level and the summary, leave the package name as written:
+
+     ```markdown
+     ---
+     "@read-frog/extension": patch
+     ---
+
+     fix(subtitles): follow YouTube's own default caption track
+     ```
+
    - Changeset summary should use conventional commit style and should match the descriptive PR title
    - **Versioning rules:**
      - `patch` (0.0.x) — Users barely notice
@@ -44,6 +55,7 @@ Follow these steps:
        - Removal of existing features
        - API/storage structure breaking changes
        - Fundamental migrations (e.g., Manifest V2 → V3)
+   - Verify the changeset before committing: `pnpm exec changeset status` must list the expected bump under `@read-frog/extension`. A non-zero exit means the changeset is malformed and the release plan will not generate.
 
 5. **Ensure all changes are committed**
    - Stage and commit any uncommitted changes

--- a/.claude/commands/prepare-pr.md
+++ b/.claude/commands/prepare-pr.md
@@ -25,6 +25,17 @@ Follow these steps:
 
 4. **Add changeset record if necessary**
    - Manually add a file in `.changeset/` directory following changeset convention
+   - The package name is always `@read-frog/extension`. This is a single-package workspace and changesets matches the header against the `name` in the root `package.json`; a bare `read-frog` is not a workspace package and makes the release plan fail.
+   - File shape — fill in the bump level and the summary, leave the package name as written:
+
+     ```markdown
+     ---
+     "@read-frog/extension": patch
+     ---
+
+     fix(subtitles): follow YouTube's own default caption track
+     ```
+
    - Changeset summary should use conventional commit style and should match the descriptive PR title
    - **Versioning rules:**
      - `patch` (0.0.x) — Users barely notice
@@ -44,6 +55,7 @@ Follow these steps:
        - Removal of existing features
        - API/storage structure breaking changes
        - Fundamental migrations (e.g., Manifest V2 → V3)
+   - Verify the changeset before committing: `pnpm exec changeset status` must list the expected bump under `@read-frog/extension`. A non-zero exit means the changeset is malformed and the release plan will not generate.
 
 5. **Ensure all changes are committed**
    - Stage and commit any uncommitted changes


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 5

## Type of Changes

- [x] 📦 Other changes that do not modify src or test files (chore)

## Description

The `create-pr` / `prepare-pr` workflows tell the agent to "add a file in `.changeset/` following changeset convention" but never say which package name to write. An agent that has only seen the repo directory name guesses `read-frog`, which is not a workspace package — `changeset status` then exits 1 and no release plan is generated. This happened for real on #2137 and had to be fixed in a follow-up commit.

Two additions to step 4, applied to all four copies of the block:

1. **A file-shape template with the package name pre-filled.** The agent fills in the bump level and summary; `"@read-frog/extension"` is written for it rather than inferred. Naming the package in prose alone leaves it as something the agent still has to decide.
2. **A pre-commit verification step:** `pnpm exec changeset status` must list the expected bump. This catches the whole class of malformed changesets, not just a wrong package name.

Files touched (the block is duplicated verbatim across all four):

- `.claude/commands/create-pr.md`
- `.claude/commands/prepare-pr.md`
- `.agents/skills/create-pr/SKILL.md`
- `.agents/skills/prepare-pr/SKILL.md`

No changeset for this PR — nothing here ships in the extension.

## Related Issue

Follow-up to the changeset fix in #2137.

## How Has This Been Tested?

- [x] Verified through manual testing

Given the same task, fresh agents were asked to produce the changeset content — a no-guidance control against the current wording, and two runs against the new wording:

| Arm | Task | Output |
| --- | --- | --- |
| Control (wording on `main`) | a bug fix | `'read-frog': patch` ❌ |
| New wording | a bug fix | `"@read-frog/extension": patch` ✅ |
| New wording | a complete new feature | `"@read-frog/extension": minor` ✅ |

The control reproduces the #2137 failure exactly, confirming this is a gap in the guidance rather than an occasional slip. The bump level is still chosen correctly, so the template does not cause agents to copy `patch` blindly.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)