### PR TITLE
feat(glossary): link the guide from a glossary's own page

### DIFF
--- a/.changeset/glossary-docs-link.md
+++ b/.changeset/glossary-docs-link.md
@@ -1,0 +1,12 @@
+---
+"@read-frog/extension": patch
+---
+
+feat(glossary): link the guide from a glossary's own page
+
+A glossary raises questions the settings page can only answer in a sentence: what
+`*.example.com` covers and what it leaves out, what an empty translation does, why a
+term can be written for one target language, and which providers honour any of it. The
+glossary editor now carries a **How does it work?** link to the Glossary guide on the
+website, beside the glossary's name — where those questions come up, rather than next to
+one control that only answers one of them.

--- a/src/entrypoints/options/components/config-detail-section.tsx
+++ b/src/entrypoints/options/components/config-detail-section.tsx
@@ -9,6 +9,8 @@ export interface ConfigDetailSectionProps {
   /** Where the back arrow returns to — the page holding the `ConfigNavItem` that opened this. */
   backTo: string
   title: ReactNode
+  /** Sits at the far end of the heading row — a docs link, and nothing that needs room to breathe. */
+  action?: ReactNode
   children: ReactNode
   className?: string
   contentClassName?: string
@@ -21,6 +23,7 @@ export interface ConfigDetailSectionProps {
 export function ConfigDetailSection({
   backTo,
   title,
+  action,
   children,
   className,
   contentClassName,
@@ -32,16 +35,21 @@ export function ConfigDetailSection({
       className={className}
       contentClassName={contentClassName}
       title={
-        <span className="flex items-center gap-1">
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            className="-ml-2"
-            render={<Link to={backTo} onClick={goBack} />}
-          >
-            <Icon icon="tabler:chevron-left" />
-          </Button>
-          {title}
+        // `justify-between` rather than an `ml-auto` on the action, so the title keeps
+        // truncating against the action's edge instead of pushing it off the row.
+        <span className="flex items-center justify-between gap-3">
+          <span className="flex min-w-0 items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="-ml-2"
+              render={<Link to={backTo} onClick={goBack} />}
+            >
+              <Icon icon="tabler:chevron-left" />
+            </Button>
+            {title}
+          </span>
+          {action}
         </span>
       }
     >

--- a/src/entrypoints/options/pages/advanced/glossary/editor-page.tsx
+++ b/src/entrypoints/options/pages/advanced/glossary/editor-page.tsx
@@ -1,4 +1,5 @@
 import { Navigate, useParams } from "react-router"
+import { env } from "@/env"
 import { i18n } from "@/utils/i18n"
 import { ConfigDetailSection } from "../../../components/config-detail-section"
 import { ConfigSection } from "../../../components/config-section"
@@ -44,7 +45,24 @@ export function GlossaryEditorPage() {
     >
       <ConfigDetailSection
         backTo="/advanced/glossary"
-        title={<span id="glossary-editor">{glossary.name}</span>}
+        title={
+          <span id="glossary-editor" className="truncate">
+            {glossary.name}
+          </span>
+        }
+        // On the page where the questions come up — what a website pattern covers,
+        // what an empty translation does, which providers honour any of it — rather
+        // than beside one of the controls, because it answers all of them.
+        action={
+          <a
+            href={`${env.WXT_WEBSITE_URL}/docs/glossary`}
+            className="shrink-0 text-xs font-normal text-link hover:opacity-90"
+            target="_blank"
+            rel="noreferrer"
+          >
+            {i18n.t("options.advanced.glossary.editor.docsLink")}
+          </a>
+        }
       >
         <GlossaryEditorEnableItem glossary={glossary} />
         {/* Keyed on the glossary so the debounced name and description fields

--- a/src/locales/az.yml
+++ b/src/locales/az.yml
@@ -891,6 +891,7 @@ options:
         sites: "$1 sayt"
         sitesOne: 1 sayt
       editor:
+        docsLink: Necə işləyir?
         sections:
           terms: Terminlər
           maintenance: Ehtiyat nüsxə və silmə

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -891,6 +891,7 @@ options:
         sites: "$1 websites"
         sitesOne: 1 website
       editor:
+        docsLink: How does it work?
         sections:
           terms: Terms
           maintenance: Backup and deletion

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -891,6 +891,7 @@ options:
         sites: "$1 sitios web"
         sitesOne: 1 sitio web
       editor:
+        docsLink: ¿Cómo funciona?
         sections:
           terms: Términos
           maintenance: Copia de seguridad y eliminación

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -775,6 +775,7 @@ options:
         sites: "$1 件のウェブサイト"
         sitesOne: 1 件のウェブサイト
       editor:
+        docsLink: 使い方は?
         sections:
           terms: 用語
           maintenance: バックアップと削除

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -775,6 +775,7 @@ options:
         sites: "$1개 웹사이트"
         sitesOne: 1개 웹사이트
       editor:
+        docsLink: 어떻게 작동하나요?
         sections:
           terms: 용어
           maintenance: 백업과 삭제

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -775,6 +775,7 @@ options:
         sites: "Сайтов: $1"
         sitesOne: "Сайтов: 1"
       editor:
+        docsLink: Как это работает?
         sections:
           terms: Термины
           maintenance: Резервное копирование и удаление

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -775,6 +775,7 @@ options:
         sites: "$1 web sitesi"
         sitesOne: 1 web sitesi
       editor:
+        docsLink: Nasıl çalışır?
         sections:
           terms: Terimler
           maintenance: Yedekleme ve silme

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -775,6 +775,7 @@ options:
         sites: "$1 trang web"
         sitesOne: 1 trang web
       editor:
+        docsLink: Nó hoạt động thế nào?
         sections:
           terms: Thuật ngữ
           maintenance: Sao lưu và xóa

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -891,6 +891,7 @@ options:
         sites: "$1 个网站"
         sitesOne: 1 个网站
       editor:
+        docsLink: 如何使用?
         sections:
           terms: 术语
           maintenance: 备份与删除

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -891,6 +891,7 @@ options:
         sites: "$1 個網站"
         sitesOne: 1 個網站
       editor:
+        docsLink: 如何使用？
         sections:
           terms: 術語
           maintenance: 備份與刪除


### PR DESCRIPTION
> **AI model(s) used (required):** Claude Opus 5

## Type of Changes

- [x] ✨ New feature (feat)

## Description

A glossary raises questions the settings page can only answer in a sentence: what `*.example.com` covers and what it leaves out, what an empty translation does, why a term is written for one target language, and which providers honour any of it.

This adds a **How does it work?** link to the [Glossary guide](https://www.readfrog.app/docs/glossary) at the far end of the glossary editor's heading row, beside the glossary's name — where those questions come up, rather than beside one control that only answers one of them. It follows the existing docs-link pattern from the custom-CSS editor (`env.WXT_WEBSITE_URL` + `text-link`, opens in a new tab).

`ConfigDetailSection` grows an optional `action` slot to carry it, which is also where any future per-detail-page link belongs. The heading row becomes `justify-between` with the title in its own `min-w-0` group, so a long glossary name truncates against the link rather than pushing it off the row.

Translated into all 10 locales (`az, en, es, ja, ko, ru, tr, vi, zh-CN, zh-TW`) under `options.advanced.glossary.editor.docsLink`.

The guide it points at ships in the website repo — see mengxi-ream/read-frog-monorepo#461.

## Related Issue

N/A

## How Has This Been Tested?

- [x] Verified through manual testing

- `pnpm lint` (oxlint `--type-aware --type-check`) — clean
- `pnpm fmt:check` — clean
- `pnpm test` — 324 files / 3382 tests passed
- `pnpm build`, then loaded `.output/chrome-mv3` in Chrome for Testing via Puppeteer and opened **Advanced → Glossary → a glossary** in both `en` and `zh-CN` to confirm the link renders, aligns with the heading baseline, and resolves to `/docs/glossary`.

## Screenshots

**English**

![Glossary editor heading with the How does it work? link](https://s3.us-west-004.backblazeb2.com/mengxi-public/codex-assets/read-frog/glossary-docs-link/glossary-editor.png)

**简体中文**

![术语库编辑页标题栏中的「如何使用?」链接](https://s3.us-west-004.backblazeb2.com/mengxi-public/codex-assets/read-frog/glossary-docs-link/glossary-editor.zh.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
