### PR TITLE
feat(providers): refresh built-in models and translation defaults

### DIFF
--- a/.changeset/fresh-translation-models.md
+++ b/.changeset/fresh-translation-models.md
@@ -1,0 +1,7 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(providers): refresh built-in models and translation defaults
+
+Add current model choices and update translation defaults, including GPT-5.6 Luna, Gemini 3.5 Flash-Lite, and Qwen 3.8 Flash. Preserve saved model selections and update model-specific recommended reasoning options.

--- a/src/utils/constants/__tests__/model.test.ts
+++ b/src/utils/constants/__tests__/model.test.ts
@@ -38,13 +38,13 @@ describe("getProviderOptions", () => {
 
       const thinkingLevelProOptions = getProviderOptions("gemini-3-pro-preview", "google")
       expect(thinkingLevelProOptions.google?.thinkingConfig).toMatchObject({
-        thinkingLevel: "minimal",
+        thinkingLevel: "low",
         includeThoughts: false,
       })
 
       const thinkingLevel31ProOptions = getProviderOptions("gemini-3.1-pro-preview", "google")
       expect(thinkingLevel31ProOptions.google?.thinkingConfig).toMatchObject({
-        thinkingLevel: "minimal",
+        thinkingLevel: "low",
         includeThoughts: false,
       })
 
@@ -77,7 +77,7 @@ describe("getProviderOptions", () => {
 
       const thinkingLevelFlashLatestOptions = getProviderOptions("gemini-flash-latest", "google")
       expect(thinkingLevelFlashLatestOptions.google?.thinkingConfig).toMatchObject({
-        thinkingLevel: "minimal",
+        thinkingLevel: "low",
         includeThoughts: false,
       })
 
@@ -149,9 +149,13 @@ describe("getProviderOptions", () => {
 
     it("should expose the current xAI Grok chat model ids", () => {
       expect(LLM_PROVIDER_MODELS.xai).toEqual([
+        "grok-4.3",
+        "grok-4.6",
+        "grok-4.5",
+        "grok-4.20-non-reasoning",
+        "grok-4.20-reasoning",
         "grok-4.20-0309-non-reasoning",
         "grok-4.20-0309-reasoning",
-        "grok-4.3",
       ])
     })
 
@@ -247,10 +251,10 @@ describe("getProviderOptions", () => {
 
     it("should return low/disabled defaults for more mainstream reasoning providers", () => {
       const grokOptions = getProviderOptions("grok-4.3", "xai")
-      expect(grokOptions.xai?.reasoningEffort).toBe("low")
+      expect(grokOptions.xai?.reasoningEffort).toBe("none")
 
       const mixedCaseGrokOptions = getProviderOptions("Grok-4.3", "xai")
-      expect(mixedCaseGrokOptions.xai?.reasoningEffort).toBe("low")
+      expect(mixedCaseGrokOptions.xai?.reasoningEffort).toBe("none")
 
       const datedGrokReasoningOptions = getProviderOptions("grok-4.20-0309-reasoning", "xai")
       expect(datedGrokReasoningOptions.xai?.reasoningEffort).toBe("low")
@@ -357,10 +361,10 @@ describe("getProviderOptions", () => {
       )
 
       const groqOptions = getProviderOptions("openai/gpt-oss-120b", "groq")
-      expect(groqOptions.groq?.reasoningEffort).toBe("none")
+      expect(groqOptions.groq?.reasoningEffort).toBe("low")
 
       const cerebrasOptions = getProviderOptions("gpt-oss-120b", "cerebras")
-      expect(cerebrasOptions.cerebras?.reasoningEffort).toBe("none")
+      expect(cerebrasOptions.cerebras?.reasoningEffort).toBe("low")
     })
 
     it("should apply Volcengine Doubao Seed thinking defaults with optional version suffixes", () => {

--- a/src/utils/constants/__tests__/providers.test.ts
+++ b/src/utils/constants/__tests__/providers.test.ts
@@ -19,6 +19,14 @@ import {
 } from "../providers"
 
 describe("provider constants", () => {
+  it("keeps every default provider compatible with its model schema", () => {
+    for (const provider of API_PROVIDER_TYPES) {
+      expect(apiProviderConfigItemSchema.parse(DEFAULT_PROVIDER_CONFIG[provider])).toEqual(
+        DEFAULT_PROVIDER_CONFIG[provider],
+      )
+    }
+  })
+
   it("uses the original custom provider SVG shape for both custom protocols", () => {
     expect(PROVIDER_ITEMS["openai-compatible"].logo("light")).toContain("custom-provider.svg")
     expect(PROVIDER_ITEMS["openai-compatible"].logo("dark")).toContain("custom-provider.svg")
@@ -36,7 +44,7 @@ describe("provider constants", () => {
         name: "Azure",
         provider: "azure",
         model: {
-          model: "gpt-5.4-mini",
+          model: "gpt-5.6-luna",
           isCustomModel: false,
           customModel: null,
         },

--- a/src/utils/constants/models.ts
+++ b/src/utils/constants/models.ts
@@ -9,8 +9,14 @@ interface OpenAIGPT5ReasoningEffortPolicy {
   recommendedValue?: OpenAIReasoningEffort
 }
 
+// Reviewed against provider catalogs and AI SDK docs on 2026-09-04.
+// Keep existing IDs: persisted provider configs validate against these enums.
 export const LLM_PROVIDER_MODELS = {
   openai: [
+    "gpt-5.6-luna",
+    "gpt-5.6-terra",
+    "gpt-5.6-sol",
+    "gpt-5.6",
     "gpt-5.5",
     "gpt-5.4-pro",
     "gpt-5.4",
@@ -37,6 +43,9 @@ export const LLM_PROVIDER_MODELS = {
     "gpt-4o-mini",
   ],
   azure: [
+    "gpt-5.6-luna",
+    "gpt-5.6-terra",
+    "gpt-5.6-sol",
     "gpt-5.4-mini",
     "gpt-5.4",
     "gpt-5.4-pro",
@@ -62,12 +71,15 @@ export const LLM_PROVIDER_MODELS = {
   ],
   deepseek: ["deepseek-v4-flash", "deepseek-v4-pro", "deepseek-chat", "deepseek-reasoner"],
   google: [
+    "gemini-3.5-flash-lite",
+    "gemini-3.8-flash",
+    "gemini-3.7-flash",
+    "gemini-3.1-flash-lite",
     "gemini-flash-lite-latest",
     "gemini-flash-latest",
     "gemini-pro-latest",
     "gemini-3.6-flash",
     "gemini-3.5-flash",
-    "gemini-3.5-flash-lite",
     "gemini-3.1-pro-preview",
     "gemini-3.1-flash-image-preview",
     "gemini-3.1-flash-lite-preview",
@@ -81,13 +93,16 @@ export const LLM_PROVIDER_MODELS = {
     "gemini-2.0-flash",
   ],
   anthropic: [
+    "claude-haiku-4-5",
+    "claude-sonnet-5",
+    "claude-opus-5",
+    "claude-fable-5-1",
     "claude-fable-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",
     "claude-sonnet-4-6",
     "claude-opus-4-5",
-    "claude-haiku-4-5",
     "claude-sonnet-4-5",
     "claude-opus-4-1",
     "claude-opus-4-0",
@@ -135,8 +150,17 @@ export const LLM_PROVIDER_MODELS = {
   ],
   "openai-compatible": ["use-custom-model"],
   "open-responses": ["use-custom-model"],
-  xai: ["grok-4.20-0309-non-reasoning", "grok-4.20-0309-reasoning", "grok-4.3"],
+  xai: [
+    "grok-4.3",
+    "grok-4.6",
+    "grok-4.5",
+    "grok-4.20-non-reasoning",
+    "grok-4.20-reasoning",
+    "grok-4.20-0309-non-reasoning",
+    "grok-4.20-0309-reasoning",
+  ],
   bedrock: [
+    "us.anthropic.claude-sonnet-5",
     "amazon.titan-tg1-large",
     "amazon.titan-text-express-v1",
     "amazon.titan-text-lite-v1",
@@ -206,6 +230,10 @@ export const LLM_PROVIDER_MODELS = {
     "openai.gpt-oss-120b",
   ],
   groq: [
+    "openai/gpt-oss-20b",
+    "openai/gpt-oss-120b",
+    "qwen/qwen3.8-27b",
+    "qwen/qwen3.6-27b",
     "gemma2-9b-it",
     "llama-3.1-8b-instant",
     "llama-3.3-70b-versatile",
@@ -220,10 +248,14 @@ export const LLM_PROVIDER_MODELS = {
     "qwen-qwq-32b",
     "qwen-2.5-32b",
     "deepseek-r1-distill-qwen-32b",
-    "openai/gpt-oss-20b",
-    "openai/gpt-oss-120b",
   ],
   deepinfra: [
+    "Qwen/Qwen3.5-9B",
+    "Qwen/Qwen3.8-27B",
+    "deepseek-ai/DeepSeek-V4-Flash",
+    "deepseek-ai/DeepSeek-V4-Pro",
+    "moonshotai/Kimi-K2.6",
+    "google/gemma-4-31B-it",
     "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
     "meta-llama/Llama-4-Scout-17B-16E-Instruct",
     "meta-llama/Llama-3.3-70B-Instruct-Turbo",
@@ -250,6 +282,8 @@ export const LLM_PROVIDER_MODELS = {
     "microsoft/WizardLM-2-8x22B",
   ],
   mistral: [
+    "mistral-small-latest",
+    "mistral-small-2603",
     "pixtral-large-latest",
     "mistral-large-latest",
     "mistral-medium-latest",
@@ -257,7 +291,6 @@ export const LLM_PROVIDER_MODELS = {
     "mistral-medium-2508",
     "mistral-medium-2505",
     "mistral-medium-3.5",
-    "mistral-small-latest",
     "magistral-small-2507",
     "magistral-medium-2507",
     "magistral-small-2506",
@@ -270,6 +303,15 @@ export const LLM_PROVIDER_MODELS = {
     "open-mixtral-8x22b",
   ],
   togetherai: [
+    "Qwen/Qwen3.5-9B",
+    "Qwen/Qwen3.5-397B-A17B",
+    "Qwen/Qwen3.7-Max",
+    "moonshotai/Kimi-K2.6",
+    "deepseek-ai/DeepSeek-V4-Pro",
+    "MiniMaxAI/MiniMax-M2.7",
+    "zai-org/GLM-5.1",
+    "openai/gpt-oss-20b",
+    "openai/gpt-oss-120b",
     "meta-llama/Llama-3.3-70B-Instruct-Turbo",
     "deepseek-ai/DeepSeek-V3",
     "meta-llama/Meta-Llama-3.3-70B-Instruct-Turbo",
@@ -291,6 +333,8 @@ export const LLM_PROVIDER_MODELS = {
     "command-r7b-12-2024",
   ],
   fireworks: [
+    "accounts/fireworks/models/gpt-oss-120b",
+    "accounts/fireworks/models/kimi-k2p6",
     "accounts/fireworks/models/firefunction-v1",
     "accounts/fireworks/models/deepseek-r1",
     "accounts/fireworks/models/deepseek-v3",
@@ -314,9 +358,10 @@ export const LLM_PROVIDER_MODELS = {
     "accounts/fireworks/models/minimax-m2",
   ],
   cerebras: [
+    "gpt-oss-120b",
+    "gemma-4-31b",
     "llama3.1-8b",
     "llama-3.3-70b",
-    "gpt-oss-120b",
     "qwen-3-32b",
     "qwen-3-235b-a22b-instruct-2507",
     "qwen-3-235b-a22b-thinking-2507",
@@ -332,7 +377,14 @@ export const LLM_PROVIDER_MODELS = {
     "sonar",
   ],
   vercel: ["v0-1.5-md", "v0-1.5-lg", "v0-1.0-md"],
-  openrouter: ["x-ai/grok-4-fast:free", "openai/gpt-4.1-mini"],
+  openrouter: [
+    "google/gemma-4-31b-it:free",
+    "openai/gpt-5.6-luna",
+    "google/gemini-3.5-flash-lite",
+    "deepseek/deepseek-v4-flash",
+    "x-ai/grok-4-fast:free",
+    "openai/gpt-4.1-mini",
+  ],
   ollama: ["gemma4:e2b", "gemma4:e4b", "gemma3:4b", "llama3.2:3b"],
   volcengine: [
     "doubao-seed-1-6-flash-250828",
@@ -351,6 +403,14 @@ export const LLM_PROVIDER_MODELS = {
     "MiniMax-M2-Stable",
   ],
   alibaba: [
+    "qwen3.8-flash",
+    "qwen3.8-max",
+    "qwen3.7-flash",
+    "qwen3.7-plus",
+    "deepseek-v4-flash",
+    "deepseek-v4-pro",
+    "kimi-k2.6",
+    "glm-5.2",
     "qwen3-max",
     "qwen3.5-plus",
     "qwen3.5-flash",
@@ -368,6 +428,8 @@ export const LLM_PROVIDER_MODELS = {
     "glm-5",
   ],
   moonshotai: [
+    "kimi-k2.6",
+    "kimi-k3",
     "moonshot-v1-8k",
     "moonshot-v1-32k",
     "moonshot-v1-128k",
@@ -378,6 +440,12 @@ export const LLM_PROVIDER_MODELS = {
     "kimi-k2-turbo",
   ],
   huggingface: [
+    "Qwen/Qwen3.5-9B",
+    "Qwen/Qwen3.8-27B",
+    "deepseek-ai/DeepSeek-V4-Flash",
+    "deepseek-ai/DeepSeek-V4-Pro",
+    "moonshotai/Kimi-K2.6",
+    "google/gemma-4-31B-it",
     "meta-llama/Llama-3.1-8B-Instruct",
     "meta-llama/Llama-3.1-70B-Instruct",
     "meta-llama/Llama-3.3-70B-Instruct",
@@ -411,6 +479,11 @@ export const PURE_TRANSLATE_PROVIDERS = [
 ] as const
 
 const OPENAI_GPT5_REASONING_EFFORT_POLICIES: OpenAIGPT5ReasoningEffortPolicy[] = [
+  {
+    pattern: /^(?:openai\/)?gpt-5\.6(?:-(?:luna|terra|sol))?$/i,
+    supportedValues: ["none", "low", "medium", "high", "xhigh", "max"],
+    recommendedValue: "none",
+  },
   {
     pattern: /^gpt-5\.4-pro$/i,
     supportedValues: ["medium", "high", "xhigh"],
@@ -486,9 +559,11 @@ export const LLM_MODEL_OPTIONS: Array<{
 }> = [
   // Gemini - specific patterns first
   // The versionless aliases track the newest generation, which uses thinkingLevel;
-  // the pro tier does not accept "minimal".
+  // Pro and Flash 3.7/3.8 do not accept "minimal".
+  // https://ai.google.dev/gemini-api/docs/thinking
   {
-    pattern: /^gemini-pro-latest$/i,
+    pattern:
+      /^(?:gemini-pro-latest|gemini-3(?:\.1)?-pro-preview(?:-customtools)?|gemini-3\.[78]-flash|gemini-flash-latest)$/i,
     options: { thinkingConfig: { thinkingLevel: "low", includeThoughts: false } },
   },
   {
@@ -525,18 +600,24 @@ export const LLM_MODEL_OPTIONS: Array<{
   // GPT-5 chat-latest variants are intentionally omitted because their docs do not advertise reasoning.effort.
   ...OPENAI_GPT5_RECOMMENDED_MODEL_OPTIONS,
 
-  // xAI Grok reasoning-capable text models - keep effort at the lowest supported level.
-  // Non-reasoning Grok variants are intentionally omitted because they do not need reasoning options.
-  // TODO: switch Grok 4.3 to the non-reasoning path once stable @ai-sdk/xai supports reasoning.effort = "none".
+  // Grok 4.3 can disable thinking; 4.5 and 4.6 cannot.
   {
-    pattern: /^(?:grok-4\.3|grok-4\.20-0309-reasoning)$/i,
+    pattern: /^grok-4\.3$/i,
+    options: { reasoningEffort: "none" },
+  },
+  {
+    pattern: /^grok-4\.[56]$/i,
+    options: { reasoningEffort: "low" },
+  },
+  {
+    pattern: /^grok-4\.20-0309-reasoning$/i,
     options: { reasoningEffort: "low" },
   },
 
   // OpenAI-compatible reasoning models exposed by Groq/Cerebras and similar providers
   {
-    pattern: /^(?:openai\/)?gpt-oss-(?:20|120)b$/i,
-    options: { reasoningEffort: "none" },
+    pattern: /^(?:openai\/|accounts\/fireworks\/models\/)?gpt-oss-(?:20|120)b$/i,
+    options: { reasoningEffort: "low" },
   },
 
   // Volcengine Doubao Seed models - disable thinking by default.
@@ -578,6 +659,11 @@ export const LLM_MODEL_OPTIONS: Array<{
   {
     pattern: /(?:^|\/)kimi-k2(?!-instruct(?:[a-z0-9.-].*)?$)(?:[a-z0-9.-].*)?$/i,
     options: { thinking: { type: "disabled" }, reasoningHistory: "disabled" },
+  },
+  // Kimi K3 always reasons and does not accept the K2 thinking options.
+  {
+    pattern: /^kimi-k3$/i,
+    options: { reasoningEffort: "low" },
   },
 
   // Namespaced Qwen3 models - disable reasoning by default.

--- a/src/utils/constants/providers.ts
+++ b/src/utils/constants/providers.ts
@@ -36,7 +36,7 @@ import { getLobeIconsCDNUrlFn } from "../logo"
 
 export const DEFAULT_LLM_PROVIDER_MODELS: LLMProviderModels = {
   openrouter: {
-    model: "x-ai/grok-4-fast:free",
+    model: "google/gemma-4-31b-it:free",
     isCustomModel: false,
     customModel: null,
   },
@@ -61,12 +61,12 @@ export const DEFAULT_LLM_PROVIDER_MODELS: LLMProviderModels = {
     customModel: null,
   },
   openai: {
-    model: "gpt-5.4-mini",
+    model: "gpt-5.6-luna",
     isCustomModel: false,
     customModel: null,
   },
   azure: {
-    model: "gpt-5.4-mini",
+    model: "gpt-5.6-luna",
     isCustomModel: false,
     customModel: null,
   },
@@ -76,7 +76,7 @@ export const DEFAULT_LLM_PROVIDER_MODELS: LLMProviderModels = {
     customModel: null,
   },
   google: {
-    model: "gemini-2.5-flash-lite",
+    model: "gemini-3.5-flash-lite",
     isCustomModel: false,
     customModel: null,
   },
@@ -86,7 +86,7 @@ export const DEFAULT_LLM_PROVIDER_MODELS: LLMProviderModels = {
     customModel: null,
   },
   xai: {
-    model: "grok-4.20-0309-non-reasoning",
+    model: "grok-4.3",
     isCustomModel: false,
     customModel: null,
   },
@@ -96,22 +96,22 @@ export const DEFAULT_LLM_PROVIDER_MODELS: LLMProviderModels = {
     customModel: null,
   },
   groq: {
-    model: "llama-3.1-8b-instant",
+    model: "openai/gpt-oss-20b",
     isCustomModel: false,
     customModel: null,
   },
   deepinfra: {
-    model: "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+    model: "Qwen/Qwen3.5-9B",
     isCustomModel: false,
     customModel: null,
   },
   mistral: {
-    model: "magistral-small-2507",
+    model: "mistral-small-latest",
     isCustomModel: false,
     customModel: null,
   },
   togetherai: {
-    model: "deepseek-ai/DeepSeek-V3",
+    model: "Qwen/Qwen3.5-9B",
     isCustomModel: false,
     customModel: null,
   },
@@ -121,12 +121,12 @@ export const DEFAULT_LLM_PROVIDER_MODELS: LLMProviderModels = {
     customModel: null,
   },
   fireworks: {
-    model: "accounts/fireworks/models/llama-v3p2-3b-instruct",
+    model: "accounts/fireworks/models/gpt-oss-120b",
     isCustomModel: false,
     customModel: null,
   },
   cerebras: {
-    model: "llama3.1-8b",
+    model: "gpt-oss-120b",
     isCustomModel: false,
     customModel: null,
   },
@@ -171,17 +171,17 @@ export const DEFAULT_LLM_PROVIDER_MODELS: LLMProviderModels = {
     customModel: null,
   },
   alibaba: {
-    model: "qwen3.5-flash",
+    model: "qwen3.8-flash",
     isCustomModel: false,
     customModel: null,
   },
   moonshotai: {
-    model: "kimi-k2-turbo",
+    model: "kimi-k2.6",
     isCustomModel: false,
     customModel: null,
   },
   huggingface: {
-    model: "meta-llama/Llama-3.1-8B-Instruct",
+    model: "Qwen/Qwen3.5-9B",
     isCustomModel: false,
     customModel: null,
   },


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-6 (Codex)

## Type of Changes

- [x] ✨ New feature (feat)
- [ ] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

The provider model pickers are missing current models, and several defaults still point to older generations. Add 59 model choices across 16 providers and refresh 14 defaults for translation workloads. For example, newly added OpenAI providers now select `gpt-5.6-luna` instead of `gpt-5.4-mini`.

| Provider | New default model |
| --- | --- |
| OpenAI, Azure | `gpt-5.6-luna` |
| Google | `gemini-3.5-flash-lite` |
| xAI | `grok-4.3` |
| Groq | `openai/gpt-oss-20b` |
| Cerebras | `gpt-oss-120b` |
| Fireworks | `accounts/fireworks/models/gpt-oss-120b` |
| DeepInfra, Together AI, Hugging Face | `Qwen/Qwen3.5-9B` |
| Mistral | `mistral-small-latest` |
| Alibaba | `qwen3.8-flash` |
| Moonshot AI | `kimi-k2.6` |
| OpenRouter | `google/gemma-4-31b-it:free` |

Retain all previous model IDs because saved provider configurations validate against the catalog enums. Existing model selections remain valid; the new defaults apply when creating providers.

Update model-specific recommended reasoning options for GPT-5.6, Gemini, Grok, GPT-OSS, and Kimi K3. Explicit reasoning values and user-written provider options keep their existing precedence, and unsupported combinations surface SDK/API errors.

Add a patch changeset for `@read-frog/extension` and a regression check that every default provider passes its configuration schema.

## Related Issue

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

- Full pre-push test suite: **290 files, 2,828 tests passed**, with `SKIP_FREE_API=true` and `free-api.test.ts` intentionally excluded.
- `pnpm exec nx fmt:check` passed.
- `pnpm exec nx lint` passed, including type checking.
- `WXT_SKIP_ENV_VALIDATION=true pnpm build` passed for Chrome MV3.
- `pnpm exec changeset status` confirmed a patch release for `@read-frog/extension`.
- Compared catalogs before and after the change: no existing model IDs were removed and no duplicates were introduced.

## Screenshots

Not applicable; this change updates model choices and defaults without changing the UI layout.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Model IDs and capabilities were checked against provider catalogs and documentation on September 4, 2026, including the [AI SDK provider documentation](https://ai-sdk.dev/providers/ai-sdk-providers), [OpenAI GPT-5.6 Luna documentation](https://developers.openai.com/api/docs/models/gpt-5.6-luna), [Gemini thinking documentation](https://ai.google.dev/gemini-api/docs/thinking), and [Groq model catalog](https://console.groq.com/docs/models). Selection reflects documented cost and capabilities; authenticated live translation quality comparisons were not performed.
