### PR TITLE
fix(i18n): give the note suggestion feature one Chinese name

### DIFF
--- a/.changeset/note-suggestion-chinese-name.md
+++ b/.changeset/note-suggestion-chinese-name.md
@@ -1,0 +1,10 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(i18n): give the note suggestion feature one Chinese name
+
+In Chinese the feature was 猜你想存 on the card and in the Built-in AI lists, but
+保存建议 (儲存建議 in zh-TW) in the settings toggle, the command palette, and the
+card's own on/off switch — so searching the settings for the name you saw on the page
+turned up nothing (#2176). All of them now read 猜你想存.

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -571,12 +571,12 @@ options:
         title: 朗读
         description: 在工具栏中显示朗读按钮，用于朗读选中的文本
       noteSuggestion:
-        title: 保存建议
+        title: 猜你想存
         description: 使用 AI 提供商进行划词翻译后，推荐可存入笔记库的词条
         action: 指令
-        actionDescription: 用于生成保存建议的指令
+        actionDescription: 用于生成「猜你想存」的指令
         provider: 提供商
-        providerDescription: 用于生成保存建议的 AI 提供商
+        providerDescription: 用于生成「猜你想存」的 AI 提供商
     display:
       title: 显示
       opacity:
@@ -1385,7 +1385,7 @@ noteSuggestion:
   save: 保存
   saved: 已保存
   staleSuggestion: 该建议已过期
-  toggleLabel: 显示保存建议
+  toggleLabel: 显示猜你想存
 thinking:
   label: 思考中
   complete: 思考完成

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -571,12 +571,12 @@ options:
         title: 朗讀
         description: 在工具列中顯示朗讀按鈕，用於朗讀選取的文字
       noteSuggestion:
-        title: 儲存建議
+        title: 猜你想存
         description: 使用 AI 供應商進行劃詞翻譯後，推薦可存入筆記庫的詞條
         action: 指令
-        actionDescription: 用於產生儲存建議的指令
+        actionDescription: 用於產生「猜你想存」的指令
         provider: 提供者
-        providerDescription: 用於產生儲存建議的 AI 提供者
+        providerDescription: 用於產生「猜你想存」的 AI 提供者
     display:
       title: 顯示
       opacity:
@@ -1385,7 +1385,7 @@ noteSuggestion:
   save: 儲存
   saved: 已儲存
   staleSuggestion: 該建議已過期
-  toggleLabel: 顯示儲存建議
+  toggleLabel: 顯示猜你想存
 thinking:
   label: 思考中
   complete: 思考完成


### PR DESCRIPTION
Closes #2176.

In [#2176](https://github.com/mengxi-ream/read-frog/issues/2176) someone wanted to turn the note suggestion feature off, searched the settings for the name they had seen on the page, and had to come back and ask whether 保存建议 was the same thing. It was. In Chinese the feature had two names.

## What it was called where

| Surface | zh-CN before | zh-CN after |
|---|---|---|
| Card title after a selection translation | 猜你想存 | 猜你想存 |
| The card's own on/off switch, right beside that title | 显示**保存建议** | 显示**猜你想存** |
| Selection toolbar settings toggle | **保存建议** | **猜你想存** |
| Command palette entry leading to that toggle | **保存建议** | **猜你想存** |
| Built-in AI feature list | 猜你想存 | 猜你想存 |
| Built-in AI quota list | 猜你想存 | 猜你想存 |

zh-TW had the same split, with 儲存建議 in place of 保存建议.

The sharpest case is the second row: the switch that turns the feature off sits on the same line as the 猜你想存 title it turns off, and was labelled with the other name.

## Which name won

猜你想存, because it is the one users actually meet — it titles the card, it is what the reporter searched for, and both feature lists already used it. 保存建议 only ever appeared in settings and in two sentences describing them, so moving in that direction would have deleted the searchable name instead of unifying on it. The two description strings that referenced the old name now read 用于生成「猜你想存」的指令 / 的 AI 提供商, using the 「」 convention already in `zh-CN.yml`.

## Deliberately not changed

The other eight locales are already internally consistent under a different, defensible pattern: the card title is a friendly phrase and every naming slot carries the feature name.

```
en     settings=Note suggestions | card=You might want to save | toggle=Show note suggestions | quota=Note suggestions
ja     settings=ノートの提案     | card=保存におすすめ          | toggle=ノートの提案を表示   | quota=ノートの提案
```

That split has the same discoverability cost — an English user meets "You might want to save" and has to find "Note suggestions" in settings — but collapsing it is a product copy call rather than a bug fix, so it is left for you. zh did not have the split cleanly: 猜你想存 had leaked into the naming slots, which is what broke.

Changeset included (patch). Targeted tests and the full pre-push suite pass; no code or test asserts either string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
