### PR TITLE
fix(floating-button): let clicks pass through collapsed controls

### DIFF
--- a/.changeset/collapsed-floating-button-hit-area.md
+++ b/.changeset/collapsed-floating-button-hit-area.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(floating-button): let clicks pass through collapsed controls

--- a/src/entrypoints/side.content/components/floating-button/index.tsx
+++ b/src/entrypoints/side.content/components/floating-button/index.tsx
@@ -388,6 +388,7 @@ export default function FloatingButton() {
       data-testid="floating-button-container"
       className={cn(
         "fixed z-2147483647 flex flex-col gap-2 print:hidden",
+        isFloatingButtonExpanded ? "pointer-events-auto" : "pointer-events-none",
         isDraggingButton
           ? "items-center"
           : floatingButtonSide === "right"
@@ -408,7 +409,7 @@ export default function FloatingButton() {
           ref={mainButtonRef}
           data-testid="floating-main-button"
           className={cn(
-            "relative flex h-10 items-center border-border bg-white shadow-lg transition-transform duration-300 dark:bg-neutral-900",
+            "pointer-events-auto relative flex h-10 items-center border-border bg-white shadow-lg transition-transform duration-300 dark:bg-neutral-900",
             isDraggingButton
               ? "w-10 cursor-grabbing touch-none justify-center rounded-full border opacity-100"
               : floatingButtonSide === "right"


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-6 (Codex)

## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

After the floating controls collapse, their buttons slide offscreen but the fixed flex container remains over the page and intercepts clicks. This also blocks the blank area beside the partially retracted frog button.

Make the container accept pointer events only while expanded, and keep the main frog button interactive at all times. The expanded container continues to bridge the gaps between controls so moving between buttons does not collapse the menu. Existing layout and slide animations are preserved. Includes a patch changeset.

## Related Issue

[Feedback: collapsed controls leave invisible hit areas that block page interaction](https://feedback.readfrog.app/p/kuo-zhan-shou-qi-hou-reng-can-liu-bu-ke)

## How Has This Been Tested?

- [x] Verified through manual testing
- Existing floating-button component tests: 16 passed.
- Rebuilt and installed the actual extension in Chrome 152, with no runtime CSS overrides: verified underlying page clicks on both docking sides, main-button hover, movement across the control gap, locked collapse, and the open options menu.
- `WXT_SKIP_ENV_VALIDATION=true node_modules/.bin/wxt build`
- `pnpm exec changeset status`: confirms a patch for `@read-frog/extension`.
- Repository pre-push format and lint/type checks passed. Full test suite: 305 files and 3,059 tests passed, with `SKIP_FREE_API=true` to intentionally skip the live external translation API tests.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.
