### PR TITLE
fix(translate): preserve MathML formulas in translated paragraphs

### DIFF
--- a/.changeset/fix-mathml-in-translations.md
+++ b/.changeset/fix-mathml-in-translations.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): preserve MathML formulas in translated paragraphs

--- a/src/assets/styles/translation-node-preset.css
+++ b/src/assets/styles/translation-node-preset.css
@@ -24,6 +24,15 @@
   text-decoration: inherit;
 }
 
+/* Target-language presets set a UI font on every translated descendant.
+ * MathML needs a math font and must not inherit aggressive word wrapping. */
+.read-frog-translated-content-wrapper math.read-frog-preserved-math,
+.read-frog-translated-content-wrapper math.read-frog-preserved-math * {
+  overflow-wrap: normal;
+  word-break: normal;
+  font-family: math;
+}
+
 /* Simplified Chinese - macOS > Windows > Cross-platform > Fallback */
 .read-frog-translated-content-wrapper[lang="zh"],
 .read-frog-translated-content-wrapper[lang="zh"] * {

--- a/src/utils/constants/dom-labels.ts
+++ b/src/utils/constants/dom-labels.ts
@@ -25,6 +25,11 @@ export const MARK_ATTRIBUTES = new Set([
 
 export const NOTRANSLATE_CLASS = "notranslate"
 
+// Marks MathML cloned into bilingual translations. The class lets the preset
+// stylesheet restore a math font after target-language typography is applied
+// to the rest of the translated wrapper.
+export const PRESERVED_MATH_CLASS = "read-frog-preserved-math"
+
 export const REACT_SHADOW_HOST_CLASS = "read-frog-react-shadow-host"
 
 export const SPINNER_CLASS = "read-frog-spinner"

--- a/src/utils/constants/dom-rules.ts
+++ b/src/utils/constants/dom-rules.ts
@@ -61,6 +61,11 @@ export const MATH_TAGS = new Set([
   "semantics",
 ])
 
+/** MathML keeps lowercase local names even inside an HTML document. */
+export function isMathRootElement(element: Element): boolean {
+  return element.localName.toLowerCase() === "math"
+}
+
 // Don't walk into these tags
 export const DONT_WALK_AND_TRANSLATE_TAGS = new Set([
   "HEAD",

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -3274,6 +3274,36 @@ describe("translate", () => {
         expect(sourceMath[0]?.getAttribute("id")).toBe("h-zero")
         expect(sourceMath[1]?.getAttribute("id")).toBe("steps")
       })
+
+      it("bilingual mode: preserves formulas in newline-separated virtual paragraphs", async () => {
+        const requestText = "First {{READ_FROG_MATH_0}} sentence.\n\nSecond sentence."
+        vi.mocked(translateTextForPage).mockResolvedValueOnce(
+          "第一句 {{READ_FROG_MATH_0}}。\n\n第二句。",
+        )
+        const callsBeforeTranslation = vi.mocked(translateTextForPage).mock.calls.length
+        render(<div data-testid="test-node" style={{ whiteSpace: "pre-wrap" }} />)
+        const node = screen.getByTestId("test-node")
+        node.innerHTML =
+          'First <math id="formula" class="ltx_Math" alttext="H_{0}"><semantics><msub><mi>H</mi><mn>0</mn></msub><annotation encoding="application/x-tex">H_{0}</annotation></semantics></math> sentence.\n\nSecond sentence.'
+        const sourceMath = node.querySelector("math")
+
+        await removeOrShowPageTranslation("bilingual", true)
+
+        expect(vi.mocked(translateTextForPage).mock.calls.slice(callsBeforeTranslation)).toEqual([
+          [requestText, "plain", PRESERVE_LINE_BREAKS_TRANSLATION_OPTIONS],
+        ])
+        const wrapper = expectTranslationWrapper(node, "bilingual")!
+        expect(wrapper.hasAttribute(VIRTUAL_PARAGRAPH_ATTRIBUTE)).toBe(false)
+        expect(wrapper).toHaveTextContent("第一句")
+        expect(wrapper).toHaveTextContent("第二句")
+
+        const translatedMath = wrapper.querySelector("math")
+        expect(translatedMath).toBeTruthy()
+        expect(translatedMath).not.toBe(sourceMath)
+        expect(translatedMath?.getAttribute("alttext")).toBe("H_{0}")
+        expect(translatedMath?.hasAttribute("id")).toBe(false)
+        expect(sourceMath?.getAttribute("id")).toBe("formula")
+      })
     })
   })
 

--- a/src/utils/host/__tests__/translate.integration.test.tsx
+++ b/src/utils/host/__tests__/translate.integration.test.tsx
@@ -13,6 +13,7 @@ import {
   INLINE_ATTRIBUTE,
   INLINE_CONTENT_CLASS,
   PARAGRAPH_ATTRIBUTE,
+  PRESERVED_MATH_CLASS,
   TRANSLATION_ERROR_CONTAINER_CLASS,
   TRANSLATION_ONLY_ATTRIBUTE,
   VIRTUAL_PARAGRAPH_ATTRIBUTE,
@@ -3238,6 +3239,40 @@ describe("translate", () => {
         expectNodeLabels(node, [BLOCK_ATTRIBUTE, PARAGRAPH_ATTRIBUTE])
         const wrapper = expectTranslationWrapper(node, "translationOnly")
         expect(wrapper).toBe(node.children[0])
+      })
+    })
+
+    describe("MathML formulas", () => {
+      it("bilingual mode: keeps formulas at their translated placeholder positions", async () => {
+        vi.mocked(translateTextForPage).mockImplementationOnce(async (text: string) =>
+          text
+            .replace("Starting from the initial harness", "从初始执行框架开始")
+            .replace("the protocol runs for", "该协议运行")
+            .replace("steps", "步"),
+        )
+        render(<p data-testid="test-node" />)
+        const node = screen.getByTestId("test-node")
+        node.innerHTML =
+          'Starting from the initial harness <math id="h-zero" class="ltx_Math" alttext="H_{0}"><semantics><msub><mi>H</mi><mn>0</mn></msub><annotation encoding="application/x-tex">H_{0}</annotation></semantics></math>, the protocol runs for <math id="steps" class="ltx_Math" alttext="T"><semantics><mi>T</mi><annotation encoding="application/x-tex">T</annotation></semantics></math> steps.'
+        const sourceMath = [...node.querySelectorAll("math")]
+
+        await removeOrShowPageTranslation("bilingual", true)
+
+        const request = vi.mocked(translateTextForPage).mock.calls.at(-1)?.[0]
+        expect(request).toContain("{{READ_FROG_MATH_0}}")
+        expect(request).toContain("{{READ_FROG_MATH_1}}")
+        expect(request).not.toContain("H_{0}")
+
+        const wrapper = expectTranslationWrapper(node, "bilingual")
+        const translatedMath = [...wrapper!.querySelectorAll("math")]
+        expect(translatedMath).toHaveLength(2)
+        expect(translatedMath[0]).not.toBe(sourceMath[0])
+        expect(translatedMath[0]?.classList.contains(PRESERVED_MATH_CLASS)).toBe(true)
+        expect(translatedMath[0]?.hasAttribute("id")).toBe(false)
+        expect(translatedMath[0]?.getAttribute("alttext")).toBe("H_{0}")
+        expect(translatedMath[1]?.getAttribute("alttext")).toBe("T")
+        expect(sourceMath[0]?.getAttribute("id")).toBe("h-zero")
+        expect(sourceMath[1]?.getAttribute("id")).toBe("steps")
       })
     })
   })

--- a/src/utils/host/dom/traversal.ts
+++ b/src/utils/host/dom/traversal.ts
@@ -24,7 +24,16 @@ import {
 
 const NON_NEWLINE_WHITESPACE_RE = /[^\S\n]/
 
-export function extractTextContent(node: TransNode, config: Config): string {
+export interface ExtractTextContentOptions {
+  /** Return an atomic replacement for an element, or undefined to use the normal extraction. */
+  replaceElement?: (element: HTMLElement) => string | undefined
+}
+
+export function extractTextContent(
+  node: TransNode,
+  config: Config,
+  options: ExtractTextContentOptions = {},
+): string {
   if (isTextNode(node)) {
     const text = node.textContent ?? ""
     const trimmed = text.trim()
@@ -39,6 +48,11 @@ export function extractTextContent(node: TransNode, config: Config): string {
   // Handle <br> elements as line breaks
   if (isHTMLElement(node) && node.tagName === "BR") {
     return "\n"
+  }
+
+  const replacement = isHTMLElement(node) ? options.replaceElement?.(node) : undefined
+  if (replacement !== undefined) {
+    return replacement
   }
 
   // We already don't walk and label the element which isDontWalkIntoElement
@@ -64,7 +78,7 @@ export function extractTextContent(node: TransNode, config: Config): string {
   return childNodes.reduce((text: string, child: Node): string => {
     // TODO: support SVGElement in the future
     if (isTextNode(child) || isHTMLElement(child)) {
-      return text + extractTextContent(child, config)
+      return text + extractTextContent(child, config, options)
     }
     return text
   }, "")

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -29,6 +29,7 @@ import {
 import { unwrapDeepestOnlyHTMLChild } from "../../dom/find"
 import { getOwnerDocument } from "../../dom/node"
 import { canSplitGiantWithoutStrandingOwnText, extractTextContent } from "../../dom/traversal"
+import { protectBilingualMath } from "../dom/bilingual-math"
 import {
   buildVirtualParagraphPlan,
   canMaterializeVirtualParagraphUnits,
@@ -518,11 +519,12 @@ export async function translateNodesBilingualMode(
     const sourceTextBeforeFilter = isHTMLElement(layoutSource)
       ? collectSourceTextExcludingWrappers(layoutSource)
       : null
-    const textContent = transNodes
-      .map((node) => extractTextContent(node, config))
-      .join("")
-      .trim()
-    if (!textContent || isNumericContent(textContent)) return
+    const protectedMath = protectBilingualMath(transNodes, config)
+    const filterText = protectedMath.filterText.trim()
+    const textContent = protectedMath.requestText.trim()
+    // Keep formula-only display blocks untouched. MathML is protected inline
+    // content for a prose translation, not a translation unit of its own.
+    if (!filterText || !textContent || isNumericContent(filterText)) return
 
     let bilingualState: BilingualTranslationState | undefined
     if (isHTMLElement(layoutSource) && sourceTextBeforeFilter !== null) {
@@ -542,8 +544,8 @@ export async function translateNodesBilingualMode(
       // Target-language skip runs here, BEFORE the wrapper/spinner is inserted,
       // so same-language paragraphs never touch the DOM.
       shouldFilter =
-        (await shouldFilterSmallParagraph(textContent, config)) ||
-        (await shouldSkipAsTargetLanguage(textContent, config))
+        (await shouldFilterSmallParagraph(filterText, config)) ||
+        (await shouldSkipAsTargetLanguage(filterText, config))
     } catch (error) {
       if (bilingualState) unregisterBilingualTranslationState(bilingualState)
       throw error
@@ -673,7 +675,8 @@ export async function translateNodesBilingualMode(
         onContentInserted: (wrapper) => {
           if (bilingualState) bilingualState.wrapperTextContent = wrapper.textContent
         },
-        sourceText: textContent,
+        renderTranslatedContent: protectedMath.hasMath ? protectedMath.renderInto : undefined,
+        sourceText: filterText,
       },
       translatedText,
       config.pageTranslation.translationNodeStyle,

--- a/src/utils/host/translate/core/translation-modes.ts
+++ b/src/utils/host/translate/core/translation-modes.ts
@@ -459,9 +459,14 @@ export async function translateNodesBilingualMode(
 
     if (virtualLayoutSource) {
       const virtualParagraphPlan = buildVirtualParagraphPlan(virtualLayoutSource, config)
-      if (virtualParagraphPlan.units.length >= 2) {
+      if (
+        virtualParagraphPlan.units.length >= 2 &&
+        virtualLayoutSource.querySelector("math") === null
+      ) {
         // Explicit blank-line boundaries represent block paragraphs even when
         // an individual unit is short enough for the compact-label heuristic.
+        // MathML is excluded from virtual-unit text, so keep MathML blocks on
+        // the regular path where protectBilingualMath can preserve its position.
         await translateVirtualParagraphs(
           nodes,
           virtualParagraphPlan.units,

--- a/src/utils/host/translate/dom/__tests__/bilingual-math.test.ts
+++ b/src/utils/host/translate/dom/__tests__/bilingual-math.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest"
+import { DEFAULT_CONFIG } from "@/utils/constants/config"
+import { PRESERVED_MATH_CLASS } from "@/utils/constants/dom-labels"
+import { protectBilingualMath } from "../bilingual-math"
+
+function createParagraph(): HTMLElement {
+  const paragraph = document.createElement("p")
+  paragraph.innerHTML =
+    'Starting from harness <math id="formula" class="ltx_Math" alttext="H_{0}" display="inline" onclick="evil()"><semantics><msub><mi id="symbol">H</mi><mn>0</mn></msub><annotation encoding="application/x-tex">H_{0}</annotation></semantics></math>, the protocol runs for <math alttext="T"><semantics><mi>T</mi><annotation encoding="application/x-tex">T</annotation></semantics></math> steps.'
+  return paragraph
+}
+
+describe("bilingual MathML protection", () => {
+  it("sends stable placeholders and renders cloned formulas in translated order", () => {
+    const paragraph = createParagraph()
+    const sourceMath = [...paragraph.querySelectorAll("math")]
+    const protectedMath = protectBilingualMath([paragraph], DEFAULT_CONFIG)
+
+    expect(protectedMath.filterText).toBe("Starting from harness , the protocol runs for  steps.")
+    expect(protectedMath.requestText).toBe(
+      "Starting from harness {{READ_FROG_MATH_0}}, the protocol runs for {{READ_FROG_MATH_1}} steps.",
+    )
+
+    const output = document.createElement("span")
+    protectedMath.renderInto(
+      output,
+      "协议运行 {{READ_FROG_MATH_1}} 步，初始框架是 {{READ_FROG_MATH_0}}。",
+    )
+
+    const renderedMath = [...output.querySelectorAll("math")]
+    expect(renderedMath).toHaveLength(2)
+    expect(renderedMath[0]?.getAttribute("alttext")).toBe("T")
+    expect(renderedMath[1]?.getAttribute("alttext")).toBe("H_{0}")
+    expect(renderedMath[1]).not.toBe(sourceMath[0])
+    expect(renderedMath[1]?.classList.contains(PRESERVED_MATH_CLASS)).toBe(true)
+    expect(renderedMath[1]?.getAttribute("translate")).toBe("no")
+    expect(renderedMath[1]?.hasAttribute("id")).toBe(false)
+    expect(renderedMath[1]?.hasAttribute("onclick")).toBe(false)
+    expect(renderedMath[1]?.querySelector("#symbol")).toBeNull()
+    expect(sourceMath[0]?.getAttribute("id")).toBe("formula")
+    expect(sourceMath[0]?.getAttribute("onclick")).toBe("evil()")
+  })
+
+  it("keeps formulas visible when a provider drops their placeholders", () => {
+    const paragraph = createParagraph()
+    const protectedMath = protectBilingualMath([paragraph], DEFAULT_CONFIG)
+    const output = document.createElement("span")
+
+    protectedMath.renderInto(output, "没有返回任何公式占位符。")
+
+    expect(output.querySelectorAll("math")).toHaveLength(2)
+    expect(output.textContent).toContain("没有返回任何公式占位符。")
+  })
+
+  it("chooses a collision-free marker stem deterministically", () => {
+    const paragraph = createParagraph()
+    paragraph.prepend("Literal {{ read_frog_math_0 }} marker. ")
+
+    const protectedMath = protectBilingualMath([paragraph], DEFAULT_CONFIG)
+
+    expect(protectedMath.requestText).toContain("{{ read_frog_math_0 }} marker")
+    expect(protectedMath.requestText).toContain("{{READ_FROG_MATH_X_0}}")
+    expect(protectedMath.requestText).toContain("{{READ_FROG_MATH_X_1}}")
+  })
+})

--- a/src/utils/host/translate/dom/__tests__/translation-html-attributes.test.ts
+++ b/src/utils/host/translate/dom/__tests__/translation-html-attributes.test.ts
@@ -13,6 +13,40 @@ function createNodes(html: string): TransNode[] {
 }
 
 describe("translation HTML attribute protection", () => {
+  it("restores exact MathML after compact and legacy HTML translation", () => {
+    const [paragraph] = createNodes(
+      '<p>Start <math id="formula" class="ltx_Math" alttext="H_{0}" display="inline"><semantics><msub><mi id="symbol">H</mi><mn>0</mn></msub><annotation encoding="application/x-tex">H_{0}</annotation></semantics></math> end.</p>',
+    )
+    const sourceMath = (paragraph as HTMLElement).querySelector("math")!
+    const protectedHtml = protectTranslationHtmlAttributes([paragraph!], document)
+
+    const corruptFormula = (html: string, start: string, end: string) => {
+      const template = document.createElement("template")
+      template.innerHTML = html.replace("Start", start).replace("end", end)
+      const math = template.content.querySelector("math")!
+      expect(math.classList.contains("notranslate")).toBe(true)
+      expect(math.getAttribute("translate")).toBe("no")
+      math.innerHTML = "<mi>translated-away</mi>"
+      math.setAttribute("alttext", "translated-away")
+      return template.innerHTML
+    }
+
+    const restoredCompact = document.createElement("template")
+    restoredCompact.innerHTML = protectedHtml.restore(
+      corruptFormula(protectedHtml.requestHtml, "开头", "结尾"),
+    )
+    const compactMath = restoredCompact.content.querySelector("math")!
+    expect(compactMath.outerHTML).toBe(sourceMath.outerHTML)
+    expect(restoredCompact.content.textContent).toContain("开头")
+    expect(restoredCompact.content.textContent).toContain("结尾")
+
+    const restoredLegacy = document.createElement("template")
+    restoredLegacy.innerHTML = protectedHtml.restoreLegacy(
+      corruptFormula(protectedHtml.legacyRequestHtml, "开头", "结尾"),
+    )
+    expect(restoredLegacy.content.querySelector("math")?.outerHTML).toBe(sourceMath.outerHTML)
+  })
+
   it("removes non-language attributes while retaining translatable and no-translate semantics", () => {
     const longToken = "utility-class-".repeat(80)
     const [link] = createNodes(

--- a/src/utils/host/translate/dom/bilingual-math.ts
+++ b/src/utils/host/translate/dom/bilingual-math.ts
@@ -1,0 +1,129 @@
+import type { Config } from "@/types/config/config"
+import type { TransNode } from "@/types/dom"
+import { MARK_ATTRIBUTES, PRESERVED_MATH_CLASS } from "@/utils/constants/dom-labels"
+import { isMathRootElement } from "@/utils/constants/dom-rules"
+import { extractTextContent } from "../../dom/traversal"
+
+const DEFAULT_MARKER_STEM = "READ_FROG_MATH"
+const UNSAFE_CLONED_ATTRIBUTE_NAMES = new Set(["formaction", "href", "src", "xlink:href"])
+
+export interface ProtectedBilingualMath {
+  /** Existing prose-only extraction, used for filtering and language detection. */
+  filterText: string
+  /** Text sent to the provider, with each MathML root replaced by a stable marker. */
+  requestText: string
+  hasMath: boolean
+  renderInto: (container: HTMLElement, translatedText: string) => void
+}
+
+function markerStemAbsentFrom(text: string): string {
+  let stem = DEFAULT_MARKER_STEM
+  while (new RegExp(`\\{\\{\\s*${stem}_\\d+\\s*\\}\\}`, "i").test(text)) stem += "_X"
+  return stem
+}
+
+function cloneMathForTranslation(source: HTMLElement): HTMLElement {
+  const clone = source.cloneNode(true) as HTMLElement
+  const elements = [clone, ...clone.querySelectorAll<HTMLElement>("*")]
+
+  for (const element of elements) {
+    element.removeAttribute("id")
+    MARK_ATTRIBUTES.forEach((attribute) => element.removeAttribute(attribute))
+    for (const attribute of [...element.attributes]) {
+      const name = attribute.name.toLowerCase()
+      if (name.startsWith("on") || UNSAFE_CLONED_ATTRIBUTE_NAMES.has(name)) {
+        element.removeAttributeNode(attribute)
+      }
+    }
+  }
+
+  clone.classList.add(PRESERVED_MATH_CLASS)
+  clone.setAttribute("translate", "no")
+  return clone
+}
+
+/**
+ * Protect MathML in bilingual mode without exposing its internal text to the
+ * translation provider. MathML textContent is not a usable fallback: arXiv's
+ * accessibility annotation repeats the rendered formula (for example
+ * `H0H_{0}`), and translating either copy can corrupt the notation.
+ */
+export function protectBilingualMath(
+  nodes: readonly TransNode[],
+  config: Config,
+): ProtectedBilingualMath {
+  const filterText = nodes.map((node) => extractTextContent(node, config)).join("")
+  const markerStem = markerStemAbsentFrom(filterText)
+  const mathElements: HTMLElement[] = []
+  const mathIndexes = new Map<HTMLElement, number>()
+
+  const requestText = nodes
+    .map((node) =>
+      extractTextContent(node, config, {
+        replaceElement: (element) => {
+          if (!isMathRootElement(element)) return undefined
+
+          let index = mathIndexes.get(element)
+          if (index === undefined) {
+            index = mathElements.length
+            mathIndexes.set(element, index)
+            mathElements.push(element)
+          }
+          return `{{${markerStem}_${index}}}`
+        },
+      }),
+    )
+    .join("")
+
+  const markerPattern = new RegExp(`\\{\\{\\s*${markerStem}_(\\d+)\\s*\\}\\}`, "gi")
+
+  return {
+    filterText,
+    requestText,
+    hasMath: mathElements.length > 0,
+    renderInto(container, translatedText) {
+      if (mathElements.length === 0) {
+        container.textContent = translatedText
+        return
+      }
+
+      const ownerDoc = container.ownerDocument
+      const fragment = ownerDoc.createDocumentFragment()
+      const inserted = new Set<number>()
+      let cursor = 0
+
+      for (const match of translatedText.matchAll(markerPattern)) {
+        const matchIndex = match.index ?? 0
+        if (matchIndex > cursor) {
+          fragment.append(ownerDoc.createTextNode(translatedText.slice(cursor, matchIndex)))
+        }
+
+        const mathIndex = Number.parseInt(match[1]!, 10)
+        const source = mathElements[mathIndex]
+        if (source && !inserted.has(mathIndex)) {
+          fragment.append(cloneMathForTranslation(source))
+          inserted.add(mathIndex)
+        } else if (!source) {
+          // Do not silently eat a provider-generated token we do not own.
+          fragment.append(ownerDoc.createTextNode(match[0]))
+        }
+        cursor = matchIndex + match[0].length
+      }
+
+      if (cursor < translatedText.length) {
+        fragment.append(ownerDoc.createTextNode(translatedText.slice(cursor)))
+      }
+
+      // The two built-in translators round-trip these markers. If another
+      // provider drops one, keep the formula visible at the end rather than
+      // reproducing the original silent data loss.
+      const missing = mathElements.filter((_, index) => !inserted.has(index))
+      for (const source of missing) {
+        if (fragment.childNodes.length > 0) fragment.append(ownerDoc.createTextNode(" "))
+        fragment.append(cloneMathForTranslation(source))
+      }
+
+      container.replaceChildren(fragment)
+    },
+  }
+}

--- a/src/utils/host/translate/dom/translation-html-attributes.ts
+++ b/src/utils/host/translate/dom/translation-html-attributes.ts
@@ -1,5 +1,6 @@
 import type { TransNode } from "@/types/dom"
 import { MARK_ATTRIBUTES, NOTRANSLATE_CLASS } from "@/utils/constants/dom-labels"
+import { isMathRootElement } from "@/utils/constants/dom-rules"
 import {
   assertHtmlAttributeMarkerIntegrity,
   HTML_ATTRIBUTE_MARKER,
@@ -33,9 +34,16 @@ interface AttributeSnapshot {
 
 interface ElementAttributeSnapshot {
   attributes: AttributeSnapshot[]
+  preservedChildren?: ChildNode[]
   tagName: string
   translatableAttributes: AttributeSnapshot[]
   translatableAttributeNames: Set<string>
+}
+
+interface LegacyMarkerSnapshot {
+  attributes?: AttributeSnapshot[]
+  preservedChildren?: ChildNode[]
+  value: string | null
 }
 
 export interface ProtectedTranslationHtml {
@@ -103,6 +111,38 @@ function getElementsWithAttribute(
   attributeName: string,
 ): Element[] {
   return getAllElements(root).filter((element) => element.hasAttribute(attributeName))
+}
+
+function closestMathRoot(element: Element): Element | null {
+  let current: Element | null = element
+  while (current) {
+    if (isMathRootElement(current)) return current
+    current = current.parentElement
+  }
+  return null
+}
+
+function cloneChildNodes(element: Element): ChildNode[] {
+  return [...element.childNodes].map((child) => child.cloneNode(true) as ChildNode)
+}
+
+function restorePreservedElement(
+  element: Element,
+  attributes: readonly AttributeSnapshot[],
+  children: readonly ChildNode[],
+): void {
+  for (const attribute of [...element.attributes]) element.removeAttributeNode(attribute)
+  attributes.forEach((attribute) => restoreAttribute(element, attribute))
+  element.replaceChildren(...children.map((child) => child.cloneNode(true)))
+}
+
+function isInsidePreservedRoot(element: Element, roots: ReadonlySet<Element>): boolean {
+  let current: Element | null = element
+  while (current) {
+    if (roots.has(current)) return true
+    current = current.parentElement
+  }
+  return false
 }
 
 function normalizeHtmlForComparison(html: string, ownerDoc: Document): string {
@@ -209,22 +249,53 @@ export function protectTranslationHtmlAttributes(
   const snapshots = new Map<string, ElementAttributeSnapshot>()
   const legacyContainer = ownerDoc.createElement("template")
   legacyContainer.innerHTML = sourceHtml
-  const legacyMarkerSnapshots = new Map<string, { value: string }>()
+  const legacyMarkerSnapshots = new Map<string, LegacyMarkerSnapshot>()
 
-  getElementsWithAttribute(legacyContainer.content, HTML_ATTRIBUTE_MARKER).forEach((element) => {
+  getAllElements(legacyContainer.content).forEach((element) => {
+    const mathRoot = closestMathRoot(element)
+    if (mathRoot && mathRoot !== element) {
+      // The root snapshot restores this subtree wholesale. Nested page-owned
+      // marker attributes must not accidentally join our integrity protocol.
+      element.removeAttribute(HTML_ATTRIBUTE_MARKER)
+      return
+    }
+    if (!element.hasAttribute(HTML_ATTRIBUTE_MARKER) && !isMathRootElement(element)) return
+
     const markerId = `rf-page-${legacyMarkerSnapshots.size}`
+    const preserveMath = isMathRootElement(element)
     legacyMarkerSnapshots.set(markerId, {
-      value: element.getAttribute(HTML_ATTRIBUTE_MARKER) ?? "",
+      value: element.getAttribute(HTML_ATTRIBUTE_MARKER),
+      ...(preserveMath
+        ? {
+            attributes: [...element.attributes].map(snapshotAttribute),
+            preservedChildren: cloneChildNodes(element),
+          }
+        : {}),
     })
     element.setAttribute(HTML_ATTRIBUTE_MARKER, markerId)
+    if (preserveMath) {
+      element.classList.add(NOTRANSLATE_CLASS)
+      element.setAttribute("translate", "no")
+    }
   })
   const legacyRequestHtml = legacyContainer.innerHTML
 
   getAllElements(container.content).forEach((element) => {
+    const mathRoot = closestMathRoot(element)
+    if (mathRoot && mathRoot !== element) {
+      // Only the MathML root participates in the marker protocol; its exact
+      // children are restored from the snapshot after translation.
+      element.removeAttribute(HTML_ATTRIBUTE_MARKER)
+      return
+    }
+
+    const preserveMath = isMathRootElement(element)
     const attributes = Array.from(element.attributes)
-    const translatableAttributes = attributes
-      .filter((attribute) => isTranslatableAttribute(element, attribute.name))
-      .map(snapshotAttribute)
+    const translatableAttributes = preserveMath
+      ? []
+      : attributes
+          .filter((attribute) => isTranslatableAttribute(element, attribute.name))
+          .map(snapshotAttribute)
     const translatableAttributeNames = new Set(
       translatableAttributes.map((attribute) => attribute.name.toLowerCase()),
     )
@@ -232,7 +303,7 @@ export function protectTranslationHtmlAttributes(
       .filter((attribute) => !translatableAttributeNames.has(attribute.name.toLowerCase()))
       .map(snapshotAttribute)
 
-    if (protectedAttributes.length === 0) return
+    if (protectedAttributes.length === 0 && !preserveMath) return
 
     const markerId = String(snapshots.size)
     const preserveNotranslateClass = protectedAttributes.some(
@@ -252,10 +323,15 @@ export function protectTranslationHtmlAttributes(
     if (preserveTranslateNo) {
       element.setAttribute("translate", "no")
     }
+    if (preserveMath) {
+      element.setAttribute("class", NOTRANSLATE_CLASS)
+      element.setAttribute("translate", "no")
+    }
     element.setAttribute(HTML_ATTRIBUTE_MARKER, markerId)
 
     snapshots.set(markerId, {
       attributes: protectedAttributes,
+      preservedChildren: preserveMath ? cloneChildNodes(element) : undefined,
       tagName: element.localName.toLowerCase(),
       translatableAttributes,
       translatableAttributeNames,
@@ -280,6 +356,7 @@ export function protectTranslationHtmlAttributes(
       template.innerHTML = translatedHtml
       const markedElements = getElementsWithAttribute(template.content, HTML_ATTRIBUTE_MARKER)
       const markedElementSet = new Set(markedElements)
+      const restoredPreservedRoots = new Set<Element>()
       const restoredIds = new Set<string>()
 
       for (const element of markedElements) {
@@ -308,6 +385,12 @@ export function protectTranslationHtmlAttributes(
             : element.hasAttribute(attribute.name)
           if (!hasTranslatedAttribute) restoreAttribute(element, attribute)
         })
+        if (snapshot.preservedChildren) {
+          element.replaceChildren(
+            ...snapshot.preservedChildren.map((child) => child.cloneNode(true)),
+          )
+          restoredPreservedRoots.add(element)
+        }
         restoredIds.add(markerId)
       }
 
@@ -317,7 +400,10 @@ export function protectTranslationHtmlAttributes(
       }
 
       getAllElements(template.content).forEach((element) => {
-        if (!markedElementSet.has(element)) {
+        if (
+          !markedElementSet.has(element) &&
+          !isInsidePreservedRoot(element, restoredPreservedRoots)
+        ) {
           stripUnexpectedAttributes(element)
         }
       })
@@ -344,7 +430,13 @@ export function protectTranslationHtmlAttributes(
         if (!snapshot) {
           throw new HtmlAttributeMarkerIntegrityError("unknown-output-marker", markerId ?? "")
         }
-        element.setAttribute(HTML_ATTRIBUTE_MARKER, snapshot.value)
+        if (snapshot.attributes && snapshot.preservedChildren) {
+          restorePreservedElement(element, snapshot.attributes, snapshot.preservedChildren)
+        } else if (snapshot.value === null) {
+          element.removeAttribute(HTML_ATTRIBUTE_MARKER)
+        } else {
+          element.setAttribute(HTML_ATTRIBUTE_MARKER, snapshot.value)
+        }
       })
 
       return template.innerHTML

--- a/src/utils/host/translate/dom/translation-insertion.ts
+++ b/src/utils/host/translate/dom/translation-insertion.ts
@@ -27,6 +27,8 @@ interface TranslationInsertionContext {
   // expected content. Not fired on the no-append early return, so stray empty
   // wrappers never enter tamper surveillance.
   onContentInserted?: (wrapper: HTMLElement) => void
+  /** Render protected inline content (for example MathML) into the translated span. */
+  renderTranslatedContent?: (container: HTMLElement, translatedText: string) => void
 }
 
 function sourceRunMatchesSelector(sources: readonly TransNode[], selector: string | null): boolean {
@@ -131,6 +133,7 @@ export async function insertTranslatedNodeIntoWrapper(
     sourceText,
     isCurrent,
     onContentInserted,
+    renderTranslatedContent,
   }: TranslationInsertionContext,
   translatedText: string,
   translationNodeStyle: TranslationNodeStyleConfig,
@@ -184,7 +187,11 @@ export async function insertTranslatedNodeIntoWrapper(
     return
   }
 
-  translatedNode.textContent = translatedText
+  if (renderTranslatedContent) {
+    renderTranslatedContent(translatedNode, translatedText)
+  } else {
+    translatedNode.textContent = translatedText
+  }
   translatedWrapperNode.appendChild(translatedNode)
   // Synchronous, pre-await: see TranslationInsertionContext.onContentInserted.
   onContentInserted?.(translatedWrapperNode)


### PR DESCRIPTION
> **AI model(s) used (required):** OpenAI GPT-5 (Codex); DeepSeek-V4-Flash (translation compatibility testing)

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

Fix MathML formulas disappearing from translated content, particularly on arXiv HTML pages.

This change:

- Replaces MathML roots with stable placeholders before sending surrounding text to the translation provider.
- Reinserts sanitized clones of the original formulas at their translated positions.
- Preserves exact MathML subtrees in translation-only mode.
- Keeps formula-only elements out of language detection and translation requests.
- Falls back to appending formulas when a translation provider unexpectedly drops their placeholders.
- Prevents cloned formulas from introducing duplicate IDs, event handlers, or URL-bearing attributes.
- Restores suitable math fonts and wrapping inside translated content.
- Continues to exclude the formula content itself from translation, preserving the behavior introduced for #650.

## Related Issue

Closes #1911

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

Validation performed:

- MathML-related unit and integration tests: 170/170 passed.
- TypeScript type checking passed.
- Formatting and changeset validation passed.
- Chrome MV3 and Edge MV3 production builds passed.
- Tested in a real Microsoft Edge instance against an arXiv-style MathML fixture.
- Tested with both Microsoft Translator and DeepSeek-V4-Flash.
- Verified bilingual and translation-only modes.
- Verified that disabling translation restores the original DOM.
- Verified that formulas retain their MathML structure and TeX annotations.
- Verified that cloned formulas do not contain duplicate IDs.
- No browser console or page errors were observed.

## Screenshots

The issue can be reproduced on:

https://arxiv.org/html/2605.30621v1

Automated DOM assertions were used to verify the formula structure, placement, and restoration behavior.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

The implementation targets native MathML, which is the format used by the affected arXiv HTML page. KaTeX or MathJax pages that render formulas entirely as HTML or SVG are outside the direct scope of this fix.

A patch changeset for `@read-frog/extension` is included.