### PR TITLE
fix(site-rules): translate the Details body on Alibaba RFQ pages

### DIFF
--- a/.changeset/alibaba-rfq-pre-details.md
+++ b/.changeset/alibaba-rfq-pre-details.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(site-rules): translate the Details body on Alibaba RFQ pages

--- a/src/utils/site-rules/__tests__/built-in.test.ts
+++ b/src/utils/site-rules/__tests__/built-in.test.ts
@@ -517,6 +517,41 @@ describe("built-in site rules", () => {
     expect(disabled.dontWalkButTranslateTags).toBeNull()
   })
 
+  // Alibaba's RFQ detail page renders the buyer's hand-written request body in
+  // `<pre class="value">` (Details / 详细描述). PRE sits in
+  // DONT_WALK_AND_TRANSLATE_TAGS and the plain-text exemption in
+  // `utils/host/dom/filter` only fires for `text/plain` documents, so on this
+  // text/html page the whole body was dropped from the walk while every sibling
+  // field (Product Name, Category, Quantity) translated normally.
+  it("un-blocks PRE on Alibaba's RFQ sourcing portal", () => {
+    const resolved = resolveSiteRule(
+      "https://sourcing.alibaba.com/rfq_detail.htm?p=ID1op9Nz9xuJFsQZPZUe4DBR",
+      BUILT_IN_SITE_RULES,
+      [],
+      [],
+    )
+
+    expect(resolved.matchedRuleIds).toContain("alibaba-sourcing-rfq")
+    expect(resolved.dontWalkTags).not.toBeNull()
+    expect(resolved.dontWalkTags!.has("PRE")).toBe(false)
+    expect(resolved.dontWalkTags!.has("SCRIPT")).toBe(true)
+    // Removal must not register as an explicit add, or the plain-text `<pre>`
+    // exemption in `utils/host/dom/filter` would read it as an authoring
+    // decision to keep PRE blocked.
+    expect(resolved.dontWalkTagsExplicitAdds?.has("PRE") ?? false).toBe(false)
+
+    const elsewhere = resolveSiteRule("https://www.alibaba.com/", BUILT_IN_SITE_RULES, [], [])
+    expect(elsewhere.dontWalkTags).toBeNull()
+
+    const disabled = resolveSiteRule(
+      "https://sourcing.alibaba.com/rfq_detail.htm",
+      BUILT_IN_SITE_RULES,
+      [],
+      ["alibaba-sourcing-rfq"],
+    )
+    expect(disabled.dontWalkTags).toBeNull()
+  })
+
   it("retains independently verified content roots that cover their full match scope", () => {
     const paulGraham = resolveSiteRule(
       "https://paulgraham.com/greatwork.html",

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -4540,6 +4540,12 @@
     "dontWalkButTranslateTags.remove": ["CODE"]
   },
   {
+    "id": "alibaba-sourcing-rfq",
+    "description": "Alibaba's RFQ portal renders the buyer's hand-written request body in <pre class=\"value\"> (the Details / 详细描述 field). PRE is hard-blocked by default for authored code, so the entire request body was dropped from the walk while every field around it translated. This host serves sourcing pages only, no code",
+    "matches": "sourcing.alibaba.com",
+    "dontWalkTags.remove": ["PRE"]
+  },
+  {
     "id": "readfrog-x-chat",
     "description": "Skip the X Chat message footer (send time + delivery receipt). It renders twice inside the bubble — once as an aria-hidden opacity-0 spacer in the text flow, once in the absolutely positioned overlay — so both copies otherwise land in the message's translation unit. Target the footer root only: excluding its `.absolute.bottom-0.inset-e-0` wrapper too would hide that wrapper from unwrapDeepestOnlyHTMLChild, turning the bubble row into an only-child chain and moving the translation wrapper down into the pre-wrap text block",
     "matches": ["chat.x.com"],


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 5

## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

On Alibaba's RFQ detail page, everything translates **except the one field a supplier actually reads** — the buyer's request body. Reported as "阿里巴巴国际站只有一部分能翻译出来".

It is not a missed translation. That text never enters the pipeline.

Alibaba renders the buyer's hand-written body in `<pre class="value">`:

```html
<div class="row">
  <span class="label">Details:</span>
  <pre class="value">Hello,I'm interested in your offering for this product…
product: Automatic motion detection camera
Resolution: 2MP
…</pre>
</div>
```

`PRE` ships in `DONT_WALK_AND_TRANSLATE_TAGS` to protect authored code, logs and ASCII art. The only escape is `isPlainTextDocumentPre`, which fires when `ownerDocument.contentType` is exactly `text/plain` — the nifty.org / RFC case from #2087. This page is `text/html`, so the walk stopped at the element **and** `extractTextContent` returned `""` for it, meaning the parent `div.row` could not fold the text in either.

Verified live before the fix: the page labeled 531 walked elements, and `pre.value` carried no `data-read-frog-*` attribute at all, while its sibling fields — Product Name, Category, Quantity, and the `Details:` label itself — all translated normally. That asymmetry is exactly what makes it read as a flaky AI miss rather than a structural skip.

### The fix

One built-in site rule:

```json
{
  "id": "alibaba-sourcing-rfq",
  "matches": "sourcing.alibaba.com",
  "dontWalkTags.remove": ["PRE"]
}
```

`dontWalkTags.remove` is the mechanism `PROTECTED_DONT_WALK_TAGS` deliberately leaves open for PRE ("un-blocking it is a legitimate per-site choice") — it is used here for the first time in the built-in set. No default changes, so `<pre>` stays blocked everywhere else.

Once un-blocked, the existing machinery does the rest with no further work: `PRE` is already in `FORCE_BLOCK_TAGS`, so the element labels as a block paragraph, and its preserved white-space feeds the virtual-paragraph plan from #2087 — the body splits per line, and each line's translation lands under its own line inside the `pre-wrap` flow.

### Why a site rule and not a default change

The underlying shape is not Alibaba-specific: any site that dumps user-authored prose into `<pre>` (ticket systems, forums, mail bodies) hits it. But relaxing the default would translate real code blocks, which is the reason PRE is blocked in the first place. Scoping to `sourcing.alibaba.com` keeps the blast radius at one sourcing portal that serves no authored code. If more hosts turn up, they are one `matches` entry each.

## Related Issue

Closes #

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

**Automated** — full suite green (2827 tests, 291 files), lint and format clean. New coverage in `built-in.test.ts`, modeled on the `sillytavern` case:

- the rule matches an RFQ detail URL and `PRE` leaves the effective `dontWalkTags`;
- `SCRIPT` is still in the set (the removal is surgical, and `PROTECTED_DONT_WALK_TAGS` still guards the dangerous tags);
- `dontWalkTagsExplicitAdds` does **not** contain `PRE` — otherwise `isPlainTextDocumentPre` would read this removal as an author's decision to keep PRE blocked, which is the one way this rule could silently invert;
- `www.alibaba.com` is unaffected (`dontWalkTags` stays `null`, so the hot path keeps the shipped constant);
- disabling the rule via `disabledBuiltInRules` restores the default.

**Real browser** (built extension loaded in Chrome via DevTools MCP, on a live public RFQ page — no login needed: `sourcing.alibaba.com/rfq_detail.htm`, reached from `rfq_search_list.htm`):

| | walked elements | `pre.value` walked | translations inside it |
|---|---|---|---|
| rule disabled | 531 | ✗ | 0 |
| rule enabled | 548 | ✓ | 16 |

- **Bilingual**: each source line gets its translation directly underneath; the `white-space: pre-wrap` layout is intact, no reflow of the surrounding table.
- **Translation-only**: the body is replaced in place, line structure preserved, no residue.

One thing I chased and ruled out: switching modes *on an already-translated page* leaves the first paragraph unreplaced plus a stray glyph. It reproduces on `Attachments`, which is a plain `<div>` outside any `<pre>`, and disappears after a reload — a pre-existing mode-switch re-render issue, unrelated to this change.

## Screenshots

Same page, same scroll position, bilingual mode — only the rule differs.

**Before** (`docs/alibaba-rfq-before.png`) — every field around it translated, the whole body untouched:

![before](alibaba-rfq-before.png)

**After** (`docs/alibaba-rfq-after.png`):

![after](alibaba-rfq-after.png)

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Debugging note for the next person: "one block untranslated while its siblings translate" is worth checking against `<pre>` before suspecting the model. It is a one-liner in the console on a translated page —

```js
document.querySelector('pre')   // exists, but has no data-read-frog-walked
```

— and it distinguishes this class of bug from the sentinel/echo path (#2053), where the element *is* walked but renders an empty translation.
