### PR TITLE
feat(provider): lock OpenRouter requests to specific providers

### DIFF
--- a/.changeset/openrouter-provider-lock.md
+++ b/.changeset/openrouter-provider-lock.md
@@ -1,0 +1,14 @@
+---
+"@read-frog/extension": minor
+---
+
+feat(provider): lock OpenRouter requests to specific providers
+
+OpenRouter spreads each request across every provider serving a model, so the same prompt
+can be answered by a different provider from one call to the next. The OpenRouter provider
+now has a **Lock providers** field: list the provider slugs you want, comma-separated
+(`deepinfra, together`), optionally down to a single endpoint variant or region
+(`deepinfra/turbo`, `google-vertex/us-east5`). Requests then go only to those providers,
+with fallbacks disabled, so a failure surfaces as an error instead of silently drifting to
+a provider you did not choose. Leave the field empty to keep OpenRouter's default
+price-based load balancing.

--- a/src/entrypoints/options/pages/api-providers/providers-config/provider-config-form/__tests__/provider-specific-settings-field.test.tsx
+++ b/src/entrypoints/options/pages/api-providers/providers-config/provider-config-form/__tests__/provider-specific-settings-field.test.tsx
@@ -105,6 +105,28 @@ describe("providerSpecificSettingsField", () => {
     )
   })
 
+  it("renders the OpenRouter provider lock and persists it", async () => {
+    render(
+      <ProviderSpecificSettingsFieldHarness initialConfig={DEFAULT_PROVIDER_CONFIG.openrouter} />,
+    )
+
+    const onlyInput = screen.getByLabelText(
+      "options.apiProviders.form.providerSettingLabels.onlyProviders",
+    )
+    expect(onlyInput).toHaveValue("")
+
+    fireEvent.change(onlyInput, { target: { value: "deepinfra, together" } })
+
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+      await Promise.resolve()
+    })
+
+    expect(screen.getByLabelText("persisted-provider-specific-settings")).toHaveTextContent(
+      '{"only":"deepinfra, together"}',
+    )
+  })
+
   it("does not render or write settings for providers without provider-specific schemas", async () => {
     render(<ProviderSpecificSettingsFieldHarness initialConfig={DEFAULT_PROVIDER_CONFIG.openai} />)
 

--- a/src/entrypoints/options/pages/api-providers/providers-config/provider-config-form/provider-specific-settings-field.tsx
+++ b/src/entrypoints/options/pages/api-providers/providers-config/provider-config-form/provider-specific-settings-field.tsx
@@ -2,6 +2,7 @@ import type { APIProviderConfig, ProviderSpecificSettingField } from "@/types/co
 import { useSelector } from "@tanstack/react-store"
 import { useMemo } from "react"
 import { useAutosaveContext } from "@/components/form/use-autosave"
+import { HelpTooltip } from "@/components/help-tooltip"
 import { Field, FieldGroup, FieldLabel } from "@/components/ui/base-ui/field"
 import { Input } from "@/components/ui/base-ui/input"
 import {
@@ -61,6 +62,17 @@ export const ProviderSpecificSettingsField = withForm({
       const fieldLabel = i18n.t(
         `options.apiProviders.form.providerSettingLabels.${def.labelKey}` as never,
       )
+      const fieldHint = def.hintKey
+        ? i18n.t(`options.apiProviders.form.providerSettingHints.${def.hintKey}` as never)
+        : undefined
+      const label = fieldHint ? (
+        <div className="flex items-center gap-1.5">
+          <span>{fieldLabel}</span>
+          <HelpTooltip>{fieldHint}</HelpTooltip>
+        </div>
+      ) : (
+        fieldLabel
+      )
       const fieldValue = localSettings[def.key]
 
       if (def.type === "select") {
@@ -69,7 +81,7 @@ export const ProviderSpecificSettingsField = withForm({
 
         return (
           <Field key={fieldId}>
-            <FieldLabel htmlFor={fieldId}>{fieldLabel}</FieldLabel>
+            <FieldLabel htmlFor={fieldId}>{label}</FieldLabel>
             <Select
               value={selectedValue}
               onValueChange={(value) =>
@@ -103,7 +115,7 @@ export const ProviderSpecificSettingsField = withForm({
 
       return (
         <Field key={fieldId}>
-          <FieldLabel htmlFor={fieldId}>{fieldLabel}</FieldLabel>
+          <FieldLabel htmlFor={fieldId}>{label}</FieldLabel>
           <Input
             id={fieldId}
             type={def.type}

--- a/src/locales/az.yml
+++ b/src/locales/az.yml
@@ -218,6 +218,9 @@ options:
         apiMode: API rejimi
         resourceName: Azure resursunun adı (istəyə bağlı)
         apiVersion: API versiyası
+        onlyProviders: Provayderləri kilidlə
+      providerSettingHints:
+        onlyProvidersHint: Vergüllə ayrılmış OpenRouter provayder slug-ları (məs. deepinfra, together və ya deepinfra/turbo). Sorğular yalnızca bu provayderlərə göndərilir və ehtiyat variantlar söndürülür. OpenRouter-ın standart yük balanslaşdırması üçün boş buraxın.
       providerSettingOptionLabels:
         responses: Responses API
         chatCompletions: Chat Completions

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -218,6 +218,9 @@ options:
         apiMode: API mode
         resourceName: Azure resource name (optional)
         apiVersion: API version
+        onlyProviders: Lock providers
+      providerSettingHints:
+        onlyProvidersHint: Comma-separated OpenRouter provider slugs, e.g. deepinfra, together or deepinfra/turbo. Requests are sent only to these providers, with fallbacks disabled. Leave empty to use OpenRouter's default load balancing.
       providerSettingOptionLabels:
         responses: Responses API
         chatCompletions: Chat Completions

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -218,6 +218,9 @@ options:
         apiMode: Modo de API
         resourceName: Nombre del recurso de Azure (opcional)
         apiVersion: Versión de API
+        onlyProviders: Bloquear proveedores
+      providerSettingHints:
+        onlyProvidersHint: Slugs de proveedores de OpenRouter separados por comas (p. ej. deepinfra, together o deepinfra/turbo). Las solicitudes se envían solo a estos proveedores y se desactivan los respaldos. Déjalo vacío para usar el balanceo de carga predeterminado de OpenRouter.
       providerSettingOptionLabels:
         responses: Responses API
         chatCompletions: Chat Completions

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -217,6 +217,9 @@ options:
         apiMode: API モード
         resourceName: Azure リソース名（任意）
         apiVersion: API バージョン
+        onlyProviders: プロバイダーを固定
+      providerSettingHints:
+        onlyProvidersHint: OpenRouter のプロバイダー slug をカンマ区切りで入力します（例：deepinfra、together、deepinfra/turbo）。リクエストはこれらのプロバイダーにのみ送信され、フォールバックは無効になります。空欄の場合は OpenRouter のデフォルトの負荷分散を使用します。
       providerSettingOptionLabels:
         responses: Responses API
         chatCompletions: Chat Completions

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -217,6 +217,9 @@ options:
         apiMode: API 모드
         resourceName: Azure 리소스 이름(선택 사항)
         apiVersion: API 버전
+        onlyProviders: 프로바이더 고정
+      providerSettingHints:
+        onlyProvidersHint: OpenRouter 프로바이더 slug를 쉼표로 구분해 입력하세요(예：deepinfra, together, deepinfra/turbo). 요청은 이 프로바이더로만 전송되며 폴백이 비활성화됩니다. 비워 두면 OpenRouter의 기본 로드 밸런싱을 사용합니다.
       providerSettingOptionLabels:
         responses: Responses API
         chatCompletions: Chat Completions

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -217,6 +217,9 @@ options:
         apiMode: Режим API
         resourceName: Имя ресурса Azure (необязательно)
         apiVersion: Версия API
+        onlyProviders: Зафиксировать провайдеров
+      providerSettingHints:
+        onlyProvidersHint: Slugs провайдеров OpenRouter через запятую (например, deepinfra, together или deepinfra/turbo). Запросы отправляются только этим провайдерам, резервные варианты отключены. Оставьте пустым, чтобы использовать балансировку нагрузки OpenRouter по умолчанию.
       providerSettingOptionLabels:
         responses: Responses API
         chatCompletions: Chat Completions

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -217,6 +217,9 @@ options:
         apiMode: API modu
         resourceName: Azure kaynak adı (isteğe bağlı)
         apiVersion: API sürümü
+        onlyProviders: Sağlayıcıları kilitle
+      providerSettingHints:
+        onlyProvidersHint: Virgülle ayrılmış OpenRouter sağlayıcı slug'ları (örn. deepinfra, together veya deepinfra/turbo). İstekler yalnızca bu sağlayıcılara gönderilir ve yedekler devre dışı bırakılır. OpenRouter'ın varsayılan yük dengelemesi için boş bırakın.
       providerSettingOptionLabels:
         responses: Responses API
         chatCompletions: Chat Completions

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -217,6 +217,9 @@ options:
         apiMode: Chế độ API
         resourceName: Tên tài nguyên Azure (tùy chọn)
         apiVersion: Phiên bản API
+        onlyProviders: Khóa nhà cung cấp
+      providerSettingHints:
+        onlyProvidersHint: Các slug nhà cung cấp OpenRouter cách nhau bằng dấu phẩy (ví dụ deepinfra, together hoặc deepinfra/turbo). Yêu cầu chỉ được gửi đến các nhà cung cấp này và tắt dự phòng. Để trống để dùng cân bằng tải mặc định của OpenRouter.
       providerSettingOptionLabels:
         responses: Responses API
         chatCompletions: Chat Completions

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -218,6 +218,9 @@ options:
         apiMode: API 模式
         resourceName: Azure 资源名称（可选）
         apiVersion: API 版本
+        onlyProviders: 锁定供应商
+      providerSettingHints:
+        onlyProvidersHint: 用英文逗号分隔的 OpenRouter 供应商 slug，例如 deepinfra、together 或 deepinfra/turbo。请求只会发送给这些供应商，并禁用回退。留空则使用 OpenRouter 默认的负载均衡。
       providerSettingOptionLabels:
         responses: Responses API
         chatCompletions: Chat Completions

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -218,6 +218,9 @@ options:
         apiMode: API 模式
         resourceName: Azure 資源名稱（選填）
         apiVersion: API 版本
+        onlyProviders: 鎖定供應商
+      providerSettingHints:
+        onlyProvidersHint: 以半形逗號分隔的 OpenRouter 供應商 slug，例如 deepinfra、together 或 deepinfra/turbo。請求只會傳送給這些供應商，並停用備援。留空則使用 OpenRouter 預設的負載平衡。
       providerSettingOptionLabels:
         responses: Responses API
         chatCompletions: Chat Completions

--- a/src/types/config/__tests__/provider-specific-settings.test.ts
+++ b/src/types/config/__tests__/provider-specific-settings.test.ts
@@ -4,6 +4,7 @@ import {
   azureProviderSpecificSettingsSchema,
   bedrockProviderSpecificSettingsSchema,
   getProviderSpecificSettingFields,
+  openrouterProviderSpecificSettingsSchema,
 } from "../provider"
 
 describe("provider-specific settings metadata", () => {
@@ -41,6 +42,18 @@ describe("provider-specific settings metadata", () => {
         labelKey: "apiVersion",
         type: "text",
         placeholder: "v1",
+      },
+    ])
+  })
+
+  it("returns the OpenRouter provider lock field from Zod metadata", () => {
+    expect(getProviderSpecificSettingFields(openrouterProviderSpecificSettingsSchema)).toEqual([
+      {
+        key: "only",
+        labelKey: "onlyProviders",
+        type: "text",
+        placeholder: "deepinfra, together",
+        hintKey: "onlyProvidersHint",
       },
     ])
   })

--- a/src/types/config/provider/provider-specific-settings.ts
+++ b/src/types/config/provider/provider-specific-settings.ts
@@ -8,6 +8,7 @@ export const DEFAULT_AZURE_API_MODE: AzureApiMode = "responses"
 interface ProviderSettingBaseUiMeta {
   labelKey: string
   placeholder?: string
+  hintKey?: string
 }
 
 interface ProviderSettingTextUiMeta extends ProviderSettingBaseUiMeta {
@@ -90,11 +91,40 @@ export const azureProviderSpecificSettingsSchema = z.strictObject({
     }),
 })
 
+/**
+ * OpenRouter load balances each request across every provider serving the model unless told
+ * otherwise. `only` pins the request to an explicit provider allow-list, which is what
+ * "lock the provider" means here; leaving it empty keeps OpenRouter's default price-based
+ * load balancing.
+ *
+ * Slugs are the ones OpenRouter prints on each model's provider list, and may target a
+ * single endpoint variant (`deepinfra/turbo`) or region (`google-vertex/us-east5`) as well
+ * as a whole provider (`deepinfra`).
+ */
+export const openrouterProviderSpecificSettingsSchema = z.strictObject({
+  only: z
+    .string()
+    .trim()
+    .optional()
+    .meta({
+      providerSettingUi: {
+        labelKey: "onlyProviders",
+        type: "text",
+        placeholder: "deepinfra, together",
+        hintKey: "onlyProvidersHint",
+      },
+    }),
+})
+export type OpenRouterProviderSpecificSettings = z.infer<
+  typeof openrouterProviderSpecificSettingsSchema
+>
+
 export const PROVIDER_SPECIFIC_SETTINGS_SCHEMAS: Partial<
   Record<LLMProviderTypes, ProviderSpecificSettingsSchema>
 > = {
   azure: azureProviderSpecificSettingsSchema,
   bedrock: bedrockProviderSpecificSettingsSchema,
+  openrouter: openrouterProviderSpecificSettingsSchema,
 }
 
 export function getProviderSpecificSettingFields(

--- a/src/types/config/provider/schemas.ts
+++ b/src/types/config/provider/schemas.ts
@@ -19,6 +19,7 @@ import {
 import {
   azureProviderSpecificSettingsSchema,
   bedrockProviderSpecificSettingsSchema,
+  openrouterProviderSpecificSettingsSchema,
 } from "./provider-specific-settings"
 
 export const providerSponsorConfigSchema = z.object({
@@ -109,6 +110,7 @@ const llmProviderConfigSchemaList = [
   baseOpenAICompatibleLLMProviderConfigSchema.extend({
     provider: z.literal("openrouter"),
     model: createProviderModelSchema<"openrouter">("openrouter"),
+    providerSpecificSettings: openrouterProviderSpecificSettingsSchema.optional(),
   }),
   baseOpenAICompatibleLLMProviderConfigSchema.extend({
     provider: z.literal("minimax"),

--- a/src/utils/constants/__tests__/providers.test.ts
+++ b/src/utils/constants/__tests__/providers.test.ts
@@ -132,6 +132,22 @@ describe("provider constants", () => {
     )
   })
 
+  it("accepts an OpenRouter provider lock and rejects unknown provider-specific settings", () => {
+    const locked = {
+      ...DEFAULT_PROVIDER_CONFIG.openrouter,
+      providerSpecificSettings: { only: "deepinfra/turbo, together" },
+    }
+
+    expect(apiProviderConfigItemSchema.parse(locked)).toEqual(locked)
+
+    expect(() =>
+      apiProviderConfigItemSchema.parse({
+        ...DEFAULT_PROVIDER_CONFIG.openrouter,
+        providerSpecificSettings: { order: ["deepinfra"] },
+      }),
+    ).toThrow(/Unrecognized key/)
+  })
+
   it("uses distinct connection URL fields for the two protocol adapters", () => {
     const openAICompatibleConfig = DEFAULT_PROVIDER_CONFIG["openai-compatible"]
     expect(apiProviderConfigItemSchema.parse(openAICompatibleConfig)).toEqual(

--- a/src/utils/providers/__tests__/model.test.ts
+++ b/src/utils/providers/__tests__/model.test.ts
@@ -101,7 +101,10 @@ function createAnthropicProviderConfig(headers?: Record<string, unknown>) {
   }
 }
 
-function createOpenRouterProviderConfig(headers?: Record<string, unknown>) {
+function createOpenRouterProviderConfig(
+  headers?: Record<string, unknown>,
+  providerSpecificSettings?: Record<string, unknown>,
+) {
   return {
     id: "openrouter-default",
     name: "OpenRouter",
@@ -115,6 +118,7 @@ function createOpenRouterProviderConfig(headers?: Record<string, unknown>) {
       customModel: null,
     },
     ...(headers !== undefined && { headers }),
+    ...(providerSpecificSettings !== undefined && { providerSpecificSettings }),
   }
 }
 
@@ -185,6 +189,67 @@ describe("getModelById", () => {
     )
     expect(createOpenAICompatibleMock.mock.calls[0]?.[0]).not.toHaveProperty("url")
     expect(openAICompatibleLanguageModelMock).toHaveBeenCalledWith("x-ai/grok-4-fast:free")
+  })
+
+  it("locks the OpenRouter request body to the configured providers", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [createOpenRouterProviderConfig(undefined, { only: "deepinfra, together" })],
+    })
+
+    const { getModelById } = await import("../model")
+    await getModelById("openrouter-default")
+
+    const transformRequestBody = createOpenAICompatibleMock.mock.calls[0]?.[0]
+      ?.transformRequestBody as (body: Record<string, unknown>) => Record<string, unknown>
+    expect(transformRequestBody).toBeTypeOf("function")
+
+    expect(
+      transformRequestBody({ model: "x-ai/grok-4-fast:free", messages: [{ role: "user" }] }),
+    ).toEqual({
+      model: "x-ai/grok-4-fast:free",
+      messages: [{ role: "user" }],
+      provider: {
+        only: ["deepinfra", "together"],
+        allow_fallbacks: false,
+      },
+    })
+  })
+
+  it("keeps other OpenRouter routing fields the user set through provider options", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [createOpenRouterProviderConfig(undefined, { only: "deepinfra" })],
+    })
+
+    const { getModelById } = await import("../model")
+    await getModelById("openrouter-default")
+
+    const transformRequestBody = createOpenAICompatibleMock.mock.calls[0]?.[0]
+      ?.transformRequestBody as (body: Record<string, unknown>) => Record<string, unknown>
+
+    expect(transformRequestBody({ provider: { sort: "throughput" } })).toEqual({
+      provider: {
+        sort: "throughput",
+        only: ["deepinfra"],
+        allow_fallbacks: false,
+      },
+    })
+    expect(transformRequestBody({ provider: "not-an-object" })).toEqual({
+      provider: {
+        only: ["deepinfra"],
+        allow_fallbacks: false,
+      },
+    })
+  })
+
+  it("leaves OpenRouter requests untouched without a provider lock", async () => {
+    getStorageItemMock.mockResolvedValue({
+      providersConfig: [createOpenRouterProviderConfig()],
+    })
+
+    const { getModelById } = await import("../model")
+    await getModelById("openrouter-default")
+
+    expect(createOpenAICompatibleMock.mock.calls[0]?.[0]).not.toHaveProperty("transformRequestBody")
   })
 
   it("passes Ollama root base URL and disables think on the language model", async () => {

--- a/src/utils/providers/__tests__/openrouter-routing.test.ts
+++ b/src/utils/providers/__tests__/openrouter-routing.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import { getOpenRouterProviderRouting, parseOpenRouterProviderSlugs } from "../openrouter-routing"
+
+describe("parseOpenRouterProviderSlugs", () => {
+  it("splits on commas and trims surrounding whitespace", () => {
+    expect(parseOpenRouterProviderSlugs(" deepinfra , together ")).toEqual([
+      "deepinfra",
+      "together",
+    ])
+  })
+
+  it("drops empty entries left by stray or trailing commas", () => {
+    expect(parseOpenRouterProviderSlugs("deepinfra,,together,")).toEqual(["deepinfra", "together"])
+  })
+
+  it("keeps the first occurrence of a duplicated slug", () => {
+    expect(parseOpenRouterProviderSlugs("together, deepinfra, together")).toEqual([
+      "together",
+      "deepinfra",
+    ])
+  })
+
+  it("keeps endpoint variants and region slugs verbatim", () => {
+    expect(parseOpenRouterProviderSlugs("deepinfra/turbo, google-vertex/us-east5")).toEqual([
+      "deepinfra/turbo",
+      "google-vertex/us-east5",
+    ])
+  })
+
+  it("returns an empty list for an absent or blank value", () => {
+    expect(parseOpenRouterProviderSlugs(undefined)).toEqual([])
+    expect(parseOpenRouterProviderSlugs("")).toEqual([])
+    expect(parseOpenRouterProviderSlugs("  ,  ")).toEqual([])
+  })
+})
+
+describe("getOpenRouterProviderRouting", () => {
+  it("locks to the listed providers and disables fallbacks", () => {
+    expect(getOpenRouterProviderRouting({ only: "deepinfra, together" })).toEqual({
+      only: ["deepinfra", "together"],
+      allow_fallbacks: false,
+    })
+  })
+
+  it("returns undefined when no provider is locked", () => {
+    expect(getOpenRouterProviderRouting(undefined)).toBeUndefined()
+    expect(getOpenRouterProviderRouting({})).toBeUndefined()
+    expect(getOpenRouterProviderRouting({ only: " , " })).toBeUndefined()
+  })
+})

--- a/src/utils/providers/model.ts
+++ b/src/utils/providers/model.ts
@@ -40,6 +40,7 @@ import { getLLMProvidersConfig, getProviderConfigById } from "../config/helpers"
 import { CONFIG_STORAGE_KEY } from "../constants/config"
 import { getProviderHeadersWithOverride } from "./headers"
 import { resolveModelId } from "./model-id"
+import { getOpenRouterProviderRouting } from "./openrouter-routing"
 
 const DEDICATED_PROVIDER_FACTORY_BY_TYPE = {
   openai: createOpenAI,
@@ -89,6 +90,35 @@ function getAzureApiMode(providerConfig: LLMProviderConfig): AzureApiMode {
   return apiMode === "chat" ? "chat" : DEFAULT_AZURE_API_MODE
 }
 
+/**
+ * OpenRouter's provider lock can only be expressed as a `provider` object in the request
+ * body, and the AI SDK's OpenAI-compatible provider exposes no first-class option for it.
+ * Its `transformRequestBody` hook is the one place that sees every request — streaming and
+ * not — so the lock is applied there instead of at each call site.
+ *
+ * Routing the user already wrote into provider options (a `sort`, say) survives; the lock
+ * only wins on the fields it owns.
+ */
+function getOpenRouterRequestBodyTransform(providerConfig: LLMProviderConfig) {
+  if (providerConfig.provider !== "openrouter") {
+    return undefined
+  }
+
+  const routing = getOpenRouterProviderRouting(providerConfig.providerSpecificSettings)
+  if (!routing) {
+    return undefined
+  }
+
+  return (body: Record<string, unknown>): Record<string, unknown> => {
+    const existingRouting =
+      typeof body.provider === "object" && body.provider !== null && !Array.isArray(body.provider)
+        ? (body.provider as Record<string, unknown>)
+        : {}
+
+    return { ...body, provider: { ...existingRouting, ...routing } }
+  }
+}
+
 async function getLanguageModelById(providerId: string) {
   const config = await storage.getItem<Config>(`local:${CONFIG_STORAGE_KEY}`)
   if (!config) {
@@ -117,15 +147,18 @@ export function getLanguageModelForConfig(providerConfig: LLMProviderConfig) {
   const providerSpecificSettings = getProviderSpecificSettings(providerConfig)
 
   const provider = match(providerConfig)
-    .when(isOpenAICompatibleLLMProviderConfig, (matchedConfig) =>
-      createOpenAICompatible({
+    .when(isOpenAICompatibleLLMProviderConfig, (matchedConfig) => {
+      const transformRequestBody = getOpenRouterRequestBodyTransform(matchedConfig)
+
+      return createOpenAICompatible({
         name: matchedConfig.provider,
         baseURL: matchedConfig.baseURL,
         supportsStructuredOutputs: true,
         ...(matchedConfig.apiKey && { apiKey: matchedConfig.apiKey }),
         ...(headers && { headers }),
-      }),
-    )
+        ...(transformRequestBody && { transformRequestBody }),
+      })
+    })
     .when(isOpenResponsesLLMProviderConfig, (matchedConfig) =>
       createOpenResponses({
         name: matchedConfig.provider,

--- a/src/utils/providers/openrouter-routing.ts
+++ b/src/utils/providers/openrouter-routing.ts
@@ -1,0 +1,57 @@
+import type { OpenRouterProviderSpecificSettings } from "@/types/config/provider"
+
+/**
+ * The subset of OpenRouter's `provider` routing object this app sets. Field names are
+ * OpenRouter's own — see https://openrouter.ai/docs/guides/routing/provider-selection.
+ */
+export interface OpenRouterProviderRouting {
+  only: string[]
+  allow_fallbacks: boolean
+}
+
+/**
+ * Split the comma-separated slug list a user typed into OpenRouter provider slugs.
+ * Empty entries are dropped, surrounding whitespace is trimmed, and duplicates keep
+ * their first position so `only` reads in the order the user wrote it.
+ */
+export function parseOpenRouterProviderSlugs(value: string | undefined): string[] {
+  if (!value) {
+    return []
+  }
+
+  const slugs: string[] = []
+  const seen = new Set<string>()
+
+  for (const part of value.split(",")) {
+    const slug = part.trim()
+    if (slug === "" || seen.has(slug)) {
+      continue
+    }
+
+    seen.add(slug)
+    slugs.push(slug)
+  }
+
+  return slugs
+}
+
+/**
+ * Build OpenRouter's `provider` routing object for a locked selection, or `undefined`
+ * when no provider is locked and OpenRouter's default load balancing should apply.
+ *
+ * Locking means two things, and they are set together on purpose: `only` narrows the
+ * request to the listed providers, and `allow_fallbacks: false` drops the backup
+ * providers OpenRouter would otherwise reach for when one of them is unavailable.
+ * The user asked for these providers specifically, so a request either uses one of
+ * them or fails with OpenRouter's own error instead of silently drifting elsewhere.
+ */
+export function getOpenRouterProviderRouting(
+  settings: OpenRouterProviderSpecificSettings | undefined,
+): OpenRouterProviderRouting | undefined {
+  const only = parseOpenRouterProviderSlugs(settings?.only)
+  if (only.length === 0) {
+    return undefined
+  }
+
+  return { only, allow_fallbacks: false }
+}


### PR DESCRIPTION
> **AI model(s) used (required):** DeepSeek Harness (`deepseek-flash`) — implementation, tests, and the locale strings.

## Type of Changes

- [x] ✨ New feature (feat)

## Description

OpenRouter load balances every request across all providers serving a model, so the same prompt can be answered by a different provider from one call to the next. There was no way to say "only this one".

The OpenRouter provider now has a **Lock providers** field. Its comma-separated slugs become OpenRouter's `provider` routing object, per [Provider Routing](https://openrouter.ai/docs/guides/routing/provider-selection):

```json
{ "provider": { "only": ["deepinfra", "together"], "allow_fallbacks": false } }
```

`only` narrows the request to the listed providers, and `allow_fallbacks: false` drops the backups OpenRouter would otherwise reach for. A request therefore either uses one of the providers the user asked for or fails with OpenRouter's own error, instead of silently drifting to another one. This matters when a model is served by several hosts at very different quality, price or data policies.

- Slugs may name a whole provider (`deepinfra`), a single endpoint variant (`deepinfra/turbo`), or a region (`google-vertex/us-east5`) — which is why the field is free text rather than a bundled list that goes stale. OpenRouter's base-slug matching means `deepinfra` still covers all of that provider's endpoints.
- Leaving the field empty keeps OpenRouter's default price-based load balancing.
- Routing fields already written into provider options (a `sort`, say) are preserved; the lock only owns the two fields it sets.

### Implementation notes

- Reuses the existing `providerSpecificSettings` mechanism (same as Azure and Bedrock), so the field is declared once and the form renders it from Zod metadata. It is optional, so stored configs parse unchanged — no migration and no schema-version bump.
- Applied through the OpenAI-compatible provider's `transformRequestBody` hook, the one hook that sees streaming and non-streaming requests alike. Page/selection translation, subtitles, custom actions, note suggestions, language detection and the connection test are all covered without touching any call site.
- `providerSettingUi` gains an optional `hintKey`, rendered as a help tooltip next to the label. Labels and hints are translated in all 10 supported locales.
- `feat` changeset (`minor`) for `@read-frog/extension`.

## Related Issue

No matching issue found. I searched the tracker for OpenRouter provider locking and could not find one this closes, so the field is left empty rather than pointing at something unrelated.

## How Has This Been Tested?

- [x] Added unit tests
- [ ] Verified through manual testing

Automated verification (rebased onto `main` at `02318d0a`):

- `SKIP_FREE_API=true pnpm test` — 318 test files, 3252 tests pass (free-api skipped per `AGENTS.md`)
- `pnpm lint` (`oxlint --type-aware --type-check`) — 0 warnings, 0 errors
- `pnpm fmt:check` — clean
- `pnpm build` — builds successfully
- New tests cover slug parsing (commas, whitespace, duplicates, endpoint variants), routing-object generation, `transformRequestBody` injection and merge behaviour, the untouched no-lock case, schema accept/reject, and form render + persist.
- The field's rendering was verified through the component test rather than a loaded browser, so a quick look at the options page is still worth it before merge.

## Screenshots

Not attached. The field appears in the provider form directly below the connection fields (Base URL / API key) when an OpenRouter provider is selected, labelled "Lock providers".

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

- **Semantics are a hard lock by design.** If none of the chosen providers can serve the request, it fails rather than falling back. A softer "prioritise these, still fall back" mode (`order` without disabling fallbacks) was left out of scope — happy to add it as a follow-up if wanted.
- Only `only` and `allow_fallbacks` are set by the field; the rest of OpenRouter's routing object (`sort`, `ignore`, `require_parameters`, `data_collection`, `max_price`, …) can still be set through the existing provider-options JSON editor.
