### PR TITLE
fix(translation): distinguish preserved names from foreign prose

### DIFF
--- a/.changeset/safer-target-language-sentinel.md
+++ b/.changeset/safer-target-language-sentinel.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translation): distinguish preserved names and code from foreign-language prose when skipping already-translated paragraphs

--- a/src/utils/constants/prompt.ts
+++ b/src/utils/constants/prompt.ts
@@ -208,54 +208,21 @@ Direct translation without separators
 `
 
 /**
- * The marker rule: a heading plus a single body line. Both sentences in that
- * line are load-bearing — the language test, and the ban on mixing the marker
- * into translated text (isNoTranslationSentinel matches the marker exactly, so
- * mixed output reaches the page verbatim).
+ * Safety-first marker rule selected from the September 2026 target-language
+ * benchmark: 12 prompt variants, six strong/weak Atlas models, 416 tasks, and
+ * Simplified Chinese/English/Japanese targets. Compared with the previous
+ * every-word rule, this wording distinguishes preserved tokens (brand names,
+ * handles, URLs, numbers, code) from foreign-language prose while producing the
+ * fewest hidden owed translations among the Chinese finalists.
  *
- * Benchmarked on 120 real paragraphs scraped from react.dev / MDN / Wikipedia /
- * vitejs / arXiv, each hand-labelled for whether a translation is actually owed
- * — identifiers like `ArrayBuffer` and pure code are excluded, since dropping
- * those is correct rather than a bug, leaving 107. 4 runs x 8 models:
- * deepseek-v4-pro/flash, glm-4.7, qwen3.5-27b, gpt-5-nano, gpt-5.4-nano/mini,
- * gpt-4o-mini, target language Simplified Chinese. Share of owed paragraphs
- * that rendered nothing:
- *
- *   original wording, marker shown in the example   7.9%   (deepseek-v4-pro 18.0%)
- *   this wording, marker absent from the example    4.7%   (deepseek-v4-pro  1.6%)
- *   two longer variants, same removal               4.2% and 4.9%
- *
- * Original vs any fix is significant (z = -5.5); the three fixes are not
- * distinguishable from each other (|z| < 1.3). One edit carries the win —
- * deleting the marked slot from the worked example — so among wordings that
- * measure the same, take the shortest. Concretely, do not add back:
- *
- * 1. The marked example slot. Showing one of three example segments marked
- *    taught a ~1-in-3 marker base rate that outweighed the rule. Re-wording that
- *    segment does not help, only deleting it does — which is why the page
- *    pipeline now uses the same plain DEFAULT_BATCH_TRANSLATE_PROMPT that
- *    subtitles use. See the "keeps the marker out of the batch format example"
- *    test, which is what actually guards this.
- * 2. A negative list of the misfiring shapes (headings, API names, bibliography
- *    entries, error messages). It costs +894 characters on every batch request
- *    and buys nothing measurable. It also made gpt-5-nano worse — and gpt-5-nano
- *    never emits the marker at all, so the block was not changing its marker
- *    decisions; naming those shapes primed it to leave them untranslated by
- *    echoing the source, which the equality check in getDisplayTranslation then
- *    renders as nothing just the same.
- * 3. The clause "instead of repeating the paragraph". Told not to repeat, models
- *    produce something different rather than nothing: already-target-language
- *    paragraphs translated back into the source language rose from 8 to 22
- *    occurrences over the same runs.
- *
- * The wording that caused the bug was the conjunct "and needs no translation",
- * read by models as an independent trigger for anything they judged
- * untranslatable — a smaller effect than the example, but the same failure.
- * Code maps the marker to "", so each such paragraph rendered as nothing. Keep
- * the condition a pure language test.
+ * Keep the rule parameterized: the user selected it for every target language.
+ * It remains a probabilistic fallback, not the primary language detector. In
+ * particular, keep BatchQueue's count validation and individual fallback: they
+ * reject a multi-item batch that collapses to one marker instead of accepting
+ * it as a verdict for every item.
  */
 export const DEFAULT_SENTINEL_TRANSLATE_PROMPT = `## Already-translated Input Rule
-Use the exact marker ${NO_TRANSLATION_SENTINEL} as a paragraph's entire translation only when every word of it is already ${getTokenCellText(TARGET_LANGUAGE)}; otherwise always translate. Never mix the marker with translated text.`
+Output only ${NO_TRANSLATION_SENTINEL} when only non-translatable names, brands, handles, URLs, numbers, or code differ from ${getTokenCellText(TARGET_LANGUAGE)}. A foreign-language phrase or clause must be translated.`
 
 // === Subtitles Segmentation Prompts ===
 

--- a/src/utils/prompts/__tests__/translate.test.ts
+++ b/src/utils/prompts/__tests__/translate.test.ts
@@ -350,18 +350,19 @@ describe("no-translation sentinel", () => {
     customPromptsConfig: { promptId: DEFAULT_TRANSLATE_PROMPT_ID, patterns: [] },
   }
 
-  it("appends the sentinel rule to batch prompts with the target language substituted", () => {
-    const result = getTranslatePromptFromConfig(defaultPromptsConfig, "Simplified Chinese", "Hi", {
-      isBatch: true,
-    })
+  it.each(["Simplified Chinese", "English", "Japanese"])(
+    "appends the sentinel rule to batch prompts with %s substituted",
+    (targetLanguage) => {
+      const result = getTranslatePromptFromConfig(defaultPromptsConfig, targetLanguage, "Hi", {
+        isBatch: true,
+      })
 
-    expect(result.systemPrompt).toContain("Already-translated Input Rule")
-    expect(result.systemPrompt).toContain(NO_TRANSLATION_SENTINEL)
-    expect(result.systemPrompt).toContain(
-      "only when every word of it is already Simplified Chinese",
-    )
-    expect(result.systemPrompt).not.toContain("{{targetLanguage}}")
-  })
+      expect(result.systemPrompt).toContain("Already-translated Input Rule")
+      expect(result.systemPrompt).toContain(NO_TRANSLATION_SENTINEL)
+      expect(result.systemPrompt).toContain(`differ from ${targetLanguage}`)
+      expect(result.systemPrompt).not.toContain("{{targetLanguage}}")
+    },
+  )
 
   it("keeps the marker out of the batch format example", () => {
     const result = getTranslatePromptFromConfig(defaultPromptsConfig, "Simplified Chinese", "Hi", {
@@ -378,26 +379,16 @@ describe("no-translation sentinel", () => {
     expect(result.systemPrompt).toContain(DEFAULT_BATCH_TRANSLATE_PROMPT)
   })
 
-  it("keeps the marker rule small and free of the wordings that misfired", () => {
-    // Three wordings this block has already been burned by, none of them
-    // visible to a behavioural test, so pin the shape instead:
-    //   - "and needs no translation" let models treat "untranslatable" as a
-    //     trigger — the wording that caused the missing-paragraph bug;
-    //   - enumerating the misfiring shapes (headings, API names, bibliography
-    //     entries, error messages) primes small models to skip them;
-    //   - "instead of repeating the paragraph" pushed models to render
-    //     already-target-language paragraphs back into the source language.
-    // The body is deliberately ONE line: a list would be appended as further
-    // lines, which a sentence count split on ". " cannot see.
+  it("keeps the selected marker rule small and pins its safety boundary", () => {
     const lines = DEFAULT_SENTINEL_TRANSLATE_PROMPT.split("\n")
     expect(lines).toHaveLength(2)
     expect(lines[1]!.length).toBeLessThan(240)
-    expect(DEFAULT_SENTINEL_TRANSLATE_PROMPT).not.toContain("needs no translation")
-    expect(DEFAULT_SENTINEL_TRANSLATE_PROMPT).not.toContain("instead of repeating the paragraph")
-    // The one clause in here that is not part of the language test. Without it
-    // a model can mix the marker into otherwise translated output, which
-    // isNoTranslationSentinel (exact match only) would then render verbatim.
-    expect(DEFAULT_SENTINEL_TRANSLATE_PROMPT).toContain("Never mix the marker with translated text")
+    expect(DEFAULT_SENTINEL_TRANSLATE_PROMPT).toContain(
+      "names, brands, handles, URLs, numbers, or code",
+    )
+    expect(DEFAULT_SENTINEL_TRANSLATE_PROMPT).toContain(
+      "A foreign-language phrase or clause must be translated",
+    )
   })
 
   it("never leaks the sentinel into subtitle prompts, which share the batch rules", async () => {


### PR DESCRIPTION
> **AI model(s) used (required):** Codex (GPT-5) for implementation and test orchestration; `deepseek-ai/deepseek-v4-pro`, `qwen/qwen3.7-plus`, `moonshotai/kimi-k2.5`, `deepseek-ai/deepseek-v4-flash`, `qwen/qwen3.5-flash`, and `bytedance/doubao-seed-2.0-mini-260428` for the prompt benchmark. DeepSeek V4 Pro and Qwen 3.7 Plus also performed the blinded semantic audit.

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

### Problem

The webpage LLM batch prompt previously allowed `{{NO_TRANSLATION_NEEDED}}` only when "every word" was already in the target language. That wording treats preserved tokens such as product names, handles, URLs, numbers, and code as evidence that a target-language paragraph still needs translation.

A short mixed-token paragraph can bypass the deterministic target-language precheck and then be paraphrased into the same language:

```text
Source:
iPhone Duo看样子挺值得入手，就是太贵了，我们还是努力挣钱吧。

Leaked same-language "translation":
iPhone Duo 看起来挺值得入手的，就是太贵了，我们还是努力赚钱吧。
```

The result is not equal to the source after the existing cosmetic normalization, so users see a redundant second line.

### Change

Replace the global, parameterized webpage sentinel rule with the safety-first P5 candidate selected from the benchmark:

```text
Output only {{NO_TRANSLATION_NEEDED}} when only non-translatable names, brands, handles, URLs, numbers, or code differ from {{targetLanguage}}. A foreign-language phrase or clause must be translated.
```

The rule remains appended only to webpage LLM batch prompts. Subtitle prompts still never receive the sentinel because their pipeline has no sentinel mapping.

The tests now verify target-language substitution for Simplified Chinese, English, and Japanese, pin the preserved-token boundary, keep the prompt body under 240 characters, and preserve the existing subtitle isolation and exact-marker parsing guarantees.

This PR includes a patch changeset for `@read-frog/extension`.

## Prompt Experiment

### Goal and safety order

The experiment looked for the shortest prompt that distinguishes target-language prose containing preserved tokens from prose that still contains translatable foreign-language meaning.

Errors were ranked by user impact:

1. A required translation disappears: false sentinel, empty/missing output, normalized source echo hidden by the production equality check, or unalignable batch output.
2. Batch structure fails or a marker is mixed with translated text.
3. Target-language content is paraphrased and becomes a visible duplicate.
4. Target-language content is echoed exactly; the production equality fallback hides it, but the request was wasted.

False sentinels and hidden required translations were never offset by high sentinel recall when selecting a winner.

### Fixtures

Fixtures were labelled before execution as:

- `SKIP`: all translatable prose is already in the target language.
- `TRANSLATE`: at least one meaningful foreign-language phrase or clause must be translated.

The set covers:

- pure target-language and pure foreign-language prose;
- brands and product names such as `iPhone Duo`, `MacBook Pro`, and `Nintendo Switch 2`;
- people, company names, handles, hashtags, URLs, email addresses, and paths;
- code, commands, API identifiers, acronyms, versions, currency, and units;
- meaningful foreign clauses embedded in target-language prose;
- short phrases such as `not ready`;
- warnings, negation, error messages, button copy, quoted prose, and alternating languages;
- Simplified Chinese, English, and Japanese target-language runs.

Batch shapes included a single regression paragraph, all-SKIP, all-TRANSLATE, balanced 50/50, eleven SKIP plus one TRANSLATE, and one SKIP plus eleven TRANSLATE.

### Models and execution

The benchmark used three higher-capability and three lower-cost/weaker Atlas Cloud models:

```text
deepseek-ai/deepseek-v4-pro
qwen/qwen3.7-plus
moonshotai/kimi-k2.5
deepseek-ai/deepseek-v4-flash
qwen/qwen3.5-flash
bytedance/doubao-seed-2.0-mini-260428
```

- 12 prompt variants (`P0`–`P11`).
- 416 unique benchmark tasks; 415 completed and one Atlas `content_filter` infrastructure failure was excluded from model accuracy.
- Two additional blinded judge calls on ten critical cases.
- 187,639 benchmark input tokens and 200,161 output tokens; 390,270 total including the audit.
- Estimated Atlas cost at the catalog prices returned during the run: approximately $0.299.
- `reasoning_effort: "none"`, temperature 0, fixed bounded seeds, resumable JSONL output.

### Metrics

- **Swallowed translation:** a `TRANSLATE` item returns an exact sentinel, empty/missing output, a normalized source echo that production hides, or an unalignable batch result. Batch count mismatches were conservatively scored as swallowed in the benchmark; production `BatchQueue` rejects count mismatches and falls back to individual requests.
- **False sentinel:** a `TRANSLATE` item returns exact `{{NO_TRANSLATION_NEEDED}}`.
- **Structural failure:** one batch cannot be mapped one-to-one to its inputs.
- **Visible duplicate:** a `SKIP` item returns neither the sentinel nor a normalized source echo.
- **Sentinel recall:** the share of `SKIP` items returning the exact sentinel.

### Main results

Initial equal-condition phase, 24 tasks per candidate:

| Prompt | Swallowed translation | False sentinel | Structural failures | Visible duplicate | Sentinel recall |
| --- | ---: | ---: | ---: | ---: | ---: |
| P0 current | 55/192 (28.6%) | 0 | 3/24 | 52/198 (26.3%) | 9/198 (4.5%) |
| P1 | 39/192 (20.3%) | 0 | 5/24 | 107/198 (54.0%) | 24/198 (12.1%) |
| P2 | 32/192 (16.7%) | 0 | 1/24 | 34/198 (17.2%) | 1/198 (0.5%) |
| P3 | 24/192 (12.5%) | **1** | 0/24 | **12/198 (6.1%)** | **33/198 (16.7%)** |
| P4 | 40/192 (20.8%) | 0 | 0/24 | 14/198 (7.1%) | 1/198 (0.5%) |
| **P5** | **18/192 (9.4%)** | **0** | **0/24** | 35/198 (17.7%) | 1/198 (0.5%) |

P3 had the best skip recall but produced a real false sentinel with Doubao Mini:

```text
Target: Simplified Chinese
Source: 系统提示 Error: connection timed out，请稍后重试。
Output: {{NO_TRANSLATION_NEEDED}}
```

The English error meaning should have been translated, so P3 was not selected.

Stability phase, two additional seeds and adversarial batch ratios:

| Prompt | Swallowed translation | False sentinel | Structural failures | Visible duplicate | Sentinel recall |
| --- | ---: | ---: | ---: | ---: | ---: |
| P3 | 43/384 (11.2%) | 0 | 1/48 | 96/384 (25.0%) | 16/384 (4.2%) |
| P4 | 44/384 (11.5%) | 0 | 1/48 | 87/384 (22.7%) | 10/384 (2.6%) |
| **P5** | **17/384 (4.4%)** | **0** | **0/48** | **86/384 (22.4%)** | 10/384 (2.6%) |

P5 therefore had the lowest safety-priority failure rate and no Chinese structural failures across the finalist reruns. It is also shorter than P0: 199 vs 211 characters and 24 vs 29 English words.

### Known boundaries and product decision

Prompt-only handling is not deterministic:

- On the single `iPhone Duo` regression, P5 returned an exact sentinel on 1/6 models; P0 returned it on 2/6. P5's aggregate benefit came mainly from safer exact echoes instead of same-language paraphrases, not from high sentinel recall on that single fixture.
- Explicitly naming `iPhone Duo` in later candidates did not make most models emit the sentinel; one candidate caused DeepSeek V4 Pro to translate the Chinese paragraph backwards into English.
- In a Japanese mostly-SKIP batch, DeepSeek V4 Pro collapsed P5's nine input items to one sentinel, including the only `not ready` item that required translation. Production's existing batch-count validation rejects this shape and falls back to individual translation.
- P0 also emitted a per-item false sentinel for the same Japanese `not ready` case.
- Both blinded judge models incorrectly classified target=Simplified Chinese/source=Chinese cases as requiring translation, reinforcing that an LLM should not be the primary same-language detector.

After reviewing these boundaries, the product decision is to use P5 for every target language. It remains a probabilistic fallback behind deterministic target-language detection, normalized echo removal, and batch-count fallback.

### Public experiment artifacts

- [Scored results (JSON, 950,715 bytes)](https://mengxi-public.s3.us-west-004.backblazeb2.com/codex-assets/e6/e6d5896589a5530b3159.json)
- [Raw model responses (JSONL, 1,996,438 bytes)](https://mengxi-public.s3.us-west-004.backblazeb2.com/codex-assets/0c/0c2bd05ad109744d0030.jsonl)
- [Prompt candidates P0–P11 (JSON, 3,329 bytes)](https://mengxi-public.s3.us-west-004.backblazeb2.com/codex-assets/7d/7d44731c44a5cd1eb47e.json)

The files were scanned for API keys, authorization headers, and environment assignments before upload. Backblaze anonymously verified all three URLs with HTTP 200.

## Related Issue

Closes #2055

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

### Automated checks

- `SKIP_FREE_API=true pnpm exec vitest run src/utils/prompts/__tests__/translate.test.ts` — 30/30 passed.
- `pnpm exec oxfmt --check ...` — passed.
- `pnpm exec oxlint --type-aware --type-check ...` — passed.
- `pnpm build` — production Chrome MV3 build passed; manifest verified.
- Pre-push repository hooks — full formatting and type-aware lint passed; 318 files / 3,245 tests passed.
- `SKIP_FREE_API=true pnpm test` — 317 files / 3,241 tests passed; 1 file / 4 live-service tests intentionally skipped per `AGENTS.md`.
- `pnpm exec changeset status` — this PR's changeset is a patch; the aggregate workspace status is currently minor because `user-glossary.md` already exists on `main`.

### Real Chrome E2E

Chrome `152.0.7977.83` loaded the freshly built `.output/chrome-mv3` through Puppeteer's extension installation API. The test used a local OpenAI-compatible provider and deliberately disabled the deterministic target-language precheck so the LLM sentinel path was exercised.

Runtime assertions:

- Every provider request contained the P5 rule with `Simplified Mandarin Chinese` substituted.
- No request contained the previous `every word` P0 rule.
- The `iPhone Duo` Chinese paragraph returned the sentinel and had zero translation wrappers.
- `System warning: connection timed out.` rendered `系统警告：连接超时。` in exactly one wrapper.
- The sentinel was not visible in the document.
- No page errors, React errors, or `NotFoundError`s were recorded.
- Disabling translation removed all wrappers/translation-only anchors and restored the original HTML modulo persistent walker labels.

## Screenshots

![P5 sentinel browser E2E showing one skipped Chinese paragraph and one translated English paragraph](https://mengxi-public.s3.us-west-004.backblazeb2.com/codex-assets/0d/0d1ce363766481aa3a1a.png)

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- This changes only the webpage LLM batch sentinel rule. Pure translation providers are unaffected.
- Subtitle prompts remain isolated from `{{NO_TRANSLATION_NEEDED}}`.
- The full benchmark/report workspace remains gitignored; only the production prompt, regression tests, and patch changeset are committed.
