### PR TITLE
fix(translate): prevent duplicates from transient DOM wrappers

### DIFF
--- a/.changeset/calm-frogs-hover.md
+++ b/.changeset/calm-frogs-hover.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): prevent duplicate translations from temporary DOM wrappers

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -668,6 +668,58 @@ describe("pageTranslationManager mutation re-walk", () => {
     manager.stop()
   })
 
+  it("ignores temporary wrappers around unchanged text inside a translated source (#2185)", async () => {
+    document.body.innerHTML = `<p id="summary">Original summary</p>`
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observer = intersectionObservers[0]!
+    const summary = document.getElementById("summary") as HTMLElement
+    const source = summary.firstChild as Text
+    const wrapper = document.createElement("span")
+    wrapper.className = "notranslate read-frog-translated-content-wrapper"
+    wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+    wrapper.append("译文")
+    summary.append(wrapper)
+    const state: BilingualTranslationState = {
+      layoutSource: summary,
+      sourceTextContent: "Original summary",
+      status: "active",
+      walkId: "walk-id",
+      wrapper,
+      wrapperTextContent: "译文",
+    }
+    registerBilingualTranslationState(state)
+    await flushDomUpdates()
+    observer.observe.mockClear()
+    mockWalkAndLabelElement.mockClear()
+    mockTranslateNodesBilingualMode.mockClear()
+
+    // Google AI Overview citation hover temporarily moves the existing Text
+    // node into a decorator, then unwraps it while preserving child nodes.
+    for (let i = 0; i < 3; i += 1) {
+      const decorator = document.createElement("span")
+      decorator.className = "yADgie"
+      decorator.append(source)
+      summary.prepend(decorator)
+      await flushDomUpdates()
+
+      summary.insertBefore(source, decorator)
+      decorator.remove()
+      await flushDomUpdates()
+    }
+
+    expect(observer.observe).not.toHaveBeenCalled()
+    expect(mockWalkAndLabelElement).not.toHaveBeenCalled()
+    expect(mockTranslateNodesBilingualMode).not.toHaveBeenCalled()
+    expect(summary.querySelectorAll(".read-frog-translated-content-wrapper")).toHaveLength(1)
+
+    unregisterBilingualTranslationState(state)
+    manager.stop()
+  })
+
   it("retranslates exactly once when the site re-renders a node containing our wrapper (#1831)", async () => {
     document.body.innerHTML = `
       <p id="tweet"><span id="source">Original content</span></p>

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -851,6 +851,9 @@ describe("pageTranslationManager mutation re-walk", () => {
     ["nested shadow host", "class", "notranslate"],
     ["nested shadow host", "hidden", ""],
     ["nested shadow host", "aria-hidden", "true"],
+    ["nested dynamic shadow host", "class", "notranslate"],
+    ["nested dynamic shadow host", "hidden", ""],
+    ["nested dynamic shadow host", "aria-hidden", "true"],
   ])(
     "observes later shadow mutations after a blocked %s (%s) becomes walkable",
     async (blockedTarget, attribute, value) => {
@@ -883,9 +886,18 @@ describe("pageTranslationManager mutation re-walk", () => {
         element.classList.contains("notranslate"),
       )
 
+      mockHasNoWalkAncestor.mockImplementation((element: HTMLElement) => {
+        let parent = element.parentElement
+        while (parent) {
+          if (isBlockedForTraversal(parent) || parent.classList.contains("notranslate")) return true
+          parent = parent.parentElement
+        }
+        return false
+      })
+
       const host = document.createElement("span")
       const blockedElement = blockedTarget === "host" ? host : document.createElement("span")
-      if (blockedTarget === "nested shadow host") {
+      if (blockedTarget.includes("shadow host")) {
         blockedElement.attachShadow({ mode: "open" }).append(host)
       } else if (blockedElement !== host) {
         blockedElement.append(host)
@@ -914,6 +926,17 @@ describe("pageTranslationManager mutation re-walk", () => {
 
       blockedElement.removeAttribute(attribute)
       await flushDomUpdates()
+
+      let mutationContainer = shadowContainer
+      if (blockedTarget === "nested dynamic shadow host") {
+        // The still-blocked top-level shadow child has its own observer so it
+        // can detect unblocking. Adding a host beneath it must retain the gate.
+        const addedHost = document.createElement("span")
+        mutationContainer = document.createElement("div")
+        addedHost.attachShadow({ mode: "open" }).append(mutationContainer)
+        host.append(addedHost)
+        await flushDomUpdates()
+      }
       observer.observe.mockClear()
 
       // Unblocking the outer ancestor must preserve any remaining inner gate,
@@ -921,7 +944,7 @@ describe("pageTranslationManager mutation re-walk", () => {
       mockWalkAndLabelElement.mockClear()
       const paragraphAfterOuterUnblock = document.createElement("p")
       paragraphAfterOuterUnblock.textContent = "Content added after the outer element opens"
-      shadowContainer.append(paragraphAfterOuterUnblock)
+      mutationContainer.append(paragraphAfterOuterUnblock)
       await flushDomUpdates()
 
       const stillBlocked = blockedTarget.startsWith("nested")
@@ -935,7 +958,7 @@ describe("pageTranslationManager mutation re-walk", () => {
 
       const laterParagraph = document.createElement("p")
       laterParagraph.textContent = "Content added after unblocking"
-      shadowContainer.append(laterParagraph)
+      mutationContainer.append(laterParagraph)
       await flushDomUpdates()
 
       expect(observer.observe).toHaveBeenCalledWith(laterParagraph)

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -203,7 +203,10 @@ function walkAndLabelVisibleParagraphs(
   walkId: string,
   onBlockedElement?: (blocked: HTMLElement) => void,
 ) {
-  if (isBlockedForTraversal(element)) {
+  if (
+    mockIsDontWalkIntoButTranslateAsChildElement(element, DEFAULT_CONFIG) ||
+    mockIsDontWalkIntoAndDontTranslateAsChildElement(element, DEFAULT_CONFIG)
+  ) {
     onBlockedElement?.(element)
     return {
       forceBlock: false,
@@ -213,7 +216,8 @@ function walkAndLabelVisibleParagraphs(
 
   element.setAttribute("data-read-frog-walked", walkId)
 
-  for (const child of element.children) {
+  // Like the real labeling walk, one call traverses nested shadow trees too.
+  for (const child of [...element.children, ...(element.shadowRoot?.children ?? [])]) {
     if (child instanceof HTMLElement) {
       walkAndLabelVisibleParagraphs(child, walkId, onBlockedElement)
     }
@@ -834,46 +838,86 @@ describe("pageTranslationManager mutation re-walk", () => {
     }
   })
 
-  it("still observes shadow content added inside a current translated source (#2185)", async () => {
-    document.body.innerHTML = `<p id="summary">Original summary</p>`
+  it.each(["current source", "new source", "unblocked source"])(
+    "walks nested shadow content once under a %s (#2185)",
+    async (sourceKind) => {
+      document.body.innerHTML = `<p id="summary">Original summary</p>`
 
-    const manager = new PageTranslationManager()
-    await manager.start()
-    await flushDomUpdates()
+      const manager = new PageTranslationManager()
+      await manager.start()
+      await flushDomUpdates()
 
-    const observer = intersectionObservers[0]!
-    const summary = document.getElementById("summary") as HTMLElement
-    const wrapper = document.createElement("span")
-    wrapper.className = "notranslate read-frog-translated-content-wrapper"
-    wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
-    wrapper.append("译文")
-    summary.append(wrapper)
-    const state: BilingualTranslationState = {
-      layoutSource: summary,
-      sourceTextContent: "Original summary",
-      status: "active",
-      walkId: "walk-id",
-      wrapper,
-      wrapperTextContent: "译文",
-    }
-    registerBilingualTranslationState(state)
-    await flushDomUpdates()
-    observer.observe.mockClear()
+      const observer = intersectionObservers[0]!
+      const summary = document.getElementById("summary") as HTMLElement
+      const wrapper = document.createElement("span")
+      wrapper.className = "notranslate read-frog-translated-content-wrapper"
+      wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+      wrapper.append("译文")
+      summary.append(wrapper)
+      const state: BilingualTranslationState = {
+        layoutSource: summary,
+        sourceTextContent: "Original summary",
+        status: "active",
+        walkId: "walk-id",
+        wrapper,
+        wrapperTextContent: "译文",
+      }
+      if (sourceKind === "current source") registerBilingualTranslationState(state)
+      await flushDomUpdates()
+      observer.observe.mockClear()
 
-    const host = document.createElement("span")
-    const shadowRoot = host.attachShadow({ mode: "open" })
-    const shadowContainer = document.createElement("div")
-    shadowContainer.innerHTML = `<p id="shadow-paragraph">New shadow content</p>`
-    shadowRoot.append(shadowContainer)
-    summary.prepend(host)
-    await flushDomUpdates()
+      const host = document.createElement("span")
+      const shadowRoot = host.attachShadow({ mode: "open" })
+      const shadowContainer = document.createElement("div")
+      shadowContainer.innerHTML = `<p id="shadow-paragraph">New shadow content</p>`
+      shadowRoot.append(shadowContainer)
+      const paragraphs = [shadowContainer.firstElementChild as HTMLElement]
+      let innermostContainer = shadowContainer
+      for (let depth = 1; depth < 4; depth += 1) {
+        const nestedHost = document.createElement("span")
+        const nestedContainer = document.createElement("div")
+        nestedContainer.innerHTML = `<p>Shadow content at depth ${depth}</p>`
+        nestedHost.attachShadow({ mode: "open" }).append(nestedContainer)
+        innermostContainer.append(nestedHost)
+        innermostContainer = nestedContainer
+        paragraphs.push(nestedContainer.firstElementChild as HTMLElement)
+      }
+      host.hidden = sourceKind === "unblocked source"
+      mockWalkAndLabelElement.mockClear()
+      try {
+        summary.prepend(host)
+        await flushDomUpdates()
 
-    const shadowParagraph = shadowRoot.getElementById("shadow-paragraph") as HTMLElement
-    expect(observer.observe).toHaveBeenCalledWith(shadowParagraph)
+        if (sourceKind === "unblocked source") {
+          mockWalkAndLabelElement.mockClear()
+          host.hidden = false
+          await flushDomUpdates()
+        }
+        expect(mockWalkAndLabelElement).toHaveBeenCalledExactlyOnceWith(
+          sourceKind === "current source" ? shadowContainer : host,
+          "walk-id",
+          DEFAULT_CONFIG,
+          expect.anything(),
+        )
+        for (const paragraph of paragraphs) {
+          expect(observer.observe).toHaveBeenCalledWith(paragraph)
+        }
 
-    unregisterBilingualTranslationState(state)
-    manager.stop()
-  })
+        // Register every nested observer even though labeling starts only once.
+        observer.observe.mockClear()
+        mockWalkAndLabelElement.mockClear()
+        const laterParagraph = document.createElement("p")
+        laterParagraph.textContent = "Later innermost content"
+        innermostContainer.append(laterParagraph)
+        await flushDomUpdates()
+        expect(observer.observe).toHaveBeenCalledExactlyOnceWith(laterParagraph)
+        expect(mockWalkAndLabelElement).toHaveBeenCalledTimes(1)
+      } finally {
+        unregisterBilingualTranslationState(state)
+        manager.stop()
+      }
+    },
+  )
 
   it.each([
     ["host", "class", "notranslate"],

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -761,57 +761,118 @@ describe("pageTranslationManager mutation re-walk", () => {
     manager.stop()
   })
 
-  it("does not scan a blocked shadow host added inside a current translated source", async () => {
-    document.body.innerHTML = `<p id="summary">Original summary</p>`
+  it.each([
+    ["host", "class", "notranslate"],
+    ["ancestor", "class", "notranslate"],
+    ["host", "hidden", ""],
+    ["ancestor", "hidden", ""],
+    ["host", "aria-hidden", "true"],
+    ["ancestor", "aria-hidden", "true"],
+  ])(
+    "observes later shadow mutations after a blocked %s (%s) becomes walkable",
+    async (blockedTarget, attribute, value) => {
+      document.body.innerHTML = `<p id="summary">Original summary</p>`
 
-    const manager = new PageTranslationManager()
-    await manager.start()
-    await flushDomUpdates()
+      const manager = new PageTranslationManager()
+      await manager.start()
+      await flushDomUpdates()
 
-    const observer = intersectionObservers[0]!
-    const summary = document.getElementById("summary") as HTMLElement
-    const wrapper = document.createElement("span")
-    wrapper.className = "notranslate read-frog-translated-content-wrapper"
-    wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
-    wrapper.append("译文")
-    summary.append(wrapper)
-    const state: BilingualTranslationState = {
-      layoutSource: summary,
-      sourceTextContent: "Original summary",
-      status: "active",
-      walkId: "walk-id",
-      wrapper,
-      wrapperTextContent: "译文",
-    }
-    registerBilingualTranslationState(state)
-    await flushDomUpdates()
-    observer.observe.mockClear()
-    mockWalkAndLabelElement.mockClear()
-    mockIsDontWalkIntoButTranslateAsChildElement.mockImplementation((element: HTMLElement) =>
-      element.classList.contains("notranslate"),
-    )
+      const observer = intersectionObservers[0]!
+      const summary = document.getElementById("summary") as HTMLElement
+      const wrapper = document.createElement("span")
+      wrapper.className = "notranslate read-frog-translated-content-wrapper"
+      wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+      wrapper.append("译文")
+      summary.append(wrapper)
+      const state: BilingualTranslationState = {
+        layoutSource: summary,
+        sourceTextContent: "Original summary",
+        status: "active",
+        walkId: "walk-id",
+        wrapper,
+        wrapperTextContent: "译文",
+      }
+      registerBilingualTranslationState(state)
+      await flushDomUpdates()
+      observer.observe.mockClear()
+      mockWalkAndLabelElement.mockClear()
+      mockIsDontWalkIntoButTranslateAsChildElement.mockImplementation((element: HTMLElement) =>
+        element.classList.contains("notranslate"),
+      )
 
-    const host = document.createElement("span")
-    host.className = "notranslate"
-    const shadowRoot = host.attachShadow({ mode: "open" })
-    const shadowContainer = document.createElement("div")
-    shadowContainer.innerHTML = `<p id="blocked-shadow-paragraph">Blocked shadow content</p>`
-    shadowRoot.append(shadowContainer)
-    summary.prepend(host)
-    await flushDomUpdates()
+      const host = document.createElement("span")
+      const blockedElement = blockedTarget === "host" ? host : document.createElement("span")
+      if (blockedElement !== host) blockedElement.append(host)
+      blockedElement.setAttribute("data-site-rule-blocked", "")
+      blockedElement.setAttribute(attribute, value)
+      const shadowRoot = host.attachShadow({ mode: "open" })
+      const shadowContainer = document.createElement("div")
+      shadowContainer.innerHTML = `<p id="blocked-shadow-paragraph">Blocked shadow content</p>`
+      shadowRoot.append(shadowContainer)
+      summary.prepend(blockedElement)
+      await flushDomUpdates()
 
-    const shadowParagraph = shadowRoot.getElementById("blocked-shadow-paragraph") as HTMLElement
-    expect(observer.observe).not.toHaveBeenCalledWith(shadowParagraph)
-    expect(mockWalkAndLabelElement).not.toHaveBeenCalledWith(
-      shadowContainer,
-      "walk-id",
-      DEFAULT_CONFIG,
-      expect.anything(),
-    )
+      const shadowParagraph = shadowRoot.getElementById("blocked-shadow-paragraph") as HTMLElement
+      expect(observer.observe).not.toHaveBeenCalledWith(shadowParagraph)
+      expect(mockWalkAndLabelElement).not.toHaveBeenCalledWith(
+        shadowContainer,
+        "walk-id",
+        DEFAULT_CONFIG,
+        expect.anything(),
+      )
 
-    unregisterBilingualTranslationState(state)
-    manager.stop()
-  })
+      blockedElement.removeAttribute(attribute)
+      await flushDomUpdates()
+      observer.observe.mockClear()
+
+      const laterParagraph = document.createElement("p")
+      laterParagraph.textContent = "Content added after unblocking"
+      shadowContainer.append(laterParagraph)
+      await flushDomUpdates()
+
+      expect(observer.observe).toHaveBeenCalledWith(laterParagraph)
+      await observer.triggerIntersect(laterParagraph)
+      await flushDomUpdates()
+      expect(mockTranslateWalkedElement).toHaveBeenCalledWith(
+        laterParagraph,
+        "walk-id",
+        DEFAULT_CONFIG,
+        false,
+        expect.anything(),
+        expect.anything(),
+      )
+
+      // Text edits must also reach the stale-source retranslation path.
+      const shadowWrapper = document.createElement("span")
+      shadowWrapper.className = "notranslate read-frog-translated-content-wrapper"
+      shadowWrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+      shadowWrapper.textContent = "后续译文"
+      laterParagraph.append(shadowWrapper)
+      const shadowState: BilingualTranslationState = {
+        layoutSource: laterParagraph,
+        sourceTextContent: "Content added after unblocking",
+        status: "active",
+        walkId: "walk-id",
+        wrapper: shadowWrapper,
+        wrapperTextContent: "后续译文",
+      }
+      registerBilingualTranslationState(shadowState)
+      await flushDomUpdates()
+      mockTranslateNodesBilingualMode.mockClear()
+
+      ;(laterParagraph.firstChild as Text).data = "Updated shadow content"
+      await flushDomUpdates()
+      expect(mockTranslateNodesBilingualMode).toHaveBeenCalledExactlyOnceWith(
+        [laterParagraph],
+        "walk-id",
+        DEFAULT_CONFIG,
+      )
+
+      unregisterBilingualTranslationState(shadowState)
+      unregisterBilingualTranslationState(state)
+      manager.stop()
+    },
+  )
 
   it("retranslates exactly once when the site re-renders a node containing our wrapper (#1831)", async () => {
     document.body.innerHTML = `

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -768,6 +768,9 @@ describe("pageTranslationManager mutation re-walk", () => {
     ["ancestor", "hidden", ""],
     ["host", "aria-hidden", "true"],
     ["ancestor", "aria-hidden", "true"],
+    ["nested host", "class", "notranslate"],
+    ["nested host", "hidden", ""],
+    ["nested host", "aria-hidden", "true"],
   ])(
     "observes later shadow mutations after a blocked %s (%s) becomes walkable",
     async (blockedTarget, attribute, value) => {
@@ -805,6 +808,10 @@ describe("pageTranslationManager mutation re-walk", () => {
       if (blockedElement !== host) blockedElement.append(host)
       blockedElement.setAttribute("data-site-rule-blocked", "")
       blockedElement.setAttribute(attribute, value)
+      if (blockedTarget === "nested host") {
+        host.setAttribute("data-site-rule-blocked", "")
+        host.setAttribute(attribute, value)
+      }
       const shadowRoot = host.attachShadow({ mode: "open" })
       const shadowContainer = document.createElement("div")
       shadowContainer.innerHTML = `<p id="blocked-shadow-paragraph">Blocked shadow content</p>`
@@ -823,6 +830,23 @@ describe("pageTranslationManager mutation re-walk", () => {
 
       blockedElement.removeAttribute(attribute)
       await flushDomUpdates()
+      observer.observe.mockClear()
+
+      // Unblocking the outer ancestor must preserve any remaining inner gate,
+      // including for content added while that host is still blocked.
+      mockWalkAndLabelElement.mockClear()
+      const paragraphAfterOuterUnblock = document.createElement("p")
+      paragraphAfterOuterUnblock.textContent = "Content added after the outer element opens"
+      shadowContainer.append(paragraphAfterOuterUnblock)
+      await flushDomUpdates()
+
+      const stillBlocked = blockedTarget === "nested host"
+      expect(observer.observe).toHaveBeenCalledTimes(stillBlocked ? 0 : 1)
+      expect(mockWalkAndLabelElement).toHaveBeenCalledTimes(stillBlocked ? 0 : 1)
+
+      if (stillBlocked) host.removeAttribute(attribute)
+      await flushDomUpdates()
+      expect(observer.observe).toHaveBeenCalledWith(paragraphAfterOuterUnblock)
       observer.observe.mockClear()
 
       const laterParagraph = document.createElement("p")

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -771,6 +771,9 @@ describe("pageTranslationManager mutation re-walk", () => {
     ["nested host", "class", "notranslate"],
     ["nested host", "hidden", ""],
     ["nested host", "aria-hidden", "true"],
+    ["nested shadow host", "class", "notranslate"],
+    ["nested shadow host", "hidden", ""],
+    ["nested shadow host", "aria-hidden", "true"],
   ])(
     "observes later shadow mutations after a blocked %s (%s) becomes walkable",
     async (blockedTarget, attribute, value) => {
@@ -805,10 +808,14 @@ describe("pageTranslationManager mutation re-walk", () => {
 
       const host = document.createElement("span")
       const blockedElement = blockedTarget === "host" ? host : document.createElement("span")
-      if (blockedElement !== host) blockedElement.append(host)
+      if (blockedTarget === "nested shadow host") {
+        blockedElement.attachShadow({ mode: "open" }).append(host)
+      } else if (blockedElement !== host) {
+        blockedElement.append(host)
+      }
       blockedElement.setAttribute("data-site-rule-blocked", "")
       blockedElement.setAttribute(attribute, value)
-      if (blockedTarget === "nested host") {
+      if (blockedTarget.startsWith("nested")) {
         host.setAttribute("data-site-rule-blocked", "")
         host.setAttribute(attribute, value)
       }
@@ -840,7 +847,7 @@ describe("pageTranslationManager mutation re-walk", () => {
       shadowContainer.append(paragraphAfterOuterUnblock)
       await flushDomUpdates()
 
-      const stillBlocked = blockedTarget === "nested host"
+      const stillBlocked = blockedTarget.startsWith("nested")
       expect(observer.observe).toHaveBeenCalledTimes(stillBlocked ? 0 : 1)
       expect(mockWalkAndLabelElement).toHaveBeenCalledTimes(stillBlocked ? 0 : 1)
 

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -761,6 +761,58 @@ describe("pageTranslationManager mutation re-walk", () => {
     manager.stop()
   })
 
+  it("does not scan a blocked shadow host added inside a current translated source", async () => {
+    document.body.innerHTML = `<p id="summary">Original summary</p>`
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observer = intersectionObservers[0]!
+    const summary = document.getElementById("summary") as HTMLElement
+    const wrapper = document.createElement("span")
+    wrapper.className = "notranslate read-frog-translated-content-wrapper"
+    wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+    wrapper.append("译文")
+    summary.append(wrapper)
+    const state: BilingualTranslationState = {
+      layoutSource: summary,
+      sourceTextContent: "Original summary",
+      status: "active",
+      walkId: "walk-id",
+      wrapper,
+      wrapperTextContent: "译文",
+    }
+    registerBilingualTranslationState(state)
+    await flushDomUpdates()
+    observer.observe.mockClear()
+    mockWalkAndLabelElement.mockClear()
+    mockIsDontWalkIntoButTranslateAsChildElement.mockImplementation((element: HTMLElement) =>
+      element.classList.contains("notranslate"),
+    )
+
+    const host = document.createElement("span")
+    host.className = "notranslate"
+    const shadowRoot = host.attachShadow({ mode: "open" })
+    const shadowContainer = document.createElement("div")
+    shadowContainer.innerHTML = `<p id="blocked-shadow-paragraph">Blocked shadow content</p>`
+    shadowRoot.append(shadowContainer)
+    summary.prepend(host)
+    await flushDomUpdates()
+
+    const shadowParagraph = shadowRoot.getElementById("blocked-shadow-paragraph") as HTMLElement
+    expect(observer.observe).not.toHaveBeenCalledWith(shadowParagraph)
+    expect(mockWalkAndLabelElement).not.toHaveBeenCalledWith(
+      shadowContainer,
+      "walk-id",
+      DEFAULT_CONFIG,
+      expect.anything(),
+    )
+
+    unregisterBilingualTranslationState(state)
+    manager.stop()
+  })
+
   it("retranslates exactly once when the site re-renders a node containing our wrapper (#1831)", async () => {
     document.body.innerHTML = `
       <p id="tweet"><span id="source">Original content</span></p>

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -720,6 +720,47 @@ describe("pageTranslationManager mutation re-walk", () => {
     manager.stop()
   })
 
+  it("still observes shadow content added inside a current translated source (#2185)", async () => {
+    document.body.innerHTML = `<p id="summary">Original summary</p>`
+
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observer = intersectionObservers[0]!
+    const summary = document.getElementById("summary") as HTMLElement
+    const wrapper = document.createElement("span")
+    wrapper.className = "notranslate read-frog-translated-content-wrapper"
+    wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+    wrapper.append("译文")
+    summary.append(wrapper)
+    const state: BilingualTranslationState = {
+      layoutSource: summary,
+      sourceTextContent: "Original summary",
+      status: "active",
+      walkId: "walk-id",
+      wrapper,
+      wrapperTextContent: "译文",
+    }
+    registerBilingualTranslationState(state)
+    await flushDomUpdates()
+    observer.observe.mockClear()
+
+    const host = document.createElement("span")
+    const shadowRoot = host.attachShadow({ mode: "open" })
+    const shadowContainer = document.createElement("div")
+    shadowContainer.innerHTML = `<p id="shadow-paragraph">New shadow content</p>`
+    shadowRoot.append(shadowContainer)
+    summary.prepend(host)
+    await flushDomUpdates()
+
+    const shadowParagraph = shadowRoot.getElementById("shadow-paragraph") as HTMLElement
+    expect(observer.observe).toHaveBeenCalledWith(shadowParagraph)
+
+    unregisterBilingualTranslationState(state)
+    manager.stop()
+  })
+
   it("retranslates exactly once when the site re-renders a node containing our wrapper (#1831)", async () => {
     document.body.innerHTML = `
       <p id="tweet"><span id="source">Original content</span></p>

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -431,6 +431,43 @@ describe("pageTranslationManager mutation re-walk", () => {
     manager.stop()
   })
 
+  it("only rechecks branches with cached blockers after an ancestor attribute changes", async () => {
+    document.body.innerHTML = `<div id="ancestor">
+      <section><p id="blocked" hidden>Hidden content</p></section>
+      <section id="unrelated"><p>Visible content</p></section>
+    </div>`
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    try {
+      const ancestor = document.getElementById("ancestor") as HTMLElement
+      const blocked = document.getElementById("blocked") as HTMLElement
+      const unrelated = document.getElementById("unrelated") as HTMLElement
+      mockIsDontWalkIntoAndDontTranslateAsChildElement.mockClear()
+      mockWalkAndLabelElement.mockClear()
+
+      ancestor.classList.add("highlighted")
+      await flushDomUpdates()
+
+      expect(mockIsDontWalkIntoAndDontTranslateAsChildElement).toHaveBeenCalledWith(
+        blocked,
+        DEFAULT_CONFIG,
+      )
+      expect(mockIsDontWalkIntoAndDontTranslateAsChildElement).not.toHaveBeenCalledWith(
+        unrelated,
+        DEFAULT_CONFIG,
+      )
+      expect(mockIsDontWalkIntoAndDontTranslateAsChildElement).not.toHaveBeenCalledWith(
+        unrelated.firstElementChild,
+        DEFAULT_CONFIG,
+      )
+      expect(mockWalkAndLabelElement).not.toHaveBeenCalled()
+    } finally {
+      manager.stop()
+    }
+  })
+
   it("retranslates an existing logical source after its text expands in place", async () => {
     document.body.innerHTML = `
       <p id="tweet"><span id="source">Truncated tweet</span></p>
@@ -854,6 +891,8 @@ describe("pageTranslationManager mutation re-walk", () => {
     ["nested dynamic shadow host", "class", "notranslate"],
     ["nested dynamic shadow host", "hidden", ""],
     ["nested dynamic shadow host", "aria-hidden", "true"],
+    ["ancestor selector", "class", "collapsed"],
+    ["ancestor selector", "aria-hidden", "true"],
   ])(
     "observes later shadow mutations after a blocked %s (%s) becomes walkable",
     async (blockedTarget, attribute, value) => {
@@ -902,7 +941,20 @@ describe("pageTranslationManager mutation re-walk", () => {
       } else if (blockedElement !== host) {
         blockedElement.append(host)
       }
-      blockedElement.setAttribute("data-site-rule-blocked", "")
+      if (blockedTarget === "ancestor selector") {
+        document.head.innerHTML = `<style>
+          [data-css-container].collapsed [data-css-hidden],
+          [data-css-container][aria-hidden="true"] [data-css-hidden] { display: none; }
+        </style>`
+        blockedElement.setAttribute("data-css-container", "")
+        host.setAttribute("data-css-hidden", "")
+        mockIsDontWalkIntoAndDontTranslateAsChildElement.mockImplementation(
+          (element: HTMLElement) =>
+            isBlockedForTraversal(element) || getComputedStyle(element).display === "none",
+        )
+      } else {
+        blockedElement.setAttribute("data-site-rule-blocked", "")
+      }
       blockedElement.setAttribute(attribute, value)
       if (blockedTarget.startsWith("nested")) {
         host.setAttribute("data-site-rule-blocked", "")

--- a/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
+++ b/src/entrypoints/host.content/translation-control/__tests__/page-translation-mutations.test.ts
@@ -4,10 +4,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { DEFAULT_CONFIG } from "@/utils/constants/config"
 import { GIANT_SPLIT_STRANDED_TEXT_MAX_UNITS } from "@/utils/constants/translate"
 import {
+  isVirtualParagraphGroupCurrent,
   markExtensionDrivenNodeRemoval,
+  markVirtualParagraphGroupInserted,
   registerBilingualTranslationState,
+  registerVirtualParagraphGroup,
   unregisterBilingualTranslationState,
+  unregisterVirtualParagraphGroup,
   type BilingualTranslationState,
+  type VirtualParagraphGroup,
 } from "@/utils/host/translate/core/translation-state"
 import { PageTranslationManager } from "../page-translation"
 
@@ -718,6 +723,78 @@ describe("pageTranslationManager mutation re-walk", () => {
 
     unregisterBilingualTranslationState(state)
     manager.stop()
+  })
+
+  it("ignores decorators inside current virtual paragraph groups but retranslates text changes", async () => {
+    document.body.innerHTML = `<div id="summary" style="white-space: pre-wrap"><span>First paragraph</span>\n\n<span>Second paragraph</span></div>`
+    const manager = new PageTranslationManager()
+    await manager.start()
+    await flushDomUpdates()
+
+    const observer = intersectionObservers[0]!
+    const summary = document.getElementById("summary") as HTMLElement
+    const sourceSpan = summary.firstElementChild as HTMLElement
+    const source = sourceSpan.firstChild as Text
+    const group: VirtualParagraphGroup = {
+      id: "virtual-group",
+      walkId: "walk-id",
+      status: "active",
+      layoutSource: summary,
+      wrappers: new Set(),
+      splitRecords: [],
+      sourceSnapshots: [...summary.childNodes].map((node) => ({
+        source: node as Text | HTMLElement,
+        parent: summary,
+        value: node.textContent ?? "",
+      })),
+      sourceTextContent: summary.textContent ?? "",
+      wrapperPlacements: new Map(),
+    }
+    for (const span of [...summary.children]) {
+      const wrapper = document.createElement("span")
+      wrapper.className = "notranslate read-frog-translated-content-wrapper"
+      wrapper.setAttribute("data-read-frog-translation-mode", "bilingual")
+      wrapper.textContent = "译文"
+      span.after(wrapper)
+      group.wrappers.add(wrapper)
+    }
+    registerVirtualParagraphGroup(group)
+    markVirtualParagraphGroupInserted(group)
+    await flushDomUpdates()
+    observer.observe.mockClear()
+    mockWalkAndLabelElement.mockClear()
+    mockTranslateNodesBilingualMode.mockClear()
+
+    try {
+      for (let i = 0; i < 3; i += 1) {
+        // The atomic inline source stays in place; only its descendant Text
+        // moves, so the group's snapshots and wrapper placement remain valid.
+        const decorator = document.createElement("span")
+        decorator.append(source)
+        sourceSpan.append(decorator)
+        await flushDomUpdates()
+        expect(isVirtualParagraphGroupCurrent(group)).toBe(true)
+
+        sourceSpan.insertBefore(source, decorator)
+        decorator.remove()
+        await flushDomUpdates()
+      }
+      expect(observer.observe).not.toHaveBeenCalled()
+      expect(mockWalkAndLabelElement).not.toHaveBeenCalled()
+      expect(mockTranslateNodesBilingualMode).not.toHaveBeenCalled()
+      expect(summary.querySelectorAll(".read-frog-translated-content-wrapper")).toHaveLength(2)
+
+      source.data = "Updated first paragraph"
+      await flushDomUpdates()
+      expect(mockTranslateNodesBilingualMode).toHaveBeenCalledExactlyOnceWith(
+        [summary],
+        "walk-id",
+        DEFAULT_CONFIG,
+      )
+    } finally {
+      unregisterVirtualParagraphGroup(group)
+      manager.stop()
+    }
   })
 
   it("still observes shadow content added inside a current translated source (#2185)", async () => {

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -143,6 +143,7 @@ export class PageTranslationManager implements IPageTranslationManager {
   private walkId: string | null = null
   private intersectionOptions: IntersectionObserverInit
   private walkBlockedElementsCache = new WeakSet<HTMLElement>()
+  private ancestorsWithWalkBlockedElements = new WeakSet<HTMLElement>()
   private refreshingTranslatedSources = new WeakSet<HTMLElement>()
   private translatedSourceMutationVersions = new WeakMap<HTMLElement, number>()
   private retranslationBudgets = new WeakMap<HTMLElement, RetranslationBudget>()
@@ -464,6 +465,7 @@ export class PageTranslationManager implements IPageTranslationManager {
     this.translationSessionVersion += 1
     this.walkId = null
     this.walkBlockedElementsCache = new WeakSet()
+    this.ancestorsWithWalkBlockedElements = new WeakSet()
     this.refreshingTranslatedSources = new WeakSet()
     this.translatedSourceMutationVersions = new WeakMap()
     this.pendingRetranslateRetries.forEach((retry) => retry.clear())
@@ -690,7 +692,7 @@ export class PageTranslationManager implements IPageTranslationManager {
     if (hasNoWalkAncestor(container, config)) return
 
     const onBlockedElement = (element: HTMLElement) => {
-      this.walkBlockedElementsCache.add(element)
+      this.cacheWalkBlockedElement(element)
     }
     if (options.chunked) {
       const result = await walkAndLabelElementChunked(container, walkId, config, {
@@ -857,6 +859,43 @@ export class PageTranslationManager implements IPageTranslationManager {
     return isWalkBlockedElementFilter(element, config)
   }
 
+  private cacheWalkBlockedElement(element: HTMLElement): void {
+    this.walkBlockedElementsCache.add(element)
+    let current: HTMLElement | null = element
+    while (current) {
+      const root = current.getRootNode()
+      current =
+        current.parentElement ?? (root instanceof ShadowRoot ? (root.host as HTMLElement) : null)
+      if (current) this.ancestorsWithWalkBlockedElements.add(current)
+    }
+  }
+
+  private collectNewlyWalkableSubtrees(element: HTMLElement, config: Config): HTMLElement[] {
+    if (this.didChangeToWalkable(element, config)) return [element]
+    if (
+      this.walkBlockedElementsCache.has(element) ||
+      !this.ancestorsWithWalkBlockedElements.has(element)
+    )
+      return []
+
+    // Ancestor selectors can reveal a cached descendant without changing the
+    // ancestor's own walkability. Only follow branches leading to cached
+    // blockers; ordinary class/style churn must not scan the entire subtree.
+    // Weak membership avoids retaining detached nodes through their ancestors.
+    const result: HTMLElement[] = []
+    const children = [...element.children, ...(element.shadowRoot?.children ?? [])]
+    for (const child of children) {
+      if (
+        isHTMLElement(child) &&
+        (this.walkBlockedElementsCache.has(child) ||
+          this.ancestorsWithWalkBlockedElements.has(child))
+      ) {
+        result.push(...this.collectNewlyWalkableSubtrees(child, config))
+      }
+    }
+    return result
+  }
+
   /**
    * Handle attribute changes and only trigger observation
    * when element transitions from blocked to walkable.
@@ -867,7 +906,7 @@ export class PageTranslationManager implements IPageTranslationManager {
 
     // Update cache with current state
     if (isWalkBlockedNow) {
-      this.walkBlockedElementsCache.add(element)
+      this.cacheWalkBlockedElement(element)
     } else {
       this.walkBlockedElementsCache.delete(element)
     }
@@ -882,7 +921,7 @@ export class PageTranslationManager implements IPageTranslationManager {
     const walkBlockedElements = deepQueryTopLevelSelector(element, (el) =>
       this.isWalkBlockedElement(el, config),
     )
-    walkBlockedElements.forEach((el) => this.walkBlockedElementsCache.add(el))
+    walkBlockedElements.forEach((el) => this.cacheWalkBlockedElement(el))
   }
 
   /**
@@ -1057,12 +1096,13 @@ export class PageTranslationManager implements IPageTranslationManager {
         })
       } else if (this.isWalkabilityAttributeMutation(rec)) {
         const el = rec.target
-        if (isHTMLElement(el) && this.didChangeToWalkable(el, config)) {
-          void this.observeTopLevelParagraphs(el, config)
+        if (!isHTMLElement(el)) continue
+        for (const unblocked of this.collectNewlyWalkableSubtrees(el, config)) {
+          void this.observeTopLevelParagraphs(unblocked, config)
           // A blocked addition under a current source can skip isolated-tree
           // registration. Observe future shadow mutations when it unblocks.
           // Descendant hosts may still be blocked after this ancestor opens.
-          this.observeIsolatedDescendantsMutations(el, config)
+          this.observeIsolatedDescendantsMutations(unblocked, config)
         }
       }
     }
@@ -1203,7 +1243,7 @@ export class PageTranslationManager implements IPageTranslationManager {
     if (config) {
       if (hasNoWalkAncestor(element, config)) return
       if (this.isWalkBlockedElement(element, config)) {
-        this.walkBlockedElementsCache.add(element)
+        this.cacheWalkBlockedElement(element)
         return
       }
     }

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -1052,7 +1052,7 @@ export class PageTranslationManager implements IPageTranslationManager {
           if (isHTMLElement(node)) {
             this.addWalkBlockedElements(node, config)
             void this.observeTopLevelParagraphs(node, config)
-            this.observeIsolatedDescendantsMutations(node)
+            this.observeIsolatedDescendantsMutations(node, config)
           }
         })
       } else if (this.isWalkabilityAttributeMutation(rec)) {

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -1059,6 +1059,9 @@ export class PageTranslationManager implements IPageTranslationManager {
         const el = rec.target
         if (isHTMLElement(el) && this.didChangeToWalkable(el, config)) {
           void this.observeTopLevelParagraphs(el, config)
+          // A blocked addition under a current source can skip isolated-tree
+          // registration. Observe future shadow mutations when it unblocks.
+          this.observeIsolatedDescendantsMutations(el)
         }
       }
     }

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -1061,7 +1061,8 @@ export class PageTranslationManager implements IPageTranslationManager {
           void this.observeTopLevelParagraphs(el, config)
           // A blocked addition under a current source can skip isolated-tree
           // registration. Observe future shadow mutations when it unblocks.
-          this.observeIsolatedDescendantsMutations(el)
+          // Descendant hosts may still be blocked after this ancestor opens.
+          this.observeIsolatedDescendantsMutations(el, config)
         }
       }
     }

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -888,7 +888,7 @@ export class PageTranslationManager implements IPageTranslationManager {
   /**
    * Start observing mutations for a container and all its shadow roots
    */
-  private observeMutations(container: HTMLElement): void {
+  private observeMutations(container: HTMLElement, config?: Config): void {
     // Dynamic pages re-add the same subtrees repeatedly; without dedup every
     // re-added shadow host gained a duplicate subtree observer (#1831).
     if (!this.observedMutationRoots.has(container)) {
@@ -907,7 +907,7 @@ export class PageTranslationManager implements IPageTranslationManager {
 
       this.mutationObservers.push(mutationObserver)
     }
-    this.observeIsolatedDescendantsMutations(container)
+    this.observeIsolatedDescendantsMutations(container, config)
   }
 
   private static readonly SELF_NODE_CLASSES = [
@@ -1212,7 +1212,7 @@ export class PageTranslationManager implements IPageTranslationManager {
     if (element.shadowRoot) {
       for (const child of element.shadowRoot.children) {
         if (isHTMLElement(child)) {
-          this.observeMutations(child)
+          this.observeMutations(child, config)
           // A light-DOM re-walk can be skipped when its translated ancestor is
           // still current, but document observers cannot see into a newly
           // attached shadow root. Scan that isolated tree explicitly without

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -30,6 +30,7 @@ import {
   walkAndLabelElementChunked,
 } from "@/utils/host/dom/traversal"
 import {
+  findCurrentBilingualLayoutSource,
   findStaleBilingualLayoutSource,
   findStaleTranslationOnlyAnchor,
   getBilingualTranslationStateForWrapper,
@@ -1033,6 +1034,13 @@ export class PageTranslationManager implements IPageTranslationManager {
 
     for (const rec of hostRecords) {
       if (rec.type === "childList") {
+        // Sites such as Google Search temporarily wrap existing text in a new
+        // element while showing citation hover UI. If the surrounding
+        // bilingual source is still current, its host text did not change and
+        // the added subtree is structural churn, not new translatable content.
+        // Walking it would insert a duplicate wrapper that the site may retain
+        // when it later unwraps the temporary element.
+        if (findCurrentBilingualLayoutSource(rec.target)) continue
         rec.addedNodes.forEach((node) => {
           if (isHTMLElement(node)) {
             this.addWalkBlockedElements(node, config)

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -1192,6 +1192,18 @@ export class PageTranslationManager implements IPageTranslationManager {
    * considered as part of the document.
    */
   private observeIsolatedDescendantsMutations(element: HTMLElement, config?: Config): void {
+    // The config-enabled path also scans newly discovered isolated trees. Apply
+    // the same walkability gates as observeTopLevelParagraphs before crossing
+    // a shadow boundary, whose children cannot inspect their light-DOM host via
+    // parentElement.
+    if (config) {
+      if (hasNoWalkAncestor(element, config)) return
+      if (this.isWalkBlockedElement(element, config)) {
+        this.walkBlockedElementsCache.add(element)
+        return
+      }
+    }
+
     // Check if this element has a shadow root
     if (element.shadowRoot) {
       for (const child of element.shadowRoot.children) {

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -1040,7 +1040,14 @@ export class PageTranslationManager implements IPageTranslationManager {
         // the added subtree is structural churn, not new translatable content.
         // Walking it would insert a duplicate wrapper that the site may retain
         // when it later unwraps the temporary element.
-        if (findCurrentBilingualLayoutSource(rec.target)) continue
+        if (findCurrentBilingualLayoutSource(rec.target)) {
+          rec.addedNodes.forEach((node) => {
+            if (isHTMLElement(node)) {
+              this.observeIsolatedDescendantsMutations(node, config)
+            }
+          })
+          continue
+        }
         rec.addedNodes.forEach((node) => {
           if (isHTMLElement(node)) {
             this.addWalkBlockedElements(node, config)
@@ -1184,12 +1191,17 @@ export class PageTranslationManager implements IPageTranslationManager {
    * These can't be found as top level paragraph elements because isolated shadow roots and iframes are not
    * considered as part of the document.
    */
-  private observeIsolatedDescendantsMutations(element: HTMLElement): void {
+  private observeIsolatedDescendantsMutations(element: HTMLElement, config?: Config): void {
     // Check if this element has a shadow root
     if (element.shadowRoot) {
       for (const child of element.shadowRoot.children) {
         if (isHTMLElement(child)) {
           this.observeMutations(child)
+          // A light-DOM re-walk can be skipped when its translated ancestor is
+          // still current, but document observers cannot see into a newly
+          // attached shadow root. Scan that isolated tree explicitly without
+          // translating the unchanged light-DOM host (#2185).
+          if (config) void this.observeTopLevelParagraphs(child, config)
         }
       }
     }
@@ -1197,7 +1209,7 @@ export class PageTranslationManager implements IPageTranslationManager {
     // Recursively check children
     for (const child of element.children) {
       if (isHTMLElement(child)) {
-        this.observeIsolatedDescendantsMutations(child)
+        this.observeIsolatedDescendantsMutations(child, config)
       }
     }
   }

--- a/src/entrypoints/host.content/translation-control/page-translation.ts
+++ b/src/entrypoints/host.content/translation-control/page-translation.ts
@@ -1082,7 +1082,7 @@ export class PageTranslationManager implements IPageTranslationManager {
         if (findCurrentBilingualLayoutSource(rec.target)) {
           rec.addedNodes.forEach((node) => {
             if (isHTMLElement(node)) {
-              this.observeIsolatedDescendantsMutations(node, config)
+              this.observeIsolatedDescendantsMutations(node, config, { scanIsolatedTrees: true })
             }
           })
           continue
@@ -1235,11 +1235,14 @@ export class PageTranslationManager implements IPageTranslationManager {
    * These can't be found as top level paragraph elements because isolated shadow roots and iframes are not
    * considered as part of the document.
    */
-  private observeIsolatedDescendantsMutations(element: HTMLElement, config?: Config): void {
-    // The config-enabled path also scans newly discovered isolated trees. Apply
-    // the same walkability gates as observeTopLevelParagraphs before crossing
-    // a shadow boundary, whose children cannot inspect their light-DOM host via
-    // parentElement.
+  private observeIsolatedDescendantsMutations(
+    element: HTMLElement,
+    config?: Config,
+    options: { scanIsolatedTrees?: boolean } = {},
+  ): void {
+    // Keep observation and traversal behind the same walkability gates before
+    // crossing a shadow boundary: children cannot inspect their light-DOM
+    // host via parentElement.
     if (config) {
       if (hasNoWalkAncestor(element, config)) return
       if (this.isWalkBlockedElement(element, config)) {
@@ -1253,11 +1256,12 @@ export class PageTranslationManager implements IPageTranslationManager {
       for (const child of element.shadowRoot.children) {
         if (isHTMLElement(child)) {
           this.observeMutations(child, config)
-          // A light-DOM re-walk can be skipped when its translated ancestor is
-          // still current, but document observers cannot see into a newly
-          // attached shadow root. Scan that isolated tree explicitly without
-          // translating the unchanged light-DOM host (#2185).
-          if (config) void this.observeTopLevelParagraphs(child, config)
+          // Only the current-source shortcut needs a separate isolated walk.
+          // The walker already crosses nested shadow roots, so recursive
+          // observer registration above must not scan those subtrees again.
+          if (config && options.scanIsolatedTrees) {
+            void this.observeTopLevelParagraphs(child, config)
+          }
         }
       }
     }
@@ -1265,7 +1269,7 @@ export class PageTranslationManager implements IPageTranslationManager {
     // Recursively check children
     for (const child of element.children) {
       if (isHTMLElement(child)) {
-        this.observeIsolatedDescendantsMutations(child, config)
+        this.observeIsolatedDescendantsMutations(child, config, options)
       }
     }
   }

--- a/src/utils/host/translate/core/translation-state.ts
+++ b/src/utils/host/translate/core/translation-state.ts
@@ -455,6 +455,9 @@ export function isBilingualTranslationStateCurrent(state: BilingualTranslationSt
 export function findCurrentBilingualLayoutSource(node: Node): HTMLElement | undefined {
   let current = node.nodeType === Node.ELEMENT_NODE ? (node as HTMLElement) : node.parentElement
   while (current) {
+    const virtualGroup = virtualParagraphGroupsBySource.get(current)
+    if (virtualGroup && isVirtualParagraphGroupCurrent(virtualGroup)) return current
+
     const state = bilingualTranslationsBySource.get(current)
     if (state && isBilingualTranslationStateCurrent(state)) return current
     current = current.parentElement

--- a/src/utils/host/translate/core/translation-state.ts
+++ b/src/utils/host/translate/core/translation-state.ts
@@ -445,6 +445,23 @@ export function isBilingualTranslationStateCurrent(state: BilingualTranslationSt
   )
 }
 
+/**
+ * Nearest translated ancestor whose host text and wrapper are still current.
+ *
+ * Some sites temporarily wrap existing text in a new element for hover or
+ * citation decoration. Re-walking that element would translate the same text
+ * again even though the surrounding logical source has not changed.
+ */
+export function findCurrentBilingualLayoutSource(node: Node): HTMLElement | undefined {
+  let current = node.nodeType === Node.ELEMENT_NODE ? (node as HTMLElement) : node.parentElement
+  while (current) {
+    const state = bilingualTranslationsBySource.get(current)
+    if (state && isBilingualTranslationStateCurrent(state)) return current
+    current = current.parentElement
+  }
+  return undefined
+}
+
 export function findStaleBilingualLayoutSource(node: Node): HTMLElement | undefined {
   let current = node.nodeType === Node.ELEMENT_NODE ? (node as HTMLElement) : node.parentElement
   while (current) {


### PR DESCRIPTION
> **AI model(s) used (required):** OpenAI GPT-5 (Codex), GPT-6 (Codex), Claude Opus 5 (Claude Code)

## Type of Changes

- [ ] ✨ New feature (feat)
- [x] 🐛 Bug fix (fix)
- [ ] 📝 Documentation change (docs)
- [ ] 💄 UI/style change (style)
- [ ] ♻️ Code refactoring (refactor)
- [ ] ⚡ Performance improvement (perf)
- [ ] ✅ Test related (test)
- [ ] 🔧 Build or dependencies update (build)
- [ ] 🔄 CI/CD related (ci)
- [ ] 🌐 Internationalization (i18n)
- [ ] 🧠 AI model related (ai)
- [ ] 🔄 Revert a previous commit (revert)
- [ ] 📦 Other changes that do not modify src or test files (chore)

## Description

### Root cause

Google AI Overview's citation hover builds `<span class="yADgie">` **off-document**, moves the
paragraph's existing Text node into it, then inserts the span into the already-translated `<p>`.
MutationObserver cannot see the off-document assembly, so the only observable fact is "`<p>` gained
a child".

The childList branch of `handleMutationRecords` then walked that span **as a fresh walk root**.
Because "top-level paragraph" is computed *relative to the walk root* — the short-circuit when the
container itself carries `data-read-frog-paragraph`, plus the `topLevelParagraphs` filter's
`container.contains(ancestor)` — the inline span promoted itself to a translation unit and got its
own wrapper. Google then unwrapped the decorator preserving children, so the wrapper stayed: one
permanent duplicate per hover.

So the defect is not "we failed to detect churn". It is **that an added node was used as a walk root
at all while sitting inside an existing unit**.

### The fix

A node added inside an element registered as a bilingual layout source (or virtual paragraph group)
is that source's business and is never walked as a unit of its own. The guard is
**currency-independent**, and that is what makes it safe — a registered source is in exactly one of
two states, and both are already handled:

- **current** — `collectHostText` still equals its snapshot, so the addition brought no new host text
  (a hover decorator only re-parents existing Text);
- **stale** — `findStaleBilingualLayoutSource` resolves the **same element from the same record
  earlier in the same pass**, so `retranslateChangedSource` already owns it under the #1831 budget.

There is no third case, so skipping the walk strands nothing. Shadow text is invisible to
`collectHostText`, so isolated trees inside the addition are still discovered and scanned.

**Scope, stated rather than implied:** this covers the **childList route only**. The
attribute/reveal route (`collectNewlyWalkableSubtrees` → `observeTopLevelParagraphs(unblocked)`)
still creates a walk root inside a registered source, deliberately — the duality above does *not*
hold there. `collectRawSource` drops non-translatable children entirely, so revealing one changes
what is *translatable* without changing `collectHostText`: the enclosing source stays current,
nothing would retranslate it, and applying the same guard would strand revealed accordion /
"show more" content forever. Narrowing that route needs its own correctness condition and its own
tests.

The helper walks `parentElement` only and must never cross a shadow host — `collectHostText` is
shadow-blind, so a source found across a host could not vouch for text inside the shadow tree.
(`isSourceWalkBlocked` in the same class crosses hosts on purpose; its shape must not be copied.)

**translationOnly is untouched by construction, not by a mode check.** Both registries the guard
reads are written only inside `translateNodesBilingualMode`, so the guard is structurally inert in
translationOnly sessions. That matters: translationOnly staleness is *run-scoped*
(`isTranslationOnlySwapRecordCurrent` recurses only into `record.runNodes`), so a node appended
beside a recorded run can never make an anchor stale — matching anchors here would create permanent
no-walk dead zones with nothing to rescue the addition.

### Also in this PR

Everything else here is the shadow-DOM / blocked-host machinery the fix needed or that was found
while building it: isolated-tree observers stay registered while hosts are blocked, a host revealed
by a sibling or ancestor selector recovers on its next update, stale sources edited while blocked are
retried on reveal, and nested shadow subtrees are scanned once rather than per level.

Two pieces were simplified on the way in:

- `blockedStaleSources` was a `Set<WeakRef>` plus a companion `WeakMap` plus a `defer` method. The
  WeakMap's *value* was never read (no `.get` anywhere) — a WeakMap used as a WeakSet holding a
  dead-weight WeakRef. WeakRef also made the `size === 0` fast path lie after a GC, so
  characterData-only batches paid a config fetch to discover an empty set. Now a plain `Set` pruned
  by `isConnected`.
- The shadow observation gate is extracted out of `handleMutationRecords`, which was ~120 lines doing
  five jobs. Pure move; the caller still reuses the config the gate had to resolve.

### Deliberately out of scope

- **translationOnly still carries #2185** (tracked in #2211), and there it is more expensive (restore → spinner →
  provider request → re-swap per hover). Fixing it requires giving `TranslationOnlyAnchorState` a
  whole-anchor content snapshot so its staleness stops being run-scoped. That touches the restore
  path (#1846 node-identity restore) and belongs in its own PR.
- **The attribute/reveal route** (tracked in #2212) still walks a revealed descendant as its own root inside a
  registered source (see the scope note above). It is the only rescue path for revealed content, so
  it cannot take the same guard; the narrow fix is to skip only elements that just stopped matching
  `isDontWalkIntoButTranslateAsChildElement`, whose text was already folded into the enclosing
  source's translation. That is a different correctness condition and belongs in its own PR.

## Related Issue

Closes #2185

## How Has This Been Tested?

- [x] Added unit tests
- [x] Verified through manual testing

**The new stale-source regression test was proven non-vacuous**: temporarily restoring the currency
check makes exactly that test fail (`1 failed | 58 passed`); restoring the fix makes it pass. The
mock walk previously labelled a paragraph only for `tagName === "P"`, so an inline `<span>` — the
actual #2185 shape — could never be promoted under it and the test would have passed vacuously. The
mock now mirrors the real rule instead (`traversal.ts` `walkNode`: any element with a non-blank
direct Text child).

**Headed-Chrome E2E**, production MV3 build, real Microsoft provider, three paragraphs on one page:

| paragraph | interaction | main | #2186 as shipped | this PR |
|---|---|---|---|---|
| control | 3 × Google decorator wrap/unwrap | 1 → **4** | 1 → 1 | 1 → 1 |
| target | inline `<span>` inserted mid-sentence | 1 → **2** | 1 → **2** | 1 → **1** |
| bystander | untouched | 1 | 1 | 1 |

On `main` and on #2186 as shipped, the injected clause is translated **twice** — once standalone
inside the span, once inside the paragraph's retranslation. With this change the paragraph is
retranslated once and the addition gets no unit of its own.

Other checks:

- Full suite: 330 files / 3458 passed, 4 skipped, 0 failed (`SKIP_FREE_API=true`).
- `pnpm type-check`, `pnpm fmt:check`, `pnpm build`, `pnpm exec changeset status` — all clean.

## Screenshots

Not applicable; the regression is asserted through live DOM wrapper counts (table above).

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Genuine host-content additions still change the bilingual state's source-text snapshot, making the
state stale and routing the source through the existing budgeted retranslation path. Only the *walk*
of the addition is skipped, never the retranslation of the unit that contains it.
