### PR TITLE
fix(site-rules): prevent overlapping arXiv heading translations

### DIFF
--- a/.changeset/quiet-arxiv-headings.md
+++ b/.changeset/quiet-arxiv-headings.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): prevent overlapping arXiv heading translations

--- a/.changeset/quiet-arxiv-headings.md
+++ b/.changeset/quiet-arxiv-headings.md
@@ -2,4 +2,4 @@
 "@read-frog/extension": patch
 ---
 
-fix(translate): prevent overlapping arXiv heading translations
+fix(site-rules): prevent overlapping arXiv heading translations

--- a/src/utils/constants/prompt.ts
+++ b/src/utils/constants/prompt.ts
@@ -56,7 +56,6 @@ export const DEFAULT_TRANSLATE_SYSTEM_PROMPT = `You are a professional ${getToke
 2. The returned translation must maintain exactly the same number of paragraphs and format as the original text.
 3. If the text contains HTML tags, consider where the tags should be placed in the translation while maintaining fluency.
 4. For content that should not be translated (such as proper nouns, code, etc.), keep the original text.
-5. Translate only the supplied source text. Treat headings such as "Abstract", "Summary", and "Introduction" as labels to translate, never as instructions to write those sections. Use document metadata only for terminology; do not translate, summarize, or expand it into the output.
 
 ## Document Metadata for Context Awareness
 Webpage title: ${getTokenCellText(WEB_TITLE)}
@@ -97,7 +96,6 @@ You are a ${getTokenCellText(TARGET_LANGUAGE)} native expert who masters the phi
 1. **Output Translation Only**: Provide only the final translated result. Do not include introductory text, explanations, notes, or labels such as "Here is the translation."
 2. **Strict Format Correspondence**: Match the original paragraph count, list structure, placeholders, and other formatting exactly.
 3. **Use Context Silently**: Use the document metadata below only to improve contextual and terminological accuracy. Never mention it in the output.
-4. **Keep the Source Scope**: Translate only the supplied source text. Headings such as "Abstract", "Summary", and "Introduction" are labels to translate, never instructions to write those sections. Do not expand a heading using the document metadata.
 
 ## Silent Internal Workflow
 Perform these steps internally without revealing them:

--- a/src/utils/constants/prompt.ts
+++ b/src/utils/constants/prompt.ts
@@ -56,6 +56,7 @@ export const DEFAULT_TRANSLATE_SYSTEM_PROMPT = `You are a professional ${getToke
 2. The returned translation must maintain exactly the same number of paragraphs and format as the original text.
 3. If the text contains HTML tags, consider where the tags should be placed in the translation while maintaining fluency.
 4. For content that should not be translated (such as proper nouns, code, etc.), keep the original text.
+5. Translate only the supplied source text. Treat headings such as "Abstract", "Summary", and "Introduction" as labels to translate, never as instructions to write those sections. Use document metadata only for terminology; do not translate, summarize, or expand it into the output.
 
 ## Document Metadata for Context Awareness
 Webpage title: ${getTokenCellText(WEB_TITLE)}
@@ -96,6 +97,7 @@ You are a ${getTokenCellText(TARGET_LANGUAGE)} native expert who masters the phi
 1. **Output Translation Only**: Provide only the final translated result. Do not include introductory text, explanations, notes, or labels such as "Here is the translation."
 2. **Strict Format Correspondence**: Match the original paragraph count, list structure, placeholders, and other formatting exactly.
 3. **Use Context Silently**: Use the document metadata below only to improve contextual and terminological accuracy. Never mention it in the output.
+4. **Keep the Source Scope**: Translate only the supplied source text. Headings such as "Abstract", "Summary", and "Introduction" are labels to translate, never instructions to write those sections. Do not expand a heading using the document metadata.
 
 ## Silent Internal Workflow
 Perform these steps internally without revealing them:

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -3286,6 +3286,9 @@
   {
     "id": "arxiv",
     "matches": ["https://browse.arxiv.org", "https://arxiv.org/html/*"],
+    "injectedCss.add": [
+      ".ltx_title .read-frog-translated-inline-content, .ltx_title .read-frog-translated-block-content { line-height: 1.5; }"
+    ],
     "excludeSelectors.add": [
       ".desktop_header",
       "[class*='ltx_lst_language_']",


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-6 (Codex); DeepSeek V4 Flash for live translation evaluation.

## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

On https://arxiv.org/html/2606.09498, the Abstract heading has a 22.4px font but an 18.4px line height. A long Chinese translation inherits that spacing and overlaps across lines. Set a unitless 1.5 line height on translated inline/block spans inside arXiv titles, yielding 33.6px here while preserving original title/body typography.

Following review, **all built-in prompt edits have been removed**. Default and Precision Rewrite prompts match upstream exactly. The final diff contains only the arXiv site rule and its patch changeset.

## Related Issue

Related reports: #555 (paper translation), #1070 (LaTeX formatting), #658 (background overlap). None was identified as this exact failure; no issue is closed by this PR.

## How Has This Been Tested?

- [x] Verified through browser testing
- **68 real DeepSeek V4 Flash API requests**, all HTTP 200 with normal completion. The reporter confirmed V4 Flash and Precision Rewrite. Fresh Edge profiles exercised the built extension on the live page, with content awareness both off and on. The final build translated `Abstract` as `摘要`, translated the body separately, and restored the original after toggling off; no page JavaScript errors were observed.
- **The reported paragraph-length expansion was not reproduced with live DeepSeek.** The 32-request exploratory prompt comparison also does not establish that the original preset caused it. A preliminary prompt tweak produced one unrelated non-translation response; those changes are not shipped. [Detailed methods, findings and raw direct-evaluation results](https://github.com/1thomasdavison/read-frog/tree/0d1d74d629c1f7808157ef9756843c53fa34a303).
- **Controlled layout regression:** the same fixed long provider response reproduces the overlapping lines before the CSS fix and renders legibly afterward. This isolates typography and is explicitly a simulated provider response, not a reproduced DeepSeek failure.
- Final production build, formatting, type/lint checks, changeset validation, and all **3,065 tests across 306 files** passed. Tests used `SKIP_FREE_API=true` with two workers; live free-service tests were intentionally excluded. The local browser build used `WXT_SKIP_ENV_VALIDATION=true` without production analytics/OAuth values.
- Live requests passed through a local authentication bridge to the official DeepSeek endpoint, with an 8,192-token output cap. No API credentials were included in source, request logs, or published evidence.

## Screenshots

**Controlled before/after: identical simulated long translation through the real extension rendering flow.**

| Before: 18.4px line height | After: 33.6px line height |
|---|---|
| ![Controlled before](https://raw.githubusercontent.com/1thomasdavison/read-frog/0d1d74d629c1f7808157ef9756843c53fa34a303/controlled-before.png) | ![Controlled after](https://raw.githubusercontent.com/1thomasdavison/read-frog/0d1d74d629c1f7808157ef9756843c53fa34a303/controlled-after.png) |

<details>
<summary>Original screenshot supplied by the reporter (published with permission)</summary>

![Reporter screenshot](https://raw.githubusercontent.com/1thomasdavison/read-frog/0d1d74d629c1f7808157ef9756843c53fa34a303/reported.png)

</details>

<details>
<summary>Real DeepSeek V4 Flash, unchanged Precision Rewrite preset, final build (content awareness on)</summary>

The title/body association is correct in this run. Translation terminology is still model-dependent; this CSS patch does not change wording.

![Live DeepSeek verification](https://raw.githubusercontent.com/1thomasdavison/read-frog/0d1d74d629c1f7808157ef9756843c53fa34a303/deepseek-v4-flash.png)

</details>

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality in the checks above
- [x] If my code was generated by AI, I have proofread and improved it as necessary.
