### PR TITLE
docs(dev): replace removed Portless guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Ask AI to understand the project: [Dosu](https://app.dosu.dev/29569286-71ba-47dd
 
 Check out the [Contribution Guide](https://readfrog.app/en/docs/code-contribution/contribution-guide) for more details.
 
-For the local monorepo API and website, see [Portless extension development](./PORTLESS_LOCAL_DEVELOPMENT.md).
+For a local monorepo backend, start that worktree with `pnpm dev:www`, then run `pnpm dev:local` here. Set `WXT_MONOREPO_PATH` to select another worktree.
 
 ReadFrog is dual-licensed under GPLv3 and a commercial license.
 


### PR DESCRIPTION
> **AI model(s) used (required):** GPT-5 and GPT-6 (Codex)

## Type of Changes

- [x] 📝 Documentation change (docs)

## Description

The merged Portless extension PR removed `PORTLESS_LOCAL_DEVELOPMENT.md`, but README still linked to it. Replace that broken link with the two local startup commands and the `WXT_MONOREPO_PATH` worktree selector directly in README.

## Related Issue

Follow-up to https://github.com/mengxi-ream/read-frog/pull/2190.

## How Has This Been Tested?

- [x] Verified the deleted guide is absent from `main` and the README line is formatted correctly.

## Screenshots

Not applicable.

## Checklist

- [x] I have tested these changes locally
- [x] I have updated the documentation accordingly if necessary
- [x] My code follows the code style of this project
- [x] My changes do not break existing functionality
- [x] If my code was generated by AI, I have proofread and improved it as necessary.

## Additional Information

No runtime code changes or changeset.
