### PR TITLE
chore(skills): remove redundant Codex skills symlink

### DIFF
--- a/.codex/skills/migration-scripts
+++ b/.codex/skills/migration-scripts
@@ -1,1 +1,0 @@
-../../.agents/skills/migration-scripts


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-6 (Codex)

## Type of Changes

- [x] 📦 Other changes that do not modify src or test files (chore)

## Description

Remove the redundant `.codex/skills/migration-scripts` symlink. The actual skill remains in `.agents/skills/migration-scripts`, which Codex discovers directly.

## Related Issue

None.

## How Has This Been Tested?

- [x] Verified through manual testing

Confirmed the target `SKILL.md` remains present, checked that the repository has no references to `.codex/skills`, and ran `git diff --cached --check`. Application tests were not run because this only removes a redundant skill-discovery link.

## Screenshots

Not applicable.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

No changeset is needed because this is repository tooling cleanup with no extension runtime changes.
