### PR TITLE
fix(translate): serve remounted paragraphs from an in-tab memory tier

### DIFF
--- a/.changeset/scroll-remount-memory-tier.md
+++ b/.changeset/scroll-remount-memory-tier.md
@@ -1,0 +1,7 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): remember page translations in-tab so virtualized remounts stop re-translating
+
+Virtualized pages (X articles and timelines, and any React list that unmounts off-screen rows) destroy paragraph nodes on scroll and recreate brand-new ones on the way back, so scrolling down and back up re-ran the whole translation pipeline for text the tab had already translated — every paragraph flashed its original text and a spinner while a background round trip re-fetched the same cached translation. Page-translation results are now also remembered in an in-tab memory tier keyed by the same request hash as the background cache, so remounted regions recover their translations without the round trip or the visible churn.

--- a/src/utils/host/translate/__tests__/in-memory-translation-cache.test.ts
+++ b/src/utils/host/translate/__tests__/in-memory-translation-cache.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("@/utils/message", () => ({
+  sendMessage: vi.fn<(...args: any[]) => any>(),
+}))
+
+// Non-LLM provider so hash building stays prompt-free and the pipeline needs
+// no config storage; the memory tier itself is provider-agnostic.
+const googleProviderConfig = {
+  id: "google-translate-default",
+  enabled: true,
+  name: "Google Translate",
+  provider: "google-translate" as const,
+} as never
+
+const langConfig = {
+  sourceCode: "eng" as const,
+  targetCode: "cmn" as const,
+  level: "intermediate" as const,
+}
+
+async function setup() {
+  const { sendMessage } = await import("@/utils/message")
+  const { translateTextCore } = await import("../translate-text")
+  const { beginPageTranslationSession, endPageTranslationSession } =
+    await import("../translation-session")
+  const { clearInMemoryTranslationCache } = await import("../in-memory-translation-cache")
+
+  // Module-level state survives across tests in this file: drop any session
+  // and cached entries a previous test left behind.
+  endPageTranslationSession()
+  clearInMemoryTranslationCache()
+
+  const sessionId = beginPageTranslationSession()
+  const translate = (text: string, overrides: Record<string, unknown> = {}) =>
+    translateTextCore({
+      text,
+      langConfig,
+      providerConfig: googleProviderConfig,
+      hostedFeature: "pageTranslation",
+      sessionId,
+      ...overrides,
+    })
+
+  return { sendMessage: vi.mocked(sendMessage), translate, sessionId, endPageTranslationSession }
+}
+
+describe("in-memory translation tier in translateTextCore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("serves a repeated page request from memory without a second background round trip", async () => {
+    const { sendMessage, translate } = await setup()
+    sendMessage.mockResolvedValue("你好")
+
+    await expect(translate("Hello")).resolves.toBe("你好")
+    await expect(translate("Hello")).resolves.toBe("你好")
+
+    // A virtualized page recreating its nodes re-runs this exact call; the
+    // second run must not pay the message round trip again.
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it("misses when the request identity differs", async () => {
+    const { sendMessage, translate } = await setup()
+    sendMessage.mockResolvedValueOnce("你好").mockResolvedValueOnce("こんにちは")
+
+    await expect(translate("Hello")).resolves.toBe("你好")
+    await expect(
+      translate("Hello", { langConfig: { ...langConfig, targetCode: "jpn" as const } }),
+    ).resolves.toBe("こんにちは")
+
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not cache outside a page-translation session", async () => {
+    const { sendMessage, translate } = await setup()
+    sendMessage.mockResolvedValue("你好")
+
+    await expect(translate("Hello", { sessionId: undefined })).resolves.toBe("你好")
+    await expect(translate("Hello", { sessionId: undefined })).resolves.toBe("你好")
+
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it("forceRetranslation bypasses the read but refreshes the stored entry", async () => {
+    const { sendMessage, translate } = await setup()
+    sendMessage.mockResolvedValueOnce("旧译文").mockResolvedValueOnce("新译文")
+
+    await expect(translate("Hello")).resolves.toBe("旧译文")
+    await expect(translate("Hello", { forceRetranslation: true })).resolves.toBe("新译文")
+    // The forced result must replace the remembered one, or a later remount
+    // would resurrect the translation the user explicitly replaced.
+    await expect(translate("Hello")).resolves.toBe("新译文")
+
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it("remembers the no-translation sentinel as an empty result", async () => {
+    const { sendMessage, translate } = await setup()
+    const { NO_TRANSLATION_SENTINEL } = await import("@/utils/constants/prompt")
+    sendMessage.mockResolvedValue(NO_TRANSLATION_SENTINEL)
+
+    await expect(translate("Hello")).resolves.toBe("")
+    await expect(translate("Hello")).resolves.toBe("")
+
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not memorize empty results", async () => {
+    const { sendMessage, translate } = await setup()
+    sendMessage.mockResolvedValue("")
+
+    await expect(translate("Hello")).resolves.toBe("")
+    await expect(translate("Hello")).resolves.toBe("")
+
+    // An empty result must stay retryable, mirroring the background's
+    // truthy-only cache write.
+    expect(sendMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it("throws for a cancelled session instead of serving from memory", async () => {
+    const { sendMessage, translate, endPageTranslationSession } = await setup()
+    const { TranslationCancelledError } = await import("@/utils/request/cancellation")
+    sendMessage.mockResolvedValue("你好")
+
+    await expect(translate("Hello")).resolves.toBe("你好")
+    endPageTranslationSession()
+
+    await expect(translate("Hello")).rejects.toBeInstanceOf(TranslationCancelledError)
+    expect(sendMessage).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("in-memory translation cache store", () => {
+  it("evicts the least recently used entry past the cap", async () => {
+    const {
+      clearInMemoryTranslationCache,
+      getInMemoryTranslation,
+      storeInMemoryTranslation,
+      IN_MEMORY_TRANSLATION_CACHE_MAX_ENTRIES: cap,
+    } = await import("../in-memory-translation-cache")
+    clearInMemoryTranslationCache()
+
+    for (let i = 0; i < cap; i++) {
+      storeInMemoryTranslation(`hash-${i}`, `t-${i}`)
+    }
+    // Touch the oldest entry so recency, not insertion order, decides.
+    expect(getInMemoryTranslation("hash-0")).toBe("t-0")
+
+    storeInMemoryTranslation("hash-overflow", "t-overflow")
+
+    expect(getInMemoryTranslation("hash-0")).toBe("t-0")
+    expect(getInMemoryTranslation("hash-1")).toBeUndefined()
+    expect(getInMemoryTranslation("hash-overflow")).toBe("t-overflow")
+  })
+
+  it("ignores empty translations", async () => {
+    const { clearInMemoryTranslationCache, getInMemoryTranslation, storeInMemoryTranslation } =
+      await import("../in-memory-translation-cache")
+    clearInMemoryTranslationCache()
+
+    storeInMemoryTranslation("hash-empty", "")
+    expect(getInMemoryTranslation("hash-empty")).toBeUndefined()
+  })
+})

--- a/src/utils/host/translate/in-memory-translation-cache.ts
+++ b/src/utils/host/translate/in-memory-translation-cache.ts
@@ -1,0 +1,61 @@
+/**
+ * In-tab memory tier in front of the background IndexedDB translation cache,
+ * keyed by the same request hash (so the two tiers can never disagree about
+ * identity: provider, languages, prompts and text format are all inside the
+ * key).
+ *
+ * Why it exists: virtualized pages (X timelines and articles, and any React
+ * list that unmounts off-screen rows) destroy paragraph nodes on scroll and
+ * recreate brand-new ones on the way back. Every per-node marker — walked
+ * attributes, wrapper classes, WeakMap state, retranslation budgets — dies
+ * with the old node, so the added-subtree path re-runs the whole pipeline for
+ * text this tab already translated. The IndexedDB tier saves the provider
+ * call, but each paragraph still pays a message round trip, so translations
+ * re-land staggered behind spinners. Serving those re-runs synchronously from
+ * here lets a remounted region recover its translations without visible
+ * churn.
+ *
+ * Lifetime is the page itself (module scope, one copy per frame). Entries are
+ * exactly the strings this tab already rendered, so there is no staleness a
+ * user could observe; config changes rotate the hash and miss naturally.
+ */
+
+/**
+ * Insertion-ordered for LRU eviction. The cap comfortably covers the largest
+ * single-page unit count observed in the wild (~400 paragraphs for a long X
+ * article) while bounding a long timeline-scrolling session; values are
+ * translation strings only, so even the full cap stays around a megabyte.
+ */
+export const IN_MEMORY_TRANSLATION_CACHE_MAX_ENTRIES = 1000
+
+const cache = new Map<string, string>()
+
+export function getInMemoryTranslation(hash: string): string | undefined {
+  const hit = cache.get(hash)
+  if (hit !== undefined) {
+    // Refresh recency so scroll loops over the same region keep their entries.
+    cache.delete(hash)
+    cache.set(hash, hit)
+  }
+  return hit
+}
+
+export function storeInMemoryTranslation(hash: string, translation: string): void {
+  // Mirror the background's truthy-only cache write: an empty result must
+  // retry the pipeline next time, not become a permanent blank paragraph.
+  if (!translation) {
+    return
+  }
+  cache.delete(hash)
+  cache.set(hash, translation)
+  if (cache.size > IN_MEMORY_TRANSLATION_CACHE_MAX_ENTRIES) {
+    const oldest = cache.keys().next().value
+    if (oldest !== undefined) {
+      cache.delete(oldest)
+    }
+  }
+}
+
+export function clearInMemoryTranslationCache(): void {
+  cache.clear()
+}

--- a/src/utils/host/translate/translate-text.ts
+++ b/src/utils/host/translate/translate-text.ts
@@ -17,6 +17,7 @@ import { resolveProviderRefForCapability } from "@/utils/providers/provider-regi
 import { TranslationCancelledError } from "@/utils/request/cancellation"
 import { Sha256Hex } from "../../hash"
 import { sendMessage } from "../../message"
+import { getInMemoryTranslation, storeInMemoryTranslation } from "./in-memory-translation-cache"
 import { prepareTranslationText } from "./text-preparation"
 import {
   getPageTranslationSessionId,
@@ -332,9 +333,28 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
   // id had gone null) or re-populate the queue AFTER the session's cancel
   // message already drained it — both defeat cancellation (#1881). Callers on
   // the page path swallow this error; input/selection requests carry no
-  // sessionId and skip the gate entirely.
+  // sessionId and skip the gate entirely. The gate must also precede the
+  // memory-tier read below: a cancelled session must not keep painting
+  // translations out of memory.
   if (sessionId !== undefined && getPageTranslationSessionId() !== sessionId) {
     throw new TranslationCancelledError(sessionId)
+  }
+
+  const hash = Sha256Hex(...hashComponents)
+
+  // In-tab memory tier over the background cache, same hash identity.
+  // Virtualized pages (X articles/timelines) destroy and recreate paragraph
+  // nodes on scroll; the recreated nodes re-enter this pipeline for text the
+  // tab already translated, and paying the message round trip again makes the
+  // page visibly re-translate paragraph by paragraph. Scoped to
+  // page-translation runs (sessionId) so input/selection behavior is
+  // untouched; forceRetranslation bypasses the read exactly like it bypasses
+  // the background cache, but its fresh result still lands in the store below.
+  if (sessionId !== undefined && !forceRetranslation) {
+    const memoryHit = getInMemoryTranslation(hash)
+    if (memoryHit !== undefined) {
+      return isNoTranslationSentinel(memoryHit) ? "" : memoryHit
+    }
   }
 
   const result = await sendMessage("enqueueTranslateRequest", {
@@ -342,7 +362,7 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     langConfig,
     providerRef,
     scheduleAt: Date.now(),
-    hash: Sha256Hex(...hashComponents),
+    hash,
     textFormat,
     preserveLineBreaks,
     webTitle: normalizedWebPageContext?.webTitle,
@@ -353,6 +373,11 @@ export async function translateTextCore(options: TranslateTextOptions): Promise<
     forceRetranslation,
     hostedFeature,
   })
+  if (sessionId !== undefined) {
+    // Raw result, sentinel included, so a "no translation needed" verdict is
+    // remembered too; the mapping below stays the single mapping point.
+    storeInMemoryTranslation(hash, result)
+  }
   // The sentinel must be mapped here and only here: every batch-pipeline
   // consumer (page paragraphs, document title, input translation, selection
   // toolbar standard path) routes through this function and already handles


### PR DESCRIPTION
Virtualized pages (X articles/timelines) destroy paragraph nodes on scroll and recreate brand-new ones on the way back; every node-keyed marker dies with the old node, so scrolling down and back up re-ran the whole pipeline and each paragraph flashed original text plus a spinner while a background round trip re-fetched the same cached translation. Page-translation results are now also remembered in-tab, keyed by the same request hash as the background cache, so remounted regions recover translations synchronously.

A/B on a virtualized fixture (27-29 remounted paragraphs per scroll-back): before 26 background round trips, after 0, with initial-translation and scroll-down counts unchanged and wrappers restored identically.

> **AI model(s) used (required):** <!-- List every model used, or write "None" if no AI was used. -->

## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [ ] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [ ] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [ ] My code follows the code style of this project
- [ ] My changes do not break existing functionality
- [ ] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->
