### PR TITLE
fix(translate): exclude the entire Substack video player from transla…

### DIFF
--- a/.changeset/quiet-players-rest.md
+++ b/.changeset/quiet-players-rest.md
@@ -1,0 +1,5 @@
+---
+"@read-frog/extension": patch
+---
+
+fix(translate): exclude the entire Substack video player from translation

--- a/src/utils/site-rules/built-in/rules.json
+++ b/src/utils/site-rules/built-in/rules.json
@@ -882,6 +882,7 @@
     "id": "substack",
     "matches": ["*.substack.com", "newsletter.rootsofprogress.org", "www.lennysnewsletter.com"],
     "excludeSelectors": [
+      ".shows-video-player-container",
       ".publication-footer",
       ".subscribe-footer",
       ".main-menu",


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-6 (Codex)

## Type of Changes

- [x] 🐛 Bug fix (fix)

## Description

Substack video captions can receive translations between individual words. Exclude the entire `.shows-video-player-container` through the existing Substack site rule so captions and player controls stay untouched during page translation.

Includes a patch changeset for `@read-frog/extension`.

## Related Issue

Closes #2060

## How Has This Been Tested?

- Checked the reported page's HTML with JSDOM: the selector matches the complete player, including all 14 buttons, while the article heading remains outside it.
- `pnpm exec changeset status` confirms a patch bump for `@read-frog/extension`.
- Repository pre-push formatting and type-aware lint/type checking passed; all 3,378 tests across 323 files passed.
- Live-service translation tests excluded with `SKIP_FREE_API=true` as required by project instructions.

## Screenshots

Not applicable: translation exclusion rule only.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

Validation covers rule matching against fetched page HTML and automated checks; interactive playback and captions were not tested in a browser.
