### PR TITLE
ci(contributor-trust): exclude locales from PR auto-close

### DIFF
--- a/.github/scripts/contributor-trust/comment-template.js
+++ b/.github/scripts/contributor-trust/comment-template.js
@@ -40,7 +40,7 @@ function getChangedLineSignal(pullRequest, plan) {
 
   if (excludedChangedLines > 0) {
     lines.push(
-      `- Migration-related changed lines excluded: ${excludedChangedLines} (+${excludedAdditions} / -${excludedDeletions})`,
+      `- Migration and locale changed lines excluded: ${excludedChangedLines} (+${excludedAdditions} / -${excludedDeletions})`,
     )
   }
 
@@ -90,7 +90,7 @@ function buildContent({ owner, repo, pullRequest, author, metrics, score, plan }
     "**Policy**",
     `- Low-score review threshold: < ${POLICY.lowScoreThreshold}`,
     `- Auto-close: score < ${POLICY.autoCloseBelowScore} and counted changed lines > ${POLICY.autoCloseAboveChangedLines}`,
-    "- Migration-related files are excluded from the auto-close line count",
+    "- Migration-related files and `src/locales/**` are excluded from the auto-close line count",
     `- Policy version: \`${POLICY.version}\``,
     "",
     `_${pullRequest.state === "closed" ? "Manually re-evaluated on a closed PR." : "Updated automatically when the PR changes or when a maintainer reruns the workflow."}_`,

--- a/.github/scripts/contributor-trust/comment-template.test.js
+++ b/.github/scripts/contributor-trust/comment-template.test.js
@@ -61,11 +61,11 @@ describe("buildTrustComment", () => {
     expect(comment.body).toContain("stars on owned non-fork repositories")
     expect(comment.body).toContain("Repo commits: 14")
     expect(comment.body).toContain("PR counted changed lines: 1065 (+820 / -245)")
-    expect(comment.body).toContain("Migration-related changed lines excluded: 1662 (+1662 / -0)")
+    expect(comment.body).toContain("Migration and locale changed lines excluded: 1662 (+1662 / -0)")
     expect(comment.body).toContain("Repo permission: write")
     expect(comment.body).toContain("Auto-close: score < 20 and counted changed lines > 1000")
     expect(comment.body).toContain(
-      "Migration-related files are excluded from the auto-close line count",
+      "Migration-related files and `src/locales/**` are excluded from the auto-close line count",
     )
     expect(comment.body).toContain(
       "Owned non-fork repos considered: max 42, total 42 (kilidoc/browser-tools (42))",

--- a/.github/scripts/contributor-trust/config.js
+++ b/.github/scripts/contributor-trust/config.js
@@ -5,7 +5,7 @@ export const MANAGED_COMMENT_AUTHOR = "github-actions[bot]"
 export const TRUST_LABEL_PREFIX = "contrib-trust:"
 
 export const POLICY = Object.freeze({
-  version: "v1.2",
+  version: "v1.3",
   lowScoreThreshold: 30,
   autoCloseBelowScore: 20,
   autoCloseAboveChangedLines: 1000,

--- a/.github/scripts/contributor-trust/plan-actions.js
+++ b/.github/scripts/contributor-trust/plan-actions.js
@@ -1,6 +1,7 @@
 import { bucketToLabel, MANAGED_TRUST_LABELS, POLICY } from "./config.js"
 
-const CONFIG_MIGRATION_CHANGED_LINE_PATH_PATTERNS = Object.freeze([
+const EXCLUDED_CHANGED_LINE_PATH_PATTERNS = Object.freeze([
+  /^src\/locales\/.+/,
   /^src\/utils\/config\/migration-scripts\/v\d+-to-v\d+\.ts$/,
   /^src\/utils\/config\/__tests__\/migration-scripts\/v\d+-to-v\d+\.test\.ts$/,
   /^src\/utils\/config\/__tests__\/example\/v\d+\.ts$/,
@@ -18,9 +19,9 @@ function getPullRequestFilePath(file) {
   return String(file?.filename ?? file?.path ?? "")
 }
 
-export function isMigrationChangedLineFile(filePath) {
+export function isExcludedChangedLineFile(filePath) {
   const normalizedPath = String(filePath).replaceAll("\\", "/")
-  return CONFIG_MIGRATION_CHANGED_LINE_PATH_PATTERNS.some((pattern) => pattern.test(normalizedPath))
+  return EXCLUDED_CHANGED_LINE_PATH_PATTERNS.some((pattern) => pattern.test(normalizedPath))
 }
 
 function getFallbackChangedLineDetails(pullRequest) {
@@ -59,7 +60,7 @@ function getPullRequestChangedLineDetails(pullRequest, pullRequestFiles) {
     const changedLines = additions + deletions
     const filePath = getPullRequestFilePath(file)
 
-    if (isMigrationChangedLineFile(filePath)) {
+    if (isExcludedChangedLineFile(filePath)) {
       details.excludedAdditions += additions
       details.excludedChangedLines += changedLines
       details.excludedDeletions += deletions
@@ -78,7 +79,7 @@ function getPullRequestChangedLineDetails(pullRequest, pullRequestFiles) {
 function formatChangedLineThresholdReason(score, changedLineDetails) {
   const changedLineDescription =
     changedLineDetails.excludedChangedLines > 0
-      ? `${changedLineDetails.changedLines} counted lines after excluding ${changedLineDetails.excludedChangedLines} migration-related lines`
+      ? `${changedLineDetails.changedLines} counted lines after excluding ${changedLineDetails.excludedChangedLines} migration and locale lines`
       : `${changedLineDetails.changedLines} lines`
 
   return `Score ${score.total} is below ${POLICY.autoCloseBelowScore} and the PR changes ${changedLineDescription}, exceeding ${POLICY.autoCloseAboveChangedLines}.`

--- a/.github/scripts/contributor-trust/plan-actions.test.js
+++ b/.github/scripts/contributor-trust/plan-actions.test.js
@@ -1,28 +1,37 @@
 import { describe, expect, it } from "vitest"
 import { POLICY } from "./config.js"
-import { isMigrationChangedLineFile, planTrustActions } from "./plan-actions.js"
+import { isExcludedChangedLineFile, planTrustActions } from "./plan-actions.js"
 
-describe("isMigrationChangedLineFile", () => {
+describe("isExcludedChangedLineFile", () => {
   it("matches read-frog config migration scripts, tests, and generated fixtures", () => {
-    expect(isMigrationChangedLineFile("src/utils/config/migration-scripts/v080-to-v081.ts")).toBe(
+    expect(isExcludedChangedLineFile("src/utils/config/migration-scripts/v080-to-v081.ts")).toBe(
       true,
     )
     expect(
-      isMigrationChangedLineFile(
+      isExcludedChangedLineFile(
         "src/utils/config/__tests__/migration-scripts/v079-to-v080.test.ts",
       ),
     ).toBe(true)
-    expect(isMigrationChangedLineFile("src/utils/config/__tests__/example/v081.ts")).toBe(true)
-    expect(isMigrationChangedLineFile(".agents/skills/migration-scripts/SKILL.md")).toBe(false)
-    expect(isMigrationChangedLineFile("src/utils/config/migration.ts")).toBe(false)
-    expect(isMigrationChangedLineFile("src/utils/config/migration-scripts/types.ts")).toBe(false)
+    expect(isExcludedChangedLineFile("src/utils/config/__tests__/example/v081.ts")).toBe(true)
+    expect(isExcludedChangedLineFile(".agents/skills/migration-scripts/SKILL.md")).toBe(false)
+    expect(isExcludedChangedLineFile("src/utils/config/migration.ts")).toBe(false)
+    expect(isExcludedChangedLineFile("src/utils/config/migration-scripts/types.ts")).toBe(false)
     expect(
-      isMigrationChangedLineFile(
+      isExcludedChangedLineFile(
         "src/utils/config/__tests__/migration-scripts/all-migrations.test.ts",
       ),
     ).toBe(false)
-    expect(isMigrationChangedLineFile("src/utils/config/__tests__/example/types.ts")).toBe(false)
-    expect(isMigrationChangedLineFile("src/entrypoints/host.content/runtime.ts")).toBe(false)
+    expect(isExcludedChangedLineFile("src/utils/config/__tests__/example/types.ts")).toBe(false)
+    expect(isExcludedChangedLineFile("src/entrypoints/host.content/runtime.ts")).toBe(false)
+  })
+
+  it("excludes files within src/locales without matching similarly named paths", () => {
+    expect(isExcludedChangedLineFile("src/locales/az.yml")).toBe(true)
+    expect(isExcludedChangedLineFile("src/locales/nested/messages.json")).toBe(true)
+    expect(isExcludedChangedLineFile("src\\locales\\en.yml")).toBe(true)
+    expect(isExcludedChangedLineFile("src/locales.ts")).toBe(false)
+    expect(isExcludedChangedLineFile("src/locales-backup/en.yml")).toBe(false)
+    expect(isExcludedChangedLineFile("src/components/locales/en.yml")).toBe(false)
   })
 })
 
@@ -181,6 +190,64 @@ describe("planTrustActions", () => {
     ])
     expect(plan.closeReason).toBeNull()
   })
+
+  it("keeps a large locale-only PR open for a new contributor", () => {
+    const plan = planTrustActions({
+      pullRequest: { additions: 2300, deletions: 200 },
+      pullRequestFiles: [
+        { filename: "src/locales/az.yml", additions: 2200, deletions: 0 },
+        { filename: "src/locales/en.yml", additions: 100, deletions: 200 },
+      ],
+      score: { bucket: "new", total: 0 },
+    })
+
+    expect(plan).toMatchObject({
+      changedLines: 0,
+      excludedChangedLineAdditions: 2300,
+      excludedChangedLineDeletions: 200,
+      excludedChangedLines: 2500,
+      excludedChangedLineFiles: ["src/locales/az.yml", "src/locales/en.yml"],
+      needsMaintainerReview: true,
+      shouldClosePr: false,
+      closeReason: null,
+    })
+  })
+
+  it.each([
+    [1000, false, null],
+    [
+      1001,
+      true,
+      expect.stringContaining("1001 counted lines after excluding 3500 migration and locale lines"),
+    ],
+  ])(
+    "applies the threshold to %i non-excluded lines in a mixed PR",
+    (changedLines, shouldClosePr, closeReason) => {
+      const plan = planTrustActions({
+        pullRequestFiles: [
+          { filename: "src/locales/az.yml", additions: 1800, deletions: 200 },
+          {
+            filename: "src/utils/config/__tests__/example/v081.ts",
+            additions: 1500,
+            deletions: 0,
+          },
+          {
+            filename: "src/entrypoints/host.content/runtime.ts",
+            additions: 900,
+            deletions: changedLines - 900,
+          },
+        ],
+        score: { bucket: "new", total: 19 },
+      })
+
+      expect(plan).toMatchObject({
+        changedLines,
+        excludedChangedLines: 3500,
+        shouldClosePr,
+        closeReason,
+      })
+    },
+  )
 
   it("does not auto-close a low-score PR when it is still under the line threshold", () => {
     const plan = planTrustActions({

--- a/.github/scripts/contributor-trust/run.js
+++ b/.github/scripts/contributor-trust/run.js
@@ -274,7 +274,7 @@ export async function main() {
   summaryLines.push(`- Trust score: **${score.total}/100**`)
   summaryLines.push(`- PR counted changed lines: ${plan.changedLines}`)
   if (plan.excludedChangedLines > 0)
-    summaryLines.push(`- Migration-related changed lines excluded: ${plan.excludedChangedLines}`)
+    summaryLines.push(`- Migration and locale changed lines excluded: ${plan.excludedChangedLines}`)
   summaryLines.push(`- Bucket: \`${score.bucket}\``)
   summaryLines.push(`- Target label: \`${plan.targetTrustLabel}\``)
   summaryLines.push(

--- a/.github/scripts/contributor-trust/run.test.js
+++ b/.github/scripts/contributor-trust/run.test.js
@@ -232,6 +232,6 @@ describe("main", () => {
     const summary = await readFile(process.env.GITHUB_STEP_SUMMARY, "utf8")
     expect(summary).toContain("- Trust score: **78/100**")
     expect(summary).toContain("- PR counted changed lines: 25")
-    expect(summary).toContain("- Migration-related changed lines excluded: 1500")
+    expect(summary).toContain("- Migration and locale changed lines excluded: 1500")
   })
 })


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-6 (Codex)

## Type of Changes

- [x] 🔄 CI/CD related (ci)

## Description

Large translation contributions can currently be auto-closed when the contributor trust score is below 20 and their locale changes push the PR above 1,000 counted lines. Exclude files under `src/locales/**` from that count, alongside the existing versioned config migration exclusions.

For example, a PR containing 2,500 changed locale lines now counts as zero lines toward auto-close. A mixed PR still closes when its non-excluded changes exceed 1,000 lines and its contributor score is below 20.

Update the bot comment, workflow summary, and closure explanation to describe both exclusions, and bump the policy version to `v1.3`.

## Related Issue

None.

## How Has This Been Tested?

- [x] Added unit tests
- Contributor-trust suite: all 35 tests passed using an isolated Node/Vitest configuration with `SKIP_FREE_API=true`.
- Regression coverage includes large locale-only PRs, similarly named paths outside `src/locales`, and mixed PRs with exactly 1,000 or 1,001 non-excluded changed lines.
- Formatting and lint checks passed for all seven changed files.
- `git diff --check` passed.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

No changeset is needed: this changes repository automation and does not require an extension release. The updated policy takes effect after merging into the trusted base branch.
