### PR TITLE
feat(prompts): link the prompt editors to the variable reference

### DIFF
--- a/.changeset/prompt-variable-reference-link.md
+++ b/.changeset/prompt-variable-reference-link.md
@@ -1,0 +1,7 @@
+---
+"@read-frog/extension": patch
+---
+
+Point the documentation links at their new locations, and add a link from both prompt editors to the prompt variable reference.
+
+The variable chips under a prompt field carry one line of explanation each, which is not enough to write a prompt with worked examples in it: `{{targetLanguage}}` arrives as an English display name rather than a code, `{{input}}` looks different once batch translation is on, and a variable with no value becomes a literal English sentence. The new link goes to the page that shows a real sample value for each one.

--- a/.changeset/prompt-variable-reference-link.md
+++ b/.changeset/prompt-variable-reference-link.md
@@ -2,6 +2,4 @@
 "@read-frog/extension": patch
 ---
 
-Point the documentation links at their new locations, and add a link from both prompt editors to the prompt variable reference.
-
-The variable chips under a prompt field carry one line of explanation each, which is not enough to write a prompt with worked examples in it: `{{targetLanguage}}` arrives as an English display name rather than a code, `{{input}}` looks different once batch translation is on, and a variable with no value becomes a literal English sentence. The new link goes to the page that shows a real sample value for each one.
+feat(prompts): link the prompt editors to the prompt variable reference

--- a/src/components/api-config-warning.tsx
+++ b/src/components/api-config-warning.tsx
@@ -12,7 +12,7 @@ export function APIConfigWarning({ className }: { className?: string }) {
     >
       {i18n.t("noAPIKeyConfig.warningWithLink.youMust")}{" "}
       <a
-        href="https://readfrog.app/docs/api-key"
+        href="https://readfrog.app/docs/providers/overview"
         target="_blank"
         rel="noreferrer"
         className="underline"

--- a/src/entrypoints/options/pages/translation/personalized-prompts/prompts/index.tsx
+++ b/src/entrypoints/options/pages/translation/personalized-prompts/prompts/index.tsx
@@ -37,14 +37,24 @@ export function PersonalizedPromptsPage() {
           insertCells={insertCells}
           builtInPrompts={getBuiltInPageTranslatePrompts()}
           toolbarStart={
-            <a
-              href={i18n.t("options.translation.personalizedPrompts.communityPromptsUrl")}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="text-sm text-link hover:opacity-90"
-            >
-              {i18n.t("options.translation.personalizedPrompts.communityPrompts")}
-            </a>
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+              <a
+                href={i18n.t("options.translation.personalizedPrompts.communityPromptsUrl")}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-sm text-link hover:opacity-90"
+              >
+                {i18n.t("options.translation.personalizedPrompts.communityPrompts")}
+              </a>
+              <a
+                href={i18n.t("options.translation.personalizedPrompts.variableReferenceUrl")}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-sm text-link hover:opacity-90"
+              >
+                {i18n.t("options.translation.personalizedPrompts.variableReference")}
+              </a>
+            </div>
           }
         />
       </ConfigDetailSection>

--- a/src/entrypoints/options/pages/translation/translation-style/custom-css/css-editor.tsx
+++ b/src/entrypoints/options/pages/translation/translation-style/custom-css/css-editor.tsx
@@ -64,7 +64,7 @@ export function CSSEditor() {
       {/* The section heading already names this editor, so the row carries only the docs link. */}
       <div className="flex items-start justify-end">
         <a
-          href={`${env.WXT_WEBSITE_URL}/docs/custom-css`}
+          href={`${env.WXT_WEBSITE_URL}/docs/page-translation/style`}
           className="text-xs text-link hover:opacity-90"
           target="_blank"
           rel="noreferrer"

--- a/src/entrypoints/options/pages/video-subtitles/custom-prompts/prompts/index.tsx
+++ b/src/entrypoints/options/pages/video-subtitles/custom-prompts/prompts/index.tsx
@@ -35,6 +35,16 @@ export function SubtitlesCustomPromptsPage() {
           promptAtoms={promptAtoms}
           insertCells={insertCells}
           builtInPrompts={getBuiltInSubtitleTranslatePrompts()}
+          toolbarStart={
+            <a
+              href={i18n.t("options.translation.personalizedPrompts.variableReferenceUrl")}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-sm text-link hover:opacity-90"
+            >
+              {i18n.t("options.translation.personalizedPrompts.variableReference")}
+            </a>
+          }
         />
       </ConfigDetailSection>
     </PageLayout>

--- a/src/entrypoints/options/pages/video-subtitles/subtitles-style/custom-css/css-editor.tsx
+++ b/src/entrypoints/options/pages/video-subtitles/subtitles-style/custom-css/css-editor.tsx
@@ -60,7 +60,7 @@ export function CSSEditor({ value, onChange }: CSSEditorProps) {
       {/* The section heading already names this editor, so the row carries only the docs link. */}
       <div className="flex items-start justify-end">
         <a
-          href={`${env.WXT_WEBSITE_URL}/docs/subtitle-custom-css`}
+          href={`${env.WXT_WEBSITE_URL}/docs/video-subtitles/style`}
           className="text-xs text-link hover:opacity-90"
           target="_blank"
           rel="noreferrer"

--- a/src/locales/az.yml
+++ b/src/locales/az.yml
@@ -1056,6 +1056,8 @@ options:
       managePrompts: Təlimatları idarə et
       communityPrompts: İcmadan təlimat əldə et və ya icma ilə paylaş
       communityPromptsUrl: https://github.com/mengxi-ream/read-frog/discussions/821
+      variableReference: Dəyişənlər arayışı
+      variableReferenceUrl: https://readfrog.app/en/docs/page-translation/prompts/variables
       addPrompt: Təlimat əlavə et
       default: Standart
       builtIn: Daxili

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1056,6 +1056,8 @@ options:
       managePrompts: Manage prompts
       communityPrompts: Get or share prompts from community
       communityPromptsUrl: https://github.com/mengxi-ream/read-frog/discussions/821
+      variableReference: Variable reference
+      variableReferenceUrl: https://readfrog.app/en/docs/page-translation/prompts/variables
       addPrompt: Add prompt
       default: Default
       builtIn: Built-in

--- a/src/locales/es.yml
+++ b/src/locales/es.yml
@@ -1056,6 +1056,8 @@ options:
       managePrompts: Gestionar prompts
       communityPrompts: Obtener o compartir prompts de la comunidad
       communityPromptsUrl: https://github.com/mengxi-ream/read-frog/discussions/821
+      variableReference: Referencia de variables
+      variableReferenceUrl: https://readfrog.app/es/docs/page-translation/prompts/variables
       addPrompt: Añadir Prompt
       default: Predeterminado
       builtIn: Integrado

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -940,6 +940,8 @@ options:
       managePrompts: プロンプトを管理
       communityPrompts: コミュニティからプロンプトを取得・共有
       communityPromptsUrl: https://github.com/mengxi-ream/read-frog/discussions/821
+      variableReference: 変数リファレンス
+      variableReferenceUrl: https://readfrog.app/ja/docs/page-translation/prompts/variables
       addPrompt: プロンプトを追加
       default: デフォルト
       builtIn: 組み込み

--- a/src/locales/ko.yml
+++ b/src/locales/ko.yml
@@ -940,6 +940,8 @@ options:
       managePrompts: 프롬프트 관리
       communityPrompts: 커뮤니티에서 프롬프트 가져오기 또는 공유
       communityPromptsUrl: https://github.com/mengxi-ream/read-frog/discussions/821
+      variableReference: 변수 레퍼런스
+      variableReferenceUrl: https://readfrog.app/ko/docs/page-translation/prompts/variables
       addPrompt: 프롬프트 추가
       default: 기본
       builtIn: 기본 제공

--- a/src/locales/ru.yml
+++ b/src/locales/ru.yml
@@ -940,6 +940,8 @@ options:
       managePrompts: Управление промптами
       communityPrompts: Получайте или делитесь промптами с сообществом
       communityPromptsUrl: https://github.com/mengxi-ream/read-frog/discussions/821
+      variableReference: Справочник переменных
+      variableReferenceUrl: https://readfrog.app/ru/docs/page-translation/prompts/variables
       addPrompt: Добавить промпт
       default: По умолчанию
       builtIn: Встроенный

--- a/src/locales/tr.yml
+++ b/src/locales/tr.yml
@@ -940,6 +940,8 @@ options:
       managePrompts: Promptları yönet
       communityPrompts: Topluluktan prompt al veya paylaş
       communityPromptsUrl: https://github.com/mengxi-ream/read-frog/discussions/821
+      variableReference: Değişken başvurusu
+      variableReferenceUrl: https://readfrog.app/tr/docs/page-translation/prompts/variables
       addPrompt: Prompt ekle
       default: Varsayılan
       builtIn: Yerleşik

--- a/src/locales/vi.yml
+++ b/src/locales/vi.yml
@@ -940,6 +940,8 @@ options:
       managePrompts: Quản lý prompt
       communityPrompts: Nhận hoặc chia sẻ prompt từ cộng đồng
       communityPromptsUrl: https://github.com/mengxi-ream/read-frog/discussions/821
+      variableReference: Tham chiếu biến
+      variableReferenceUrl: https://readfrog.app/vi/docs/page-translation/prompts/variables
       addPrompt: Thêm Prompt
       default: Mặc định
       builtIn: Tích hợp sẵn

--- a/src/locales/zh-CN.yml
+++ b/src/locales/zh-CN.yml
@@ -1056,6 +1056,8 @@ options:
       managePrompts: 管理 Prompt
       communityPrompts: 获取或分享社区 Prompt
       communityPromptsUrl: https://github.com/mengxi-ream/read-frog/discussions/820
+      variableReference: 变量详解
+      variableReferenceUrl: https://readfrog.app/zh/docs/page-translation/prompts/variables
       addPrompt: 添加 Prompt
       default: 通用
       builtIn: 内置

--- a/src/locales/zh-TW.yml
+++ b/src/locales/zh-TW.yml
@@ -1056,6 +1056,8 @@ options:
       managePrompts: 管理提示詞
       communityPrompts: 取得或分享社群提示詞
       communityPromptsUrl: https://github.com/mengxi-ream/read-frog/discussions/820
+      variableReference: 變數詳解
+      variableReferenceUrl: https://readfrog.app/zh-TW/docs/page-translation/prompts/variables
       addPrompt: 新增提示詞
       default: 通用
       builtIn: 內建


### PR DESCRIPTION
## Type of Changes

- [x] ✨ New feature (feat)

## Description

Two things, both fallout from the docs restructure in mengxi-ream/read-frog-monorepo#463.

**The three shipped documentation deep links move with the docs.** That PR does not add redirects — the agreement was to update the extension instead and let Chrome's auto-update carry it — so these need to land close together:

| Where | Was | Now |
| --- | --- | --- |
| `api-config-warning.tsx` | `/docs/api-key` | `/docs/providers/overview` |
| `translation-style/custom-css/css-editor.tsx` | `/docs/custom-css` | `/docs/page-translation/style` |
| `video-subtitles/subtitles-style/custom-css/css-editor.tsx` | `/docs/subtitle-custom-css` | `/docs/video-subtitles/style` |

**Both prompt editors get a "Variable reference" link.** This is the discoverability half of #2124. Each variable chip explains itself in one line, which is enough to know a variable exists and not enough to write a prompt around it — `{{targetLanguage}}` is substituted with an English display name rather than a code, `{{input}}` carries several paragraphs separated by a standalone `%%` line once batch translation is on, and a variable with no value becomes a literal English sentence that then sits inside the user's own prompt. The link goes to the new reference page, which shows a real sample value for each one.

The page-translation editor already had a community-prompts link, so the two now sit side by side; the subtitle editor gains its first toolbar link. The URL is localized per UI language (`readfrog.app/<locale>/docs/…`), with Azerbaijani pointing at the English docs since there is no `az` docs build.

## Related Issue

Refs #2124 — the reporter's actual complaint is answered by the docs page; this is the link that leads them to it.

## How Has This Been Tested?

- [x] Verified through manual testing

`pnpm type-check` and `pnpm build` pass. Loaded the built extension in Chrome and confirmed both editors render the new link and that it resolves to the localized docs URL — verified in English and Simplified Chinese.

## Additional Information

Ordering: the docs PR should be merged and deployed first, or the three moved links point at pages that do not exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
