### PR TITLE
fix(firefox): ensure content scripts are ready for page translation

### DIFF
--- a/.changeset/firefox-page-translation.md
+++ b/.changeset/firefox-page-translation.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(firefox): use browser-managed page translation shortcuts and ensure content scripts are ready before shortcut or context-menu translation

--- a/src/entrypoints/background/context-menu.ts
+++ b/src/entrypoints/background/context-menu.ts
@@ -13,6 +13,7 @@ import { getSelectionToolbarActions } from "@/utils/custom-actions"
 import { i18n } from "@/utils/i18n"
 import { sendMessage } from "@/utils/message"
 import { ensureInitializedConfig } from "./config"
+import { ensureHostContentInitialized } from "./host-injection"
 import { getPageTranslationEnabled, setPageTranslationEnabled } from "./page-translation-state"
 
 export const MENU_ID_TRANSLATE = "read-frog-translate"
@@ -209,6 +210,11 @@ async function handleContextMenuClick(
  * Handle translate menu click - toggle page translation
  */
 async function handleTranslateClick(tabId: number, tabUrl?: string) {
+  if (import.meta.env.FIREFOX) {
+    const isHostReady = await ensureHostContentInitialized(tabId)
+    if (!isHostReady) return
+  }
+
   const isCurrentlyTranslated = await getPageTranslationEnabled(tabId)
   const newState = !isCurrentlyTranslated
 

--- a/src/entrypoints/background/host-injection.ts
+++ b/src/entrypoints/background/host-injection.ts
@@ -1,0 +1,51 @@
+import type { Browser } from "#imports"
+import { browser } from "#imports"
+
+const pendingHostInitialization = new Map<number, Promise<boolean>>()
+
+export async function ensureHostContentInitialized(tabId: number): Promise<boolean> {
+  const pending = pendingHostInitialization.get(tabId)
+  if (pending) return pending
+
+  const initialization = initializeHostContent(tabId)
+  pendingHostInitialization.set(tabId, initialization)
+
+  return initialization.finally(() => pendingHostInitialization.delete(tabId))
+}
+
+async function initializeHostContent(tabId: number): Promise<boolean> {
+  const isHostReady = await waitForHostContentReady(tabId)
+  if (isHostReady !== null) return isHostReady
+
+  await browser.scripting.executeScript({
+    target: { tabId },
+    files: ["/content-scripts/host.js"],
+  })
+
+  const initialized = await waitForHostContentReady(tabId)
+  if (initialized === null) throw new Error("Host content script did not initialize")
+  return initialized
+}
+
+// true: exists
+// null: not exists
+// false: exists but disabled
+async function waitForHostContentReady(tabId: number): Promise<boolean | null> {
+  const [injection] = (await browser.scripting.executeScript({
+    target: { tabId },
+    func: async () => {
+      const task = window.__READ_FROG_HOST_READY__
+      if (!task) return null
+
+      return await task
+    },
+  }))
+
+  if (injection?.result !== undefined) return injection.result
+
+  // Firefox returns script failures in the result instead of rejecting executeScript.
+  // @ts-expect-error
+  if (injection?.error !== undefined) throw injection.error
+
+  throw new Error("Failed to read host content initialization state")
+}

--- a/src/entrypoints/background/translation-signal.ts
+++ b/src/entrypoints/background/translation-signal.ts
@@ -12,6 +12,7 @@ import { shouldEnableAutoTranslation } from "@/utils/host/translate/auto-transla
 import { logger } from "@/utils/logger"
 import { onMessage, sendMessage } from "@/utils/message"
 import { getPageTranslationOriginScope } from "@/utils/url"
+import { ensureHostContentInitialized } from "./host-injection"
 import {
   injectHostContentIntoCurrentTabIframesAfterNodeTranslation,
   injectHostContentIntoTabIframes,
@@ -87,6 +88,9 @@ export function translationMessage() {
           (await browser.tabs.query({ active: true, currentWindow: true }))[0]
 
         if (targetTab?.id === undefined) return
+
+        const isHostReady = await ensureHostContentInitialized(targetTab.id)
+        if (!isHostReady) return
 
         await sendMessage(
           "togglePageTranslation",

--- a/src/entrypoints/background/translation-signal.ts
+++ b/src/entrypoints/background/translation-signal.ts
@@ -5,6 +5,7 @@ import { browser, storage } from "#imports"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext } from "@/utils/analytics"
 import { normalizeDetectedCode } from "@/utils/config/languages"
+import { TOGGLE_PAGE_TRANSLATION_COMMAND } from "@/utils/constants/commands"
 import { CONFIG_STORAGE_KEY, DEFAULT_DETECTED_CODE } from "@/utils/constants/config"
 import { getDetectedCodeStateKey, getTranslationStateKey } from "@/utils/constants/storage-keys"
 import { shouldEnableAutoTranslation } from "@/utils/host/translate/auto-translation"
@@ -75,6 +76,34 @@ async function publishAndRefreshActiveTab(tabId: number): Promise<void> {
 }
 
 export function translationMessage() {
+  if (import.meta.env.FIREFOX) {
+    browser.commands.onCommand.addListener(async (command, tab) => {
+      if (command !== TOGGLE_PAGE_TRANSLATION_COMMAND) return
+
+      try {
+        const targetTab =
+          tab ??
+          // Firefox versions before 126 do not include the triggering tab.
+          (await browser.tabs.query({ active: true, currentWindow: true }))[0]
+
+        if (targetTab?.id === undefined) return
+
+        await sendMessage(
+          "togglePageTranslation",
+          {
+            analyticsContext: createFeatureUsageContext(
+              ANALYTICS_FEATURE.PAGE_TRANSLATION,
+              ANALYTICS_SURFACE.SHORTCUT,
+            ),
+          },
+          { tabId: targetTab.id, frameId: 0 },
+        )
+      } catch (error) {
+        logger.warn("Failed to toggle page translation from browser shortcut", error)
+      }
+    })
+  }
+
   onMessage("getEnablePageTranslationByTabId", async (msg) => {
     const { tabId } = msg.data
     return await getTranslationState(tabId)

--- a/src/entrypoints/host.content/host-readiness.ts
+++ b/src/entrypoints/host.content/host-readiness.ts
@@ -1,0 +1,28 @@
+import type { ContentScriptContext } from "#imports"
+
+declare global {
+  interface Window {
+    __READ_FROG_HOST_READY__?: Promise<boolean>
+  }
+}
+
+export async function waitForHostContentReady(
+  ctx: ContentScriptContext,
+  ready: Promise<boolean>,
+): Promise<void> {
+  window.__READ_FROG_HOST_READY__ = ready
+  ctx.onInvalidated(() => {
+    if (window.__READ_FROG_HOST_READY__ === ready) {
+      delete window.__READ_FROG_HOST_READY__
+    }
+  })
+
+  try {
+    await ready
+  } catch (error) {
+    if (window.__READ_FROG_HOST_READY__ === ready) {
+      window.__READ_FROG_HOST_INJECTED__ = false
+    }
+    throw error
+  }
+}

--- a/src/entrypoints/host.content/index.tsx
+++ b/src/entrypoints/host.content/index.tsx
@@ -1,4 +1,5 @@
 import "@/utils/zod-config"
+import type { ContentScriptContext } from "#imports"
 import { defineContentScript } from "#imports"
 import { getLocalConfig } from "@/utils/config/storage"
 import { initI18n } from "@/utils/i18n"
@@ -7,11 +8,29 @@ import {
   getEffectiveSiteControlUrl,
   isSiteEnabled,
 } from "@/utils/site-control"
+import { waitForHostContentReady } from "./host-readiness"
 
 declare global {
   interface Window {
     __READ_FROG_HOST_INJECTED__?: boolean
   }
+}
+
+async function initializeHostContent(ctx: ContentScriptContext): Promise<boolean> {
+  const initialConfig = await getLocalConfig()
+  const siteControlUrl = getEffectiveSiteControlUrl(window.location.href)
+
+  if (!isSiteEnabled(siteControlUrl, initialConfig)) {
+    window.__READ_FROG_HOST_INJECTED__ = false
+    clearEffectiveSiteControlUrl()
+    return false
+  }
+
+  await initI18n(initialConfig?.uiLanguage)
+
+  const { bootstrapHostContent } = await import("./runtime")
+  await bootstrapHostContent(ctx, initialConfig)
+  return ctx.isValid
 }
 
 export default defineContentScript({
@@ -22,18 +41,11 @@ export default defineContentScript({
     if (window.__READ_FROG_HOST_INJECTED__) return
     window.__READ_FROG_HOST_INJECTED__ = true
 
-    const initialConfig = await getLocalConfig()
-    const siteControlUrl = getEffectiveSiteControlUrl(window.location.href)
-
-    if (!isSiteEnabled(siteControlUrl, initialConfig)) {
-      window.__READ_FROG_HOST_INJECTED__ = false
-      clearEffectiveSiteControlUrl()
-      return
+    const ready = initializeHostContent(ctx)
+    if (import.meta.env.FIREFOX) {
+      await waitForHostContentReady(ctx, ready)
+    } else {
+      await ready
     }
-
-    await initI18n(initialConfig?.uiLanguage)
-
-    const { bootstrapHostContent } = await import("./runtime")
-    await bootstrapHostContent(ctx, initialConfig)
   },
 })

--- a/src/entrypoints/host.content/runtime.ts
+++ b/src/entrypoints/host.content/runtime.ts
@@ -88,6 +88,14 @@ export async function bootstrapHostContent(
   }
   window.addEventListener("extension:URLChange", handleExtensionUrlChange)
 
+  const cleanupTranslationToggleListener = onMessage("togglePageTranslation", (msg) => {
+    if (manager.isActive) {
+      manager.stop({ userInitiated: true })
+    } else {
+      void manager.start(msg.data.analyticsContext)
+    }
+  })
+
   // Listen for translation state changes from background
   const cleanupTranslationStateListener = onMessage("askManagerToTogglePageTranslation", (msg) => {
     const { enabled, analyticsContext } = msg.data
@@ -131,6 +139,7 @@ export async function bootstrapHostContent(
     cleanupTranslationShortcut()
     cleanupTranslationModeShortcut()
     cleanupTranslationHubShortcut()
+    cleanupTranslationToggleListener()
     cleanupTranslationStateListener()
     cleanupFrameTranslationStateListener()
     cleanupDetectedLanguageRefreshListener()

--- a/src/entrypoints/host.content/translation-control/bind-translation-shortcut.ts
+++ b/src/entrypoints/host.content/translation-control/bind-translation-shortcut.ts
@@ -14,6 +14,9 @@ import {
  * Uses sync cached config inside the hotkey callback to avoid async overhead.
  */
 export async function bindTranslationShortcutKey(pageTranslationManager: PageTranslationManager) {
+  // Skip because this handle by browser
+  if (import.meta.env.FIREFOX) return () => {}
+
   const config = await getLocalConfig()
   if (!config || isPageTranslationShortcutEmpty(config.pageTranslation.page.shortcut)) {
     return () => {}

--- a/src/entrypoints/options/pages/shortcuts/page-translation-shortcut.tsx
+++ b/src/entrypoints/options/pages/shortcuts/page-translation-shortcut.tsx
@@ -1,12 +1,31 @@
 import { useAtom } from "jotai"
+import { Input } from "@/components/ui/base-ui/input"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
 import { DEFAULT_AUTO_TRANSLATE_SHORTCUT_KEY } from "@/utils/constants/translate"
 import { i18n } from "@/utils/i18n"
+import { ConfigItem } from "../../components/config-item"
 import { ShortcutConfigItem } from "./shortcut-config-item"
 
 export function PageTranslationShortcut() {
   const [translateConfig, setTranslateConfig] = useAtom(configFieldsAtomMap.pageTranslation)
   const shortcut = translateConfig.page.shortcut ?? DEFAULT_AUTO_TRANSLATE_SHORTCUT_KEY
+
+  if (import.meta.env.FIREFOX) {
+    return (
+      <ConfigItem
+        id="page-translation-shortcut"
+        title={i18n.t("options.shortcuts.pageTranslation.title")}
+        description={i18n.t("options.shortcuts.pageTranslation.description")}
+      >
+        <Input
+          disabled
+          placeholder={i18n.t("options.shortcuts.pageTranslation.managedByBrowser")}
+          aria-label={i18n.t("options.shortcuts.pageTranslation.title")}
+          className="w-44"
+        />
+      </ConfigItem>
+    )
+  }
 
   return (
     <ShortcutConfigItem

--- a/src/entrypoints/popup/components/translate-button.tsx
+++ b/src/entrypoints/popup/components/translate-button.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@tanstack/react-query"
 import { useAtom, useAtomValue } from "jotai"
 import { browser } from "#imports"
 import { Button } from "@/components/ui/base-ui/button"
@@ -5,6 +6,7 @@ import { Kbd, KbdGroup } from "@/components/ui/base-ui/kbd"
 import { ANALYTICS_FEATURE, ANALYTICS_SURFACE } from "@/types/analytics"
 import { createFeatureUsageContext } from "@/utils/analytics"
 import { configFieldsAtomMap } from "@/utils/atoms/config"
+import { TOGGLE_PAGE_TRANSLATION_COMMAND } from "@/utils/constants/commands"
 import { i18n } from "@/utils/i18n"
 import { sendMessage } from "@/utils/message"
 import { formatHotkeyParts } from "@/utils/os.ts"
@@ -44,9 +46,16 @@ export default function TranslateButton({ className }: { className?: string }) {
 
   const isSiteBlocked = mode === "whitelist" ? !isCurrentSiteInWhitelist : isCurrentSiteInBlacklist
   const isDisabled = isIgnoreTab || isSiteBlocked
-  const shortcutParts = isPageTranslationShortcutEmpty(translateConfig.page.shortcut)
-    ? []
-    : formatHotkeyParts(translateConfig.page.shortcut)
+
+  const { data: browserShortcut = "" } = useQuery({
+    queryKey: ["browser-commands"],
+    queryFn: () => browser.commands.getAll(),
+    select: (commands) =>
+      commands.find((command) => command.name === TOGGLE_PAGE_TRANSLATION_COMMAND)?.shortcut ?? "",
+    enabled: import.meta.env.FIREFOX,
+  })
+  const shortcut = import.meta.env.FIREFOX ? browserShortcut : translateConfig.page.shortcut
+  const shortcutParts = isPageTranslationShortcutEmpty(shortcut) ? [] : formatHotkeyParts(shortcut)
 
   return (
     <Button onClick={toggleTranslation} disabled={isDisabled} className={cn("min-w-0", className)}>

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1,4 +1,6 @@
 name: Read Frog
+commands:
+  togglePageTranslation: Toggle page translation
 extName: "Read Frog - Translate & Learn"
 extDescription: Read Frog is an open source browser extension designed to help you learn languages deeply from any website.
 uninstallSurveyUrl: https://tally.so/r/nPK6Ob
@@ -479,6 +481,7 @@ options:
     pageTranslation:
       title: Page translation
       description: Translate the whole page.
+      managedByBrowser: Managed by the browser
     translationMode:
       title: Translation mode
       description: Switch between bilingual and translation only.

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -1,4 +1,6 @@
 name: Read Frog
+commands:
+  togglePageTranslation: Alternar la traducción de la página
 extName: Read Frog - Traduce y aprende
 extDescription: Read Frog es una extensión de navegador de código abierto diseñada para ayudarte a aprender idiomas en profundidad desde cualquier sitio web.
 uninstallSurveyUrl: https://tally.so/r/nPK6Ob
@@ -479,6 +481,7 @@ options:
     pageTranslation:
       title: Traducción de la página
       description: Traduce la página completa.
+      managedByBrowser: Gestionado por el navegador
     translationMode:
       title: Modo de traducción
       description: Alterna entre bilingüe y solo traducción.

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -1,4 +1,6 @@
 name: 読書カエル
+commands:
+  togglePageTranslation: ページ翻訳を切り替える
 extName: 読書カエル - 翻訳して学ぶ
 extDescription: 読書カエルは、あらゆるウェブサイトから言語を深く学ぶために設計されたオープンソースのブラウザ拡張機能です。
 uninstallSurveyUrl: https://tally.so/r/nPK6Ob
@@ -478,6 +480,7 @@ options:
     pageTranslation:
       title: ページ翻訳
       description: ページ全体を翻訳します。
+      managedByBrowser: ブラウザーで管理
     translationMode:
       title: 翻訳モード
       description: バイリンガルと翻訳のみを切り替えます。

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -1,4 +1,6 @@
 name: Read Frog
+commands:
+  togglePageTranslation: 페이지 번역 전환
 extName: Read Frog - 번역하고 배우기
 extDescription: Read Frog는 모든 웹사이트에서 언어를 깊이 있게 학습할 수 있도록 도와주는 오픈 소스 브라우저 확장 프로그램입니다.
 uninstallSurveyUrl: https://tally.so/r/nPK6Ob
@@ -478,6 +480,7 @@ options:
     pageTranslation:
       title: 페이지 번역
       description: 페이지 전체를 번역합니다.
+      managedByBrowser: 브라우저에서 관리
     translationMode:
       title: 번역 모드
       description: 이중 언어와 번역만 사이를 전환합니다.

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -1,4 +1,6 @@
 name: Read Frog
+commands:
+  togglePageTranslation: Переключить перевод страницы
 extName: Read Frog - Переводи и учись
 extDescription: Read Frog — расширение браузера с открытым исходным кодом, которое поможет вам глубоко изучать языки на любом веб-сайте.
 uninstallSurveyUrl: https://tally.so/r/nPK6Ob
@@ -478,6 +480,7 @@ options:
     pageTranslation:
       title: Перевод страницы
       description: Перевести всю страницу.
+      managedByBrowser: Управляется браузером
     translationMode:
       title: Режим перевода
       description: Переключение между двуязычным режимом и только переводом.

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -1,4 +1,6 @@
 name: Read Frog
+commands:
+  togglePageTranslation: Sayfa çevirisini aç/kapat
 extName: Read Frog - Çevir ve Öğren
 extDescription: Read Frog, herhangi bir web sitesinden dilleri derinlemesine öğrenmenize yardımcı olmak için tasarlanmış açık kaynaklı bir tarayıcı uzantısıdır.
 uninstallSurveyUrl: https://tally.so/r/nPK6Ob
@@ -478,6 +480,7 @@ options:
     pageTranslation:
       title: Sayfa çevirisi
       description: Sayfanın tamamını çevirir.
+      managedByBrowser: Tarayıcı tarafından yönetilir
     translationMode:
       title: Çeviri modu
       description: İki dilli ve yalnızca çeviri arasında geçiş yapar.

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -1,4 +1,6 @@
 name: Read Frog
+commands:
+  togglePageTranslation: Bật/tắt dịch trang
 extName: Read Frog - Dịch và học
 extDescription: Read Frog là tiện ích mở rộng trình duyệt mã nguồn mở được thiết kế để giúp bạn học ngôn ngữ sâu từ bất kỳ trang web nào.
 uninstallSurveyUrl: https://tally.so/r/nPK6Ob
@@ -478,6 +480,7 @@ options:
     pageTranslation:
       title: Dịch trang
       description: Dịch toàn bộ trang.
+      managedByBrowser: Do trình duyệt quản lý
     translationMode:
       title: Chế độ dịch
       description: Chuyển giữa song ngữ và chỉ bản dịch.

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -1,4 +1,6 @@
 name: 陪读蛙
+commands:
+  togglePageTranslation: 切换整页翻译
 extName: 陪读蛙 - 翻译与学习
 extDescription: 陪读蛙是一款开放源代码的浏览器插件，旨在帮助您从任何网站深入学习语言。
 uninstallSurveyUrl: https://tally.so/r/3E9XDL
@@ -479,6 +481,7 @@ options:
     pageTranslation:
       title: 网页翻译
       description: 翻译整个网页。
+      managedByBrowser: 由浏览器管理
     translationMode:
       title: 翻译模式
       description: 在双语对照和仅显示翻译之间切换。

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -1,4 +1,6 @@
 name: 陪讀蛙
+commands:
+  togglePageTranslation: 切換整頁翻譯
 extName: 陪讀蛙 - 翻譯與學習
 extDescription: 陪讀蛙是一款開放原始碼的瀏覽器擴充功能，能協助使用者在任何網站上深入學習語言。
 uninstallSurveyUrl: https://tally.so/r/3E9XDL
@@ -479,6 +481,7 @@ options:
     pageTranslation:
       title: 網頁翻譯
       description: 翻譯整個網頁。
+      managedByBrowser: 由瀏覽器管理
     translationMode:
       title: 翻譯模式
       description: 在雙語對照和僅顯示翻譯之間切換。

--- a/src/utils/constants/commands.ts
+++ b/src/utils/constants/commands.ts
@@ -1,0 +1,1 @@
+export const TOGGLE_PAGE_TRANSLATION_COMMAND = "toggle-page-translation"

--- a/src/utils/message.ts
+++ b/src/utils/message.ts
@@ -68,6 +68,7 @@ interface ProtocolMap {
   refreshDetectedPageLanguage: () => void
   getDetectedCode: () => LangCodeISO6393
   detectedPageLanguageChanged: (data: { detectedCode: LangCodeISO6393 }) => void
+  togglePageTranslation: (data: { analyticsContext: FeatureUsageContext }) => void
   // ask host to start page translation
   askManagerToTogglePageTranslation: (data: {
     enabled: boolean

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,6 +8,7 @@ import {
   isLocalPackagesEnabled,
   resolveExtensionEnv,
 } from "./src/env/shared"
+import { TOGGLE_PAGE_TRANSLATION_COMMAND } from "./src/utils/constants/commands"
 
 const WXT_API_KEY_PATTERN = /^WXT_.*API_KEY/
 const ALLOWED_BUNDLED_API_KEYS = new Set(["WXT_POSTHOG_API_KEY"])
@@ -66,6 +67,12 @@ export default defineConfig({
     ],
     // Firefox-specific settings for MV3
     ...(browser === "firefox" && {
+      commands: {
+        [TOGGLE_PAGE_TRANSLATION_COMMAND]: {
+          suggested_key: { default: "Alt+E" },
+          description: "__MSG_commands_togglePageTranslation__",
+        },
+      },
       // Override default CSP to exclude `upgrade-insecure-requests` (Firefox MV3 default),
       // which would upgrade custom provider HTTP URLs (e.g. LAN) to HTTPS.
       content_security_policy: {


### PR DESCRIPTION
> **AI model(s) used (required):** GPT 6 Astra


## Type of Changes

<!--- Please select one type below -->

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

<!--- Please describe the changes in the PR and the problem it solves -->

Refactor Firefox's lifecycle-related logic.

- Delegate full-page translation shortcuts to browser This is not necessary, but it simplifies subsequent changes.

- Ensure script injection and initialization when using shortcuts and right-click for full-page translation.

## Related Issue

<!--- If this PR closes an issue, please link the issue below -->

Closes #2077

## How Has This Been Tested?

<!--- Please describe how you tested your changes -->

- [ ] Added unit tests
- [x] Verified through manual testing

## Screenshots

<!--- If applicable, add screenshots to help explain your changes -->

## Checklist

<!--- Go over all the following points before requesting a review -->

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

<!--- Any other information that reviewers should know -->
